### PR TITLE
Fix UI port misreporting and missing storage-sqlite build on startup

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -321,11 +321,17 @@ program
     killPattern('packages/server/dist/server.js');
     killPattern('packages/ui');
 
-    // 1. Only bootstrap if start-services.mjs or server dist is missing
+    // 1. Only bootstrap if start-services.mjs or any required dist is missing
     const startScript = path.join(rootDir, 'scripts', 'start-services.mjs');
-    const serverDist = path.join(rootDir, 'packages/server/dist/server.js');
+    const requiredDists = [
+        path.join(rootDir, 'packages/server/dist/server.js'),
+        path.join(rootDir, 'packages/storage-sqlite/dist/index.js'),
+        path.join(rootDir, 'packages/storage-json/dist/index.js'),
+        path.join(rootDir, 'packages/core/dist/index.js'),
+    ];
+    const missingDist = requiredDists.some(d => !fs.existsSync(d));
 
-    if (!fs.existsSync(startScript) || !fs.existsSync(serverDist) || options.rebuild) {
+    if (!fs.existsSync(startScript) || missingDist || options.rebuild) {
         console.log(chalk.yellow(options.rebuild ? '📦 Rebuild requested...' : '📦 Initial bootstrap required...'));
         try {
             execSync(`node scripts/install.mjs${options.rebuild ? ' --rebuild' : ''}`, { cwd: rootDir, stdio: 'inherit' });

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -61,14 +61,31 @@ async function run() {
     const shouldRebuild = process.argv.includes('--rebuild');
 
     // 1. Build the project
+    const npmCmd = os.platform() === 'win32' && !isMinGW ? 'npm.cmd' : 'npm';
     if (!shouldRebuild) {
-        console.log(`${GREEN}[1/14] Skipping build (using prebuilt binaries)...${NC}`);
-        const npmCmd = os.platform() === 'win32' && !isMinGW ? 'npm.cmd' : 'npm';
+        console.log(`${GREEN}[1/14] Checking prebuilt binaries...${NC}`);
         // Need all dependencies including devDependencies to run 'npm run dev' for the UI.
         spawnSync(npmCmd, ['install'], { stdio: 'inherit', cwd: rootDir, shell: true });
+
+        // Verify all required dist/ directories exist; build if any are missing
+        const requiredDists = [
+            'packages/core/dist',
+            'packages/storage-json/dist',
+            'packages/storage-sqlite/dist',
+            'packages/telemetry/dist',
+            'packages/cli/dist',
+            'packages/server/dist',
+        ];
+        const missingDists = requiredDists.filter(d => !existsSync(path.join(rootDir, d)));
+        if (missingDists.length > 0) {
+            console.log(`${YELLOW}  Missing build artifacts: ${missingDists.join(', ')}${NC}`);
+            console.log(`${YELLOW}  Running build to generate them...${NC}`);
+            spawnSync(npmCmd, ['run', 'build'], { stdio: 'inherit', cwd: rootDir, shell: true });
+        } else {
+            console.log(`  All build artifacts present, skipping build.`);
+        }
     } else {
         console.log(`${GREEN}[1/14] Building project...${NC}`);
-        const npmCmd = os.platform() === 'win32' && !isMinGW ? 'npm.cmd' : 'npm';
         spawnSync(npmCmd, ['install'], { stdio: 'inherit', cwd: rootDir, shell: true });
         spawnSync(npmCmd, ['run', 'build'], { stdio: 'inherit', cwd: rootDir, shell: true });
     }
@@ -195,7 +212,7 @@ if (!fs.existsSync(agenfkDir)) {
 
 console.log(\`Starting API Server on port \${API_PORT}...\`);
 const apiLogPath = path.join(agenfkDir, 'api.log');
-const apiLog = fs.openSync(apiLogPath, 'a');
+const apiLog = fs.openSync(apiLogPath, 'w');
 const apiProcess = spawn('node', [path.join(rootDir, 'packages/server/dist/server.js')], {
     env: { ...process.env, AGENFK_DB_PATH: dbPath, AGENFK_PORT: API_PORT, VITE_PORT: UI_PORT },
     detached: true,
@@ -205,7 +222,7 @@ apiProcess.unref();
 
 console.log(\`Starting UI on port \${UI_PORT}...\`);
 const uiLogPath = path.join(agenfkDir, 'ui.log');
-const uiLog = fs.openSync(uiLogPath, 'a');
+const uiLog = fs.openSync(uiLogPath, 'w');
 const isMinGW = !!(process.env.MSYSTEM || process.env.MINGW_PREFIX);
 const npmCmd = (os.platform() === 'win32' && !isMinGW) ? 'npm.cmd' : 'npm';
 const uiProcess = spawn(npmCmd, ['run', 'dev'], {
@@ -228,9 +245,9 @@ let uiUrl = \`http://localhost:\${UI_PORT}\`;
 for (let i = 0; i < 15; i++) {
     if (fs.existsSync(uiLogPath)) {
         const content = fs.readFileSync(uiLogPath, 'utf8');
-        const match = content.match(/http:\\/\\/localhost:[0-9]+/);
-        if (match) {
-            uiUrl = match[0];
+        const matches = content.match(/http:\\/\\/localhost:[0-9]+/g);
+        if (matches) {
+            uiUrl = matches[matches.length - 1];
             break;
         }
     }

--- a/scripts/start-services.mjs
+++ b/scripts/start-services.mjs
@@ -31,7 +31,7 @@ if (!fs.existsSync(agenfkDir)) {
 
 console.log(`Starting API Server on port ${API_PORT}...`);
 const apiLogPath = path.join(agenfkDir, 'api.log');
-const apiLog = fs.openSync(apiLogPath, 'a');
+const apiLog = fs.openSync(apiLogPath, 'w');
 const apiProcess = spawn('node', [path.join(rootDir, 'packages/server/dist/server.js')], {
     env: { ...process.env, AGENFK_DB_PATH: dbPath, AGENFK_PORT: API_PORT, VITE_PORT: UI_PORT },
     detached: true,
@@ -41,7 +41,7 @@ apiProcess.unref();
 
 console.log(`Starting UI on port ${UI_PORT}...`);
 const uiLogPath = path.join(agenfkDir, 'ui.log');
-const uiLog = fs.openSync(uiLogPath, 'a');
+const uiLog = fs.openSync(uiLogPath, 'w');
 const isMinGW = !!(process.env.MSYSTEM || process.env.MINGW_PREFIX);
 const npmCmd = (os.platform() === 'win32' && !isMinGW) ? 'npm.cmd' : 'npm';
 const uiProcess = spawn(npmCmd, ['run', 'dev'], {
@@ -64,9 +64,9 @@ let uiUrl = `http://localhost:${UI_PORT}`;
 for (let i = 0; i < 15; i++) {
     if (fs.existsSync(uiLogPath)) {
         const content = fs.readFileSync(uiLogPath, 'utf8');
-        const match = content.match(/http:\/\/localhost:[0-9]+/);
-        if (match) {
-            uiUrl = match[0];
+        const matches = content.match(/http:\/\/localhost:[0-9]+/g);
+        if (matches) {
+            uiUrl = matches[matches.length - 1];
             break;
         }
     }


### PR DESCRIPTION
The UI port was reported incorrectly (e.g. 5174 instead of 5173) because:
1. Log files were opened in append mode, accumulating entries from previous runs where Vite may have used a different port.
2. The regex matched the first URL in the log (potentially stale) instead of the last one (the current run).

The API server crashed on startup because @agenfk/storage-sqlite was never built — its dist/ directory was missing. The `up` command only checked for server/dist/server.js, so it skipped bootstrap even when other required packages had no compiled output.

Fixes:
- Truncate log files (use 'w' mode) on each service start
- Match last localhost URL in log instead of first
- Check all required dist/ directories before skipping build
- Auto-build when any dist/ is missing, even without --rebuild

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to local bootstrap/start scripts and log handling, mainly affecting developer startup behavior and build triggering.
> 
> **Overview**
> Improves `agenfk up`/install bootstrap reliability by **checking for multiple required build artifacts** (including storage packages/core) and triggering `scripts/install.mjs`/`npm run build` when any dist output is missing, not just `server.js`.
> 
> Fixes UI URL/port misreporting by **truncating** `api.log`/`ui.log` on each start and using the **last** `http://localhost:<port>` match from the Vite log when announcing/opening the UI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34c1d47da8edefb4ea6eec36559a3de39301e52f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->