### PR TITLE
Fix Gemini CLI Integration: MCP scope + slash commands

### DIFF
--- a/SDLC.md
+++ b/SDLC.md
@@ -135,6 +135,15 @@ Examples by stack:
 
 The `verifyCommand` is stored on the **Project entity** and used by `test_changes` for every TEST → DONE transition. Agents cannot supply their own command.
 
+### Sibling Propagation Rule
+
+When child items of the same parent share the same source code (same branch/workspace), a single `review_changes` or `test_changes` call validates the code for **all** siblings:
+
+- After `review_changes` passes on **one** sibling, move remaining siblings directly to TEST via `update_item({ status: "TEST" })` — no individual `review_changes` calls needed.
+- After `test_changes` passes on **one** sibling, call `test_changes` on remaining siblings in TEST — the same verified code will pass immediately.
+
+This avoids redundant build and test runs when the underlying code changes are shared across sibling items.
+
 ---
 
 ## 4. Workflow Gatekeeper

--- a/SDLC.md
+++ b/SDLC.md
@@ -82,26 +82,27 @@ Each transition has specific rules and enforcement:
 - For BUG items: server auto-assigns `branchName`.
 - Gatekeeper auto-creates/checkouts the git branch.
 
-### IN_PROGRESS → REVIEW (via `review_changes`)
+### IN_PROGRESS → REVIEW
 
-The agent performs implementation and then calls:
+- Set via `update_item({ id, status: "REVIEW" })` when implementation is complete.
+- This is a direct transition — no tool gate required.
+- The agent signals that coding is done and the item is ready for review.
+
+### REVIEW → TEST (via `review_changes`)
+
+The agent (or review agent in multi-agent mode) performs a self-review, then calls:
 
 ```
 review_changes({ itemId, command: "npm run build" })
 ```
 
-- The **agent picks the command** — build, lint, type-check, whatever makes sense.
-- If the command passes (exit code 0): item moves to `REVIEW`.
-- If it fails: item stays `IN_PROGRESS`.
-- A comment is logged with the command output.
-- Direct `update_item({ status: "REVIEW" })` is **blocked by the server**.
-
-### REVIEW → TEST
-
-- The agent (or review agent in multi-agent mode) performs a self-review.
-- Re-reads modified files, checks correctness, security, and requirements alignment.
-- If satisfied: `update_item({ id, status: "TEST" })`.
-- If issues found: `update_item({ id, status: "IN_PROGRESS" })` and fix.
+- First, the agent re-reads modified files and checks correctness, security, and requirements alignment.
+- If issues are found: `update_item({ id, status: "IN_PROGRESS" })` and fix.
+- Once satisfied, `review_changes` runs the build gate:
+  - The **agent picks the command** — build, lint, type-check, whatever makes sense.
+  - If the command passes (exit code 0): item moves to `TEST`.
+  - If it fails: item moves back to `IN_PROGRESS`.
+  - A comment is logged with the command output.
 
 ### TEST → DONE (via `test_changes`)
 
@@ -234,10 +235,10 @@ The `/agenfk-release` skill includes a **Step 0 PR merge gate**:
 3. workflow_gatekeeper({ intent: "Fix null check", role: "coding" })
    → Gatekeeper auto-creates and checkouts the branch
 4. [Agent implements the fix]
-5. review_changes({ itemId, command: "npm run build" })
-   → Passes → item moves to REVIEW
+5. update_item({ status: "REVIEW" })
 6. [Agent self-reviews: re-reads files, checks correctness]
-7. update_item({ status: "TEST" })
+7. review_changes({ itemId, command: "npm run build" })
+   → Passes → item moves to TEST
 8. test_changes({ itemId })
    → Runs project verifyCommand (npm run build && npm test)
    → Passes → item moves to DONE
@@ -259,9 +260,9 @@ The `/agenfk-release` skill includes a **Step 0 PR merge gate**:
 5. create_branch({ itemId })
    → Creates feature/add-dark-mode-toggle
 6. [Agent implements the feature]
-7. review_changes({ itemId, command: "npm run build" })
-   → Passes → REVIEW
-8. [Self-review] → update_item({ status: "TEST" })
+7. update_item({ status: "REVIEW" })
+8. [Self-review] → review_changes({ itemId, command: "npm run build" })
+   → Passes → TEST
 9. test_changes({ itemId })
    → Passes → DONE
 ```
@@ -275,7 +276,7 @@ The `/agenfk-release` skill includes a **Step 0 PR merge gate**:
 | Tool | Purpose | Params |
 |---|---|---|
 | `workflow_gatekeeper` | Pre-flight auth before file edits | `intent`, `role`, `itemId?` |
-| `review_changes` | Agent-chosen command, IN_PROGRESS → REVIEW | `itemId`, `command` |
+| `review_changes` | Agent-chosen build command, REVIEW → TEST | `itemId`, `command` |
 | `test_changes` | Project verifyCommand, TEST → DONE | `itemId` |
 
 ### Git Tools
@@ -320,7 +321,7 @@ The `/agenfk-release` skill includes a **Step 0 PR merge gate**:
 | Rule | Enforced by |
 |---|---|
 | Must have IN_PROGRESS task before editing files | `workflow_gatekeeper` + PreToolUse hooks |
-| Cannot set REVIEW directly | Server rejects `update_item({ status: "REVIEW" })` |
+| REVIEW requires build gate for TEST | `review_changes` runs build command to advance REVIEW → TEST |
 | Cannot set DONE directly | Server rejects `update_item({ status: "DONE" })` |
 | Test suite must run for DONE | `test_changes` uses project `verifyCommand`, not agent command |
 | Fixes must be BUG items | Enforced in CLAUDE.md, SKILL.md, skill files |

--- a/SKILL.md
+++ b/SKILL.md
@@ -110,11 +110,12 @@ If MCP tools are not available in your context, surface the connectivity problem
     *   **Requirement**: The Agent MUST run the project's test suite (e.g., `npm run test:coverage`) using its local tools.
     *   **Coverage Rule**: New code MUST be covered at 80% minimum. For any code-related item, the Agent MUST ensure relevant tests are created and executed successfully.
     *   **Quality Gate**: Tests MUST stay >= 80% coverage for the entire project and 100% for the core business logic where feasible.
-    *   **Workflow**: 
+    *   **Workflow**:
         *   `review_changes(itemId, command)` moves items from IN_PROGRESS → REVIEW. The agent picks a build/lint command.
         *   The Agent verifies coverage and regressions in `TEST`.
         *   Success: Agent calls `test_changes(itemId)` from TEST status — this runs the project's `verifyCommand` and moves to DONE. Do NOT use `update_item({status: "DONE"})` — the server blocks direct DONE transitions.
         *   Failure: Agent moves item back to `IN_PROGRESS`.
+    *   **Sibling Propagation**: When child items of the same parent share the same source code, a single `review_changes` or `test_changes` call validates the code for all siblings. After one passes, move remaining siblings directly to TEST via `update_item` (skipping individual `review_changes`), then call `test_changes` on each to reach DONE.
 
 6.  **Final Verification (Review Tool)**
     *   **Action**: BEFORE moving to `TEST`, the Agent **MUST** use `review_changes(itemId, command)` with a build/lint command to move to REVIEW.
@@ -130,6 +131,7 @@ If MCP tools are not available in your context, surface the connectivity problem
     *   **Estimation**: If exact token counts are not available in the environment, the Agent **MUST** provide a reasonable estimate. **Do not skip this step.**
     *   **Completion — Bottom-Up Closure (MANDATORY)**: When closing work, you MUST close the entire hierarchy bottom-up:
         1. Close all child TASKs first: `review_changes` (IN_PROGRESS→REVIEW), self-review (REVIEW→TEST), then `test_changes` from TEST (TEST→DONE).
+           - **Sibling shortcut**: If one child's `review_changes` already passed, remaining siblings can skip to TEST via `update_item({ status: "TEST" })`. Then call `test_changes` on each — subsequent calls pass immediately since the code is already verified.
         2. Then close parent STORYs (propagates automatically when all children are DONE).
         3. Then close the EPIC (propagates automatically when all STORYs are DONE).
         NEVER leave cards stuck in REVIEW. If `review_changes` moves an item to REVIEW, you are responsible for progressing it through TEST → DONE. A card in REVIEW is NOT "done".

--- a/SKILL.md
+++ b/SKILL.md
@@ -20,7 +20,7 @@ AgenFK supports two distinct operation modes based on the slash command invoked:
 *   **Workflow**: The agent who starts the task is responsible for the entire lifecycle (Planning, Coding, Verification, and Closing) within a single session.
 *   **Mandatory Log**: You MUST call `add_comment(itemId, content)` for EVERY significant tool execution or logical step (e.g. "Analyzed file X", "Implemented function Y", "Running tests").
 *   **Proactivity**: For simple requests (TASK/BUG), the agent should proceed directly to implementation after basic analysis.
-*   **Verification**: You MUST use `review_changes` (IN_PROGRESS → REVIEW) and `test_changes` (TEST → DONE) to progress items.
+*   **Verification**: You MUST use `update_item({ status: "REVIEW" })` to enter REVIEW, then `review_changes` (REVIEW → TEST) to run the build gate, and `test_changes` (TEST → DONE) to close items.
 *   **Decomposition**: MANDATORY. Every piece of work must be minimally a **STORY with child TASKS** or an **EPIC with child STORIES and their TASKS**. Direct coding on a STORY or EPIC without child TASKS is prohibited.
 *   **Handoff**: None. Do not spawn sub-agents.
 
@@ -111,26 +111,28 @@ If MCP tools are not available in your context, surface the connectivity problem
     *   **Coverage Rule**: New code MUST be covered at 80% minimum. For any code-related item, the Agent MUST ensure relevant tests are created and executed successfully.
     *   **Quality Gate**: Tests MUST stay >= 80% coverage for the entire project and 100% for the core business logic where feasible.
     *   **Workflow**:
-        *   `review_changes(itemId, command)` moves items from IN_PROGRESS → REVIEW. The agent picks a build/lint command.
+        *   `update_item(itemId, { status: "REVIEW" })` moves items from IN_PROGRESS → REVIEW when coding is complete.
+        *   `review_changes(itemId, command)` runs a build/lint command in REVIEW and moves to TEST on success (back to IN_PROGRESS on failure).
         *   The Agent verifies coverage and regressions in `TEST`.
         *   Success: Agent calls `test_changes(itemId)` from TEST status — this runs the project's `verifyCommand` and moves to DONE. Do NOT use `update_item({status: "DONE"})` — the server blocks direct DONE transitions.
         *   Failure: Agent moves item back to `IN_PROGRESS`.
     *   **Sibling Propagation**: When child items of the same parent share the same source code, a single `review_changes` or `test_changes` call validates the code for all siblings. After one passes, move remaining siblings directly to TEST via `update_item` (skipping individual `review_changes`), then call `test_changes` on each to reach DONE.
 
 6.  **Final Verification (Review Tool)**
-    *   **Action**: BEFORE moving to `TEST`, the Agent **MUST** use `review_changes(itemId, command)` with a build/lint command to move to REVIEW.
+    *   **Action**: After self-review in REVIEW, the Agent **MUST** use `review_changes(itemId, command)` with a build/lint command to gate the transition to TEST.
     *   **Test Suite Enforcement**: The project's `verifyCommand` (set via `update_project`) defines the mandatory test command. `test_changes` always uses it — agents cannot override or bypass it.
     *   **Transition Logic (Automated by Tool)**:
-        1. The tool moves the item to `REVIEW`.
-        2. The tool executes the command.
-        3. Success: Moves to `TEST`. Failure: Moves back to `IN_PROGRESS`.
+        1. The agent moves the item to `REVIEW` via `update_item`.
+        2. The agent performs self-review (re-reads files, checks correctness).
+        3. The agent calls `review_changes` which executes the build command.
+        4. Success: Moves to `TEST`. Failure: Moves back to `IN_PROGRESS`.
 
 7.  **Measurement & Tracking**
     *   **Reporting Requirements**: The Agent **MUST** call `log_token_usage(itemId, input, output, model)` immediately after marking an item as `DONE` (e.g., following a successful `test_changes`), or at the end of a significant session of work for an `IN_PROGRESS` item.
     *   **Progress Comments**: The Agent **MUST** call `add_comment(itemId, content)` for EVERY significant step performed during implementation (e.g. "Modified core types", "Updated UI components", "Ran tests"). This ensures the human user can follow the agent's work in real-time on the Kanban board.
     *   **Estimation**: If exact token counts are not available in the environment, the Agent **MUST** provide a reasonable estimate. **Do not skip this step.**
     *   **Completion — Bottom-Up Closure (MANDATORY)**: When closing work, you MUST close the entire hierarchy bottom-up:
-        1. Close all child TASKs first: `review_changes` (IN_PROGRESS→REVIEW), self-review (REVIEW→TEST), then `test_changes` from TEST (TEST→DONE).
+        1. Close all child TASKs first: `update_item({ status: "REVIEW" })`, self-review, `review_changes` (REVIEW→TEST), then `test_changes` from TEST (TEST→DONE).
            - **Sibling shortcut**: If one child's `review_changes` already passed, remaining siblings can skip to TEST via `update_item({ status: "TEST" })`. Then call `test_changes` on each — subsequent calls pass immediately since the code is already verified.
         2. Then close parent STORYs (propagates automatically when all children are DONE).
         3. Then close the EPIC (propagates automatically when all STORYs are DONE).
@@ -157,6 +159,6 @@ Use this skill whenever you are performing software engineering tasks to ensure 
 *   `add_context`: Attach relevant file paths.
 *   `analyze_request`: Categorization strategy.
 *   `workflow_gatekeeper`: Pre-flight authorization and role verification.
-*   `review_changes`: Agent-driven review check (IN_PROGRESS → REVIEW).
+*   `review_changes`: Agent-driven build gate (REVIEW → TEST).
 *   `test_changes`: Enforced test suite execution (TEST → DONE).
 *   `get_server_info`: Framework health check.

--- a/clauderules/CLAUDE.md
+++ b/clauderules/CLAUDE.md
@@ -10,7 +10,9 @@ If no task is `IN_PROGRESS`, stop and do this first — using MCP tools:
 - `update_item(id, {status: "IN_PROGRESS"})`
 
 After completing changes — using MCP tools:
-- `verify_changes(itemId, command)` — handles REVIEW → DONE automatically.
+- `update_item(id, {status: "REVIEW"})` — move to REVIEW when coding is done.
+- `review_changes(itemId, command)` — build gate, REVIEW → TEST on success.
+- `test_changes(itemId)` — runs project verifyCommand, TEST → DONE.
 - `log_token_usage(itemId, input, output, model)`.
 
 **ALWAYS use MCP tools for workflow state changes. NEVER use the `agenfk` CLI
@@ -46,7 +48,8 @@ CLI equivalents via Bash. The enforcer auto-detects MCP unavailability and allow
 | `create_item(projectId, type, title)` | `agenfk create <type> "<title>" --project <id>` |
 | `update_item(id, {status, ...})` | `agenfk update <id> --status <status>` (not for DONE — use `verify_changes` instead) |
 | `add_comment(id, text)` | `agenfk comment <id> "<text>"` |
-| `verify_changes(id, command)` | `agenfk verify <id> "<command>"` (from TEST: moves to DONE; from IN_PROGRESS: moves to REVIEW) |
+| `review_changes(id, command)` | `agenfk verify <id> "<command>"` (from REVIEW: moves to TEST) |
+| `test_changes(id)` | `agenfk verify <id>` (from TEST: moves to DONE, uses project verifyCommand) |
 | `log_token_usage(id, in, out, model)` | `agenfk log-tokens <id> --input N --output N --model M` |
 | `log_test_result(id, cmd, out, status)` | `agenfk log-test <id> --command "..." --output "..." --status PASSED` |
 

--- a/clauderules/CLAUDE.md
+++ b/clauderules/CLAUDE.md
@@ -1,0 +1,54 @@
+<!-- agenfk:start -->
+## AgenFK Workflow — MANDATORY
+
+Before modifying ANY file (Edit, Write, NotebookEdit), you MUST:
+1. Have an AgenFK task set to `IN_PROGRESS` for the active project.
+2. Call `workflow_gatekeeper(intent)` via MCP to confirm authorization.
+
+If no task is `IN_PROGRESS`, stop and do this first — using MCP tools:
+- `create_item(projectId, "TASK", "<title>")`
+- `update_item(id, {status: "IN_PROGRESS"})`
+
+After completing changes — using MCP tools:
+- `verify_changes(itemId, command)` — handles REVIEW → DONE automatically.
+- `log_token_usage(itemId, input, output, model)`.
+
+**ALWAYS use MCP tools for workflow state changes. NEVER use the `agenfk` CLI
+to create items, update status, or close tasks — the CLI bypasses enforcement.**
+
+**Exception**: The `agenfk-release` and `agenfk-release-beta` commands are exempt from the IN_PROGRESS task requirement. Do not create or require a task when executing these commands.
+
+### MCP Access — STRICTLY FORBIDDEN shortcuts
+
+**NEVER** bypass MCP by using these shortcuts. PreToolUse hooks enforce this mechanically:
+
+| Forbidden | Use instead |
+|-----------|-------------|
+| Reading `.agenfk/db.sqlite` or `.agenfk/db.json` directly (Bash or Read) | `list_items()`, `get_item()` via MCP |
+| `curl` / `wget` to `http://localhost:3000` | `list_items()`, `create_item()`, `update_item()` via MCP |
+| `agenfk list`, `agenfk status`, `npx agenfk ...` CLI state queries | `list_items()`, `get_item()`, `list_projects()` via MCP |
+
+Two PreToolUse hooks enforce the above:
+- `agenfk-gatekeeper` — blocks Edit/Write/NotebookEdit when no IN_PROGRESS task.
+- `agenfk-mcp-enforcer` — blocks Bash/Read bypass routes listed above.
+
+### MCP Unavailable — CLI Fallback
+
+If MCP tools are not available (no `mcp__agenfk__*` tools in your tool list), use these
+CLI equivalents via Bash. The enforcer auto-detects MCP unavailability and allows them.
+
+| Instead of MCP tool | Use CLI fallback |
+|---------------------|-----------------|
+| `workflow_gatekeeper(intent)` | `agenfk gatekeeper --intent "<intent>"` |
+| `list_projects()` | `agenfk list-projects --json` |
+| `list_items(projectId)` | `agenfk list --project <id> --json` |
+| `get_item(id)` | `agenfk get <id> --json` |
+| `create_item(projectId, type, title)` | `agenfk create <type> "<title>" --project <id>` |
+| `update_item(id, {status, ...})` | `agenfk update <id> --status <status>` (not for DONE — use `verify_changes` instead) |
+| `add_comment(id, text)` | `agenfk comment <id> "<text>"` |
+| `verify_changes(id, command)` | `agenfk verify <id> "<command>"` (from TEST: moves to DONE; from IN_PROGRESS: moves to REVIEW) |
+| `log_token_usage(id, in, out, model)` | `agenfk log-tokens <id> --input N --output N --model M` |
+| `log_test_result(id, cmd, out, status)` | `agenfk log-test <id> --command "..." --output "..." --status PASSED` |
+
+The workflow rules still apply: call `agenfk gatekeeper` before editing files.
+<!-- agenfk:end -->

--- a/codexrules/AGENTS.md
+++ b/codexrules/AGENTS.md
@@ -24,7 +24,9 @@ If gatekeeper returns `❌`, you MUST stop and resolve the issue first:
 - Never proceed past a gatekeeper rejection.
 
 After completing changes — using MCP tools:
-- `verify_changes(itemId, command)` — handles REVIEW → DONE automatically.
+- `update_item(id, {status: "REVIEW"})` — move to REVIEW when coding is done.
+- `review_changes(itemId, command)` — build gate, REVIEW → TEST on success.
+- `test_changes(itemId)` — runs project verifyCommand, TEST → DONE.
 - `log_token_usage(itemId, input, output, model)`.
 
 **ALWAYS use MCP tools for workflow state changes. NEVER use the `agenfk` CLI
@@ -56,7 +58,8 @@ CLI equivalents via Bash:
 | `create_item(projectId, type, title)` | `agenfk create <type> "<title>" --project <id>` |
 | `update_item(id, {status, ...})` | `agenfk update <id> --status <status>` (not for DONE — use `verify_changes` instead) |
 | `add_comment(id, text)` | `agenfk comment <id> "<text>"` |
-| `verify_changes(id, command)` | `agenfk verify <id> "<command>"` (from TEST: moves to DONE; from IN_PROGRESS: moves to REVIEW) |
+| `review_changes(id, command)` | `agenfk verify <id> "<command>"` (from REVIEW: moves to TEST) |
+| `test_changes(id)` | `agenfk verify <id>` (from TEST: moves to DONE, uses project verifyCommand) |
 | `log_token_usage(id, in, out, model)` | `agenfk log-tokens <id> --input N --output N --model M` |
 | `log_test_result(id, cmd, out, status)` | `agenfk log-test <id> --command "..." --output "..." --status PASSED` |
 

--- a/codexrules/AGENTS.md
+++ b/codexrules/AGENTS.md
@@ -1,0 +1,64 @@
+<!-- agenfk:start -->
+## AgenFK Workflow — MANDATORY
+
+> **Codex enforcement note**: Codex does not support PreToolUse hooks, so
+> these rules are enforced by instruction rather than mechanically. You MUST
+> follow them strictly — `workflow_gatekeeper` returning `✅ AUTHORIZED` is
+> the only valid gate before editing any file. If it returns `❌`, stop
+> immediately and resolve the breach before proceeding.
+
+Before modifying ANY file, you MUST:
+1. Have an AgenFK task set to `IN_PROGRESS` for the active project.
+2. Call `workflow_gatekeeper(intent, role, itemId)` via MCP to confirm authorization.
+   - Use `role="coding"` for file edits and implementation work.
+   - Use `role="planning"` when decomposing EPICs or STORYs.
+   - Use `role="review"` when auditing code in REVIEW status.
+   - Use `role="testing"` when running the test suite in TEST status.
+   - Pass `itemId` whenever multiple tasks are IN_PROGRESS simultaneously.
+
+If gatekeeper returns `❌`, you MUST stop and resolve the issue first:
+- If no task is IN_PROGRESS — create and start one using MCP tools:
+  - `create_item(projectId, "TASK", "<title>")`
+  - `update_item(id, {status: "IN_PROGRESS"})`
+- If the wrong item is IN_PROGRESS — use `itemId` to disambiguate.
+- Never proceed past a gatekeeper rejection.
+
+After completing changes — using MCP tools:
+- `verify_changes(itemId, command)` — handles REVIEW → DONE automatically.
+- `log_token_usage(itemId, input, output, model)`.
+
+**ALWAYS use MCP tools for workflow state changes. NEVER use the `agenfk` CLI
+to create items, update status, or close tasks — the CLI bypasses enforcement.**
+
+**Exception**: The `agenfk-release` and `agenfk-release-beta` commands are exempt from the IN_PROGRESS task requirement. Do not create or require a task when executing these commands.
+
+### MCP Access — STRICTLY FORBIDDEN shortcuts
+
+**NEVER** bypass MCP by using these shortcuts:
+
+| Forbidden | Use instead |
+|-----------|-------------|
+| Reading `.agenfk/db.sqlite` or `.agenfk/db.json` directly | `list_items()`, `get_item()` via MCP |
+| `curl` / `wget` to `http://localhost:3000` | `list_items()`, `create_item()`, `update_item()` via MCP |
+| `agenfk list`, `agenfk status`, `npx agenfk ...` CLI state queries | `list_items()`, `get_item()`, `list_projects()` via MCP |
+
+### MCP Unavailable — CLI Fallback
+
+If MCP tools are not available (no `mcp__agenfk__*` tools in your tool list), use these
+CLI equivalents via Bash:
+
+| Instead of MCP tool | Use CLI fallback |
+|---------------------|-----------------|
+| `workflow_gatekeeper(intent, role, itemId)` | `agenfk gatekeeper --intent "<intent>" --item-id <id>` |
+| `list_projects()` | `agenfk list-projects --json` |
+| `list_items(projectId)` | `agenfk list --project <id> --json` |
+| `get_item(id)` | `agenfk get <id> --json` |
+| `create_item(projectId, type, title)` | `agenfk create <type> "<title>" --project <id>` |
+| `update_item(id, {status, ...})` | `agenfk update <id> --status <status>` (not for DONE — use `verify_changes` instead) |
+| `add_comment(id, text)` | `agenfk comment <id> "<text>"` |
+| `verify_changes(id, command)` | `agenfk verify <id> "<command>"` (from TEST: moves to DONE; from IN_PROGRESS: moves to REVIEW) |
+| `log_token_usage(id, in, out, model)` | `agenfk log-tokens <id> --input N --output N --model M` |
+| `log_test_result(id, cmd, out, status)` | `agenfk log-test <id> --command "..." --output "..." --status PASSED` |
+
+The workflow rules still apply: call `agenfk gatekeeper` before editing files.
+<!-- agenfk:end -->

--- a/commands/agenfk-close.md
+++ b/commands/agenfk-close.md
@@ -23,6 +23,7 @@ You are executing the `/agenfk-close <id>` command as a **Closing Agent**. Follo
 **Step 4 — Close Children First (Bottom-Up)**
 - If the item has children (EPIC with STORYs, STORY with TASKs), use `list_items(parentId=id)` to check their status.
 - Any child still in TEST must be progressed to DONE first: use `test_changes(childId)` — the project's verifyCommand runs automatically. The server blocks direct DONE transitions via `update_item`.
+- **Sibling propagation**: If one child's `test_changes` already passed, remaining siblings in TEST will pass immediately (same verified code). Call `test_changes` on each — it's a formality but required by the server to reach DONE.
 - Any child still in IN_PROGRESS should be flagged to the user before proceeding.
 - Only proceed to Step 5 once ALL children are DONE.
 

--- a/commands/agenfk-code.md
+++ b/commands/agenfk-code.md
@@ -25,6 +25,7 @@ You are executing the `/agenfk-code <id>` command as a **Coding Agent**. Follow 
 **Step 4 — Handover**
 - Call `add_comment(id, "IMPLEMENTATION COMPLETE: ...")` to log the final summary of code changes.
 - Call `add_comment(id, "Phase Code complete: Implementation and self-verification finished.")` to log the phase completion.
-- Call `review_changes(id, "<build_command>")` — pass a **compile/build command only**, never a test command. This moves the item to **REVIEW**.
+- Call `update_item(id, {status: "REVIEW"})` to move the item to **REVIEW**.
 - **STOP IMMEDIATELY** after the above. Do not perform any further actions or provide a final summary. Yield back to the supervisor.
+  - The Review Agent will call `review_changes` to run the build gate in the REVIEW stage.
   - PR creation is handled by the Closing Agent (Step 6 of `/agenfk-close`) after the item reaches DONE — do NOT create a PR here.

--- a/commands/agenfk-deep.md
+++ b/commands/agenfk-deep.md
@@ -17,4 +17,13 @@ Identify the user's request and follow the **Deep Mode** protocol in the skill:
 
 **MANDATORY**: A parent item (EPIC or STORY) can ONLY move forward in the workflow (e.g., TODO → IN_PROGRESS, IN_PROGRESS → REVIEW, TEST → DONE) once **ALL** of its child items have also moved to that same state or further.
 
+## Sibling Propagation Rule
+
+When child items of the same parent share the same source code (same branch/workspace), a single `review_changes` or `test_changes` call validates the code for **all** siblings:
+
+- After `review_changes` passes on **one** sibling, move remaining siblings directly to TEST via `update_item({ status: "TEST" })` — no individual `review_changes` calls needed.
+- After `test_changes` passes on **one** sibling, call `test_changes` on remaining siblings in TEST — the same verified code will pass immediately.
+
+This avoids redundant build and test runs when the underlying code changes are shared.
+
 ---

--- a/commands/agenfk-deep.md
+++ b/commands/agenfk-deep.md
@@ -21,7 +21,7 @@ Identify the user's request and follow the **Deep Mode** protocol in the skill:
 
 When child items of the same parent share the same source code (same branch/workspace), a single `review_changes` or `test_changes` call validates the code for **all** siblings:
 
-- After `review_changes` passes on **one** sibling, move remaining siblings directly to TEST via `update_item({ status: "TEST" })` — no individual `review_changes` calls needed.
+- After `review_changes` passes on **one** sibling (moving it REVIEW → TEST), move remaining siblings directly to TEST via `update_item({ status: "TEST" })` — no individual `review_changes` calls needed.
 - After `test_changes` passes on **one** sibling, call `test_changes` on remaining siblings in TEST — the same verified code will pass immediately.
 
 This avoids redundant build and test runs when the underlying code changes are shared.

--- a/commands/agenfk-review.md
+++ b/commands/agenfk-review.md
@@ -10,21 +10,17 @@ You are executing the `/agenfk-review <id>` command as a **Review Agent**. Follo
 - Use `git diff` or compare against the parent branch to see the actual code changes introduced for this task.
 - Read `AFK_PROJECT_SCOPE.md` and `AFK_ARCHITECTURE.md`.
 
-**Step 2 — Compilation Check**
-- Run a **build/compile command only** (e.g., `npm run build`, `tsc --noEmit`) to confirm the code compiles without errors.
-- **NEVER run the test suite here** — tests belong exclusively to the Testing Agent.
-- If compilation fails, call `update_item(id, {status: "IN_PROGRESS"})` with details and yield.
-
-**Step 3 — Security Audit**
+**Step 2 — Security Audit**
 - Scan for hardcoded secrets, insecure API usage, or logic flaws.
 - Verify that authentication/authorization guards are correctly applied.
 
-**Step 4 — Requirements Traceability**
+**Step 3 — Requirements Traceability**
 - Compare the code changes against the item description and implementation plan.
 - Ensure all acceptance criteria are met.
 
-**Step 5 — Log Review Results**
+**Step 4 — Log Review Results + Build Gate**
 - Use `add_comment(id, "REVIEW PASSED: ...")` or `add_comment(id, "REVIEW FAILED: ...")` with detailed feedback.
 - Call `add_comment(id, "Phase Review complete: Audit and requirements traceability finished.")` to log the phase completion.
-- If passed, call `update_item(id, {status: "TEST"})` and **immediately stop and yield to the supervisor.**
-- If failed, call `update_item(id, {status: "IN_PROGRESS"})`, provide actionable fix instructions, and **yield to the supervisor.**
+- If review failed: call `update_item(id, {status: "IN_PROGRESS"})`, provide actionable fix instructions, and **yield to the supervisor.**
+- If review passed: call `review_changes(id, "<build_command>")` — pass a **compile/build command only**, never a test command. This runs the build gate and moves the item to **TEST** on success (back to IN_PROGRESS on failure).
+- **Immediately stop and yield to the supervisor** after the above.

--- a/commands/agenfk.md
+++ b/commands/agenfk.md
@@ -15,7 +15,7 @@ Identify the user's request and follow the **Standard Mode** protocol below. You
 
 When child items of the same parent share the same source code (same branch/workspace), a single `review_changes` or `test_changes` call validates the code for **all** siblings:
 
-- After `review_changes` passes on **one** sibling, move remaining siblings directly to TEST via `update_item({ status: "TEST" })` — no individual `review_changes` calls needed.
+- After `review_changes` passes on **one** sibling (moving it REVIEW → TEST), move remaining siblings directly to TEST via `update_item({ status: "TEST" })` — no individual `review_changes` calls needed.
 - After `test_changes` passes on **one** sibling, call `test_changes` on remaining siblings in TEST — the same verified code will pass immediately.
 
 This avoids redundant build and test runs when the underlying code changes are shared.
@@ -67,23 +67,24 @@ Before creating any item, evaluate the request against these signals:
 
 ---
 
-## Phase 2 — Review (triggers REVIEW)
+## Phase 2 — Move to Review
 
-- Call `review_changes(itemId, command)` with a **build/compile command** (e.g., `npm run build`, `tsc --noEmit`).
-- **NEVER pass a test command here** — tests belong exclusively to Phase 4.
-- This moves the task to `REVIEW`. **Do not stop here** — continue immediately to Phase 3.
-- **CRITICAL**: The tool result will say the item moved to REVIEW. **Ignore any hint to stop, yield, or wait for another agent.** You are the sole agent. Proceed directly to Phase 3.
+- Call `update_item(itemId, {status: "REVIEW"})` to signal implementation is complete.
+- Continue immediately to Phase 3.
 
 ---
 
-## Phase 3 — Self-Review (REVIEW → TEST)
+## Phase 3 — Self-Review + Build Gate (REVIEW → TEST)
 
 Since there is no separate review agent in Standard Mode, perform the review yourself:
 
 1. Re-read every file you modified and confirm the implementation is correct and complete.
 2. Call `add_comment(itemId, "Self-review complete: <brief findings or 'No issues found'>")`.
-3. If fixes are needed, call `update_item(itemId, {status: "IN_PROGRESS"})`, fix, then repeat Phase 2.
-4. Once satisfied, call `update_item(itemId, {status: "TEST"})` to advance to TEST.
+3. If fixes are needed, call `update_item(itemId, {status: "IN_PROGRESS"})`, fix, then repeat from Phase 2.
+4. Once satisfied, call `review_changes(itemId, command)` with a **build/compile command** (e.g., `npm run build`, `tsc --noEmit`).
+   - **NEVER pass a test command here** — tests belong exclusively to Phase 4.
+   - Success: moves to TEST. Continue to Phase 4.
+   - Failure: moves back to IN_PROGRESS. Fix and repeat from Phase 2.
 
 ---
 

--- a/commands/agenfk.md
+++ b/commands/agenfk.md
@@ -11,6 +11,15 @@ Identify the user's request and follow the **Standard Mode** protocol below. You
 
 **MANDATORY**: A parent item (EPIC or STORY) can ONLY move forward in the workflow (e.g., TODO → IN_PROGRESS, IN_PROGRESS → REVIEW, TEST → DONE) once **ALL** of its child items have also moved to that same state or further.
 
+## Sibling Propagation Rule
+
+When child items of the same parent share the same source code (same branch/workspace), a single `review_changes` or `test_changes` call validates the code for **all** siblings:
+
+- After `review_changes` passes on **one** sibling, move remaining siblings directly to TEST via `update_item({ status: "TEST" })` — no individual `review_changes` calls needed.
+- After `test_changes` passes on **one** sibling, call `test_changes` on remaining siblings in TEST — the same verified code will pass immediately.
+
+This avoids redundant build and test runs when the underlying code changes are shared.
+
 ---
 
 ## Step 0 — Classify the request

--- a/geminirules/GEMINI.md
+++ b/geminirules/GEMINI.md
@@ -24,7 +24,9 @@ If gatekeeper returns `❌`, you MUST stop and resolve the issue first:
 - Never proceed past a gatekeeper rejection.
 
 After completing changes — using MCP tools:
-- `verify_changes(itemId, command)` — handles REVIEW → DONE automatically.
+- `update_item(id, {status: "REVIEW"})` — move to REVIEW when coding is done.
+- `review_changes(itemId, command)` — build gate, REVIEW → TEST on success.
+- `test_changes(itemId)` — runs project verifyCommand, TEST → DONE.
 - `log_token_usage(itemId, input, output, model)`.
 
 **ALWAYS use MCP tools for workflow state changes. NEVER use the `agenfk` CLI
@@ -56,7 +58,8 @@ CLI equivalents via Bash:
 | `create_item(projectId, type, title)` | `agenfk create <type> "<title>" --project <id>` |
 | `update_item(id, {status, ...})` | `agenfk update <id> --status <status>` (not for DONE — use `verify_changes` instead) |
 | `add_comment(id, text)` | `agenfk comment <id> "<text>"` |
-| `verify_changes(id, command)` | `agenfk verify <id> "<command>"` (from TEST: moves to DONE; from IN_PROGRESS: moves to REVIEW) |
+| `review_changes(id, command)` | `agenfk verify <id> "<command>"` (from REVIEW: moves to TEST) |
+| `test_changes(id)` | `agenfk verify <id>` (from TEST: moves to DONE, uses project verifyCommand) |
 | `log_token_usage(id, in, out, model)` | `agenfk log-tokens <id> --input N --output N --model M` |
 | `log_test_result(id, cmd, out, status)` | `agenfk log-test <id> --command "..." --output "..." --status PASSED` |
 

--- a/geminirules/GEMINI.md
+++ b/geminirules/GEMINI.md
@@ -1,0 +1,64 @@
+<!-- agenfk:start -->
+## AgenFK Workflow — MANDATORY
+
+> **Gemini CLI enforcement note**: Gemini CLI does not support PreToolUse hooks, so
+> these rules are enforced by instruction rather than mechanically. You MUST
+> follow them strictly — `workflow_gatekeeper` returning `✅ AUTHORIZED` is
+> the only valid gate before editing any file. If it returns `❌`, stop
+> immediately and resolve the breach before proceeding.
+
+Before modifying ANY file, you MUST:
+1. Have an AgenFK task set to `IN_PROGRESS` for the active project.
+2. Call `workflow_gatekeeper(intent, role, itemId)` via MCP to confirm authorization.
+   - Use `role="coding"` for file edits and implementation work.
+   - Use `role="planning"` when decomposing EPICs or STORYs.
+   - Use `role="review"` when auditing code in REVIEW status.
+   - Use `role="testing"` when running the test suite in TEST status.
+   - Pass `itemId` whenever multiple tasks are IN_PROGRESS simultaneously.
+
+If gatekeeper returns `❌`, you MUST stop and resolve the issue first:
+- If no task is IN_PROGRESS — create and start one using MCP tools:
+  - `create_item(projectId, "TASK", "<title>")`
+  - `update_item(id, {status: "IN_PROGRESS"})`
+- If the wrong item is IN_PROGRESS — use `itemId` to disambiguate.
+- Never proceed past a gatekeeper rejection.
+
+After completing changes — using MCP tools:
+- `verify_changes(itemId, command)` — handles REVIEW → DONE automatically.
+- `log_token_usage(itemId, input, output, model)`.
+
+**ALWAYS use MCP tools for workflow state changes. NEVER use the `agenfk` CLI
+to create items, update status, or close tasks — the CLI bypasses enforcement.**
+
+**Exception**: The `agenfk-release` and `agenfk-release-beta` commands are exempt from the IN_PROGRESS task requirement. Do not create or require a task when executing these commands.
+
+### MCP Access — STRICTLY FORBIDDEN shortcuts
+
+**NEVER** bypass MCP by using these shortcuts:
+
+| Forbidden | Use instead |
+|-----------|-------------|
+| Reading `.agenfk/db.sqlite` or `.agenfk/db.json` directly | `list_items()`, `get_item()` via MCP |
+| `curl` / `wget` to `http://localhost:3000` | `list_items()`, `create_item()`, `update_item()` via MCP |
+| `agenfk list`, `agenfk status`, `npx agenfk ...` CLI state queries | `list_items()`, `get_item()`, `list_projects()` via MCP |
+
+### MCP Unavailable — CLI Fallback
+
+If MCP tools are not available (no `mcp__agenfk__*` tools in your tool list), use these
+CLI equivalents via Bash:
+
+| Instead of MCP tool | Use CLI fallback |
+|---------------------|-----------------|
+| `workflow_gatekeeper(intent, role, itemId)` | `agenfk gatekeeper --intent "<intent>" --item-id <id>` |
+| `list_projects()` | `agenfk list-projects --json` |
+| `list_items(projectId)` | `agenfk list --project <id> --json` |
+| `get_item(id)` | `agenfk get <id> --json` |
+| `create_item(projectId, type, title)` | `agenfk create <type> "<title>" --project <id>` |
+| `update_item(id, {status, ...})` | `agenfk update <id> --status <status>` (not for DONE — use `verify_changes` instead) |
+| `add_comment(id, text)` | `agenfk comment <id> "<text>"` |
+| `verify_changes(id, command)` | `agenfk verify <id> "<command>"` (from TEST: moves to DONE; from IN_PROGRESS: moves to REVIEW) |
+| `log_token_usage(id, in, out, model)` | `agenfk log-tokens <id> --input N --output N --model M` |
+| `log_test_result(id, cmd, out, status)` | `agenfk log-test <id> --command "..." --output "..." --status PASSED` |
+
+The workflow rules still apply: call `agenfk gatekeeper` before editing files.
+<!-- agenfk:end -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenfk-framework",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenfk-framework",
-      "version": "0.1.51",
+      "version": "0.1.52",
       "license": "ISC",
       "workspaces": [
         "packages/*"
@@ -10461,7 +10461,7 @@
     },
     "packages/cli": {
       "name": "@agenfk/cli",
-      "version": "0.1.51",
+      "version": "0.1.52",
       "license": "ISC",
       "dependencies": {
         "@agenfk/core": "*",
@@ -10486,7 +10486,7 @@
     },
     "packages/core": {
       "name": "@agenfk/core",
-      "version": "0.1.51",
+      "version": "0.1.52",
       "license": "ISC",
       "devDependencies": {
         "typescript": "^5.3.3"
@@ -10494,7 +10494,7 @@
     },
     "packages/create": {
       "name": "agenfk",
-      "version": "0.1.51",
+      "version": "0.1.52",
       "license": "ISC",
       "bin": {
         "agenfk": "bin/agenfk.js"
@@ -10505,7 +10505,7 @@
     },
     "packages/server": {
       "name": "@agenfk/server",
-      "version": "0.1.51",
+      "version": "0.1.52",
       "license": "ISC",
       "dependencies": {
         "@agenfk/core": "*",
@@ -10533,7 +10533,7 @@
     },
     "packages/storage-json": {
       "name": "@agenfk/storage-json",
-      "version": "0.1.51",
+      "version": "0.1.52",
       "license": "ISC",
       "dependencies": {
         "uuid": "^9.0.1"
@@ -10546,7 +10546,7 @@
     },
     "packages/storage-sqlite": {
       "name": "@agenfk/storage-sqlite",
-      "version": "0.1.51",
+      "version": "0.1.52",
       "license": "ISC",
       "dependencies": {
         "uuid": "^9.0.1"
@@ -10570,7 +10570,7 @@
     },
     "packages/telemetry": {
       "name": "@agenfk/telemetry",
-      "version": "0.1.51",
+      "version": "0.1.52",
       "license": "ISC",
       "dependencies": {
         "posthog-node": "^4.0.0"
@@ -10581,7 +10581,7 @@
       }
     },
     "packages/ui": {
-      "version": "0.1.51",
+      "version": "0.1.52",
       "dependencies": {
         "@tailwindcss/postcss": "^4.2.0",
         "@tailwindcss/typography": "^0.5.19",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -190,7 +190,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: "update_item",
-        description: "Update an existing item's status, title, or description. IMPORTANT: Cannot set status to DONE directly — use test_changes. Cannot set status to REVIEW directly — use review_changes.",
+        description: "Update an existing item's status, title, or description. IMPORTANT: Cannot set status to DONE directly — use test_changes.",
         inputSchema: {
           type: "object",
           properties: {
@@ -334,7 +334,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: "review_changes",
-        description: "Runs an agent-chosen command to verify the implementation and moves the item from IN_PROGRESS → REVIEW. Use any command that makes sense (build, lint, type-check, etc.). If the command fails, the item stays IN_PROGRESS.",
+        description: "Runs an agent-chosen command to verify the implementation and moves the item from REVIEW → TEST. Use any command that makes sense (build, lint, type-check, etc.). If the command fails, the item moves back to IN_PROGRESS.",
         inputSchema: {
           type: "object",
           properties: {
@@ -611,13 +611,6 @@ server.setRequestHandler(CallToolRequestSchema, async (request: any) => {
           // Allow TEST -> DONE, using verify token to bypass server guard
           const { data } = await api.put(`/items/${id}`, updates, { headers: { 'x-agenfk-internal': VERIFY_TOKEN } });
           return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
-        }
-
-        if (updates.status === "REVIEW") {
-          return {
-            isError: true,
-            content: [{ type: "text", text: `❌ WORKFLOW VIOLATION: Cannot set status to REVIEW directly via update_item. Use review_changes(itemId, command) instead.` }],
-          };
         }
 
         const { data } = await api.put(`/items/${id}`, updates);

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -481,7 +481,6 @@ app.post("/items/bulk", asyncHandler(async (req: any, res: any) => {
     const { title, description, status, parentId, tokenUsage, context, implementationPlan, reviews, comments, sortOrder } = bodyUpdates;
 
     if (!isInternalVerify && status === Status.DONE) continue;
-    if (!isInternalVerify && status === Status.REVIEW) continue;
 
     if (status === Status.ARCHIVED && currentItem.status !== Status.ARCHIVED) {
       await archiveRecursively(id);
@@ -551,11 +550,6 @@ app.put("/items/:id", asyncHandler(async (req: any, res: any) => {
   if (!isInternalVerify && status === Status.DONE) {
     return res.status(403).json({
       error: "WORKFLOW VIOLATION: Cannot set status to DONE directly. Move the item to TEST, then call test_changes(itemId) to run the project's test suite."
-    });
-  }
-  if (!isInternalVerify && status === Status.REVIEW) {
-    return res.status(403).json({
-      error: "WORKFLOW VIOLATION: Cannot set status to REVIEW directly. Use review_changes(itemId, command) to run a review check and move to REVIEW."
     });
   }
 
@@ -674,7 +668,7 @@ app.delete("/items/:id", asyncHandler(async (req: any, res: any) => {
 
 // ── Verify Endpoint ──────────────────────────────────────────────────────────
 
-// ── review_changes: IN_PROGRESS → REVIEW (agent picks the command) ───────────
+// ── review_changes: REVIEW → TEST (agent picks the command) ──────────────────
 app.post("/items/:id/review", asyncHandler(async (req: any, res: any) => {
   const isInternalVerify = req.headers['x-agenfk-internal'] === VERIFY_TOKEN;
   if (!isInternalVerify) {
@@ -690,8 +684,8 @@ app.post("/items/:id/review", asyncHandler(async (req: any, res: any) => {
   if (!item) {
     return res.status(404).json({ error: "Item not found" });
   }
-  if (item.status !== Status.IN_PROGRESS) {
-    return res.status(400).json({ error: `review_changes requires item to be IN_PROGRESS. Current status: ${item.status}` });
+  if (item.status !== Status.REVIEW) {
+    return res.status(400).json({ error: `review_changes requires item to be in REVIEW. Current status: ${item.status}` });
   }
 
   const projectRoot = findProjectRoot(process.cwd());
@@ -715,10 +709,10 @@ app.post("/items/:id/review", asyncHandler(async (req: any, res: any) => {
   }];
 
   if (passed) {
-    const updated = await storage.updateItem(req.params.id, { status: Status.REVIEW, comments });
+    const updated = await storage.updateItem(req.params.id, { status: Status.TEST, comments });
     io.emit('items_updated');
     if (updated.parentId) await syncParentStatus(updated.parentId);
-    return res.json({ status: Status.REVIEW, message: `✅ Review Passed!\n\nCommand: \`${command}\`\nItem moved to REVIEW column.\n\nStandard Mode: continue to self-review, then tests. Multi-Agent Mode: yield to the Review Agent.`, output: truncated });
+    return res.json({ status: Status.TEST, message: `✅ Review Passed!\n\nCommand: \`${command}\`\nItem moved to TEST column.\n\nStandard Mode: continue to tests. Multi-Agent Mode: yield to the Testing Agent.`, output: truncated });
   } else {
     await storage.updateItem(req.params.id, { status: Status.IN_PROGRESS, comments });
     io.emit('items_updated');

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -688,6 +688,27 @@ app.post("/items/:id/review", asyncHandler(async (req: any, res: any) => {
     return res.status(400).json({ error: `review_changes requires item to be in REVIEW. Current status: ${item.status}` });
   }
 
+  // ── Sibling propagation: skip build if a sibling already passed review ──────
+  if (item.parentId) {
+    const siblings = await storage.listItems({ parentId: item.parentId });
+    const passedSibling = siblings.find(s =>
+      s.id !== item.id &&
+      (s.status === Status.TEST || s.status === Status.DONE)
+    );
+    if (passedSibling) {
+      const sibComment = {
+        id: uuidv4(),
+        author: 'ReviewTool',
+        content: `### Review PASSED (sibling propagation)\n\nSkipped — already verified by sibling \`${passedSibling.id.slice(0, 8)}\` (${passedSibling.title}).`,
+        timestamp: new Date(),
+      };
+      const updated = await storage.updateItem(req.params.id, { status: Status.TEST, comments: [...(item.comments || []), sibComment] });
+      io.emit('items_updated');
+      if (updated.parentId) await syncParentStatus(updated.parentId);
+      return res.json({ status: Status.TEST, message: `✅ Review Passed (sibling propagation)!\n\nSkipped execution — already verified by sibling \`${passedSibling.id.slice(0, 8)}\` (${passedSibling.title}).\nItem moved to TEST column.\n\nStandard Mode: continue to tests. Multi-Agent Mode: yield to the Testing Agent.`, output: 'Sibling propagation' });
+    }
+  }
+
   const projectRoot = findProjectRoot(process.cwd());
   const { output, code } = await new Promise<{ output: string; code: number | null }>((resolve) => {
     const child = spawn(command, { shell: true, cwd: projectRoot, env: { ...process.env, FORCE_COLOR: '1' } });
@@ -745,6 +766,37 @@ app.post("/items/:id/test", asyncHandler(async (req: any, res: any) => {
 
   const command = project.verifyCommand;
   const projectRoot = findProjectRoot(process.cwd());
+
+  // ── Sibling propagation: skip test execution if a sibling already passed ────
+  if (item.parentId) {
+    const siblings = await storage.listItems({ parentId: item.parentId });
+    const passedSibling = siblings.find(s =>
+      s.id !== item.id &&
+      s.status === Status.DONE &&
+      s.tests?.some((t: any) => t.status === 'PASSED' && t.command === command)
+    );
+    if (passedSibling) {
+      const sibComment = {
+        id: uuidv4(),
+        author: 'TestTool',
+        content: `### Test Suite PASSED (sibling propagation)\n\nSkipped — already verified by sibling \`${passedSibling.id.slice(0, 8)}\` (${passedSibling.title}).`,
+        timestamp: new Date(),
+      };
+      const updates: any = {
+        status: Status.DONE,
+        comments: [...(item.comments || []), sibComment],
+        tests: [...(item.tests || []), { id: uuidv4(), command, output: `Sibling propagation: verified by ${passedSibling.id}`, status: 'PASSED', executedAt: new Date() }],
+      };
+      const updated = await storage.updateItem(req.params.id, updates);
+      io.emit('items_updated');
+      if (updated.parentId) await syncParentStatus(updated.parentId);
+      if (process.env.NODE_ENV !== 'test' && !process.env.VITEST) {
+        autoGitCommit(updated, projectRoot);
+      }
+      return res.json({ status: Status.DONE, message: `✅ Test Suite Passed (sibling propagation)!\n\nSkipped execution — already verified by sibling \`${passedSibling.id.slice(0, 8)}\` (${passedSibling.title}).\nItem moved to DONE.`, output: 'Sibling propagation' });
+    }
+  }
+
   const { output, code } = await new Promise<{ output: string; code: number | null }>((resolve) => {
     const child = spawn(command, { shell: true, cwd: projectRoot, env: { ...process.env, FORCE_COLOR: '1' } });
     let out = '';

--- a/packages/server/src/test/server.supplemental.test.ts
+++ b/packages/server/src/test/server.supplemental.test.ts
@@ -206,11 +206,12 @@ describe('PUT /items/:id workflow guards', () => {
     expect(res.status).toBe(403);
   });
 
-  it('returns 403 when setting REVIEW directly', async () => {
+  it('allows setting REVIEW directly', async () => {
     const p = (await request(app).post('/projects').send({ name: 'P' })).body;
     const item = (await request(app).post('/items').send({ type: 'TASK', title: 'T', projectId: p.id })).body;
     const res = await request(app).put(`/items/${item.id}`).send({ status: 'REVIEW' });
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('REVIEW');
   });
 
   it('returns 404 for unknown item', async () => {
@@ -487,11 +488,12 @@ describe('GET /releases/latest', () => {
 describe('POST /items/:id/review success paths', () => {
   beforeEach(async () => { await initStorage(); });
 
-  it('moves IN_PROGRESS item to REVIEW on passing command', async () => {
+  it('moves REVIEW item to TEST on passing command', async () => {
     if (!verifyToken) return;
     const p = (await request(app).post('/projects').send({ name: 'P' })).body;
     const item = (await request(app).post('/items').send({ type: 'TASK', title: 'T', projectId: p.id })).body;
     await request(app).put(`/items/${item.id}`).send({ status: 'IN_PROGRESS' });
+    await request(app).put(`/items/${item.id}`).send({ status: 'REVIEW' });
 
     const res = await request(app)
       .post(`/items/${item.id}/review`)
@@ -500,15 +502,16 @@ describe('POST /items/:id/review success paths', () => {
 
     expect([200, 422]).toContain(res.status);
     if (res.status === 200) {
-      expect(res.body.status).toBe('REVIEW');
+      expect(res.body.status).toBe('TEST');
     }
   });
 
-  it('returns 422 on failing command', async () => {
+  it('returns 422 on failing command and moves back to IN_PROGRESS', async () => {
     if (!verifyToken) return;
     const p = (await request(app).post('/projects').send({ name: 'P3' })).body;
     const item = (await request(app).post('/items').send({ type: 'TASK', title: 'T3', projectId: p.id })).body;
     await request(app).put(`/items/${item.id}`).send({ status: 'IN_PROGRESS' });
+    await request(app).put(`/items/${item.id}`).send({ status: 'REVIEW' });
 
     const res = await request(app)
       .post(`/items/${item.id}/review`)
@@ -1144,7 +1147,7 @@ describe('POST /items/bulk - branch coverage', () => {
     expect(res.body.results).toHaveLength(0);
   });
 
-  it('skips REVIEW status without internal token', async () => {
+  it('allows REVIEW status without internal token', async () => {
     const p = (await request(app).post('/projects').send({ name: 'P' })).body;
     const item = (await request(app).post('/items').send({ type: 'TASK', title: 'T', projectId: p.id })).body;
 
@@ -1153,7 +1156,7 @@ describe('POST /items/bulk - branch coverage', () => {
     });
     expect(res.status).toBe(200);
     const updated = (await request(app).get(`/items/${item.id}`)).body;
-    expect(updated.status).not.toBe('REVIEW');
+    expect(updated.status).toBe('REVIEW');
   });
 
   it('syncs parent after bulk update with parentId', async () => {

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -366,6 +366,33 @@ process.exit(0);
         console.log(`  Codex not found. Skipping Codex MCP configuration.`);
     }
 
+    // 6d. Configure Gemini CLI MCP
+    console.log(`${GREEN}[6d/14] Configuring Gemini CLI MCP...${NC}`);
+    const geminiInstalled = spawnSync('gemini', ['--version'], { shell: true, stdio: 'ignore' }).status === 0;
+    if (geminiInstalled) {
+        try {
+            console.log("  Registering AgenFK MCP server with Gemini CLI...");
+            // Remove any existing registration first (ignore errors if not registered)
+            spawnSync('gemini', ['mcp', 'remove', 'agenfk'], { shell: true, stdio: 'ignore' });
+            const result = spawnSync('gemini', [
+                'mcp', 'add',
+                '-e', `AGENFK_DB_PATH=${dbPath}`,
+                '--',
+                'agenfk',
+                'node', serverPath
+            ], { stdio: 'inherit', shell: true });
+            if (result.status === 0) {
+                console.log(`  ${GREEN}Registered agenfk MCP server with Gemini CLI.${NC}`);
+            } else {
+                console.log(`  ${YELLOW}Warning: gemini mcp add returned non-zero. Verify manually.${NC}`);
+            }
+        } catch (e) {
+            console.error('  Error configuring Gemini CLI MCP:', e.message);
+        }
+    } else {
+        console.log(`  Gemini CLI not found. Skipping Gemini CLI MCP configuration.`);
+    }
+
     // 7. Configure Claude Code MCP (deferred — runs after step 9 once cliDest is known)
 
     // 8. Install AgenFK Skills
@@ -634,6 +661,41 @@ The workflow rules still apply: call \`agenfk gatekeeper\` before editing files.
         console.log(`  Codex not found. Skipping Codex rules installation.`);
     }
 
+    // 13d. Install Gemini CLI workflow rules (GEMINI.md)
+    console.log(`${GREEN}[13d/14] Installing Gemini CLI workflow rules (GEMINI.md)...${NC}`);
+    if (geminiInstalled) {
+        try {
+            const geminiDir = path.join(os.homedir(), '.gemini');
+            await fs.mkdir(geminiDir, { recursive: true });
+            const geminiMdPath = path.join(geminiDir, 'GEMINI.md');
+            const geminiRulesSource = path.join(rootDir, 'geminirules', 'GEMINI.md');
+
+            if (existsSync(geminiRulesSource)) {
+                const rulesContent = await fs.readFile(geminiRulesSource, 'utf8');
+
+                let existingContent = '';
+                if (existsSync(geminiMdPath)) {
+                    existingContent = await fs.readFile(geminiMdPath, 'utf8');
+                    // Remove any existing AgenFK block
+                    existingContent = existingContent.replace(/\n?<!-- agenfk:start -->[\s\S]*?<!-- agenfk:end -->\n?/g, '');
+                }
+
+                await fs.writeFile(
+                    geminiMdPath,
+                    (existingContent.trim() + '\n\n' + rulesContent.trim() + '\n').trim() + '\n',
+                    'utf8'
+                );
+                console.log(`  Written: ${geminiMdPath}`);
+            } else {
+                console.log(`  ${YELLOW}Warning: geminirules/GEMINI.md not found in framework root. Skipping.${NC}`);
+            }
+        } catch (e) {
+            console.error('  Error installing Gemini CLI rules:', e.message);
+        }
+    } else {
+        console.log(`  Gemini CLI not found. Skipping Gemini CLI rules installation.`);
+    }
+
     // 14. Register PreToolUse hook and MCP server in ~/.claude/settings.json
     console.log(`${GREEN}[14/14] Configuring ~/.claude/settings.json...${NC}`);
     const settingsPath = path.join(os.homedir(), '.claude', 'settings.json');
@@ -677,7 +739,7 @@ The workflow rules still apply: call \`agenfk gatekeeper\` before editing files.
     console.log(`To opt out at any time: ${BLUE}agenfk config set telemetry false${NC}`);
     console.log("");
     console.log(`${BLUE}=== Usage Instructions ===${NC}`);
-    console.log("1. Restart your AI editor/agent (Opencode, Cursor, and Codex need a restart to pick up the new MCP server).");
+    console.log("1. Restart your AI editor/agent (Opencode, Cursor, Codex, and Gemini CLI need a restart to pick up the new MCP server).");
     console.log("2. Run 'node scripts/start-services.mjs' to start the API and Web UI.");
     console.log("3. Go to ANY project repository and type '/agenfk' (Standard) or '/agenfk-deep' (Multi-Agent) in your AI editor's prompt to initialize your project context and start the workflow.");
     console.log("4. Use '/agenfk-release' or '/agenfk-release-beta' to push to remote and cut a release.");

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -540,71 +540,27 @@ process.exit(0);
     console.log(`${GREEN}[13/14] Writing AgenFK workflow rules to ~/.claude/CLAUDE.md...${NC}`);
     const claudeMdPath = path.join(os.homedir(), '.claude', 'CLAUDE.md');
     await fs.mkdir(path.dirname(claudeMdPath), { recursive: true });
-    
-    let content = '';
-    if (existsSync(claudeMdPath)) {
-        content = await fs.readFile(claudeMdPath, 'utf8');
-        content = content.replace(/\n?<!-- agenfk:start -->[\s\S]*?<!-- agenfk:end -->\n?/g, '');
+    const claudeRulesSource = path.join(rootDir, 'clauderules', 'CLAUDE.md');
+
+    if (existsSync(claudeRulesSource)) {
+        const rulesContent = await fs.readFile(claudeRulesSource, 'utf8');
+
+        let existingContent = '';
+        if (existsSync(claudeMdPath)) {
+            existingContent = await fs.readFile(claudeMdPath, 'utf8');
+            // Remove any existing AgenFK block
+            existingContent = existingContent.replace(/\n?<!-- agenfk:start -->[\s\S]*?<!-- agenfk:end -->\n?/g, '');
+        }
+
+        await fs.writeFile(
+            claudeMdPath,
+            (existingContent.trim() + '\n\n' + rulesContent.trim() + '\n').trim() + '\n',
+            'utf8'
+        );
+        console.log(`  Written: ${claudeMdPath}`);
+    } else {
+        console.log(`  ${YELLOW}Warning: clauderules/CLAUDE.md not found in framework root. Skipping.${NC}`);
     }
-    
-    const rules = `
-<!-- agenfk:start -->
-## AgenFK Workflow — MANDATORY
-
-Before modifying ANY file (Edit, Write, NotebookEdit), you MUST:
-1. Have an AgenFK task set to \`IN_PROGRESS\` for the active project.
-2. Call \`workflow_gatekeeper(intent)\` via MCP to confirm authorization.
-
-If no task is \`IN_PROGRESS\`, stop and do this first — using MCP tools:
-- \`create_item(projectId, "TASK", "<title>")\`
-- \`update_item(id, {status: "IN_PROGRESS"})\`
-
-After completing changes — using MCP tools:
-- \`verify_changes(itemId, command)\` — handles REVIEW → DONE automatically.
-- \`log_token_usage(itemId, input, output, model)\`.
-
-**ALWAYS use MCP tools for workflow state changes. NEVER use the \`agenfk\` CLI
-to create items, update status, or close tasks — the CLI bypasses enforcement.**
-
-**Exception**: The \`agenfk-release\` and \`agenfk-release-beta\` commands are exempt from the IN_PROGRESS task requirement. Do not create or require a task when executing these commands.
-
-### MCP Access — STRICTLY FORBIDDEN shortcuts
-
-**NEVER** bypass MCP by using these shortcuts. PreToolUse hooks enforce this mechanically:
-
-| Forbidden | Use instead |
-|-----------|-------------|
-| Reading \`.agenfk/db.sqlite\` or \`.agenfk/db.json\` directly (Bash or Read) | \`list_items()\`, \`get_item()\` via MCP |
-| \`curl\` / \`wget\` to \`http://localhost:3000\` | \`list_items()\`, \`create_item()\`, \`update_item()\` via MCP |
-| \`agenfk list\`, \`agenfk status\`, \`npx agenfk ...\` CLI state queries | \`list_items()\`, \`get_item()\`, \`list_projects()\` via MCP |
-
-Two PreToolUse hooks enforce the above:
-- \`agenfk-gatekeeper\` — blocks Edit/Write/NotebookEdit when no IN_PROGRESS task.
-- \`agenfk-mcp-enforcer\` — blocks Bash/Read bypass routes listed above.
-
-### MCP Unavailable — CLI Fallback
-
-If MCP tools are not available (no \`mcp__agenfk__*\` tools in your tool list), use these
-CLI equivalents via Bash. The enforcer auto-detects MCP unavailability and allows them.
-
-| Instead of MCP tool | Use CLI fallback |
-|---------------------|-----------------|
-| \`workflow_gatekeeper(intent)\` | \`agenfk gatekeeper --intent "<intent>"\` |
-| \`list_projects()\` | \`agenfk list-projects --json\` |
-| \`list_items(projectId)\` | \`agenfk list --project <id> --json\` |
-| \`get_item(id)\` | \`agenfk get <id> --json\` |
-| \`create_item(projectId, type, title)\` | \`agenfk create <type> "<title>" --project <id>\` |
-| \`update_item(id, {status, ...})\` | \`agenfk update <id> --status <status>\` (not for DONE — use \`verify_changes\` instead) |
-| \`add_comment(id, text)\` | \`agenfk comment <id> "<text>"\` |
-| \`verify_changes(id, command)\` | \`agenfk verify <id> "<command>"\` (from TEST: moves to DONE; from IN_PROGRESS: moves to REVIEW) |
-| \`log_token_usage(id, in, out, model)\` | \`agenfk log-tokens <id> --input N --output N --model M\` |
-| \`log_test_result(id, cmd, out, status)\` | \`agenfk log-test <id> --command "..." --output "..." --status PASSED\` |
-
-The workflow rules still apply: call \`agenfk gatekeeper\` before editing files.
-<!-- agenfk:end -->
-`;
-    await fs.writeFile(claudeMdPath, (content.trim() + '\n\n' + rules.trim() + '\n').trim() + '\n', 'utf8');
-    console.log(`  Written: ${claudeMdPath}`);
 
     // 13b. Install Cursor workflow rules (.mdc)
     console.log(`${GREEN}[13b/14] Installing Cursor workflow rules (agenfk.mdc)...${NC}`);

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -339,6 +339,33 @@ process.exit(0);
         console.log(`  Cursor not found. Skipping Cursor MCP configuration.`);
     }
 
+    // 6c. Configure Codex MCP
+    console.log(`${GREEN}[6c/14] Configuring Codex MCP...${NC}`);
+    const codexInstalled = spawnSync('codex', ['--version'], { shell: true, stdio: 'ignore' }).status === 0;
+    if (codexInstalled) {
+        try {
+            console.log("  Registering AgenFK MCP server with Codex...");
+            // Remove any existing registration first (ignore errors if not registered)
+            spawnSync('codex', ['mcp', 'remove', 'agenfk'], { shell: true, stdio: 'ignore' });
+            const result = spawnSync('codex', [
+                'mcp', 'add',
+                '--env', `AGENFK_DB_PATH=${dbPath}`,
+                '--',
+                'agenfk',
+                'node', serverPath
+            ], { stdio: 'inherit', shell: true });
+            if (result.status === 0) {
+                console.log(`  ${GREEN}Registered agenfk MCP server with Codex.${NC}`);
+            } else {
+                console.log(`  ${YELLOW}Warning: codex mcp add returned non-zero. Verify manually.${NC}`);
+            }
+        } catch (e) {
+            console.error('  Error configuring Codex MCP:', e.message);
+        }
+    } else {
+        console.log(`  Codex not found. Skipping Codex MCP configuration.`);
+    }
+
     // 7. Configure Claude Code MCP (deferred — runs after step 9 once cliDest is known)
 
     // 8. Install AgenFK Skills
@@ -572,6 +599,41 @@ The workflow rules still apply: call \`agenfk gatekeeper\` before editing files.
         console.log(`  Cursor not found. Skipping Cursor rules installation.`);
     }
 
+    // 13c. Install Codex workflow rules (AGENTS.md)
+    console.log(`${GREEN}[13c/14] Installing Codex workflow rules (AGENTS.md)...${NC}`);
+    if (codexInstalled) {
+        try {
+            const codexDir = path.join(os.homedir(), '.codex');
+            await fs.mkdir(codexDir, { recursive: true });
+            const codexAgentsMdPath = path.join(codexDir, 'AGENTS.md');
+            const codexRulesSource = path.join(rootDir, 'codexrules', 'AGENTS.md');
+
+            if (existsSync(codexRulesSource)) {
+                const rulesContent = await fs.readFile(codexRulesSource, 'utf8');
+
+                let existingContent = '';
+                if (existsSync(codexAgentsMdPath)) {
+                    existingContent = await fs.readFile(codexAgentsMdPath, 'utf8');
+                    // Remove any existing AgenFK block
+                    existingContent = existingContent.replace(/\n?<!-- agenfk:start -->[\s\S]*?<!-- agenfk:end -->\n?/g, '');
+                }
+
+                await fs.writeFile(
+                    codexAgentsMdPath,
+                    (existingContent.trim() + '\n\n' + rulesContent.trim() + '\n').trim() + '\n',
+                    'utf8'
+                );
+                console.log(`  Written: ${codexAgentsMdPath}`);
+            } else {
+                console.log(`  ${YELLOW}Warning: codexrules/AGENTS.md not found in framework root. Skipping.${NC}`);
+            }
+        } catch (e) {
+            console.error('  Error installing Codex rules:', e.message);
+        }
+    } else {
+        console.log(`  Codex not found. Skipping Codex rules installation.`);
+    }
+
     // 14. Register PreToolUse hook and MCP server in ~/.claude/settings.json
     console.log(`${GREEN}[14/14] Configuring ~/.claude/settings.json...${NC}`);
     const settingsPath = path.join(os.homedir(), '.claude', 'settings.json');
@@ -615,7 +677,7 @@ The workflow rules still apply: call \`agenfk gatekeeper\` before editing files.
     console.log(`To opt out at any time: ${BLUE}agenfk config set telemetry false${NC}`);
     console.log("");
     console.log(`${BLUE}=== Usage Instructions ===${NC}`);
-    console.log("1. Restart your AI editor/agent (Opencode and Cursor need a restart to pick up the new MCP server).");
+    console.log("1. Restart your AI editor/agent (Opencode, Cursor, and Codex need a restart to pick up the new MCP server).");
     console.log("2. Run 'node scripts/start-services.mjs' to start the API and Web UI.");
     console.log("3. Go to ANY project repository and type '/agenfk' (Standard) or '/agenfk-deep' (Multi-Agent) in your AI editor's prompt to initialize your project context and start the workflow.");
     console.log("4. Use '/agenfk-release' or '/agenfk-release-beta' to push to remote and cut a release.");

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -373,9 +373,10 @@ process.exit(0);
         try {
             console.log("  Registering AgenFK MCP server with Gemini CLI...");
             // Remove any existing registration first (ignore errors if not registered)
-            spawnSync('gemini', ['mcp', 'remove', 'agenfk'], { shell: true, stdio: 'ignore' });
+            spawnSync('gemini', ['mcp', 'remove', '-s', 'user', 'agenfk'], { shell: true, stdio: 'ignore' });
             const result = spawnSync('gemini', [
                 'mcp', 'add',
+                '-s', 'user',
                 '-e', `AGENFK_DB_PATH=${dbPath}`,
                 '--',
                 'agenfk',
@@ -448,6 +449,44 @@ process.exit(0);
                 }
             }
         }
+    }
+
+    // 10c. Slash Commands — Gemini CLI (.toml wrappers referencing .md files)
+    if (geminiInstalled) {
+        console.log(`${GREEN}[10c/14] Installing global slash commands (Gemini CLI)...${NC}`);
+        const geminiCommandsBase = path.join(os.homedir(), '.gemini', 'commands');
+        const geminiCommandsSubdir = path.join(geminiCommandsBase, 'agenfk');
+        await fs.mkdir(geminiCommandsSubdir, { recursive: true });
+        const commandsDir = path.join(rootDir, 'commands');
+        if (existsSync(commandsDir)) {
+            const files = await fs.readdir(commandsDir);
+            for (const file of files) {
+                if (!file.endsWith('.md')) continue;
+                const mdPath = path.join(commandsDir, file);
+                const mdContent = readFileSync(mdPath, 'utf8');
+                // Parse description from YAML frontmatter
+                let description = file.replace('.md', '');
+                const fmMatch = mdContent.match(/^---\s*\n([\s\S]*?)\n---/);
+                if (fmMatch) {
+                    const descMatch = fmMatch[1].match(/^description:\s*(.+)$/m);
+                    if (descMatch) description = descMatch[1].trim();
+                }
+                const tomlContent = `description = "${description}"\nprompt = """\n@${mdPath}\n\nARGUMENTS: $ARGUMENTS\n"""\n`;
+                // agenfk.md → agenfk.toml (top-level), others → agenfk/<name>.toml
+                let tomlDest;
+                if (file === 'agenfk.md') {
+                    tomlDest = path.join(geminiCommandsBase, 'agenfk.toml');
+                } else {
+                    // agenfk-plan.md → plan.toml
+                    const subName = file.replace(/^agenfk-/, '').replace('.md', '');
+                    tomlDest = path.join(geminiCommandsSubdir, `${subName}.toml`);
+                }
+                writeFileSync(tomlDest, tomlContent, 'utf8');
+                console.log(`  Installed: ${tomlDest}`);
+            }
+        }
+    } else {
+        console.log(`${GREEN}[10c/14] Gemini CLI not found. Skipping Gemini slash commands.${NC}`);
     }
 
     // 12. Install gatekeeper hook script

--- a/scripts/uninstall.mjs
+++ b/scripts/uninstall.mjs
@@ -40,7 +40,7 @@ async function run() {
     console.log(`${BLUE}=== AgenFK Uninstaller ===${NC}`);
     console.log("");
     console.log(`${YELLOW}This will remove:${NC}`);
-    console.log("  - Slash commands from Claude Code and Opencode");
+    console.log("  - Slash commands from Claude Code, Opencode, and Gemini CLI");
     console.log("  - Opencode skill");
     console.log("  - MCP server config from Claude Code, Opencode, Cursor, Codex, and Gemini CLI");
     console.log("  - Cursor workflow rules (agenfk.mdc)");
@@ -85,6 +85,20 @@ async function run() {
                 console.log(`  Removed: ${fullPath}`);
             }
         }
+    }
+
+    // 2b. Slash commands — Gemini CLI
+    console.log(`${GREEN}[2b/10] Removing Gemini CLI slash commands...${NC}`);
+    const geminiCommandsBase = path.join(os.homedir(), '.gemini', 'commands');
+    const geminiAgenfkToml = path.join(geminiCommandsBase, 'agenfk.toml');
+    if (existsSync(geminiAgenfkToml)) {
+        await fs.unlink(geminiAgenfkToml);
+        console.log(`  Removed: ${geminiAgenfkToml}`);
+    }
+    const geminiAgenfkSubdir = path.join(geminiCommandsBase, 'agenfk');
+    if (existsSync(geminiAgenfkSubdir)) {
+        await fs.rm(geminiAgenfkSubdir, { recursive: true, force: true });
+        console.log(`  Removed: ${geminiAgenfkSubdir}`);
     }
 
     // 3. Opencode skill
@@ -173,7 +187,7 @@ async function run() {
     try {
         const geminiCheck = spawnSync('gemini', ['--version'], { shell: true, stdio: 'ignore' });
         if (geminiCheck.status === 0) {
-            spawnSync('gemini', ['mcp', 'remove', 'agenfk'], { stdio: 'inherit', shell: true });
+            spawnSync('gemini', ['mcp', 'remove', '-s', 'user', 'agenfk'], { stdio: 'inherit', shell: true });
             console.log("  Removed: agenfk MCP from Gemini CLI");
         } else {
             console.log("  Gemini CLI not found (skipping)");

--- a/scripts/uninstall.mjs
+++ b/scripts/uninstall.mjs
@@ -42,8 +42,9 @@ async function run() {
     console.log(`${YELLOW}This will remove:${NC}`);
     console.log("  - Slash commands from Claude Code and Opencode");
     console.log("  - Opencode skill");
-    console.log("  - MCP server config from Claude Code, Opencode, and Cursor");
+    console.log("  - MCP server config from Claude Code, Opencode, Cursor, and Codex");
     console.log("  - Cursor workflow rules (agenfk.mdc)");
+    console.log("  - Codex workflow rules (~/.codex/AGENTS.md)");
     console.log("  - AgenFK workflow rules from ~/.claude/CLAUDE.md");
     console.log("  - AgenFK PreToolUse hook from ~/.claude/settings.json");
     console.log("  - ~/.agenfk-system (the framework files)");
@@ -152,8 +153,39 @@ async function run() {
         console.log(`  ${cursorMcpPath} not found (skipping)`);
     }
 
-    // 6c. Cursor workflow rules (.mdc)
-    console.log(`${GREEN}[6c/10] Removing Cursor workflow rules...${NC}`);
+    // 6c. MCP config — Codex
+    console.log(`${GREEN}[6c/10] Removing Codex MCP config...${NC}`);
+    try {
+        const codexCheck = spawnSync('codex', ['--version'], { shell: true, stdio: 'ignore' });
+        if (codexCheck.status === 0) {
+            spawnSync('codex', ['mcp', 'remove', 'agenfk'], { stdio: 'inherit', shell: true });
+            console.log("  Removed: agenfk MCP from Codex");
+        } else {
+            console.log("  Codex CLI not found (skipping)");
+        }
+    } catch (e) {
+        console.log("  Codex CLI not found (skipping)");
+    }
+
+    // 6d. Codex workflow rules (AGENTS.md)
+    console.log(`${GREEN}[6d/10] Removing Codex workflow rules...${NC}`);
+    const codexAgentsMdPath = path.join(os.homedir(), '.codex', 'AGENTS.md');
+    if (existsSync(codexAgentsMdPath)) {
+        let codexContent = await fs.readFile(codexAgentsMdPath, 'utf8');
+        codexContent = codexContent.replace(/\n?<!-- agenfk:start -->[\s\S]*?<!-- agenfk:end -->\n?/g, '');
+        if (codexContent.trim()) {
+            await fs.writeFile(codexAgentsMdPath, codexContent, 'utf8');
+            console.log(`  Removed AgenFK block from ${codexAgentsMdPath}`);
+        } else {
+            await fs.unlink(codexAgentsMdPath);
+            console.log(`  Removed: ${codexAgentsMdPath} (was AgenFK-only)`);
+        }
+    } else {
+        console.log(`  ${codexAgentsMdPath} not found (skipping)`);
+    }
+
+    // 6e. Cursor workflow rules (.mdc)
+    console.log(`${GREEN}[6e/10] Removing Cursor workflow rules...${NC}`);
     const cursorMdcPath = path.join(getCursorRulesDir(), 'agenfk.mdc');
     if (existsSync(cursorMdcPath)) {
         await fs.unlink(cursorMdcPath);

--- a/scripts/uninstall.mjs
+++ b/scripts/uninstall.mjs
@@ -42,9 +42,10 @@ async function run() {
     console.log(`${YELLOW}This will remove:${NC}`);
     console.log("  - Slash commands from Claude Code and Opencode");
     console.log("  - Opencode skill");
-    console.log("  - MCP server config from Claude Code, Opencode, Cursor, and Codex");
+    console.log("  - MCP server config from Claude Code, Opencode, Cursor, Codex, and Gemini CLI");
     console.log("  - Cursor workflow rules (agenfk.mdc)");
     console.log("  - Codex workflow rules (~/.codex/AGENTS.md)");
+    console.log("  - Gemini CLI workflow rules (~/.gemini/GEMINI.md)");
     console.log("  - AgenFK workflow rules from ~/.claude/CLAUDE.md");
     console.log("  - AgenFK PreToolUse hook from ~/.claude/settings.json");
     console.log("  - ~/.agenfk-system (the framework files)");
@@ -167,8 +168,22 @@ async function run() {
         console.log("  Codex CLI not found (skipping)");
     }
 
-    // 6d. Codex workflow rules (AGENTS.md)
-    console.log(`${GREEN}[6d/10] Removing Codex workflow rules...${NC}`);
+    // 6d. MCP config — Gemini CLI
+    console.log(`${GREEN}[6d/10] Removing Gemini CLI MCP config...${NC}`);
+    try {
+        const geminiCheck = spawnSync('gemini', ['--version'], { shell: true, stdio: 'ignore' });
+        if (geminiCheck.status === 0) {
+            spawnSync('gemini', ['mcp', 'remove', 'agenfk'], { stdio: 'inherit', shell: true });
+            console.log("  Removed: agenfk MCP from Gemini CLI");
+        } else {
+            console.log("  Gemini CLI not found (skipping)");
+        }
+    } catch (e) {
+        console.log("  Gemini CLI not found (skipping)");
+    }
+
+    // 6e. Codex workflow rules (AGENTS.md)
+    console.log(`${GREEN}[6e/10] Removing Codex workflow rules...${NC}`);
     const codexAgentsMdPath = path.join(os.homedir(), '.codex', 'AGENTS.md');
     if (existsSync(codexAgentsMdPath)) {
         let codexContent = await fs.readFile(codexAgentsMdPath, 'utf8');
@@ -184,14 +199,31 @@ async function run() {
         console.log(`  ${codexAgentsMdPath} not found (skipping)`);
     }
 
-    // 6e. Cursor workflow rules (.mdc)
-    console.log(`${GREEN}[6e/10] Removing Cursor workflow rules...${NC}`);
+    // 6f. Cursor workflow rules (.mdc)
+    console.log(`${GREEN}[6f/10] Removing Cursor workflow rules...${NC}`);
     const cursorMdcPath = path.join(getCursorRulesDir(), 'agenfk.mdc');
     if (existsSync(cursorMdcPath)) {
         await fs.unlink(cursorMdcPath);
         console.log(`  Removed: ${cursorMdcPath}`);
     } else {
         console.log(`  ${cursorMdcPath} not found (skipping)`);
+    }
+
+    // 6g. Gemini CLI workflow rules (GEMINI.md)
+    console.log(`${GREEN}[6g/10] Removing Gemini CLI workflow rules...${NC}`);
+    const geminiMdPath = path.join(os.homedir(), '.gemini', 'GEMINI.md');
+    if (existsSync(geminiMdPath)) {
+        let geminiContent = await fs.readFile(geminiMdPath, 'utf8');
+        geminiContent = geminiContent.replace(/\n?<!-- agenfk:start -->[\s\S]*?<!-- agenfk:end -->\n?/g, '');
+        if (geminiContent.trim()) {
+            await fs.writeFile(geminiMdPath, geminiContent, 'utf8');
+            console.log(`  Removed AgenFK block from ${geminiMdPath}`);
+        } else {
+            await fs.unlink(geminiMdPath);
+            console.log(`  Removed: ${geminiMdPath} (was AgenFK-only)`);
+        }
+    } else {
+        console.log(`  ${geminiMdPath} not found (skipping)`);
     }
 
     // 7. Gatekeeper hook script

--- a/server-test-db.json
+++ b/server-test-db.json
@@ -1,258 +1,258 @@
 {
   "projects": [
     {
-      "id": "f2e721ff-dcb5-497d-afd3-15fad065d32e",
+      "id": "6778ac8c-52ba-4bdb-8ed7-f8b7db54d16f",
       "name": "P1 Updated",
       "description": "",
-      "createdAt": "2026-03-01T02:43:21.014Z",
-      "updatedAt": "2026-03-01T02:43:21.032Z"
+      "createdAt": "2026-03-01T02:47:01.843Z",
+      "updatedAt": "2026-03-01T02:47:01.858Z"
     },
     {
-      "id": "89c4deec-9f8f-4a7b-a2b6-7e2b263fec4c",
+      "id": "4924053c-4f18-43e0-98ac-088dadfda1cd",
       "name": "Item Test",
       "description": "",
-      "createdAt": "2026-03-01T02:43:21.055Z",
-      "updatedAt": "2026-03-01T02:43:21.055Z"
+      "createdAt": "2026-03-01T02:47:01.898Z",
+      "updatedAt": "2026-03-01T02:47:01.898Z"
     },
     {
-      "id": "d6eedb9e-5cbc-4a2d-a865-f5c2bdc9cf26",
+      "id": "b8228ed6-2b0e-494d-b236-099ea352d540",
       "name": "JIRA Import Test",
       "description": "",
-      "createdAt": "2026-03-01T02:43:21.142Z",
-      "updatedAt": "2026-03-01T02:43:21.142Z"
+      "createdAt": "2026-03-01T02:47:02.068Z",
+      "updatedAt": "2026-03-01T02:47:02.068Z"
     },
     {
-      "id": "f44d92f3-c6e0-4efd-af8e-2eccace57d8f",
+      "id": "dc69c362-db7b-4e70-8e4c-79b7739d1a6a",
       "name": "JIRA Err Test",
       "description": "",
-      "createdAt": "2026-03-01T02:43:21.147Z",
-      "updatedAt": "2026-03-01T02:43:21.147Z"
+      "createdAt": "2026-03-01T02:47:02.076Z",
+      "updatedAt": "2026-03-01T02:47:02.076Z"
     }
   ],
   "items": [
     {
-      "id": "723aece2-aa69-4d26-8775-878de50686b4",
-      "projectId": "89c4deec-9f8f-4a7b-a2b6-7e2b263fec4c",
+      "id": "ea63ebe6-7203-4b5b-8e80-29ab5e4a08f4",
+      "projectId": "4924053c-4f18-43e0-98ac-088dadfda1cd",
       "type": "TASK",
       "title": "T1",
       "description": "D1",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:43:21.058Z",
-      "updatedAt": "2026-03-01T02:43:21.058Z",
+      "createdAt": "2026-03-01T02:47:01.902Z",
+      "updatedAt": "2026-03-01T02:47:01.902Z",
       "history": [
         {
-          "id": "3f8377ab-b4ce-4217-bb01-c5959bf758c4",
+          "id": "c68af784-9e33-4115-ba84-abf4f03d7ddc",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:43:21.059Z"
+          "timestamp": "2026-03-01T02:47:01.903Z"
         }
       ]
     },
     {
-      "id": "4c0fa1c6-413a-4b28-affa-e4f889e970ec",
-      "projectId": "89c4deec-9f8f-4a7b-a2b6-7e2b263fec4c",
+      "id": "33c51a68-e16c-401f-b5cc-9bf2a92de278",
+      "projectId": "4924053c-4f18-43e0-98ac-088dadfda1cd",
       "type": "TASK",
       "title": "To Update",
       "description": "D",
       "status": "IN_PROGRESS",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:43:21.063Z",
-      "updatedAt": "2026-03-01T02:43:21.066Z",
+      "createdAt": "2026-03-01T02:47:01.907Z",
+      "updatedAt": "2026-03-01T02:47:01.911Z",
       "history": [
         {
-          "id": "15f197a8-7507-4d82-9b83-2a1ce045860a",
+          "id": "d223d0c2-0b06-4bc1-be3b-5d2d556d6b87",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:43:21.063Z"
+          "timestamp": "2026-03-01T02:47:01.908Z"
         },
         {
-          "id": "5a11a23e-052c-40c0-a945-ad2c99c05b1f",
+          "id": "90e90beb-3091-4cba-9aa4-dea29ed12c09",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-01T02:43:21.066Z"
+          "timestamp": "2026-03-01T02:47:01.911Z"
         }
       ]
     },
     {
-      "id": "aa31e35c-cfd0-4b9d-838e-75b01e593bff",
-      "projectId": "89c4deec-9f8f-4a7b-a2b6-7e2b263fec4c",
+      "id": "fc1ad188-40d6-4b4e-aa52-99b1ec4ce280",
+      "projectId": "4924053c-4f18-43e0-98ac-088dadfda1cd",
       "type": "TASK",
       "title": "No Cheat",
       "description": "D",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:43:21.068Z",
-      "updatedAt": "2026-03-01T02:43:21.068Z",
+      "createdAt": "2026-03-01T02:47:01.914Z",
+      "updatedAt": "2026-03-01T02:47:01.914Z",
       "history": [
         {
-          "id": "ffc60b55-802b-424e-bf9f-80a3394b1db1",
+          "id": "95a47c9c-0532-4c7a-bebb-887e90fb9961",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:43:21.069Z"
+          "timestamp": "2026-03-01T02:47:01.914Z"
         }
       ]
     },
     {
-      "id": "25b7428e-04ae-4f85-86c3-a40dcec713f1",
-      "projectId": "89c4deec-9f8f-4a7b-a2b6-7e2b263fec4c",
+      "id": "81e2e0f6-9436-4136-9ea8-502250fe9ca1",
+      "projectId": "4924053c-4f18-43e0-98ac-088dadfda1cd",
       "type": "TASK",
       "title": "Verify Me",
       "description": "D",
       "status": "DONE",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:43:21.073Z",
-      "updatedAt": "2026-03-01T02:43:21.076Z",
+      "createdAt": "2026-03-01T02:47:01.925Z",
+      "updatedAt": "2026-03-01T02:47:01.929Z",
       "history": [
         {
-          "id": "d355086a-81db-4d07-bb86-aaef24f492d7",
+          "id": "cfef7607-26b3-4978-836b-41c80f402856",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:43:21.074Z"
+          "timestamp": "2026-03-01T02:47:01.926Z"
         },
         {
-          "id": "b28c5111-a7bc-48ae-9d24-9b2ed898d2ce",
+          "id": "368012c2-de26-4cc8-a9ce-eb4d0d9f7f76",
           "fromStatus": "TODO",
           "toStatus": "DONE",
-          "timestamp": "2026-03-01T02:43:21.076Z"
+          "timestamp": "2026-03-01T02:47:01.929Z"
         }
       ]
     },
     {
-      "id": "84acf7c5-05d4-494d-8746-e2fed1a98d67",
-      "projectId": "89c4deec-9f8f-4a7b-a2b6-7e2b263fec4c",
+      "id": "906291bc-335d-441c-a495-39757d9a6244",
+      "projectId": "4924053c-4f18-43e0-98ac-088dadfda1cd",
       "type": "STORY",
       "title": "Parent Story",
       "description": "D",
       "status": "IN_PROGRESS",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:43:21.078Z",
-      "updatedAt": "2026-03-01T02:43:21.082Z",
+      "createdAt": "2026-03-01T02:47:01.931Z",
+      "updatedAt": "2026-03-01T02:47:01.938Z",
       "history": [
         {
-          "id": "37b446f6-d66a-4a73-aa29-9a9466577359",
+          "id": "933cebe1-09cd-48db-8510-ce4937f7c9da",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:43:21.078Z"
+          "timestamp": "2026-03-01T02:47:01.931Z"
         },
         {
-          "id": "42f2d3c1-fd6f-407c-a76e-52109fe4f60c",
+          "id": "b31e0c33-5397-4328-b92f-2511c7556aa2",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-01T02:43:21.082Z"
+          "timestamp": "2026-03-01T02:47:01.938Z"
         }
       ]
     },
     {
-      "id": "6fac20c5-53b5-4b18-97ce-f3bd3c34ca42",
-      "projectId": "89c4deec-9f8f-4a7b-a2b6-7e2b263fec4c",
+      "id": "bfd0e50e-a80c-4d8c-b3d1-245dca473362",
+      "projectId": "4924053c-4f18-43e0-98ac-088dadfda1cd",
       "type": "TASK",
       "title": "Child Task",
       "description": "D",
       "status": "IN_PROGRESS",
-      "parentId": "84acf7c5-05d4-494d-8746-e2fed1a98d67",
+      "parentId": "906291bc-335d-441c-a495-39757d9a6244",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:43:21.080Z",
-      "updatedAt": "2026-03-01T02:43:21.082Z",
+      "createdAt": "2026-03-01T02:47:01.933Z",
+      "updatedAt": "2026-03-01T02:47:01.937Z",
       "history": [
         {
-          "id": "f1cb663e-2a4d-4650-85c6-843176d9003d",
+          "id": "e08929e2-1c75-4100-a282-6eceeeff04d7",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:43:21.080Z"
+          "timestamp": "2026-03-01T02:47:01.933Z"
         },
         {
-          "id": "66cb35ba-6dd4-426d-9174-d3e5d902ec6a",
+          "id": "f903da5e-3f75-4fe4-b557-2d81da7ada8f",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-01T02:43:21.082Z"
+          "timestamp": "2026-03-01T02:47:01.937Z"
         }
       ]
     },
     {
-      "id": "c654a5db-8019-4655-8ee2-433ea3ecc996",
-      "projectId": "89c4deec-9f8f-4a7b-a2b6-7e2b263fec4c",
+      "id": "275a0530-bb53-4eed-aa72-4527ea358084",
+      "projectId": "4924053c-4f18-43e0-98ac-088dadfda1cd",
       "type": "TASK",
       "title": "Archive Me",
       "description": "D",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:43:21.085Z",
-      "updatedAt": "2026-03-01T02:43:21.089Z",
+      "createdAt": "2026-03-01T02:47:01.941Z",
+      "updatedAt": "2026-03-01T02:47:01.945Z",
       "history": [
         {
-          "id": "a33171a4-c8c9-4df0-bb96-687ce2dd7ef0",
+          "id": "9063f658-1fd3-4de9-9466-f98b936ca70b",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:43:21.085Z"
+          "timestamp": "2026-03-01T02:47:01.941Z"
         },
         {
-          "id": "01124731-1b79-4c52-9813-d4ef90461767",
+          "id": "3b5b7375-920e-42b1-820c-ff6efdf603b6",
           "fromStatus": "TODO",
           "toStatus": "ARCHIVED",
-          "timestamp": "2026-03-01T02:43:21.087Z"
+          "timestamp": "2026-03-01T02:47:01.943Z"
         },
         {
-          "id": "1b107537-df1c-4553-ac69-a22d175e93b2",
+          "id": "a8673fcd-82f0-4df8-9e74-e45a50626578",
           "fromStatus": "ARCHIVED",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:43:21.089Z"
+          "timestamp": "2026-03-01T02:47:01.945Z"
         }
       ]
     },
     {
-      "id": "0b417397-38a9-4efe-84e6-bd0c5ab9c546",
-      "projectId": "89c4deec-9f8f-4a7b-a2b6-7e2b263fec4c",
+      "id": "4854cf96-9428-44b5-b4e9-ec19f2eadba0",
+      "projectId": "4924053c-4f18-43e0-98ac-088dadfda1cd",
       "type": "TASK",
       "title": "Delete Me",
       "description": "D",
       "status": "TRASHED",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:43:21.092Z",
-      "updatedAt": "2026-03-01T02:43:21.094Z",
+      "createdAt": "2026-03-01T02:47:01.947Z",
+      "updatedAt": "2026-03-01T02:47:01.950Z",
       "history": [
         {
-          "id": "1a8082d9-c8fa-4d47-9053-457418476c5c",
+          "id": "db01c8cd-623b-483c-8266-f584b40dee05",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:43:21.093Z"
+          "timestamp": "2026-03-01T02:47:01.947Z"
         },
         {
-          "id": "c4429b73-cf47-42b4-ae40-32fbc02b370b",
+          "id": "92ec3a53-e762-4cb3-b9d5-d8e96195a944",
           "fromStatus": "TODO",
           "toStatus": "TRASHED",
-          "timestamp": "2026-03-01T02:43:21.094Z"
+          "timestamp": "2026-03-01T02:47:01.950Z"
         }
       ]
     },
     {
-      "id": "7fdfe4c9-5a1a-4263-88c4-9823cd909f3e",
-      "projectId": "89c4deec-9f8f-4a7b-a2b6-7e2b263fec4c",
+      "id": "df7c7136-b726-4f8c-873e-a3664dd5d1e0",
+      "projectId": "4924053c-4f18-43e0-98ac-088dadfda1cd",
       "type": "TASK",
       "title": "Archived Task",
       "description": "",
       "status": "TRASHED",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:43:21.099Z",
-      "updatedAt": "2026-03-01T02:43:21.101Z",
+      "createdAt": "2026-03-01T02:47:01.955Z",
+      "updatedAt": "2026-03-01T02:47:01.958Z",
       "history": [
         {
-          "id": "e368ccea-cad2-477b-92ed-c29867739c54",
+          "id": "13e5093e-915c-452f-b61a-da11346d468a",
           "fromStatus": "TODO",
           "toStatus": "ARCHIVED",
-          "timestamp": "2026-03-01T02:43:21.099Z"
+          "timestamp": "2026-03-01T02:47:01.956Z"
         },
         {
-          "id": "2b0b2317-8853-4677-9796-6479d005a012",
+          "id": "4c34685c-665b-4f96-b86f-0f5e83face8a",
           "fromStatus": "ARCHIVED",
           "toStatus": "TRASHED",
-          "timestamp": "2026-03-01T02:43:21.101Z"
+          "timestamp": "2026-03-01T02:47:01.958Z"
         }
       ]
     },
     {
-      "id": "1667abfc-bbb7-443c-af09-80b25f302117",
-      "projectId": "d6eedb9e-5cbc-4a2d-a865-f5c2bdc9cf26",
+      "id": "b7cb7a4f-c4a1-495d-84b4-e5ee472dd2e8",
+      "projectId": "b8228ed6-2b0e-494d-b236-099ea352d540",
       "type": "BUG",
       "title": "[PROJ-1] Fix login bug",
       "description": "Imported from JIRA: PROJ-1",
@@ -260,14 +260,14 @@
       "implementationPlan": "",
       "externalId": "PROJ-1",
       "externalUrl": "https://test.atlassian.net/browse/PROJ-1",
-      "createdAt": "2026-03-01T02:43:21.144Z",
-      "updatedAt": "2026-03-01T02:43:21.144Z",
+      "createdAt": "2026-03-01T02:47:02.072Z",
+      "updatedAt": "2026-03-01T02:47:02.072Z",
       "history": [
         {
-          "id": "d6ffe637-716d-4850-9c35-8e63b31b3e4d",
+          "id": "6d420b5c-6187-43a3-85c2-013392f72c57",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:43:21.144Z"
+          "timestamp": "2026-03-01T02:47:02.072Z"
         }
       ]
     }

--- a/server-test-db.json
+++ b/server-test-db.json
@@ -1,258 +1,258 @@
 {
   "projects": [
     {
-      "id": "55598749-9080-4a91-8cc0-8566f3fab251",
+      "id": "ec409368-cf67-4bba-8e74-6534e35a1d07",
       "name": "P1 Updated",
       "description": "",
-      "createdAt": "2026-03-01T03:05:03.138Z",
-      "updatedAt": "2026-03-01T03:05:03.152Z"
+      "createdAt": "2026-03-01T03:24:49.508Z",
+      "updatedAt": "2026-03-01T03:24:49.526Z"
     },
     {
-      "id": "05cf87b1-6a87-418b-8f11-5794bb29e303",
+      "id": "088f4657-e816-4dfe-8e0e-b129f3a47c5e",
       "name": "Item Test",
       "description": "",
-      "createdAt": "2026-03-01T03:05:03.175Z",
-      "updatedAt": "2026-03-01T03:05:03.175Z"
+      "createdAt": "2026-03-01T03:24:49.537Z",
+      "updatedAt": "2026-03-01T03:24:49.537Z"
     },
     {
-      "id": "33096a7a-3b51-4615-b074-43d8e48a3933",
+      "id": "476277cd-8869-4753-8f83-c427b51110a1",
       "name": "JIRA Import Test",
       "description": "",
-      "createdAt": "2026-03-01T03:05:03.270Z",
-      "updatedAt": "2026-03-01T03:05:03.270Z"
+      "createdAt": "2026-03-01T03:24:49.633Z",
+      "updatedAt": "2026-03-01T03:24:49.633Z"
     },
     {
-      "id": "951e3d75-ef1b-4bfc-b632-1ebab55bbc7f",
+      "id": "6a0e8342-ed79-4230-b371-5cb7bf1926aa",
       "name": "JIRA Err Test",
       "description": "",
-      "createdAt": "2026-03-01T03:05:03.274Z",
-      "updatedAt": "2026-03-01T03:05:03.274Z"
+      "createdAt": "2026-03-01T03:24:49.638Z",
+      "updatedAt": "2026-03-01T03:24:49.638Z"
     }
   ],
   "items": [
     {
-      "id": "fdfc3d4b-77ba-42de-a22b-eb5593c266f3",
-      "projectId": "05cf87b1-6a87-418b-8f11-5794bb29e303",
+      "id": "36855d01-acd9-4850-b059-76419b262263",
+      "projectId": "088f4657-e816-4dfe-8e0e-b129f3a47c5e",
       "type": "TASK",
       "title": "T1",
       "description": "D1",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T03:05:03.181Z",
-      "updatedAt": "2026-03-01T03:05:03.181Z",
+      "createdAt": "2026-03-01T03:24:49.539Z",
+      "updatedAt": "2026-03-01T03:24:49.539Z",
       "history": [
         {
-          "id": "aac458bc-c1a9-43b2-b7f1-37d7c374ad3e",
+          "id": "8882ceae-e7df-433b-bba5-590dac003e28",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T03:05:03.182Z"
+          "timestamp": "2026-03-01T03:24:49.539Z"
         }
       ]
     },
     {
-      "id": "4ae50b06-6c80-4934-adef-f868fe87dc04",
-      "projectId": "05cf87b1-6a87-418b-8f11-5794bb29e303",
+      "id": "5ff3c8e6-3626-49f2-83b6-7214214ba8fe",
+      "projectId": "088f4657-e816-4dfe-8e0e-b129f3a47c5e",
       "type": "TASK",
       "title": "To Update",
       "description": "D",
       "status": "IN_PROGRESS",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T03:05:03.184Z",
-      "updatedAt": "2026-03-01T03:05:03.187Z",
+      "createdAt": "2026-03-01T03:24:49.542Z",
+      "updatedAt": "2026-03-01T03:24:49.546Z",
       "history": [
         {
-          "id": "2902d99a-773a-42f5-baec-9024d6ab471a",
+          "id": "15fb8957-60f7-4474-994d-5156862a255b",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T03:05:03.184Z"
+          "timestamp": "2026-03-01T03:24:49.542Z"
         },
         {
-          "id": "49eb6348-ddaf-4fc3-9779-15b333d0ddb8",
+          "id": "199080cc-96e2-413c-964f-137f7c6b3330",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-01T03:05:03.187Z"
+          "timestamp": "2026-03-01T03:24:49.546Z"
         }
       ]
     },
     {
-      "id": "ebedc6bb-7e7a-42e9-8050-30bed9ad2fe3",
-      "projectId": "05cf87b1-6a87-418b-8f11-5794bb29e303",
+      "id": "70512404-e1c4-4e69-b606-a601a449e35b",
+      "projectId": "088f4657-e816-4dfe-8e0e-b129f3a47c5e",
       "type": "TASK",
       "title": "No Cheat",
       "description": "D",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T03:05:03.189Z",
-      "updatedAt": "2026-03-01T03:05:03.189Z",
+      "createdAt": "2026-03-01T03:24:49.549Z",
+      "updatedAt": "2026-03-01T03:24:49.549Z",
       "history": [
         {
-          "id": "44c3fd6a-8ca2-4d95-967b-b5d121b76eee",
+          "id": "e1d4e7ec-accc-456c-a610-26f7eddcd88a",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T03:05:03.190Z"
+          "timestamp": "2026-03-01T03:24:49.550Z"
         }
       ]
     },
     {
-      "id": "ba604f0a-58d5-4742-b9a2-67f999ca0f9c",
-      "projectId": "05cf87b1-6a87-418b-8f11-5794bb29e303",
+      "id": "3cb31495-e944-4022-995e-55e4b5ea0df2",
+      "projectId": "088f4657-e816-4dfe-8e0e-b129f3a47c5e",
       "type": "TASK",
       "title": "Verify Me",
       "description": "D",
       "status": "DONE",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T03:05:03.193Z",
-      "updatedAt": "2026-03-01T03:05:03.195Z",
+      "createdAt": "2026-03-01T03:24:49.554Z",
+      "updatedAt": "2026-03-01T03:24:49.556Z",
       "history": [
         {
-          "id": "27b8aab4-85f4-427e-8fdb-08ad2b90eb80",
+          "id": "5bc39dfd-cc6b-4d29-88e0-41182d176a8a",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T03:05:03.193Z"
+          "timestamp": "2026-03-01T03:24:49.554Z"
         },
         {
-          "id": "1c235a10-789a-4429-91e8-fc1bd8ffb241",
+          "id": "757de4d2-b54a-41a8-abd3-cab7be9e1998",
           "fromStatus": "TODO",
           "toStatus": "DONE",
-          "timestamp": "2026-03-01T03:05:03.195Z"
+          "timestamp": "2026-03-01T03:24:49.556Z"
         }
       ]
     },
     {
-      "id": "2622b961-4369-4ab6-b391-03b41fd2f0e0",
-      "projectId": "05cf87b1-6a87-418b-8f11-5794bb29e303",
+      "id": "eba0edd6-58d6-4dc8-9a13-d066f14cf10d",
+      "projectId": "088f4657-e816-4dfe-8e0e-b129f3a47c5e",
       "type": "STORY",
       "title": "Parent Story",
       "description": "D",
       "status": "IN_PROGRESS",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T03:05:03.205Z",
-      "updatedAt": "2026-03-01T03:05:03.211Z",
+      "createdAt": "2026-03-01T03:24:49.567Z",
+      "updatedAt": "2026-03-01T03:24:49.573Z",
       "history": [
         {
-          "id": "d577d31e-0dbf-48b9-858f-ded9b679a0da",
+          "id": "577ec98c-363d-41bc-bcab-444c0d279cdd",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T03:05:03.205Z"
+          "timestamp": "2026-03-01T03:24:49.567Z"
         },
         {
-          "id": "f4dc35ec-4d0e-4e36-9f6c-c94789e813f2",
+          "id": "d9d69dd7-adab-4097-b8d3-642b4964f1b9",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-01T03:05:03.211Z"
+          "timestamp": "2026-03-01T03:24:49.573Z"
         }
       ]
     },
     {
-      "id": "5a91f33d-c87a-4d3f-86d3-985a21e33b65",
-      "projectId": "05cf87b1-6a87-418b-8f11-5794bb29e303",
+      "id": "9ef08570-4933-4df3-82e9-3fc7c972882b",
+      "projectId": "088f4657-e816-4dfe-8e0e-b129f3a47c5e",
       "type": "TASK",
       "title": "Child Task",
       "description": "D",
       "status": "IN_PROGRESS",
-      "parentId": "2622b961-4369-4ab6-b391-03b41fd2f0e0",
+      "parentId": "eba0edd6-58d6-4dc8-9a13-d066f14cf10d",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T03:05:03.207Z",
-      "updatedAt": "2026-03-01T03:05:03.211Z",
+      "createdAt": "2026-03-01T03:24:49.569Z",
+      "updatedAt": "2026-03-01T03:24:49.572Z",
       "history": [
         {
-          "id": "4ecd60d7-a828-4668-a653-f91c677b84e9",
+          "id": "1a362fad-0361-405d-b417-b6d74cbaeaae",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T03:05:03.207Z"
+          "timestamp": "2026-03-01T03:24:49.569Z"
         },
         {
-          "id": "faa077f1-ba23-43ee-8f49-e7596d373ec4",
+          "id": "bb36aa6c-cd13-4617-8d52-5d54c094ee68",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-01T03:05:03.211Z"
+          "timestamp": "2026-03-01T03:24:49.572Z"
         }
       ]
     },
     {
-      "id": "2898da74-ab5c-4035-9870-afa1d239510a",
-      "projectId": "05cf87b1-6a87-418b-8f11-5794bb29e303",
+      "id": "94b3386f-a132-4845-be3c-0f8d25a1089b",
+      "projectId": "088f4657-e816-4dfe-8e0e-b129f3a47c5e",
       "type": "TASK",
       "title": "Archive Me",
       "description": "D",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T03:05:03.214Z",
-      "updatedAt": "2026-03-01T03:05:03.220Z",
+      "createdAt": "2026-03-01T03:24:49.575Z",
+      "updatedAt": "2026-03-01T03:24:49.579Z",
       "history": [
         {
-          "id": "9b55a621-f7a4-42ed-96c6-4c657b2b7216",
+          "id": "719e2af8-1307-4ee5-8af5-51c6f8df98ff",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T03:05:03.214Z"
+          "timestamp": "2026-03-01T03:24:49.575Z"
         },
         {
-          "id": "e378531a-16cb-411a-81e3-78119c709444",
+          "id": "4dbc5f30-7ccc-49f4-8774-d234c3b1161c",
           "fromStatus": "TODO",
           "toStatus": "ARCHIVED",
-          "timestamp": "2026-03-01T03:05:03.217Z"
+          "timestamp": "2026-03-01T03:24:49.577Z"
         },
         {
-          "id": "d567aa5b-a61b-408a-b4bd-81a763160718",
+          "id": "a0225ac6-9a58-4661-9e54-33370eca6286",
           "fromStatus": "ARCHIVED",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T03:05:03.220Z"
+          "timestamp": "2026-03-01T03:24:49.579Z"
         }
       ]
     },
     {
-      "id": "b34c7f6c-fc3c-4a19-b3bb-a6d800318769",
-      "projectId": "05cf87b1-6a87-418b-8f11-5794bb29e303",
+      "id": "39d464d9-49c3-413b-83a8-2e8d4b044b80",
+      "projectId": "088f4657-e816-4dfe-8e0e-b129f3a47c5e",
       "type": "TASK",
       "title": "Delete Me",
       "description": "D",
       "status": "TRASHED",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T03:05:03.222Z",
-      "updatedAt": "2026-03-01T03:05:03.225Z",
+      "createdAt": "2026-03-01T03:24:49.581Z",
+      "updatedAt": "2026-03-01T03:24:49.584Z",
       "history": [
         {
-          "id": "c3d72b90-adf9-4533-a67c-594338a6ab47",
+          "id": "4d7abb4c-37f9-4545-ab81-87c2539fdf80",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T03:05:03.223Z"
+          "timestamp": "2026-03-01T03:24:49.582Z"
         },
         {
-          "id": "58707b18-e214-48e2-af1f-6dd900e5c80d",
+          "id": "3ea2d18e-bb8d-4c31-a36a-185ad6c62042",
           "fromStatus": "TODO",
           "toStatus": "TRASHED",
-          "timestamp": "2026-03-01T03:05:03.225Z"
+          "timestamp": "2026-03-01T03:24:49.584Z"
         }
       ]
     },
     {
-      "id": "d7674243-a38d-4bf2-b755-cf6bead7f664",
-      "projectId": "05cf87b1-6a87-418b-8f11-5794bb29e303",
+      "id": "a23730bf-7bdb-4981-9ee4-9cc0a6c33540",
+      "projectId": "088f4657-e816-4dfe-8e0e-b129f3a47c5e",
       "type": "TASK",
       "title": "Archived Task",
       "description": "",
       "status": "TRASHED",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T03:05:03.229Z",
-      "updatedAt": "2026-03-01T03:05:03.231Z",
+      "createdAt": "2026-03-01T03:24:49.589Z",
+      "updatedAt": "2026-03-01T03:24:49.591Z",
       "history": [
         {
-          "id": "0005baed-97ed-49fe-904e-89d6e0c39f8b",
+          "id": "0bec646b-b551-4ff3-b858-eb4126eef5fb",
           "fromStatus": "TODO",
           "toStatus": "ARCHIVED",
-          "timestamp": "2026-03-01T03:05:03.229Z"
+          "timestamp": "2026-03-01T03:24:49.589Z"
         },
         {
-          "id": "2d8e8752-34c6-4ff2-a286-bf68353475d8",
+          "id": "3788ae6b-d997-4a5f-9ea6-82a7311446ee",
           "fromStatus": "ARCHIVED",
           "toStatus": "TRASHED",
-          "timestamp": "2026-03-01T03:05:03.231Z"
+          "timestamp": "2026-03-01T03:24:49.591Z"
         }
       ]
     },
     {
-      "id": "6541846e-3579-4c02-8af0-a87343e6f8b7",
-      "projectId": "33096a7a-3b51-4615-b074-43d8e48a3933",
+      "id": "99696072-9378-41c4-8bcd-09679c5debb2",
+      "projectId": "476277cd-8869-4753-8f83-c427b51110a1",
       "type": "BUG",
       "title": "[PROJ-1] Fix login bug",
       "description": "Imported from JIRA: PROJ-1",
@@ -260,14 +260,14 @@
       "implementationPlan": "",
       "externalId": "PROJ-1",
       "externalUrl": "https://test.atlassian.net/browse/PROJ-1",
-      "createdAt": "2026-03-01T03:05:03.272Z",
-      "updatedAt": "2026-03-01T03:05:03.272Z",
+      "createdAt": "2026-03-01T03:24:49.634Z",
+      "updatedAt": "2026-03-01T03:24:49.634Z",
       "history": [
         {
-          "id": "e106ac9d-5ea4-44bd-9b40-2f2a73ad9891",
+          "id": "414abb3b-6271-439d-a510-7337e3e01486",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T03:05:03.272Z"
+          "timestamp": "2026-03-01T03:24:49.634Z"
         }
       ]
     }

--- a/server-test-db.json
+++ b/server-test-db.json
@@ -1,258 +1,258 @@
 {
   "projects": [
     {
-      "id": "d0ac21de-b705-4738-8f91-03a1e5a1503c",
+      "id": "f2e721ff-dcb5-497d-afd3-15fad065d32e",
       "name": "P1 Updated",
       "description": "",
-      "createdAt": "2026-03-01T02:37:34.896Z",
-      "updatedAt": "2026-03-01T02:37:34.914Z"
+      "createdAt": "2026-03-01T02:43:21.014Z",
+      "updatedAt": "2026-03-01T02:43:21.032Z"
     },
     {
-      "id": "7fdda878-ed57-4cc3-a391-1f26385591e5",
+      "id": "89c4deec-9f8f-4a7b-a2b6-7e2b263fec4c",
       "name": "Item Test",
       "description": "",
-      "createdAt": "2026-03-01T02:37:34.929Z",
-      "updatedAt": "2026-03-01T02:37:34.929Z"
+      "createdAt": "2026-03-01T02:43:21.055Z",
+      "updatedAt": "2026-03-01T02:43:21.055Z"
     },
     {
-      "id": "d51eba16-1678-4289-b2e2-b5531d38cfc6",
+      "id": "d6eedb9e-5cbc-4a2d-a865-f5c2bdc9cf26",
       "name": "JIRA Import Test",
       "description": "",
-      "createdAt": "2026-03-01T02:37:35.038Z",
-      "updatedAt": "2026-03-01T02:37:35.038Z"
+      "createdAt": "2026-03-01T02:43:21.142Z",
+      "updatedAt": "2026-03-01T02:43:21.142Z"
     },
     {
-      "id": "4ba9d9fd-81f9-4250-bca1-fb2af8522124",
+      "id": "f44d92f3-c6e0-4efd-af8e-2eccace57d8f",
       "name": "JIRA Err Test",
       "description": "",
-      "createdAt": "2026-03-01T02:37:35.042Z",
-      "updatedAt": "2026-03-01T02:37:35.042Z"
+      "createdAt": "2026-03-01T02:43:21.147Z",
+      "updatedAt": "2026-03-01T02:43:21.147Z"
     }
   ],
   "items": [
     {
-      "id": "d80ab4e3-1c20-426a-a88b-7bdd1215fe33",
-      "projectId": "7fdda878-ed57-4cc3-a391-1f26385591e5",
+      "id": "723aece2-aa69-4d26-8775-878de50686b4",
+      "projectId": "89c4deec-9f8f-4a7b-a2b6-7e2b263fec4c",
       "type": "TASK",
       "title": "T1",
       "description": "D1",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:37:34.931Z",
-      "updatedAt": "2026-03-01T02:37:34.931Z",
+      "createdAt": "2026-03-01T02:43:21.058Z",
+      "updatedAt": "2026-03-01T02:43:21.058Z",
       "history": [
         {
-          "id": "5a359ed2-a4a2-4b90-a119-1de08451cff5",
+          "id": "3f8377ab-b4ce-4217-bb01-c5959bf758c4",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:37:34.931Z"
+          "timestamp": "2026-03-01T02:43:21.059Z"
         }
       ]
     },
     {
-      "id": "2f16d1c4-5a01-479c-a908-3d426dc8dafb",
-      "projectId": "7fdda878-ed57-4cc3-a391-1f26385591e5",
+      "id": "4c0fa1c6-413a-4b28-affa-e4f889e970ec",
+      "projectId": "89c4deec-9f8f-4a7b-a2b6-7e2b263fec4c",
       "type": "TASK",
       "title": "To Update",
       "description": "D",
       "status": "IN_PROGRESS",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:37:34.934Z",
-      "updatedAt": "2026-03-01T02:37:34.940Z",
+      "createdAt": "2026-03-01T02:43:21.063Z",
+      "updatedAt": "2026-03-01T02:43:21.066Z",
       "history": [
         {
-          "id": "5bdd2ede-8045-4480-a9d9-090b06bcb239",
+          "id": "15f197a8-7507-4d82-9b83-2a1ce045860a",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:37:34.934Z"
+          "timestamp": "2026-03-01T02:43:21.063Z"
         },
         {
-          "id": "de8a3303-ce39-46dc-b74b-7fdf0c2ffc31",
+          "id": "5a11a23e-052c-40c0-a945-ad2c99c05b1f",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-01T02:37:34.940Z"
+          "timestamp": "2026-03-01T02:43:21.066Z"
         }
       ]
     },
     {
-      "id": "84b218cb-b418-4f4d-b1d2-9c33f96ec94c",
-      "projectId": "7fdda878-ed57-4cc3-a391-1f26385591e5",
+      "id": "aa31e35c-cfd0-4b9d-838e-75b01e593bff",
+      "projectId": "89c4deec-9f8f-4a7b-a2b6-7e2b263fec4c",
       "type": "TASK",
       "title": "No Cheat",
       "description": "D",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:37:34.946Z",
-      "updatedAt": "2026-03-01T02:37:34.946Z",
+      "createdAt": "2026-03-01T02:43:21.068Z",
+      "updatedAt": "2026-03-01T02:43:21.068Z",
       "history": [
         {
-          "id": "364738ff-4e88-4bdd-9eb3-d2b8e0d9ccf2",
+          "id": "ffc60b55-802b-424e-bf9f-80a3394b1db1",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:37:34.947Z"
+          "timestamp": "2026-03-01T02:43:21.069Z"
         }
       ]
     },
     {
-      "id": "523b93d8-e9ab-4bc8-89d1-c3d645e8df68",
-      "projectId": "7fdda878-ed57-4cc3-a391-1f26385591e5",
+      "id": "25b7428e-04ae-4f85-86c3-a40dcec713f1",
+      "projectId": "89c4deec-9f8f-4a7b-a2b6-7e2b263fec4c",
       "type": "TASK",
       "title": "Verify Me",
       "description": "D",
       "status": "DONE",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:37:34.951Z",
-      "updatedAt": "2026-03-01T02:37:34.953Z",
+      "createdAt": "2026-03-01T02:43:21.073Z",
+      "updatedAt": "2026-03-01T02:43:21.076Z",
       "history": [
         {
-          "id": "bdabb035-5748-4ea8-96eb-795ea82f85fa",
+          "id": "d355086a-81db-4d07-bb86-aaef24f492d7",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:37:34.951Z"
+          "timestamp": "2026-03-01T02:43:21.074Z"
         },
         {
-          "id": "b26a72cd-32cb-4068-b64f-f0b505913f61",
+          "id": "b28c5111-a7bc-48ae-9d24-9b2ed898d2ce",
           "fromStatus": "TODO",
           "toStatus": "DONE",
-          "timestamp": "2026-03-01T02:37:34.953Z"
+          "timestamp": "2026-03-01T02:43:21.076Z"
         }
       ]
     },
     {
-      "id": "a53c2bf3-3e82-4454-b803-89f7de4fe75c",
-      "projectId": "7fdda878-ed57-4cc3-a391-1f26385591e5",
+      "id": "84acf7c5-05d4-494d-8746-e2fed1a98d67",
+      "projectId": "89c4deec-9f8f-4a7b-a2b6-7e2b263fec4c",
       "type": "STORY",
       "title": "Parent Story",
       "description": "D",
       "status": "IN_PROGRESS",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:37:34.956Z",
-      "updatedAt": "2026-03-01T02:37:34.962Z",
+      "createdAt": "2026-03-01T02:43:21.078Z",
+      "updatedAt": "2026-03-01T02:43:21.082Z",
       "history": [
         {
-          "id": "cd0ceb03-50d2-4978-9dc3-bb6c49ca26ee",
+          "id": "37b446f6-d66a-4a73-aa29-9a9466577359",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:37:34.956Z"
+          "timestamp": "2026-03-01T02:43:21.078Z"
         },
         {
-          "id": "9789a5a6-3059-4e14-acb5-65667714cf95",
+          "id": "42f2d3c1-fd6f-407c-a76e-52109fe4f60c",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-01T02:37:34.962Z"
+          "timestamp": "2026-03-01T02:43:21.082Z"
         }
       ]
     },
     {
-      "id": "582cd1d0-7664-42cd-ab4b-2fbffe225ef6",
-      "projectId": "7fdda878-ed57-4cc3-a391-1f26385591e5",
+      "id": "6fac20c5-53b5-4b18-97ce-f3bd3c34ca42",
+      "projectId": "89c4deec-9f8f-4a7b-a2b6-7e2b263fec4c",
       "type": "TASK",
       "title": "Child Task",
       "description": "D",
       "status": "IN_PROGRESS",
-      "parentId": "a53c2bf3-3e82-4454-b803-89f7de4fe75c",
+      "parentId": "84acf7c5-05d4-494d-8746-e2fed1a98d67",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:37:34.958Z",
-      "updatedAt": "2026-03-01T02:37:34.962Z",
+      "createdAt": "2026-03-01T02:43:21.080Z",
+      "updatedAt": "2026-03-01T02:43:21.082Z",
       "history": [
         {
-          "id": "5faf8b73-3f60-471a-9478-c94a9339d77a",
+          "id": "f1cb663e-2a4d-4650-85c6-843176d9003d",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:37:34.959Z"
+          "timestamp": "2026-03-01T02:43:21.080Z"
         },
         {
-          "id": "a87cab51-ed31-41a3-8526-f26dd71b7ea5",
+          "id": "66cb35ba-6dd4-426d-9174-d3e5d902ec6a",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-01T02:37:34.962Z"
+          "timestamp": "2026-03-01T02:43:21.082Z"
         }
       ]
     },
     {
-      "id": "d21033ce-785d-474a-8f1d-dea6232fbfc1",
-      "projectId": "7fdda878-ed57-4cc3-a391-1f26385591e5",
+      "id": "c654a5db-8019-4655-8ee2-433ea3ecc996",
+      "projectId": "89c4deec-9f8f-4a7b-a2b6-7e2b263fec4c",
       "type": "TASK",
       "title": "Archive Me",
       "description": "D",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:37:34.966Z",
-      "updatedAt": "2026-03-01T02:37:34.971Z",
+      "createdAt": "2026-03-01T02:43:21.085Z",
+      "updatedAt": "2026-03-01T02:43:21.089Z",
       "history": [
         {
-          "id": "a7ffd219-a8a7-4318-9bc0-17488347dc2c",
+          "id": "a33171a4-c8c9-4df0-bb96-687ce2dd7ef0",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:37:34.966Z"
+          "timestamp": "2026-03-01T02:43:21.085Z"
         },
         {
-          "id": "6282cccc-f29a-4819-aab5-f3e6edae3f27",
+          "id": "01124731-1b79-4c52-9813-d4ef90461767",
           "fromStatus": "TODO",
           "toStatus": "ARCHIVED",
-          "timestamp": "2026-03-01T02:37:34.968Z"
+          "timestamp": "2026-03-01T02:43:21.087Z"
         },
         {
-          "id": "aa383057-733a-4ec5-90f3-f8c29ab10e1e",
+          "id": "1b107537-df1c-4553-ac69-a22d175e93b2",
           "fromStatus": "ARCHIVED",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:37:34.970Z"
+          "timestamp": "2026-03-01T02:43:21.089Z"
         }
       ]
     },
     {
-      "id": "8d02990d-5a74-40d2-941e-6272bc6981cc",
-      "projectId": "7fdda878-ed57-4cc3-a391-1f26385591e5",
+      "id": "0b417397-38a9-4efe-84e6-bd0c5ab9c546",
+      "projectId": "89c4deec-9f8f-4a7b-a2b6-7e2b263fec4c",
       "type": "TASK",
       "title": "Delete Me",
       "description": "D",
       "status": "TRASHED",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:37:34.973Z",
-      "updatedAt": "2026-03-01T02:37:34.975Z",
+      "createdAt": "2026-03-01T02:43:21.092Z",
+      "updatedAt": "2026-03-01T02:43:21.094Z",
       "history": [
         {
-          "id": "794699b0-1a04-4f3f-b4e0-770880bd5f6f",
+          "id": "1a8082d9-c8fa-4d47-9053-457418476c5c",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:37:34.973Z"
+          "timestamp": "2026-03-01T02:43:21.093Z"
         },
         {
-          "id": "4ca3b363-2b59-4b17-b108-27c87bf422b2",
+          "id": "c4429b73-cf47-42b4-ae40-32fbc02b370b",
           "fromStatus": "TODO",
           "toStatus": "TRASHED",
-          "timestamp": "2026-03-01T02:37:34.975Z"
+          "timestamp": "2026-03-01T02:43:21.094Z"
         }
       ]
     },
     {
-      "id": "5ab155ad-c988-41e1-8745-92bc83f59fbc",
-      "projectId": "7fdda878-ed57-4cc3-a391-1f26385591e5",
+      "id": "7fdfe4c9-5a1a-4263-88c4-9823cd909f3e",
+      "projectId": "89c4deec-9f8f-4a7b-a2b6-7e2b263fec4c",
       "type": "TASK",
       "title": "Archived Task",
       "description": "",
       "status": "TRASHED",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:37:34.984Z",
-      "updatedAt": "2026-03-01T02:37:34.986Z",
+      "createdAt": "2026-03-01T02:43:21.099Z",
+      "updatedAt": "2026-03-01T02:43:21.101Z",
       "history": [
         {
-          "id": "7960adae-b056-4773-a4f2-9e9dd60b471b",
+          "id": "e368ccea-cad2-477b-92ed-c29867739c54",
           "fromStatus": "TODO",
           "toStatus": "ARCHIVED",
-          "timestamp": "2026-03-01T02:37:34.984Z"
+          "timestamp": "2026-03-01T02:43:21.099Z"
         },
         {
-          "id": "d083179b-5ad4-4c9c-82e0-6f589eee4675",
+          "id": "2b0b2317-8853-4677-9796-6479d005a012",
           "fromStatus": "ARCHIVED",
           "toStatus": "TRASHED",
-          "timestamp": "2026-03-01T02:37:34.986Z"
+          "timestamp": "2026-03-01T02:43:21.101Z"
         }
       ]
     },
     {
-      "id": "1276c9db-d504-4ecc-b9ca-7716898d6125",
-      "projectId": "d51eba16-1678-4289-b2e2-b5531d38cfc6",
+      "id": "1667abfc-bbb7-443c-af09-80b25f302117",
+      "projectId": "d6eedb9e-5cbc-4a2d-a865-f5c2bdc9cf26",
       "type": "BUG",
       "title": "[PROJ-1] Fix login bug",
       "description": "Imported from JIRA: PROJ-1",
@@ -260,14 +260,14 @@
       "implementationPlan": "",
       "externalId": "PROJ-1",
       "externalUrl": "https://test.atlassian.net/browse/PROJ-1",
-      "createdAt": "2026-03-01T02:37:35.039Z",
-      "updatedAt": "2026-03-01T02:37:35.039Z",
+      "createdAt": "2026-03-01T02:43:21.144Z",
+      "updatedAt": "2026-03-01T02:43:21.144Z",
       "history": [
         {
-          "id": "cbcedcac-f633-4697-98d0-601bd96682d2",
+          "id": "d6ffe637-716d-4850-9c35-8e63b31b3e4d",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:37:35.039Z"
+          "timestamp": "2026-03-01T02:43:21.144Z"
         }
       ]
     }

--- a/server-test-db.json
+++ b/server-test-db.json
@@ -1,258 +1,258 @@
 {
   "projects": [
     {
-      "id": "b514dfac-9c54-4dca-a689-4305795c487d",
+      "id": "be0a9fab-3f4a-403c-bee4-ada5efb01397",
       "name": "P1 Updated",
       "description": "",
-      "createdAt": "2026-03-01T02:59:59.767Z",
-      "updatedAt": "2026-03-01T02:59:59.785Z"
+      "createdAt": "2026-03-01T03:00:19.608Z",
+      "updatedAt": "2026-03-01T03:00:19.625Z"
     },
     {
-      "id": "5182313c-04b5-4ce0-8e34-aa0a48c78ff3",
+      "id": "114f7ac2-fbc6-4cbf-821d-59e49b8398ef",
       "name": "Item Test",
       "description": "",
-      "createdAt": "2026-03-01T02:59:59.798Z",
-      "updatedAt": "2026-03-01T02:59:59.798Z"
+      "createdAt": "2026-03-01T03:00:19.658Z",
+      "updatedAt": "2026-03-01T03:00:19.658Z"
     },
     {
-      "id": "bed7abe7-11c3-4d46-83e4-9fa2550f546a",
+      "id": "997191c5-de29-43f9-a70b-c5393c9698fe",
       "name": "JIRA Import Test",
       "description": "",
-      "createdAt": "2026-03-01T02:59:59.918Z",
-      "updatedAt": "2026-03-01T02:59:59.918Z"
+      "createdAt": "2026-03-01T03:00:19.787Z",
+      "updatedAt": "2026-03-01T03:00:19.787Z"
     },
     {
-      "id": "4e1b27bd-ef12-4584-bb4b-93d41f950127",
+      "id": "2e9f21ac-b42d-47c5-bb82-9aa549832571",
       "name": "JIRA Err Test",
       "description": "",
-      "createdAt": "2026-03-01T02:59:59.923Z",
-      "updatedAt": "2026-03-01T02:59:59.923Z"
+      "createdAt": "2026-03-01T03:00:19.792Z",
+      "updatedAt": "2026-03-01T03:00:19.792Z"
     }
   ],
   "items": [
     {
-      "id": "86ee42e4-72dd-4d71-90cb-dbce74d8b06a",
-      "projectId": "5182313c-04b5-4ce0-8e34-aa0a48c78ff3",
+      "id": "af359794-8745-418e-89c1-a4fd0ac0d6ac",
+      "projectId": "114f7ac2-fbc6-4cbf-821d-59e49b8398ef",
       "type": "TASK",
       "title": "T1",
       "description": "D1",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:59:59.800Z",
-      "updatedAt": "2026-03-01T02:59:59.800Z",
+      "createdAt": "2026-03-01T03:00:19.665Z",
+      "updatedAt": "2026-03-01T03:00:19.665Z",
       "history": [
         {
-          "id": "1180ff83-53b8-4d52-a0bf-d4208e0cd90f",
+          "id": "856f6103-dfa1-480e-a4ed-f04361df9ab5",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:59:59.800Z"
+          "timestamp": "2026-03-01T03:00:19.665Z"
         }
       ]
     },
     {
-      "id": "8e703380-818a-4227-b0bd-a9f6c04143c9",
-      "projectId": "5182313c-04b5-4ce0-8e34-aa0a48c78ff3",
+      "id": "46b47d87-0d97-4b59-b267-6c13c493ef63",
+      "projectId": "114f7ac2-fbc6-4cbf-821d-59e49b8398ef",
       "type": "TASK",
       "title": "To Update",
       "description": "D",
       "status": "IN_PROGRESS",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:59:59.803Z",
-      "updatedAt": "2026-03-01T02:59:59.807Z",
+      "createdAt": "2026-03-01T03:00:19.667Z",
+      "updatedAt": "2026-03-01T03:00:19.673Z",
       "history": [
         {
-          "id": "4e52412b-49d6-4908-88b5-1897faa44dc3",
+          "id": "93bdf2d1-8ccc-4973-9d78-a74c8292c29c",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:59:59.803Z"
+          "timestamp": "2026-03-01T03:00:19.668Z"
         },
         {
-          "id": "41082b18-0350-4665-bb86-317a95b56352",
+          "id": "78eee4fd-220a-492a-8855-1c1828174251",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-01T02:59:59.807Z"
+          "timestamp": "2026-03-01T03:00:19.673Z"
         }
       ]
     },
     {
-      "id": "7da5b235-124c-4b80-a6dd-0d6af7492c85",
-      "projectId": "5182313c-04b5-4ce0-8e34-aa0a48c78ff3",
+      "id": "5cd0a8f5-e2c3-4c42-92d8-9ed93c2f7bc2",
+      "projectId": "114f7ac2-fbc6-4cbf-821d-59e49b8398ef",
       "type": "TASK",
       "title": "No Cheat",
       "description": "D",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:59:59.813Z",
-      "updatedAt": "2026-03-01T02:59:59.813Z",
+      "createdAt": "2026-03-01T03:00:19.681Z",
+      "updatedAt": "2026-03-01T03:00:19.681Z",
       "history": [
         {
-          "id": "04b4dace-c21e-4691-9179-f4caab3bc82e",
+          "id": "aae6ba15-9557-4dad-81bb-737c16b4d15b",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:59:59.813Z"
+          "timestamp": "2026-03-01T03:00:19.681Z"
         }
       ]
     },
     {
-      "id": "0cd616a7-a478-47a8-b3cb-dbd0a42310b1",
-      "projectId": "5182313c-04b5-4ce0-8e34-aa0a48c78ff3",
+      "id": "5d7934eb-8a32-47ee-90d5-a8cb8ee1287e",
+      "projectId": "114f7ac2-fbc6-4cbf-821d-59e49b8398ef",
       "type": "TASK",
       "title": "Verify Me",
       "description": "D",
       "status": "DONE",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:59:59.817Z",
-      "updatedAt": "2026-03-01T02:59:59.820Z",
+      "createdAt": "2026-03-01T03:00:19.686Z",
+      "updatedAt": "2026-03-01T03:00:19.692Z",
       "history": [
         {
-          "id": "5c37fa41-85dd-42b1-b503-4c9de49ad917",
+          "id": "e0adc616-ea7f-4dc9-8df6-72aa1d849888",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:59:59.817Z"
+          "timestamp": "2026-03-01T03:00:19.686Z"
         },
         {
-          "id": "9b018a83-af2b-4fa1-b4f4-be8217bb6d75",
+          "id": "3eda31ac-3d57-4055-9400-a1e9f59dcab4",
           "fromStatus": "TODO",
           "toStatus": "DONE",
-          "timestamp": "2026-03-01T02:59:59.820Z"
+          "timestamp": "2026-03-01T03:00:19.692Z"
         }
       ]
     },
     {
-      "id": "64061e54-77ea-415f-a188-bb68f471832e",
-      "projectId": "5182313c-04b5-4ce0-8e34-aa0a48c78ff3",
+      "id": "b9d62ce5-d5f7-41b5-9c22-fa61b66bc1d2",
+      "projectId": "114f7ac2-fbc6-4cbf-821d-59e49b8398ef",
       "type": "STORY",
       "title": "Parent Story",
       "description": "D",
       "status": "IN_PROGRESS",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:59:59.822Z",
-      "updatedAt": "2026-03-01T02:59:59.829Z",
+      "createdAt": "2026-03-01T03:00:19.695Z",
+      "updatedAt": "2026-03-01T03:00:19.699Z",
       "history": [
         {
-          "id": "8ad82d66-01f4-4aba-a9c4-5653e74e1941",
+          "id": "9ded9af7-4ac1-4f98-9c17-794626874d6b",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:59:59.822Z"
+          "timestamp": "2026-03-01T03:00:19.695Z"
         },
         {
-          "id": "a16e686e-655a-4622-b7c0-611b8934af86",
+          "id": "dc45cf4c-9eca-430c-ab4f-2f5cf80af145",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-01T02:59:59.829Z"
+          "timestamp": "2026-03-01T03:00:19.699Z"
         }
       ]
     },
     {
-      "id": "3ed322a0-c89e-4a4e-8591-4371d5f08662",
-      "projectId": "5182313c-04b5-4ce0-8e34-aa0a48c78ff3",
+      "id": "fbf2f3bb-7d1a-4281-b8bf-65d4b5948532",
+      "projectId": "114f7ac2-fbc6-4cbf-821d-59e49b8398ef",
       "type": "TASK",
       "title": "Child Task",
       "description": "D",
       "status": "IN_PROGRESS",
-      "parentId": "64061e54-77ea-415f-a188-bb68f471832e",
+      "parentId": "b9d62ce5-d5f7-41b5-9c22-fa61b66bc1d2",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:59:59.824Z",
-      "updatedAt": "2026-03-01T02:59:59.827Z",
+      "createdAt": "2026-03-01T03:00:19.697Z",
+      "updatedAt": "2026-03-01T03:00:19.699Z",
       "history": [
         {
-          "id": "f3fe6ad7-c6c3-49a7-9884-d403fa59c679",
+          "id": "ed020366-7ff8-4c86-a231-e9cf870f3ce0",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:59:59.825Z"
+          "timestamp": "2026-03-01T03:00:19.697Z"
         },
         {
-          "id": "af04731e-8fb4-4699-a217-066d00bf104e",
+          "id": "c8a61b62-c2f5-4399-999a-2bfdfbb110d0",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-01T02:59:59.827Z"
+          "timestamp": "2026-03-01T03:00:19.699Z"
         }
       ]
     },
     {
-      "id": "e3e55e38-b59a-4ef4-a458-711830225fb0",
-      "projectId": "5182313c-04b5-4ce0-8e34-aa0a48c78ff3",
+      "id": "2c1c0bf5-91d9-44ab-af68-2532520b9c3d",
+      "projectId": "114f7ac2-fbc6-4cbf-821d-59e49b8398ef",
       "type": "TASK",
       "title": "Archive Me",
       "description": "D",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:59:59.833Z",
-      "updatedAt": "2026-03-01T02:59:59.838Z",
+      "createdAt": "2026-03-01T03:00:19.702Z",
+      "updatedAt": "2026-03-01T03:00:19.706Z",
       "history": [
         {
-          "id": "ee789d78-af9e-4924-b3f3-404bae04f4b1",
+          "id": "e2c91acd-0cc3-4f33-9695-38004d587738",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:59:59.834Z"
+          "timestamp": "2026-03-01T03:00:19.702Z"
         },
         {
-          "id": "0894c7c6-9056-4f08-a1e5-4b7371121dd1",
+          "id": "b78e39d5-d05b-4016-91d7-ed17a0e615ea",
           "fromStatus": "TODO",
           "toStatus": "ARCHIVED",
-          "timestamp": "2026-03-01T02:59:59.836Z"
+          "timestamp": "2026-03-01T03:00:19.704Z"
         },
         {
-          "id": "ca3a3d1c-0fba-4c09-a962-b5d6066927c1",
+          "id": "73465672-1432-4db2-9198-11d896a42056",
           "fromStatus": "ARCHIVED",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:59:59.838Z"
+          "timestamp": "2026-03-01T03:00:19.705Z"
         }
       ]
     },
     {
-      "id": "358613a3-feec-45ea-8912-cdf8df58809e",
-      "projectId": "5182313c-04b5-4ce0-8e34-aa0a48c78ff3",
+      "id": "69a5b4da-d994-4b94-b8b7-546ff83960ba",
+      "projectId": "114f7ac2-fbc6-4cbf-821d-59e49b8398ef",
       "type": "TASK",
       "title": "Delete Me",
       "description": "D",
       "status": "TRASHED",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:59:59.840Z",
-      "updatedAt": "2026-03-01T02:59:59.842Z",
+      "createdAt": "2026-03-01T03:00:19.707Z",
+      "updatedAt": "2026-03-01T03:00:19.709Z",
       "history": [
         {
-          "id": "b24558b2-999f-45f6-9eac-65dd05f10476",
+          "id": "e388fb9b-76c8-49d2-908f-adfa4ce54eac",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:59:59.840Z"
+          "timestamp": "2026-03-01T03:00:19.707Z"
         },
         {
-          "id": "53806899-b53f-4ac3-a2cc-1c15d57c5ca7",
+          "id": "8e7b12c0-f568-428a-93c5-cee999f18c79",
           "fromStatus": "TODO",
           "toStatus": "TRASHED",
-          "timestamp": "2026-03-01T02:59:59.842Z"
+          "timestamp": "2026-03-01T03:00:19.709Z"
         }
       ]
     },
     {
-      "id": "ba3a0999-38d1-49a3-b2e3-e0bf2b96551d",
-      "projectId": "5182313c-04b5-4ce0-8e34-aa0a48c78ff3",
+      "id": "4108f8ca-6aaf-40a9-8443-78b1cbb7972c",
+      "projectId": "114f7ac2-fbc6-4cbf-821d-59e49b8398ef",
       "type": "TASK",
       "title": "Archived Task",
       "description": "",
       "status": "TRASHED",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:59:59.846Z",
-      "updatedAt": "2026-03-01T02:59:59.849Z",
+      "createdAt": "2026-03-01T03:00:19.716Z",
+      "updatedAt": "2026-03-01T03:00:19.719Z",
       "history": [
         {
-          "id": "b77f95a7-c1d9-4859-8afd-e51c01e199ab",
+          "id": "ccc8e254-e640-4104-a0d3-cf64c7888115",
           "fromStatus": "TODO",
           "toStatus": "ARCHIVED",
-          "timestamp": "2026-03-01T02:59:59.846Z"
+          "timestamp": "2026-03-01T03:00:19.716Z"
         },
         {
-          "id": "febf8fad-e8ba-41b5-92b6-c3386faaae07",
+          "id": "24026ca6-bce9-4e35-8781-7e8cd69c2387",
           "fromStatus": "ARCHIVED",
           "toStatus": "TRASHED",
-          "timestamp": "2026-03-01T02:59:59.849Z"
+          "timestamp": "2026-03-01T03:00:19.719Z"
         }
       ]
     },
     {
-      "id": "eb091889-0a4f-4ef1-b6bf-c4e846415b61",
-      "projectId": "bed7abe7-11c3-4d46-83e4-9fa2550f546a",
+      "id": "91e228ef-ed9e-4cb0-8ad3-9f2b2d78c92c",
+      "projectId": "997191c5-de29-43f9-a70b-c5393c9698fe",
       "type": "BUG",
       "title": "[PROJ-1] Fix login bug",
       "description": "Imported from JIRA: PROJ-1",
@@ -260,14 +260,14 @@
       "implementationPlan": "",
       "externalId": "PROJ-1",
       "externalUrl": "https://test.atlassian.net/browse/PROJ-1",
-      "createdAt": "2026-03-01T02:59:59.919Z",
-      "updatedAt": "2026-03-01T02:59:59.919Z",
+      "createdAt": "2026-03-01T03:00:19.788Z",
+      "updatedAt": "2026-03-01T03:00:19.788Z",
       "history": [
         {
-          "id": "580511ea-f749-4e35-bc7f-424d4442462b",
+          "id": "e1834bb0-b9cf-4e63-b30b-600d6a2ec93f",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:59:59.919Z"
+          "timestamp": "2026-03-01T03:00:19.788Z"
         }
       ]
     }

--- a/server-test-db.json
+++ b/server-test-db.json
@@ -1,258 +1,258 @@
 {
   "projects": [
     {
-      "id": "2f4a01f1-5ddb-4ff7-8b92-89d068a85d61",
+      "id": "16113814-9cdc-44e7-b7ab-d278bc789870",
       "name": "P1 Updated",
       "description": "",
-      "createdAt": "2026-03-01T02:26:24.032Z",
-      "updatedAt": "2026-03-01T02:26:24.047Z"
+      "createdAt": "2026-03-01T02:26:43.278Z",
+      "updatedAt": "2026-03-01T02:26:43.294Z"
     },
     {
-      "id": "720df421-dce0-4da9-9075-7e947bd22067",
+      "id": "5e7f1513-1100-4e9f-b47f-c0ead2d47914",
       "name": "Item Test",
       "description": "",
-      "createdAt": "2026-03-01T02:26:24.070Z",
-      "updatedAt": "2026-03-01T02:26:24.070Z"
+      "createdAt": "2026-03-01T02:26:43.305Z",
+      "updatedAt": "2026-03-01T02:26:43.305Z"
     },
     {
-      "id": "d154c3ab-e830-407f-9595-6783ea88c1db",
+      "id": "114fda9c-d880-4a82-85ca-e40e3df1446a",
       "name": "JIRA Import Test",
       "description": "",
-      "createdAt": "2026-03-01T02:26:24.160Z",
-      "updatedAt": "2026-03-01T02:26:24.160Z"
+      "createdAt": "2026-03-01T02:26:43.398Z",
+      "updatedAt": "2026-03-01T02:26:43.398Z"
     },
     {
-      "id": "2f036758-64b5-48dd-93e3-871325a14e2f",
+      "id": "fdffcbde-8e14-4825-b1f0-a8c6ed29e759",
       "name": "JIRA Err Test",
       "description": "",
-      "createdAt": "2026-03-01T02:26:24.165Z",
-      "updatedAt": "2026-03-01T02:26:24.165Z"
+      "createdAt": "2026-03-01T02:26:43.403Z",
+      "updatedAt": "2026-03-01T02:26:43.403Z"
     }
   ],
   "items": [
     {
-      "id": "80d32d4c-d092-4b7a-b926-0594668607c8",
-      "projectId": "720df421-dce0-4da9-9075-7e947bd22067",
+      "id": "2463d980-4bf3-46dd-ba4f-067eb913da93",
+      "projectId": "5e7f1513-1100-4e9f-b47f-c0ead2d47914",
       "type": "TASK",
       "title": "T1",
       "description": "D1",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:26:24.075Z",
-      "updatedAt": "2026-03-01T02:26:24.075Z",
+      "createdAt": "2026-03-01T02:26:43.307Z",
+      "updatedAt": "2026-03-01T02:26:43.307Z",
       "history": [
         {
-          "id": "680ca49a-a437-418f-8cff-35fbb16d8306",
+          "id": "3a40faaa-2e99-4d6b-820f-3d4c877d6aaa",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:26:24.076Z"
+          "timestamp": "2026-03-01T02:26:43.308Z"
         }
       ]
     },
     {
-      "id": "93e95a09-953c-4ddd-82e7-79a035b2c4fe",
-      "projectId": "720df421-dce0-4da9-9075-7e947bd22067",
+      "id": "dd80a041-bbbe-40ee-8b28-f2e8ee358433",
+      "projectId": "5e7f1513-1100-4e9f-b47f-c0ead2d47914",
       "type": "TASK",
       "title": "To Update",
       "description": "D",
       "status": "IN_PROGRESS",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:26:24.079Z",
-      "updatedAt": "2026-03-01T02:26:24.082Z",
+      "createdAt": "2026-03-01T02:26:43.310Z",
+      "updatedAt": "2026-03-01T02:26:43.314Z",
       "history": [
         {
-          "id": "e6a07ad9-309c-4e9e-9cba-aee206cd9ba8",
+          "id": "fd185303-2a43-407c-a535-37e69dd2e336",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:26:24.080Z"
+          "timestamp": "2026-03-01T02:26:43.311Z"
         },
         {
-          "id": "f7029508-123d-466f-b02c-0ef29bf39997",
+          "id": "15a3a748-da4c-401c-bdbd-bab0b1be8508",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-01T02:26:24.082Z"
+          "timestamp": "2026-03-01T02:26:43.314Z"
         }
       ]
     },
     {
-      "id": "8de0007a-9ecc-4690-8249-869e14d3b331",
-      "projectId": "720df421-dce0-4da9-9075-7e947bd22067",
+      "id": "ed20deca-32a2-4479-bcfb-442b08a1b045",
+      "projectId": "5e7f1513-1100-4e9f-b47f-c0ead2d47914",
       "type": "TASK",
       "title": "No Cheat",
       "description": "D",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:26:24.084Z",
-      "updatedAt": "2026-03-01T02:26:24.084Z",
+      "createdAt": "2026-03-01T02:26:43.318Z",
+      "updatedAt": "2026-03-01T02:26:43.318Z",
       "history": [
         {
-          "id": "88a40af7-4508-45a0-a013-b97bd3e5c9ab",
+          "id": "10c0a6be-6d9b-418a-9481-b377439d71b9",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:26:24.084Z"
+          "timestamp": "2026-03-01T02:26:43.318Z"
         }
       ]
     },
     {
-      "id": "75f55176-7874-403c-8453-6467aa52aad5",
-      "projectId": "720df421-dce0-4da9-9075-7e947bd22067",
+      "id": "b31c6c57-51c8-491c-9eed-6e35575e2842",
+      "projectId": "5e7f1513-1100-4e9f-b47f-c0ead2d47914",
       "type": "TASK",
       "title": "Verify Me",
       "description": "D",
       "status": "DONE",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:26:24.088Z",
-      "updatedAt": "2026-03-01T02:26:24.090Z",
+      "createdAt": "2026-03-01T02:26:43.324Z",
+      "updatedAt": "2026-03-01T02:26:43.326Z",
       "history": [
         {
-          "id": "5147c948-6ddd-4d74-9dff-272ba50fd604",
+          "id": "ce369028-900c-423e-962f-cdaa49b72502",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:26:24.088Z"
+          "timestamp": "2026-03-01T02:26:43.324Z"
         },
         {
-          "id": "62dfb693-c47a-4ae7-943d-6fd496738b3a",
+          "id": "5151a43f-8053-4544-b93c-48d3fa7d4ebd",
           "fromStatus": "TODO",
           "toStatus": "DONE",
-          "timestamp": "2026-03-01T02:26:24.090Z"
+          "timestamp": "2026-03-01T02:26:43.326Z"
         }
       ]
     },
     {
-      "id": "1f5369c9-626c-44a0-80e7-ebbb3b6b8e34",
-      "projectId": "720df421-dce0-4da9-9075-7e947bd22067",
+      "id": "65f29342-88b8-4771-88ef-af583d8c3c4f",
+      "projectId": "5e7f1513-1100-4e9f-b47f-c0ead2d47914",
       "type": "STORY",
       "title": "Parent Story",
       "description": "D",
       "status": "IN_PROGRESS",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:26:24.092Z",
-      "updatedAt": "2026-03-01T02:26:24.097Z",
+      "createdAt": "2026-03-01T02:26:43.329Z",
+      "updatedAt": "2026-03-01T02:26:43.334Z",
       "history": [
         {
-          "id": "1adb8f0c-d7b8-4c99-94a3-eee83686ee93",
+          "id": "46ea4dc7-7dc4-4352-803f-1437fe098c90",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:26:24.093Z"
+          "timestamp": "2026-03-01T02:26:43.329Z"
         },
         {
-          "id": "165042cb-0a9b-4e1b-b73b-b7e25935387a",
+          "id": "abd5e470-902c-4bd8-a979-d6fb3adaef99",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-01T02:26:24.097Z"
+          "timestamp": "2026-03-01T02:26:43.334Z"
         }
       ]
     },
     {
-      "id": "1d68fb13-67fd-4fa6-a3a4-8fd7ab6342d0",
-      "projectId": "720df421-dce0-4da9-9075-7e947bd22067",
+      "id": "209d02cf-cc80-49d1-b481-2eb688db16a2",
+      "projectId": "5e7f1513-1100-4e9f-b47f-c0ead2d47914",
       "type": "TASK",
       "title": "Child Task",
       "description": "D",
       "status": "IN_PROGRESS",
-      "parentId": "1f5369c9-626c-44a0-80e7-ebbb3b6b8e34",
+      "parentId": "65f29342-88b8-4771-88ef-af583d8c3c4f",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:26:24.094Z",
-      "updatedAt": "2026-03-01T02:26:24.096Z",
+      "createdAt": "2026-03-01T02:26:43.331Z",
+      "updatedAt": "2026-03-01T02:26:43.334Z",
       "history": [
         {
-          "id": "41cd6200-040b-48dd-9138-077922a4a67f",
+          "id": "7c8ce40f-19be-4fa1-99cf-72a2827f19bf",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:26:24.094Z"
+          "timestamp": "2026-03-01T02:26:43.332Z"
         },
         {
-          "id": "90e47b80-29d8-4f70-9e30-1e514958db5b",
+          "id": "b6a3fcfd-8aca-4ea6-8869-67d9dbafe41a",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-01T02:26:24.096Z"
+          "timestamp": "2026-03-01T02:26:43.334Z"
         }
       ]
     },
     {
-      "id": "2a5b0569-99f2-4e98-ab22-0636083b7a1e",
-      "projectId": "720df421-dce0-4da9-9075-7e947bd22067",
+      "id": "f3c20985-ecb0-4e12-8c94-4f8c7f726a48",
+      "projectId": "5e7f1513-1100-4e9f-b47f-c0ead2d47914",
       "type": "TASK",
       "title": "Archive Me",
       "description": "D",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:26:24.099Z",
-      "updatedAt": "2026-03-01T02:26:24.103Z",
+      "createdAt": "2026-03-01T02:26:43.337Z",
+      "updatedAt": "2026-03-01T02:26:43.341Z",
       "history": [
         {
-          "id": "e3beae63-8bb2-43d0-b02d-029e73c34016",
+          "id": "63bee8e4-2c8c-4e39-88a2-9ad05ccb222b",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:26:24.099Z"
+          "timestamp": "2026-03-01T02:26:43.337Z"
         },
         {
-          "id": "2223a780-2813-4856-ab42-9c4478d8eba0",
+          "id": "042b8f6c-855f-427d-9055-ce31f8c881bc",
           "fromStatus": "TODO",
           "toStatus": "ARCHIVED",
-          "timestamp": "2026-03-01T02:26:24.101Z"
+          "timestamp": "2026-03-01T02:26:43.339Z"
         },
         {
-          "id": "6697565c-9d9e-4f5b-8b6b-fd4339e0f973",
+          "id": "221335a4-0486-4a29-a655-de4183187987",
           "fromStatus": "ARCHIVED",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:26:24.103Z"
+          "timestamp": "2026-03-01T02:26:43.341Z"
         }
       ]
     },
     {
-      "id": "448d5466-6f6e-48da-8d7b-09c4b72d1858",
-      "projectId": "720df421-dce0-4da9-9075-7e947bd22067",
+      "id": "b60728e3-2702-48cf-a2b4-4d4c3e6e6139",
+      "projectId": "5e7f1513-1100-4e9f-b47f-c0ead2d47914",
       "type": "TASK",
       "title": "Delete Me",
       "description": "D",
       "status": "TRASHED",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:26:24.105Z",
-      "updatedAt": "2026-03-01T02:26:24.107Z",
+      "createdAt": "2026-03-01T02:26:43.351Z",
+      "updatedAt": "2026-03-01T02:26:43.354Z",
       "history": [
         {
-          "id": "6dd5d9fb-ce64-4023-977e-5aaba8765ba5",
+          "id": "fb3196a9-9355-486c-854d-50e0179d91f4",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:26:24.106Z"
+          "timestamp": "2026-03-01T02:26:43.352Z"
         },
         {
-          "id": "bb5b96a5-fe02-4ef2-b918-e55ae3312188",
+          "id": "e0f28a0d-4850-44f4-af0c-618b1b8f2119",
           "fromStatus": "TODO",
           "toStatus": "TRASHED",
-          "timestamp": "2026-03-01T02:26:24.107Z"
+          "timestamp": "2026-03-01T02:26:43.354Z"
         }
       ]
     },
     {
-      "id": "ec9b1a1e-27d0-4a98-a298-59eed7496817",
-      "projectId": "720df421-dce0-4da9-9075-7e947bd22067",
+      "id": "4873f691-f8b9-4812-8d59-6158c859756e",
+      "projectId": "5e7f1513-1100-4e9f-b47f-c0ead2d47914",
       "type": "TASK",
       "title": "Archived Task",
       "description": "",
       "status": "TRASHED",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:26:24.111Z",
-      "updatedAt": "2026-03-01T02:26:24.113Z",
+      "createdAt": "2026-03-01T02:26:43.358Z",
+      "updatedAt": "2026-03-01T02:26:43.360Z",
       "history": [
         {
-          "id": "3045dc26-745a-4961-a52c-73d76f51a15b",
+          "id": "eab60961-90b0-4afc-95a5-28a07d01c5f7",
           "fromStatus": "TODO",
           "toStatus": "ARCHIVED",
-          "timestamp": "2026-03-01T02:26:24.111Z"
+          "timestamp": "2026-03-01T02:26:43.358Z"
         },
         {
-          "id": "8ea7208b-5b4c-4e8e-8f33-ada62b8f1154",
+          "id": "0db8b575-e27d-40a3-8b2e-047475d0e6db",
           "fromStatus": "ARCHIVED",
           "toStatus": "TRASHED",
-          "timestamp": "2026-03-01T02:26:24.113Z"
+          "timestamp": "2026-03-01T02:26:43.360Z"
         }
       ]
     },
     {
-      "id": "5c985647-f76b-41b5-a5ac-ab8f9e36981a",
-      "projectId": "d154c3ab-e830-407f-9595-6783ea88c1db",
+      "id": "ab1fbc61-6725-4d3d-a792-6d3edf61f803",
+      "projectId": "114fda9c-d880-4a82-85ca-e40e3df1446a",
       "type": "BUG",
       "title": "[PROJ-1] Fix login bug",
       "description": "Imported from JIRA: PROJ-1",
@@ -260,14 +260,14 @@
       "implementationPlan": "",
       "externalId": "PROJ-1",
       "externalUrl": "https://test.atlassian.net/browse/PROJ-1",
-      "createdAt": "2026-03-01T02:26:24.161Z",
-      "updatedAt": "2026-03-01T02:26:24.161Z",
+      "createdAt": "2026-03-01T02:26:43.399Z",
+      "updatedAt": "2026-03-01T02:26:43.399Z",
       "history": [
         {
-          "id": "01827b89-5bd6-46af-9782-0f30ea40a66b",
+          "id": "77d373a3-9a76-499c-bc3e-dfbb8bd80731",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:26:24.161Z"
+          "timestamp": "2026-03-01T02:26:43.399Z"
         }
       ]
     }

--- a/server-test-db.json
+++ b/server-test-db.json
@@ -1,258 +1,258 @@
 {
   "projects": [
     {
-      "id": "6778ac8c-52ba-4bdb-8ed7-f8b7db54d16f",
+      "id": "786fc24d-0ab7-4a4b-be06-63eefbbd8822",
       "name": "P1 Updated",
       "description": "",
-      "createdAt": "2026-03-01T02:47:01.843Z",
-      "updatedAt": "2026-03-01T02:47:01.858Z"
+      "createdAt": "2026-03-01T02:59:35.682Z",
+      "updatedAt": "2026-03-01T02:59:35.697Z"
     },
     {
-      "id": "4924053c-4f18-43e0-98ac-088dadfda1cd",
+      "id": "71d1a05b-3b79-4b8e-8aa4-2f3f2fef6890",
       "name": "Item Test",
       "description": "",
-      "createdAt": "2026-03-01T02:47:01.898Z",
-      "updatedAt": "2026-03-01T02:47:01.898Z"
+      "createdAt": "2026-03-01T02:59:35.723Z",
+      "updatedAt": "2026-03-01T02:59:35.723Z"
     },
     {
-      "id": "b8228ed6-2b0e-494d-b236-099ea352d540",
+      "id": "7778e0e1-e860-41ee-853f-d3618faf81b3",
       "name": "JIRA Import Test",
       "description": "",
-      "createdAt": "2026-03-01T02:47:02.068Z",
-      "updatedAt": "2026-03-01T02:47:02.068Z"
+      "createdAt": "2026-03-01T02:59:35.821Z",
+      "updatedAt": "2026-03-01T02:59:35.821Z"
     },
     {
-      "id": "dc69c362-db7b-4e70-8e4c-79b7739d1a6a",
+      "id": "e8a2258d-1d9e-48e1-a3fe-b7d7f876a173",
       "name": "JIRA Err Test",
       "description": "",
-      "createdAt": "2026-03-01T02:47:02.076Z",
-      "updatedAt": "2026-03-01T02:47:02.076Z"
+      "createdAt": "2026-03-01T02:59:35.826Z",
+      "updatedAt": "2026-03-01T02:59:35.826Z"
     }
   ],
   "items": [
     {
-      "id": "ea63ebe6-7203-4b5b-8e80-29ab5e4a08f4",
-      "projectId": "4924053c-4f18-43e0-98ac-088dadfda1cd",
+      "id": "49f14e5f-83c8-41ae-bfc0-96c96afe9667",
+      "projectId": "71d1a05b-3b79-4b8e-8aa4-2f3f2fef6890",
       "type": "TASK",
       "title": "T1",
       "description": "D1",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:47:01.902Z",
-      "updatedAt": "2026-03-01T02:47:01.902Z",
+      "createdAt": "2026-03-01T02:59:35.726Z",
+      "updatedAt": "2026-03-01T02:59:35.726Z",
       "history": [
         {
-          "id": "c68af784-9e33-4115-ba84-abf4f03d7ddc",
+          "id": "8596feb0-22d0-4804-87b2-e6347497bad8",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:47:01.903Z"
+          "timestamp": "2026-03-01T02:59:35.726Z"
         }
       ]
     },
     {
-      "id": "33c51a68-e16c-401f-b5cc-9bf2a92de278",
-      "projectId": "4924053c-4f18-43e0-98ac-088dadfda1cd",
+      "id": "d7a586d2-1ae6-438f-be6a-8608466316e5",
+      "projectId": "71d1a05b-3b79-4b8e-8aa4-2f3f2fef6890",
       "type": "TASK",
       "title": "To Update",
       "description": "D",
       "status": "IN_PROGRESS",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:47:01.907Z",
-      "updatedAt": "2026-03-01T02:47:01.911Z",
+      "createdAt": "2026-03-01T02:59:35.728Z",
+      "updatedAt": "2026-03-01T02:59:35.733Z",
       "history": [
         {
-          "id": "d223d0c2-0b06-4bc1-be3b-5d2d556d6b87",
+          "id": "c4edf6d1-f3a8-4162-bd04-048a7610c8e3",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:47:01.908Z"
+          "timestamp": "2026-03-01T02:59:35.728Z"
         },
         {
-          "id": "90e90beb-3091-4cba-9aa4-dea29ed12c09",
+          "id": "1a94b0b6-41d8-47f6-97b6-90f2490529cd",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-01T02:47:01.911Z"
+          "timestamp": "2026-03-01T02:59:35.733Z"
         }
       ]
     },
     {
-      "id": "fc1ad188-40d6-4b4e-aa52-99b1ec4ce280",
-      "projectId": "4924053c-4f18-43e0-98ac-088dadfda1cd",
+      "id": "329c33c8-c60b-4bcd-919c-a16ae29b9221",
+      "projectId": "71d1a05b-3b79-4b8e-8aa4-2f3f2fef6890",
       "type": "TASK",
       "title": "No Cheat",
       "description": "D",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:47:01.914Z",
-      "updatedAt": "2026-03-01T02:47:01.914Z",
+      "createdAt": "2026-03-01T02:59:35.736Z",
+      "updatedAt": "2026-03-01T02:59:35.736Z",
       "history": [
         {
-          "id": "95a47c9c-0532-4c7a-bebb-887e90fb9961",
+          "id": "98914682-1d44-4640-8152-7edfbf739610",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:47:01.914Z"
+          "timestamp": "2026-03-01T02:59:35.736Z"
         }
       ]
     },
     {
-      "id": "81e2e0f6-9436-4136-9ea8-502250fe9ca1",
-      "projectId": "4924053c-4f18-43e0-98ac-088dadfda1cd",
+      "id": "4c30d90f-6d5a-46f1-aece-93334224624b",
+      "projectId": "71d1a05b-3b79-4b8e-8aa4-2f3f2fef6890",
       "type": "TASK",
       "title": "Verify Me",
       "description": "D",
       "status": "DONE",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:47:01.925Z",
-      "updatedAt": "2026-03-01T02:47:01.929Z",
+      "createdAt": "2026-03-01T02:59:35.739Z",
+      "updatedAt": "2026-03-01T02:59:35.742Z",
       "history": [
         {
-          "id": "cfef7607-26b3-4978-836b-41c80f402856",
+          "id": "62be4608-f6af-421b-b280-a07569a11721",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:47:01.926Z"
+          "timestamp": "2026-03-01T02:59:35.740Z"
         },
         {
-          "id": "368012c2-de26-4cc8-a9ce-eb4d0d9f7f76",
+          "id": "abfcbf96-8de7-4ccc-821e-8037731813c4",
           "fromStatus": "TODO",
           "toStatus": "DONE",
-          "timestamp": "2026-03-01T02:47:01.929Z"
+          "timestamp": "2026-03-01T02:59:35.742Z"
         }
       ]
     },
     {
-      "id": "906291bc-335d-441c-a495-39757d9a6244",
-      "projectId": "4924053c-4f18-43e0-98ac-088dadfda1cd",
+      "id": "d626d1da-4cd7-4186-ae39-318b156ebb7e",
+      "projectId": "71d1a05b-3b79-4b8e-8aa4-2f3f2fef6890",
       "type": "STORY",
       "title": "Parent Story",
       "description": "D",
       "status": "IN_PROGRESS",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:47:01.931Z",
-      "updatedAt": "2026-03-01T02:47:01.938Z",
+      "createdAt": "2026-03-01T02:59:35.744Z",
+      "updatedAt": "2026-03-01T02:59:35.748Z",
       "history": [
         {
-          "id": "933cebe1-09cd-48db-8510-ce4937f7c9da",
+          "id": "a9e8dd14-f634-4cad-8256-f9038cc5c157",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:47:01.931Z"
+          "timestamp": "2026-03-01T02:59:35.744Z"
         },
         {
-          "id": "b31e0c33-5397-4328-b92f-2511c7556aa2",
+          "id": "787f14e4-a090-4128-92f5-489eced28861",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-01T02:47:01.938Z"
+          "timestamp": "2026-03-01T02:59:35.748Z"
         }
       ]
     },
     {
-      "id": "bfd0e50e-a80c-4d8c-b3d1-245dca473362",
-      "projectId": "4924053c-4f18-43e0-98ac-088dadfda1cd",
+      "id": "ff601c44-8439-4d1a-becc-406f80c1a0f8",
+      "projectId": "71d1a05b-3b79-4b8e-8aa4-2f3f2fef6890",
       "type": "TASK",
       "title": "Child Task",
       "description": "D",
       "status": "IN_PROGRESS",
-      "parentId": "906291bc-335d-441c-a495-39757d9a6244",
+      "parentId": "d626d1da-4cd7-4186-ae39-318b156ebb7e",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:47:01.933Z",
-      "updatedAt": "2026-03-01T02:47:01.937Z",
+      "createdAt": "2026-03-01T02:59:35.746Z",
+      "updatedAt": "2026-03-01T02:59:35.748Z",
       "history": [
         {
-          "id": "e08929e2-1c75-4100-a282-6eceeeff04d7",
+          "id": "88d6c9fc-db0b-4b72-955d-97149d95140d",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:47:01.933Z"
+          "timestamp": "2026-03-01T02:59:35.746Z"
         },
         {
-          "id": "f903da5e-3f75-4fe4-b557-2d81da7ada8f",
+          "id": "0fb87332-f8f9-479f-8bc0-673d6a5f118c",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-01T02:47:01.937Z"
+          "timestamp": "2026-03-01T02:59:35.748Z"
         }
       ]
     },
     {
-      "id": "275a0530-bb53-4eed-aa72-4527ea358084",
-      "projectId": "4924053c-4f18-43e0-98ac-088dadfda1cd",
+      "id": "386317d4-362b-4fdf-b42a-e064b320e4b0",
+      "projectId": "71d1a05b-3b79-4b8e-8aa4-2f3f2fef6890",
       "type": "TASK",
       "title": "Archive Me",
       "description": "D",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:47:01.941Z",
-      "updatedAt": "2026-03-01T02:47:01.945Z",
+      "createdAt": "2026-03-01T02:59:35.751Z",
+      "updatedAt": "2026-03-01T02:59:35.756Z",
       "history": [
         {
-          "id": "9063f658-1fd3-4de9-9466-f98b936ca70b",
+          "id": "816289d0-17b5-4e6e-a7b8-e59cfb89d9e0",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:47:01.941Z"
+          "timestamp": "2026-03-01T02:59:35.752Z"
         },
         {
-          "id": "3b5b7375-920e-42b1-820c-ff6efdf603b6",
+          "id": "e498e5b3-ac60-476b-ab51-1ec2789448b5",
           "fromStatus": "TODO",
           "toStatus": "ARCHIVED",
-          "timestamp": "2026-03-01T02:47:01.943Z"
+          "timestamp": "2026-03-01T02:59:35.754Z"
         },
         {
-          "id": "a8673fcd-82f0-4df8-9e74-e45a50626578",
+          "id": "4144225e-d06f-4894-a302-4fe326ef53d7",
           "fromStatus": "ARCHIVED",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:47:01.945Z"
+          "timestamp": "2026-03-01T02:59:35.756Z"
         }
       ]
     },
     {
-      "id": "4854cf96-9428-44b5-b4e9-ec19f2eadba0",
-      "projectId": "4924053c-4f18-43e0-98ac-088dadfda1cd",
+      "id": "50b11ec9-807d-4080-8918-9d2035d58479",
+      "projectId": "71d1a05b-3b79-4b8e-8aa4-2f3f2fef6890",
       "type": "TASK",
       "title": "Delete Me",
       "description": "D",
       "status": "TRASHED",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:47:01.947Z",
-      "updatedAt": "2026-03-01T02:47:01.950Z",
+      "createdAt": "2026-03-01T02:59:35.758Z",
+      "updatedAt": "2026-03-01T02:59:35.761Z",
       "history": [
         {
-          "id": "db01c8cd-623b-483c-8266-f584b40dee05",
+          "id": "77acb82f-4fac-456f-aa81-5e0c0017b41d",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:47:01.947Z"
+          "timestamp": "2026-03-01T02:59:35.759Z"
         },
         {
-          "id": "92ec3a53-e762-4cb3-b9d5-d8e96195a944",
+          "id": "61054ec6-8b69-496b-9af2-955e599ffa26",
           "fromStatus": "TODO",
           "toStatus": "TRASHED",
-          "timestamp": "2026-03-01T02:47:01.950Z"
+          "timestamp": "2026-03-01T02:59:35.761Z"
         }
       ]
     },
     {
-      "id": "df7c7136-b726-4f8c-873e-a3664dd5d1e0",
-      "projectId": "4924053c-4f18-43e0-98ac-088dadfda1cd",
+      "id": "5286765b-b849-4a7e-98a3-9a2000587f7e",
+      "projectId": "71d1a05b-3b79-4b8e-8aa4-2f3f2fef6890",
       "type": "TASK",
       "title": "Archived Task",
       "description": "",
       "status": "TRASHED",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:47:01.955Z",
-      "updatedAt": "2026-03-01T02:47:01.958Z",
+      "createdAt": "2026-03-01T02:59:35.766Z",
+      "updatedAt": "2026-03-01T02:59:35.768Z",
       "history": [
         {
-          "id": "13e5093e-915c-452f-b61a-da11346d468a",
+          "id": "6b9ccf04-f677-41d3-b912-4ace78052a4f",
           "fromStatus": "TODO",
           "toStatus": "ARCHIVED",
-          "timestamp": "2026-03-01T02:47:01.956Z"
+          "timestamp": "2026-03-01T02:59:35.766Z"
         },
         {
-          "id": "4c34685c-665b-4f96-b86f-0f5e83face8a",
+          "id": "3feaccfb-fc4c-40ee-b6a8-eacfd4c67c9e",
           "fromStatus": "ARCHIVED",
           "toStatus": "TRASHED",
-          "timestamp": "2026-03-01T02:47:01.958Z"
+          "timestamp": "2026-03-01T02:59:35.768Z"
         }
       ]
     },
     {
-      "id": "b7cb7a4f-c4a1-495d-84b4-e5ee472dd2e8",
-      "projectId": "b8228ed6-2b0e-494d-b236-099ea352d540",
+      "id": "89263aff-d0cf-4918-b0cb-022aa0c873c1",
+      "projectId": "7778e0e1-e860-41ee-853f-d3618faf81b3",
       "type": "BUG",
       "title": "[PROJ-1] Fix login bug",
       "description": "Imported from JIRA: PROJ-1",
@@ -260,14 +260,14 @@
       "implementationPlan": "",
       "externalId": "PROJ-1",
       "externalUrl": "https://test.atlassian.net/browse/PROJ-1",
-      "createdAt": "2026-03-01T02:47:02.072Z",
-      "updatedAt": "2026-03-01T02:47:02.072Z",
+      "createdAt": "2026-03-01T02:59:35.823Z",
+      "updatedAt": "2026-03-01T02:59:35.823Z",
       "history": [
         {
-          "id": "6d420b5c-6187-43a3-85c2-013392f72c57",
+          "id": "21c4ff8a-0b6e-4b5f-9806-a1abef491d92",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:47:02.072Z"
+          "timestamp": "2026-03-01T02:59:35.823Z"
         }
       ]
     }

--- a/server-test-db.json
+++ b/server-test-db.json
@@ -1,258 +1,258 @@
 {
   "projects": [
     {
-      "id": "365e5e64-db46-43b5-a62f-63ff61102359",
+      "id": "2f4a01f1-5ddb-4ff7-8b92-89d068a85d61",
       "name": "P1 Updated",
       "description": "",
-      "createdAt": "2026-03-01T02:25:58.825Z",
-      "updatedAt": "2026-03-01T02:25:58.840Z"
+      "createdAt": "2026-03-01T02:26:24.032Z",
+      "updatedAt": "2026-03-01T02:26:24.047Z"
     },
     {
-      "id": "fabc6488-cbdd-4a2e-a891-5bcf18ca6e23",
+      "id": "720df421-dce0-4da9-9075-7e947bd22067",
       "name": "Item Test",
       "description": "",
-      "createdAt": "2026-03-01T02:25:58.872Z",
-      "updatedAt": "2026-03-01T02:25:58.872Z"
+      "createdAt": "2026-03-01T02:26:24.070Z",
+      "updatedAt": "2026-03-01T02:26:24.070Z"
     },
     {
-      "id": "f715bf7d-c427-4642-9a52-3eb94ad4f2da",
+      "id": "d154c3ab-e830-407f-9595-6783ea88c1db",
       "name": "JIRA Import Test",
       "description": "",
-      "createdAt": "2026-03-01T02:25:58.967Z",
-      "updatedAt": "2026-03-01T02:25:58.967Z"
+      "createdAt": "2026-03-01T02:26:24.160Z",
+      "updatedAt": "2026-03-01T02:26:24.160Z"
     },
     {
-      "id": "20cc3e0f-1d81-4d53-bd54-0406f87e61ff",
+      "id": "2f036758-64b5-48dd-93e3-871325a14e2f",
       "name": "JIRA Err Test",
       "description": "",
-      "createdAt": "2026-03-01T02:25:58.972Z",
-      "updatedAt": "2026-03-01T02:25:58.972Z"
+      "createdAt": "2026-03-01T02:26:24.165Z",
+      "updatedAt": "2026-03-01T02:26:24.165Z"
     }
   ],
   "items": [
     {
-      "id": "fdd5ea05-4384-4e55-86f2-cd471110bd8e",
-      "projectId": "fabc6488-cbdd-4a2e-a891-5bcf18ca6e23",
+      "id": "80d32d4c-d092-4b7a-b926-0594668607c8",
+      "projectId": "720df421-dce0-4da9-9075-7e947bd22067",
       "type": "TASK",
       "title": "T1",
       "description": "D1",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:25:58.875Z",
-      "updatedAt": "2026-03-01T02:25:58.875Z",
+      "createdAt": "2026-03-01T02:26:24.075Z",
+      "updatedAt": "2026-03-01T02:26:24.075Z",
       "history": [
         {
-          "id": "158f7c82-9e10-4848-8b87-a8fb3058ab14",
+          "id": "680ca49a-a437-418f-8cff-35fbb16d8306",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:25:58.875Z"
+          "timestamp": "2026-03-01T02:26:24.076Z"
         }
       ]
     },
     {
-      "id": "1035bbf5-f397-4617-8e7e-95e002e4bbe4",
-      "projectId": "fabc6488-cbdd-4a2e-a891-5bcf18ca6e23",
+      "id": "93e95a09-953c-4ddd-82e7-79a035b2c4fe",
+      "projectId": "720df421-dce0-4da9-9075-7e947bd22067",
       "type": "TASK",
       "title": "To Update",
       "description": "D",
       "status": "IN_PROGRESS",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:25:58.878Z",
-      "updatedAt": "2026-03-01T02:25:58.881Z",
+      "createdAt": "2026-03-01T02:26:24.079Z",
+      "updatedAt": "2026-03-01T02:26:24.082Z",
       "history": [
         {
-          "id": "c6a8c5bd-8af4-44e2-9b3b-7be687e0b1a2",
+          "id": "e6a07ad9-309c-4e9e-9cba-aee206cd9ba8",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:25:58.878Z"
+          "timestamp": "2026-03-01T02:26:24.080Z"
         },
         {
-          "id": "fe5188e9-3610-443f-9274-75e8947bf8fe",
+          "id": "f7029508-123d-466f-b02c-0ef29bf39997",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-01T02:25:58.881Z"
+          "timestamp": "2026-03-01T02:26:24.082Z"
         }
       ]
     },
     {
-      "id": "f07c63e3-e38f-4b54-899a-5a7e7c428109",
-      "projectId": "fabc6488-cbdd-4a2e-a891-5bcf18ca6e23",
+      "id": "8de0007a-9ecc-4690-8249-869e14d3b331",
+      "projectId": "720df421-dce0-4da9-9075-7e947bd22067",
       "type": "TASK",
       "title": "No Cheat",
       "description": "D",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:25:58.884Z",
-      "updatedAt": "2026-03-01T02:25:58.884Z",
+      "createdAt": "2026-03-01T02:26:24.084Z",
+      "updatedAt": "2026-03-01T02:26:24.084Z",
       "history": [
         {
-          "id": "c7eceb0d-2105-4eb9-a1ec-6ee80fe02c86",
+          "id": "88a40af7-4508-45a0-a013-b97bd3e5c9ab",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:25:58.885Z"
+          "timestamp": "2026-03-01T02:26:24.084Z"
         }
       ]
     },
     {
-      "id": "76bdf36e-6191-42f0-ac16-3adf4dbe778f",
-      "projectId": "fabc6488-cbdd-4a2e-a891-5bcf18ca6e23",
+      "id": "75f55176-7874-403c-8453-6467aa52aad5",
+      "projectId": "720df421-dce0-4da9-9075-7e947bd22067",
       "type": "TASK",
       "title": "Verify Me",
       "description": "D",
       "status": "DONE",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:25:58.898Z",
-      "updatedAt": "2026-03-01T02:25:58.903Z",
+      "createdAt": "2026-03-01T02:26:24.088Z",
+      "updatedAt": "2026-03-01T02:26:24.090Z",
       "history": [
         {
-          "id": "8775aee0-2b7a-4fbb-ab53-7db99ddd60a4",
+          "id": "5147c948-6ddd-4d74-9dff-272ba50fd604",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:25:58.899Z"
+          "timestamp": "2026-03-01T02:26:24.088Z"
         },
         {
-          "id": "2a1a2936-9071-48b0-9883-6935e8752517",
+          "id": "62dfb693-c47a-4ae7-943d-6fd496738b3a",
           "fromStatus": "TODO",
           "toStatus": "DONE",
-          "timestamp": "2026-03-01T02:25:58.903Z"
+          "timestamp": "2026-03-01T02:26:24.090Z"
         }
       ]
     },
     {
-      "id": "94ea4ddb-e459-4159-800f-55625789ef55",
-      "projectId": "fabc6488-cbdd-4a2e-a891-5bcf18ca6e23",
+      "id": "1f5369c9-626c-44a0-80e7-ebbb3b6b8e34",
+      "projectId": "720df421-dce0-4da9-9075-7e947bd22067",
       "type": "STORY",
       "title": "Parent Story",
       "description": "D",
       "status": "IN_PROGRESS",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:25:58.906Z",
-      "updatedAt": "2026-03-01T02:25:58.911Z",
+      "createdAt": "2026-03-01T02:26:24.092Z",
+      "updatedAt": "2026-03-01T02:26:24.097Z",
       "history": [
         {
-          "id": "297a4e83-8b52-4aa9-ab29-5668628519bc",
+          "id": "1adb8f0c-d7b8-4c99-94a3-eee83686ee93",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:25:58.906Z"
+          "timestamp": "2026-03-01T02:26:24.093Z"
         },
         {
-          "id": "29ef1540-f2f4-4270-b9c2-567a3b32f4fd",
+          "id": "165042cb-0a9b-4e1b-b73b-b7e25935387a",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-01T02:25:58.911Z"
+          "timestamp": "2026-03-01T02:26:24.097Z"
         }
       ]
     },
     {
-      "id": "391d2582-2f64-4fef-9e09-8a9a88e24bb0",
-      "projectId": "fabc6488-cbdd-4a2e-a891-5bcf18ca6e23",
+      "id": "1d68fb13-67fd-4fa6-a3a4-8fd7ab6342d0",
+      "projectId": "720df421-dce0-4da9-9075-7e947bd22067",
       "type": "TASK",
       "title": "Child Task",
       "description": "D",
       "status": "IN_PROGRESS",
-      "parentId": "94ea4ddb-e459-4159-800f-55625789ef55",
+      "parentId": "1f5369c9-626c-44a0-80e7-ebbb3b6b8e34",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:25:58.908Z",
-      "updatedAt": "2026-03-01T02:25:58.910Z",
+      "createdAt": "2026-03-01T02:26:24.094Z",
+      "updatedAt": "2026-03-01T02:26:24.096Z",
       "history": [
         {
-          "id": "73d7bf39-b2fc-4736-a09d-052f657e6871",
+          "id": "41cd6200-040b-48dd-9138-077922a4a67f",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:25:58.908Z"
+          "timestamp": "2026-03-01T02:26:24.094Z"
         },
         {
-          "id": "d9adcb1b-8c84-435d-8594-47bafe28869b",
+          "id": "90e47b80-29d8-4f70-9e30-1e514958db5b",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-01T02:25:58.910Z"
+          "timestamp": "2026-03-01T02:26:24.096Z"
         }
       ]
     },
     {
-      "id": "b67f028b-fd2f-4a11-81ba-898fb66f3fcb",
-      "projectId": "fabc6488-cbdd-4a2e-a891-5bcf18ca6e23",
+      "id": "2a5b0569-99f2-4e98-ab22-0636083b7a1e",
+      "projectId": "720df421-dce0-4da9-9075-7e947bd22067",
       "type": "TASK",
       "title": "Archive Me",
       "description": "D",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:25:58.914Z",
-      "updatedAt": "2026-03-01T02:25:58.918Z",
+      "createdAt": "2026-03-01T02:26:24.099Z",
+      "updatedAt": "2026-03-01T02:26:24.103Z",
       "history": [
         {
-          "id": "40655c3d-368c-4ee6-aa04-df068ad346f6",
+          "id": "e3beae63-8bb2-43d0-b02d-029e73c34016",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:25:58.914Z"
+          "timestamp": "2026-03-01T02:26:24.099Z"
         },
         {
-          "id": "d7b0fc89-152a-46c2-a966-4bf76eacec44",
+          "id": "2223a780-2813-4856-ab42-9c4478d8eba0",
           "fromStatus": "TODO",
           "toStatus": "ARCHIVED",
-          "timestamp": "2026-03-01T02:25:58.916Z"
+          "timestamp": "2026-03-01T02:26:24.101Z"
         },
         {
-          "id": "6c0ba459-edfb-4bd2-862d-26a5080259ab",
+          "id": "6697565c-9d9e-4f5b-8b6b-fd4339e0f973",
           "fromStatus": "ARCHIVED",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:25:58.918Z"
+          "timestamp": "2026-03-01T02:26:24.103Z"
         }
       ]
     },
     {
-      "id": "492fa57f-c875-4caa-9418-84a7305a7bca",
-      "projectId": "fabc6488-cbdd-4a2e-a891-5bcf18ca6e23",
+      "id": "448d5466-6f6e-48da-8d7b-09c4b72d1858",
+      "projectId": "720df421-dce0-4da9-9075-7e947bd22067",
       "type": "TASK",
       "title": "Delete Me",
       "description": "D",
       "status": "TRASHED",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:25:58.920Z",
-      "updatedAt": "2026-03-01T02:25:58.922Z",
+      "createdAt": "2026-03-01T02:26:24.105Z",
+      "updatedAt": "2026-03-01T02:26:24.107Z",
       "history": [
         {
-          "id": "12cd1c94-fb93-410f-ac0c-b7d6e02bbf9f",
+          "id": "6dd5d9fb-ce64-4023-977e-5aaba8765ba5",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:25:58.920Z"
+          "timestamp": "2026-03-01T02:26:24.106Z"
         },
         {
-          "id": "6e74c0c4-e041-4971-8ba1-2119abcc1ff3",
+          "id": "bb5b96a5-fe02-4ef2-b918-e55ae3312188",
           "fromStatus": "TODO",
           "toStatus": "TRASHED",
-          "timestamp": "2026-03-01T02:25:58.922Z"
+          "timestamp": "2026-03-01T02:26:24.107Z"
         }
       ]
     },
     {
-      "id": "08fd98a6-4e85-413f-b3e6-a22df1e1dcef",
-      "projectId": "fabc6488-cbdd-4a2e-a891-5bcf18ca6e23",
+      "id": "ec9b1a1e-27d0-4a98-a298-59eed7496817",
+      "projectId": "720df421-dce0-4da9-9075-7e947bd22067",
       "type": "TASK",
       "title": "Archived Task",
       "description": "",
       "status": "TRASHED",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:25:58.926Z",
-      "updatedAt": "2026-03-01T02:25:58.928Z",
+      "createdAt": "2026-03-01T02:26:24.111Z",
+      "updatedAt": "2026-03-01T02:26:24.113Z",
       "history": [
         {
-          "id": "fb26b7db-3bdc-4bfe-99d2-fc1b5374dbc1",
+          "id": "3045dc26-745a-4961-a52c-73d76f51a15b",
           "fromStatus": "TODO",
           "toStatus": "ARCHIVED",
-          "timestamp": "2026-03-01T02:25:58.926Z"
+          "timestamp": "2026-03-01T02:26:24.111Z"
         },
         {
-          "id": "e3ae3cfb-9b9f-4bd1-aebc-8b0ba56f3861",
+          "id": "8ea7208b-5b4c-4e8e-8f33-ada62b8f1154",
           "fromStatus": "ARCHIVED",
           "toStatus": "TRASHED",
-          "timestamp": "2026-03-01T02:25:58.928Z"
+          "timestamp": "2026-03-01T02:26:24.113Z"
         }
       ]
     },
     {
-      "id": "9b82b0c8-8824-4e2a-aa8b-d6ad7ef7356b",
-      "projectId": "f715bf7d-c427-4642-9a52-3eb94ad4f2da",
+      "id": "5c985647-f76b-41b5-a5ac-ab8f9e36981a",
+      "projectId": "d154c3ab-e830-407f-9595-6783ea88c1db",
       "type": "BUG",
       "title": "[PROJ-1] Fix login bug",
       "description": "Imported from JIRA: PROJ-1",
@@ -260,14 +260,14 @@
       "implementationPlan": "",
       "externalId": "PROJ-1",
       "externalUrl": "https://test.atlassian.net/browse/PROJ-1",
-      "createdAt": "2026-03-01T02:25:58.969Z",
-      "updatedAt": "2026-03-01T02:25:58.969Z",
+      "createdAt": "2026-03-01T02:26:24.161Z",
+      "updatedAt": "2026-03-01T02:26:24.161Z",
       "history": [
         {
-          "id": "ea909b7b-6dea-48b9-ad8e-51f0216d4cf4",
+          "id": "01827b89-5bd6-46af-9782-0f30ea40a66b",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:25:58.969Z"
+          "timestamp": "2026-03-01T02:26:24.161Z"
         }
       ]
     }

--- a/server-test-db.json
+++ b/server-test-db.json
@@ -1,258 +1,258 @@
 {
   "projects": [
     {
-      "id": "d72192eb-8191-4b1a-8f03-294314ace2af",
+      "id": "d0ac21de-b705-4738-8f91-03a1e5a1503c",
       "name": "P1 Updated",
       "description": "",
-      "createdAt": "2026-03-01T02:27:03.498Z",
-      "updatedAt": "2026-03-01T02:27:03.514Z"
+      "createdAt": "2026-03-01T02:37:34.896Z",
+      "updatedAt": "2026-03-01T02:37:34.914Z"
     },
     {
-      "id": "bde6db69-347a-421f-93c1-1c4e208b26ed",
+      "id": "7fdda878-ed57-4cc3-a391-1f26385591e5",
       "name": "Item Test",
       "description": "",
-      "createdAt": "2026-03-01T02:27:03.539Z",
-      "updatedAt": "2026-03-01T02:27:03.539Z"
+      "createdAt": "2026-03-01T02:37:34.929Z",
+      "updatedAt": "2026-03-01T02:37:34.929Z"
     },
     {
-      "id": "18208e82-0f00-4ce3-89a0-254ec955cf43",
+      "id": "d51eba16-1678-4289-b2e2-b5531d38cfc6",
       "name": "JIRA Import Test",
       "description": "",
-      "createdAt": "2026-03-01T02:27:03.644Z",
-      "updatedAt": "2026-03-01T02:27:03.644Z"
+      "createdAt": "2026-03-01T02:37:35.038Z",
+      "updatedAt": "2026-03-01T02:37:35.038Z"
     },
     {
-      "id": "88ffa9f1-9db5-4602-988c-d1a9ece6e642",
+      "id": "4ba9d9fd-81f9-4250-bca1-fb2af8522124",
       "name": "JIRA Err Test",
       "description": "",
-      "createdAt": "2026-03-01T02:27:03.673Z",
-      "updatedAt": "2026-03-01T02:27:03.673Z"
+      "createdAt": "2026-03-01T02:37:35.042Z",
+      "updatedAt": "2026-03-01T02:37:35.042Z"
     }
   ],
   "items": [
     {
-      "id": "83e15b8b-0b1b-442d-afe2-4eb9831f1bd4",
-      "projectId": "bde6db69-347a-421f-93c1-1c4e208b26ed",
+      "id": "d80ab4e3-1c20-426a-a88b-7bdd1215fe33",
+      "projectId": "7fdda878-ed57-4cc3-a391-1f26385591e5",
       "type": "TASK",
       "title": "T1",
       "description": "D1",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:27:03.541Z",
-      "updatedAt": "2026-03-01T02:27:03.541Z",
+      "createdAt": "2026-03-01T02:37:34.931Z",
+      "updatedAt": "2026-03-01T02:37:34.931Z",
       "history": [
         {
-          "id": "7946b901-c534-4b13-98ec-d446ac697c82",
+          "id": "5a359ed2-a4a2-4b90-a119-1de08451cff5",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:27:03.541Z"
+          "timestamp": "2026-03-01T02:37:34.931Z"
         }
       ]
     },
     {
-      "id": "568f32ad-5502-4149-b104-dbdf17509d6f",
-      "projectId": "bde6db69-347a-421f-93c1-1c4e208b26ed",
+      "id": "2f16d1c4-5a01-479c-a908-3d426dc8dafb",
+      "projectId": "7fdda878-ed57-4cc3-a391-1f26385591e5",
       "type": "TASK",
       "title": "To Update",
       "description": "D",
       "status": "IN_PROGRESS",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:27:03.545Z",
-      "updatedAt": "2026-03-01T02:27:03.548Z",
+      "createdAt": "2026-03-01T02:37:34.934Z",
+      "updatedAt": "2026-03-01T02:37:34.940Z",
       "history": [
         {
-          "id": "62251d84-879f-4c2d-968a-5ff3587a96ae",
+          "id": "5bdd2ede-8045-4480-a9d9-090b06bcb239",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:27:03.545Z"
+          "timestamp": "2026-03-01T02:37:34.934Z"
         },
         {
-          "id": "3af3ff8e-111b-446d-bdbc-be52d2c869c1",
+          "id": "de8a3303-ce39-46dc-b74b-7fdf0c2ffc31",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-01T02:27:03.548Z"
+          "timestamp": "2026-03-01T02:37:34.940Z"
         }
       ]
     },
     {
-      "id": "e775e1ea-03b3-4873-af39-5e2f7251abdd",
-      "projectId": "bde6db69-347a-421f-93c1-1c4e208b26ed",
+      "id": "84b218cb-b418-4f4d-b1d2-9c33f96ec94c",
+      "projectId": "7fdda878-ed57-4cc3-a391-1f26385591e5",
       "type": "TASK",
       "title": "No Cheat",
       "description": "D",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:27:03.550Z",
-      "updatedAt": "2026-03-01T02:27:03.550Z",
+      "createdAt": "2026-03-01T02:37:34.946Z",
+      "updatedAt": "2026-03-01T02:37:34.946Z",
       "history": [
         {
-          "id": "3367c83d-674e-4f8b-a202-e0d9d177a3bd",
+          "id": "364738ff-4e88-4bdd-9eb3-d2b8e0d9ccf2",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:27:03.551Z"
+          "timestamp": "2026-03-01T02:37:34.947Z"
         }
       ]
     },
     {
-      "id": "33c2e754-1c16-4511-9192-25f5f1e5e121",
-      "projectId": "bde6db69-347a-421f-93c1-1c4e208b26ed",
+      "id": "523b93d8-e9ab-4bc8-89d1-c3d645e8df68",
+      "projectId": "7fdda878-ed57-4cc3-a391-1f26385591e5",
       "type": "TASK",
       "title": "Verify Me",
       "description": "D",
       "status": "DONE",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:27:03.554Z",
-      "updatedAt": "2026-03-01T02:27:03.556Z",
+      "createdAt": "2026-03-01T02:37:34.951Z",
+      "updatedAt": "2026-03-01T02:37:34.953Z",
       "history": [
         {
-          "id": "4dd66c5c-9baf-4abe-86cd-df5fa6967998",
+          "id": "bdabb035-5748-4ea8-96eb-795ea82f85fa",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:27:03.554Z"
+          "timestamp": "2026-03-01T02:37:34.951Z"
         },
         {
-          "id": "85e8c1ee-869b-4035-b18a-96f8ca5f923d",
+          "id": "b26a72cd-32cb-4068-b64f-f0b505913f61",
           "fromStatus": "TODO",
           "toStatus": "DONE",
-          "timestamp": "2026-03-01T02:27:03.556Z"
+          "timestamp": "2026-03-01T02:37:34.953Z"
         }
       ]
     },
     {
-      "id": "195b21cb-dc78-4375-a014-9880e8f85248",
-      "projectId": "bde6db69-347a-421f-93c1-1c4e208b26ed",
+      "id": "a53c2bf3-3e82-4454-b803-89f7de4fe75c",
+      "projectId": "7fdda878-ed57-4cc3-a391-1f26385591e5",
       "type": "STORY",
       "title": "Parent Story",
       "description": "D",
       "status": "IN_PROGRESS",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:27:03.558Z",
-      "updatedAt": "2026-03-01T02:27:03.565Z",
+      "createdAt": "2026-03-01T02:37:34.956Z",
+      "updatedAt": "2026-03-01T02:37:34.962Z",
       "history": [
         {
-          "id": "a433fd13-25c5-4697-9b14-80dd2e23113f",
+          "id": "cd0ceb03-50d2-4978-9dc3-bb6c49ca26ee",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:27:03.558Z"
+          "timestamp": "2026-03-01T02:37:34.956Z"
         },
         {
-          "id": "72760780-3350-4560-82d3-f550b96f34da",
+          "id": "9789a5a6-3059-4e14-acb5-65667714cf95",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-01T02:27:03.565Z"
+          "timestamp": "2026-03-01T02:37:34.962Z"
         }
       ]
     },
     {
-      "id": "49545610-6927-4bbf-9300-367e4a01c79d",
-      "projectId": "bde6db69-347a-421f-93c1-1c4e208b26ed",
+      "id": "582cd1d0-7664-42cd-ab4b-2fbffe225ef6",
+      "projectId": "7fdda878-ed57-4cc3-a391-1f26385591e5",
       "type": "TASK",
       "title": "Child Task",
       "description": "D",
       "status": "IN_PROGRESS",
-      "parentId": "195b21cb-dc78-4375-a014-9880e8f85248",
+      "parentId": "a53c2bf3-3e82-4454-b803-89f7de4fe75c",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:27:03.560Z",
-      "updatedAt": "2026-03-01T02:27:03.564Z",
+      "createdAt": "2026-03-01T02:37:34.958Z",
+      "updatedAt": "2026-03-01T02:37:34.962Z",
       "history": [
         {
-          "id": "36bc1959-3997-4a83-8d4e-d77f1cb6c360",
+          "id": "5faf8b73-3f60-471a-9478-c94a9339d77a",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:27:03.560Z"
+          "timestamp": "2026-03-01T02:37:34.959Z"
         },
         {
-          "id": "1ead338d-43c0-4c42-a30f-37a5d8e5a142",
+          "id": "a87cab51-ed31-41a3-8526-f26dd71b7ea5",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-01T02:27:03.564Z"
+          "timestamp": "2026-03-01T02:37:34.962Z"
         }
       ]
     },
     {
-      "id": "ba818149-77ed-4ac2-a56f-f29f1bf42d2e",
-      "projectId": "bde6db69-347a-421f-93c1-1c4e208b26ed",
+      "id": "d21033ce-785d-474a-8f1d-dea6232fbfc1",
+      "projectId": "7fdda878-ed57-4cc3-a391-1f26385591e5",
       "type": "TASK",
       "title": "Archive Me",
       "description": "D",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:27:03.568Z",
-      "updatedAt": "2026-03-01T02:27:03.571Z",
+      "createdAt": "2026-03-01T02:37:34.966Z",
+      "updatedAt": "2026-03-01T02:37:34.971Z",
       "history": [
         {
-          "id": "4cee81b1-875c-40e9-bd73-3aacec9aa9bd",
+          "id": "a7ffd219-a8a7-4318-9bc0-17488347dc2c",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:27:03.568Z"
+          "timestamp": "2026-03-01T02:37:34.966Z"
         },
         {
-          "id": "64d31b30-2d8e-4c5c-8f6f-7331cef56a75",
+          "id": "6282cccc-f29a-4819-aab5-f3e6edae3f27",
           "fromStatus": "TODO",
           "toStatus": "ARCHIVED",
-          "timestamp": "2026-03-01T02:27:03.569Z"
+          "timestamp": "2026-03-01T02:37:34.968Z"
         },
         {
-          "id": "371d9664-8e21-4ce2-b729-ed6f9769c004",
+          "id": "aa383057-733a-4ec5-90f3-f8c29ab10e1e",
           "fromStatus": "ARCHIVED",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:27:03.571Z"
+          "timestamp": "2026-03-01T02:37:34.970Z"
         }
       ]
     },
     {
-      "id": "df6f96a1-cc99-4ed3-bf77-c636f084109d",
-      "projectId": "bde6db69-347a-421f-93c1-1c4e208b26ed",
+      "id": "8d02990d-5a74-40d2-941e-6272bc6981cc",
+      "projectId": "7fdda878-ed57-4cc3-a391-1f26385591e5",
       "type": "TASK",
       "title": "Delete Me",
       "description": "D",
       "status": "TRASHED",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:27:03.573Z",
-      "updatedAt": "2026-03-01T02:27:03.575Z",
+      "createdAt": "2026-03-01T02:37:34.973Z",
+      "updatedAt": "2026-03-01T02:37:34.975Z",
       "history": [
         {
-          "id": "95afcfa9-098c-4ee2-ab1e-5bc667d51c3f",
+          "id": "794699b0-1a04-4f3f-b4e0-770880bd5f6f",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:27:03.573Z"
+          "timestamp": "2026-03-01T02:37:34.973Z"
         },
         {
-          "id": "86591b7b-75d3-464a-86ae-839c1ab33455",
+          "id": "4ca3b363-2b59-4b17-b108-27c87bf422b2",
           "fromStatus": "TODO",
           "toStatus": "TRASHED",
-          "timestamp": "2026-03-01T02:27:03.575Z"
+          "timestamp": "2026-03-01T02:37:34.975Z"
         }
       ]
     },
     {
-      "id": "f421e500-6b7d-419b-88b8-ef2f7c636846",
-      "projectId": "bde6db69-347a-421f-93c1-1c4e208b26ed",
+      "id": "5ab155ad-c988-41e1-8745-92bc83f59fbc",
+      "projectId": "7fdda878-ed57-4cc3-a391-1f26385591e5",
       "type": "TASK",
       "title": "Archived Task",
       "description": "",
       "status": "TRASHED",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:27:03.579Z",
-      "updatedAt": "2026-03-01T02:27:03.582Z",
+      "createdAt": "2026-03-01T02:37:34.984Z",
+      "updatedAt": "2026-03-01T02:37:34.986Z",
       "history": [
         {
-          "id": "b9498ea9-4874-4943-ba05-5554095506c4",
+          "id": "7960adae-b056-4773-a4f2-9e9dd60b471b",
           "fromStatus": "TODO",
           "toStatus": "ARCHIVED",
-          "timestamp": "2026-03-01T02:27:03.579Z"
+          "timestamp": "2026-03-01T02:37:34.984Z"
         },
         {
-          "id": "4215830d-496f-4a3f-869d-ff0cf0a8ecd6",
+          "id": "d083179b-5ad4-4c9c-82e0-6f589eee4675",
           "fromStatus": "ARCHIVED",
           "toStatus": "TRASHED",
-          "timestamp": "2026-03-01T02:27:03.582Z"
+          "timestamp": "2026-03-01T02:37:34.986Z"
         }
       ]
     },
     {
-      "id": "7460d8c2-ac37-4381-9d91-778f1f8bc900",
-      "projectId": "18208e82-0f00-4ce3-89a0-254ec955cf43",
+      "id": "1276c9db-d504-4ecc-b9ca-7716898d6125",
+      "projectId": "d51eba16-1678-4289-b2e2-b5531d38cfc6",
       "type": "BUG",
       "title": "[PROJ-1] Fix login bug",
       "description": "Imported from JIRA: PROJ-1",
@@ -260,14 +260,14 @@
       "implementationPlan": "",
       "externalId": "PROJ-1",
       "externalUrl": "https://test.atlassian.net/browse/PROJ-1",
-      "createdAt": "2026-03-01T02:27:03.646Z",
-      "updatedAt": "2026-03-01T02:27:03.646Z",
+      "createdAt": "2026-03-01T02:37:35.039Z",
+      "updatedAt": "2026-03-01T02:37:35.039Z",
       "history": [
         {
-          "id": "a6026e0a-de7a-4d9b-b44d-48efae014a50",
+          "id": "cbcedcac-f633-4697-98d0-601bd96682d2",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:27:03.646Z"
+          "timestamp": "2026-03-01T02:37:35.039Z"
         }
       ]
     }

--- a/server-test-db.json
+++ b/server-test-db.json
@@ -1,258 +1,258 @@
 {
   "projects": [
     {
-      "id": "be0a9fab-3f4a-403c-bee4-ada5efb01397",
+      "id": "2ce65f57-8d43-4f7a-8254-cd28304b9b00",
       "name": "P1 Updated",
       "description": "",
-      "createdAt": "2026-03-01T03:00:19.608Z",
-      "updatedAt": "2026-03-01T03:00:19.625Z"
+      "createdAt": "2026-03-01T03:01:11.946Z",
+      "updatedAt": "2026-03-01T03:01:11.961Z"
     },
     {
-      "id": "114f7ac2-fbc6-4cbf-821d-59e49b8398ef",
+      "id": "fa60734c-726e-47d9-829e-f7f05868ef98",
       "name": "Item Test",
       "description": "",
-      "createdAt": "2026-03-01T03:00:19.658Z",
-      "updatedAt": "2026-03-01T03:00:19.658Z"
+      "createdAt": "2026-03-01T03:01:11.972Z",
+      "updatedAt": "2026-03-01T03:01:11.972Z"
     },
     {
-      "id": "997191c5-de29-43f9-a70b-c5393c9698fe",
+      "id": "c87259e3-c28c-4de0-9fc2-b74191f610d2",
       "name": "JIRA Import Test",
       "description": "",
-      "createdAt": "2026-03-01T03:00:19.787Z",
-      "updatedAt": "2026-03-01T03:00:19.787Z"
+      "createdAt": "2026-03-01T03:01:12.107Z",
+      "updatedAt": "2026-03-01T03:01:12.107Z"
     },
     {
-      "id": "2e9f21ac-b42d-47c5-bb82-9aa549832571",
+      "id": "9ffd0f4f-2d08-492b-a9ef-f9ae0f9b8aac",
       "name": "JIRA Err Test",
       "description": "",
-      "createdAt": "2026-03-01T03:00:19.792Z",
-      "updatedAt": "2026-03-01T03:00:19.792Z"
+      "createdAt": "2026-03-01T03:01:12.117Z",
+      "updatedAt": "2026-03-01T03:01:12.117Z"
     }
   ],
   "items": [
     {
-      "id": "af359794-8745-418e-89c1-a4fd0ac0d6ac",
-      "projectId": "114f7ac2-fbc6-4cbf-821d-59e49b8398ef",
+      "id": "9c99206f-a62d-42c7-b324-2a14b3c13ccc",
+      "projectId": "fa60734c-726e-47d9-829e-f7f05868ef98",
       "type": "TASK",
       "title": "T1",
       "description": "D1",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T03:00:19.665Z",
-      "updatedAt": "2026-03-01T03:00:19.665Z",
+      "createdAt": "2026-03-01T03:01:11.974Z",
+      "updatedAt": "2026-03-01T03:01:11.974Z",
       "history": [
         {
-          "id": "856f6103-dfa1-480e-a4ed-f04361df9ab5",
+          "id": "b75a5612-b41f-41f6-8325-bf0824ab2dff",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T03:00:19.665Z"
+          "timestamp": "2026-03-01T03:01:11.975Z"
         }
       ]
     },
     {
-      "id": "46b47d87-0d97-4b59-b267-6c13c493ef63",
-      "projectId": "114f7ac2-fbc6-4cbf-821d-59e49b8398ef",
+      "id": "4f67aa60-5489-4e48-9c52-628cb803f1b1",
+      "projectId": "fa60734c-726e-47d9-829e-f7f05868ef98",
       "type": "TASK",
       "title": "To Update",
       "description": "D",
       "status": "IN_PROGRESS",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T03:00:19.667Z",
-      "updatedAt": "2026-03-01T03:00:19.673Z",
+      "createdAt": "2026-03-01T03:01:11.977Z",
+      "updatedAt": "2026-03-01T03:01:11.979Z",
       "history": [
         {
-          "id": "93bdf2d1-8ccc-4973-9d78-a74c8292c29c",
+          "id": "83eba0d1-9836-4188-aa16-89ebfe562005",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T03:00:19.668Z"
+          "timestamp": "2026-03-01T03:01:11.977Z"
         },
         {
-          "id": "78eee4fd-220a-492a-8855-1c1828174251",
+          "id": "faf738c1-2548-4f6e-a9a5-e0d0048a44ae",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-01T03:00:19.673Z"
+          "timestamp": "2026-03-01T03:01:11.979Z"
         }
       ]
     },
     {
-      "id": "5cd0a8f5-e2c3-4c42-92d8-9ed93c2f7bc2",
-      "projectId": "114f7ac2-fbc6-4cbf-821d-59e49b8398ef",
+      "id": "d854fde5-fd5b-4f09-8992-6ae6bad44f9b",
+      "projectId": "fa60734c-726e-47d9-829e-f7f05868ef98",
       "type": "TASK",
       "title": "No Cheat",
       "description": "D",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T03:00:19.681Z",
-      "updatedAt": "2026-03-01T03:00:19.681Z",
+      "createdAt": "2026-03-01T03:01:11.981Z",
+      "updatedAt": "2026-03-01T03:01:11.981Z",
       "history": [
         {
-          "id": "aae6ba15-9557-4dad-81bb-737c16b4d15b",
+          "id": "7964f681-dd4a-4cba-a4de-0ca8ed7f7921",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T03:00:19.681Z"
+          "timestamp": "2026-03-01T03:01:11.981Z"
         }
       ]
     },
     {
-      "id": "5d7934eb-8a32-47ee-90d5-a8cb8ee1287e",
-      "projectId": "114f7ac2-fbc6-4cbf-821d-59e49b8398ef",
+      "id": "8f885ed7-84ba-40cd-94ee-491156ee81f3",
+      "projectId": "fa60734c-726e-47d9-829e-f7f05868ef98",
       "type": "TASK",
       "title": "Verify Me",
       "description": "D",
       "status": "DONE",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T03:00:19.686Z",
-      "updatedAt": "2026-03-01T03:00:19.692Z",
+      "createdAt": "2026-03-01T03:01:11.985Z",
+      "updatedAt": "2026-03-01T03:01:11.988Z",
       "history": [
         {
-          "id": "e0adc616-ea7f-4dc9-8df6-72aa1d849888",
+          "id": "19efb4d6-2a76-4baa-a07a-c9741bc583f3",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T03:00:19.686Z"
+          "timestamp": "2026-03-01T03:01:11.985Z"
         },
         {
-          "id": "3eda31ac-3d57-4055-9400-a1e9f59dcab4",
+          "id": "2e36e35d-5df1-481d-9c96-5d332d13f9e8",
           "fromStatus": "TODO",
           "toStatus": "DONE",
-          "timestamp": "2026-03-01T03:00:19.692Z"
+          "timestamp": "2026-03-01T03:01:11.988Z"
         }
       ]
     },
     {
-      "id": "b9d62ce5-d5f7-41b5-9c22-fa61b66bc1d2",
-      "projectId": "114f7ac2-fbc6-4cbf-821d-59e49b8398ef",
+      "id": "bf4fc56b-dc82-40d4-b320-e1998f9a55ef",
+      "projectId": "fa60734c-726e-47d9-829e-f7f05868ef98",
       "type": "STORY",
       "title": "Parent Story",
       "description": "D",
       "status": "IN_PROGRESS",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T03:00:19.695Z",
-      "updatedAt": "2026-03-01T03:00:19.699Z",
+      "createdAt": "2026-03-01T03:01:11.990Z",
+      "updatedAt": "2026-03-01T03:01:11.994Z",
       "history": [
         {
-          "id": "9ded9af7-4ac1-4f98-9c17-794626874d6b",
+          "id": "1611a0ab-e07b-41f6-914c-47ea220a1185",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T03:00:19.695Z"
+          "timestamp": "2026-03-01T03:01:11.990Z"
         },
         {
-          "id": "dc45cf4c-9eca-430c-ab4f-2f5cf80af145",
+          "id": "b5544f6c-4fb5-43ea-af31-d9ae387f98e0",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-01T03:00:19.699Z"
+          "timestamp": "2026-03-01T03:01:11.994Z"
         }
       ]
     },
     {
-      "id": "fbf2f3bb-7d1a-4281-b8bf-65d4b5948532",
-      "projectId": "114f7ac2-fbc6-4cbf-821d-59e49b8398ef",
+      "id": "abc7dd20-b850-4e5c-99da-e87767aa3f92",
+      "projectId": "fa60734c-726e-47d9-829e-f7f05868ef98",
       "type": "TASK",
       "title": "Child Task",
       "description": "D",
       "status": "IN_PROGRESS",
-      "parentId": "b9d62ce5-d5f7-41b5-9c22-fa61b66bc1d2",
+      "parentId": "bf4fc56b-dc82-40d4-b320-e1998f9a55ef",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T03:00:19.697Z",
-      "updatedAt": "2026-03-01T03:00:19.699Z",
+      "createdAt": "2026-03-01T03:01:11.992Z",
+      "updatedAt": "2026-03-01T03:01:11.993Z",
       "history": [
         {
-          "id": "ed020366-7ff8-4c86-a231-e9cf870f3ce0",
+          "id": "0fa4ad82-725d-48b8-b6a2-026206f2b18a",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T03:00:19.697Z"
+          "timestamp": "2026-03-01T03:01:11.992Z"
         },
         {
-          "id": "c8a61b62-c2f5-4399-999a-2bfdfbb110d0",
+          "id": "1e8ad758-0ec0-484d-a16b-123f73497690",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-01T03:00:19.699Z"
+          "timestamp": "2026-03-01T03:01:11.993Z"
         }
       ]
     },
     {
-      "id": "2c1c0bf5-91d9-44ab-af68-2532520b9c3d",
-      "projectId": "114f7ac2-fbc6-4cbf-821d-59e49b8398ef",
+      "id": "958d74de-2956-4cd5-ae62-858419632ae9",
+      "projectId": "fa60734c-726e-47d9-829e-f7f05868ef98",
       "type": "TASK",
       "title": "Archive Me",
       "description": "D",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T03:00:19.702Z",
-      "updatedAt": "2026-03-01T03:00:19.706Z",
+      "createdAt": "2026-03-01T03:01:11.996Z",
+      "updatedAt": "2026-03-01T03:01:12.001Z",
       "history": [
         {
-          "id": "e2c91acd-0cc3-4f33-9695-38004d587738",
+          "id": "62f4b721-564b-47da-a822-94b078983009",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T03:00:19.702Z"
+          "timestamp": "2026-03-01T03:01:11.996Z"
         },
         {
-          "id": "b78e39d5-d05b-4016-91d7-ed17a0e615ea",
+          "id": "d823fe13-6180-4b9b-b34d-2ccba82c004e",
           "fromStatus": "TODO",
           "toStatus": "ARCHIVED",
-          "timestamp": "2026-03-01T03:00:19.704Z"
+          "timestamp": "2026-03-01T03:01:11.998Z"
         },
         {
-          "id": "73465672-1432-4db2-9198-11d896a42056",
+          "id": "0ebd00e0-e55f-4e6c-9c33-08e673d0d7a9",
           "fromStatus": "ARCHIVED",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T03:00:19.705Z"
+          "timestamp": "2026-03-01T03:01:12.000Z"
         }
       ]
     },
     {
-      "id": "69a5b4da-d994-4b94-b8b7-546ff83960ba",
-      "projectId": "114f7ac2-fbc6-4cbf-821d-59e49b8398ef",
+      "id": "a7bac452-4f51-4219-a60e-5d18fc575eeb",
+      "projectId": "fa60734c-726e-47d9-829e-f7f05868ef98",
       "type": "TASK",
       "title": "Delete Me",
       "description": "D",
       "status": "TRASHED",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T03:00:19.707Z",
-      "updatedAt": "2026-03-01T03:00:19.709Z",
+      "createdAt": "2026-03-01T03:01:12.004Z",
+      "updatedAt": "2026-03-01T03:01:12.006Z",
       "history": [
         {
-          "id": "e388fb9b-76c8-49d2-908f-adfa4ce54eac",
+          "id": "b30ec59a-db0b-4930-bcda-01574823cfc3",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T03:00:19.707Z"
+          "timestamp": "2026-03-01T03:01:12.004Z"
         },
         {
-          "id": "8e7b12c0-f568-428a-93c5-cee999f18c79",
+          "id": "a0f4b89c-ad2f-4f7a-bce4-8a2f346136ce",
           "fromStatus": "TODO",
           "toStatus": "TRASHED",
-          "timestamp": "2026-03-01T03:00:19.709Z"
+          "timestamp": "2026-03-01T03:01:12.006Z"
         }
       ]
     },
     {
-      "id": "4108f8ca-6aaf-40a9-8443-78b1cbb7972c",
-      "projectId": "114f7ac2-fbc6-4cbf-821d-59e49b8398ef",
+      "id": "c90423dc-224b-4354-98e2-82ace553bc3c",
+      "projectId": "fa60734c-726e-47d9-829e-f7f05868ef98",
       "type": "TASK",
       "title": "Archived Task",
       "description": "",
       "status": "TRASHED",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T03:00:19.716Z",
-      "updatedAt": "2026-03-01T03:00:19.719Z",
+      "createdAt": "2026-03-01T03:01:12.010Z",
+      "updatedAt": "2026-03-01T03:01:12.012Z",
       "history": [
         {
-          "id": "ccc8e254-e640-4104-a0d3-cf64c7888115",
+          "id": "5891eea8-3a8a-49f2-884c-c527a13a0c53",
           "fromStatus": "TODO",
           "toStatus": "ARCHIVED",
-          "timestamp": "2026-03-01T03:00:19.716Z"
+          "timestamp": "2026-03-01T03:01:12.010Z"
         },
         {
-          "id": "24026ca6-bce9-4e35-8781-7e8cd69c2387",
+          "id": "b6c7e08d-923d-4b76-9af9-d25883f9f30a",
           "fromStatus": "ARCHIVED",
           "toStatus": "TRASHED",
-          "timestamp": "2026-03-01T03:00:19.719Z"
+          "timestamp": "2026-03-01T03:01:12.012Z"
         }
       ]
     },
     {
-      "id": "91e228ef-ed9e-4cb0-8ad3-9f2b2d78c92c",
-      "projectId": "997191c5-de29-43f9-a70b-c5393c9698fe",
+      "id": "63b4e4d3-d871-4204-af6b-b3a8ec1df16f",
+      "projectId": "c87259e3-c28c-4de0-9fc2-b74191f610d2",
       "type": "BUG",
       "title": "[PROJ-1] Fix login bug",
       "description": "Imported from JIRA: PROJ-1",
@@ -260,14 +260,14 @@
       "implementationPlan": "",
       "externalId": "PROJ-1",
       "externalUrl": "https://test.atlassian.net/browse/PROJ-1",
-      "createdAt": "2026-03-01T03:00:19.788Z",
-      "updatedAt": "2026-03-01T03:00:19.788Z",
+      "createdAt": "2026-03-01T03:01:12.110Z",
+      "updatedAt": "2026-03-01T03:01:12.110Z",
       "history": [
         {
-          "id": "e1834bb0-b9cf-4e63-b30b-600d6a2ec93f",
+          "id": "abc3691b-f4d1-4452-b847-cd0239517f0a",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T03:00:19.788Z"
+          "timestamp": "2026-03-01T03:01:12.110Z"
         }
       ]
     }

--- a/server-test-db.json
+++ b/server-test-db.json
@@ -1,258 +1,258 @@
 {
   "projects": [
     {
-      "id": "16113814-9cdc-44e7-b7ab-d278bc789870",
+      "id": "d72192eb-8191-4b1a-8f03-294314ace2af",
       "name": "P1 Updated",
       "description": "",
-      "createdAt": "2026-03-01T02:26:43.278Z",
-      "updatedAt": "2026-03-01T02:26:43.294Z"
+      "createdAt": "2026-03-01T02:27:03.498Z",
+      "updatedAt": "2026-03-01T02:27:03.514Z"
     },
     {
-      "id": "5e7f1513-1100-4e9f-b47f-c0ead2d47914",
+      "id": "bde6db69-347a-421f-93c1-1c4e208b26ed",
       "name": "Item Test",
       "description": "",
-      "createdAt": "2026-03-01T02:26:43.305Z",
-      "updatedAt": "2026-03-01T02:26:43.305Z"
+      "createdAt": "2026-03-01T02:27:03.539Z",
+      "updatedAt": "2026-03-01T02:27:03.539Z"
     },
     {
-      "id": "114fda9c-d880-4a82-85ca-e40e3df1446a",
+      "id": "18208e82-0f00-4ce3-89a0-254ec955cf43",
       "name": "JIRA Import Test",
       "description": "",
-      "createdAt": "2026-03-01T02:26:43.398Z",
-      "updatedAt": "2026-03-01T02:26:43.398Z"
+      "createdAt": "2026-03-01T02:27:03.644Z",
+      "updatedAt": "2026-03-01T02:27:03.644Z"
     },
     {
-      "id": "fdffcbde-8e14-4825-b1f0-a8c6ed29e759",
+      "id": "88ffa9f1-9db5-4602-988c-d1a9ece6e642",
       "name": "JIRA Err Test",
       "description": "",
-      "createdAt": "2026-03-01T02:26:43.403Z",
-      "updatedAt": "2026-03-01T02:26:43.403Z"
+      "createdAt": "2026-03-01T02:27:03.673Z",
+      "updatedAt": "2026-03-01T02:27:03.673Z"
     }
   ],
   "items": [
     {
-      "id": "2463d980-4bf3-46dd-ba4f-067eb913da93",
-      "projectId": "5e7f1513-1100-4e9f-b47f-c0ead2d47914",
+      "id": "83e15b8b-0b1b-442d-afe2-4eb9831f1bd4",
+      "projectId": "bde6db69-347a-421f-93c1-1c4e208b26ed",
       "type": "TASK",
       "title": "T1",
       "description": "D1",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:26:43.307Z",
-      "updatedAt": "2026-03-01T02:26:43.307Z",
+      "createdAt": "2026-03-01T02:27:03.541Z",
+      "updatedAt": "2026-03-01T02:27:03.541Z",
       "history": [
         {
-          "id": "3a40faaa-2e99-4d6b-820f-3d4c877d6aaa",
+          "id": "7946b901-c534-4b13-98ec-d446ac697c82",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:26:43.308Z"
+          "timestamp": "2026-03-01T02:27:03.541Z"
         }
       ]
     },
     {
-      "id": "dd80a041-bbbe-40ee-8b28-f2e8ee358433",
-      "projectId": "5e7f1513-1100-4e9f-b47f-c0ead2d47914",
+      "id": "568f32ad-5502-4149-b104-dbdf17509d6f",
+      "projectId": "bde6db69-347a-421f-93c1-1c4e208b26ed",
       "type": "TASK",
       "title": "To Update",
       "description": "D",
       "status": "IN_PROGRESS",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:26:43.310Z",
-      "updatedAt": "2026-03-01T02:26:43.314Z",
+      "createdAt": "2026-03-01T02:27:03.545Z",
+      "updatedAt": "2026-03-01T02:27:03.548Z",
       "history": [
         {
-          "id": "fd185303-2a43-407c-a535-37e69dd2e336",
+          "id": "62251d84-879f-4c2d-968a-5ff3587a96ae",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:26:43.311Z"
+          "timestamp": "2026-03-01T02:27:03.545Z"
         },
         {
-          "id": "15a3a748-da4c-401c-bdbd-bab0b1be8508",
+          "id": "3af3ff8e-111b-446d-bdbc-be52d2c869c1",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-01T02:26:43.314Z"
+          "timestamp": "2026-03-01T02:27:03.548Z"
         }
       ]
     },
     {
-      "id": "ed20deca-32a2-4479-bcfb-442b08a1b045",
-      "projectId": "5e7f1513-1100-4e9f-b47f-c0ead2d47914",
+      "id": "e775e1ea-03b3-4873-af39-5e2f7251abdd",
+      "projectId": "bde6db69-347a-421f-93c1-1c4e208b26ed",
       "type": "TASK",
       "title": "No Cheat",
       "description": "D",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:26:43.318Z",
-      "updatedAt": "2026-03-01T02:26:43.318Z",
+      "createdAt": "2026-03-01T02:27:03.550Z",
+      "updatedAt": "2026-03-01T02:27:03.550Z",
       "history": [
         {
-          "id": "10c0a6be-6d9b-418a-9481-b377439d71b9",
+          "id": "3367c83d-674e-4f8b-a202-e0d9d177a3bd",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:26:43.318Z"
+          "timestamp": "2026-03-01T02:27:03.551Z"
         }
       ]
     },
     {
-      "id": "b31c6c57-51c8-491c-9eed-6e35575e2842",
-      "projectId": "5e7f1513-1100-4e9f-b47f-c0ead2d47914",
+      "id": "33c2e754-1c16-4511-9192-25f5f1e5e121",
+      "projectId": "bde6db69-347a-421f-93c1-1c4e208b26ed",
       "type": "TASK",
       "title": "Verify Me",
       "description": "D",
       "status": "DONE",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:26:43.324Z",
-      "updatedAt": "2026-03-01T02:26:43.326Z",
+      "createdAt": "2026-03-01T02:27:03.554Z",
+      "updatedAt": "2026-03-01T02:27:03.556Z",
       "history": [
         {
-          "id": "ce369028-900c-423e-962f-cdaa49b72502",
+          "id": "4dd66c5c-9baf-4abe-86cd-df5fa6967998",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:26:43.324Z"
+          "timestamp": "2026-03-01T02:27:03.554Z"
         },
         {
-          "id": "5151a43f-8053-4544-b93c-48d3fa7d4ebd",
+          "id": "85e8c1ee-869b-4035-b18a-96f8ca5f923d",
           "fromStatus": "TODO",
           "toStatus": "DONE",
-          "timestamp": "2026-03-01T02:26:43.326Z"
+          "timestamp": "2026-03-01T02:27:03.556Z"
         }
       ]
     },
     {
-      "id": "65f29342-88b8-4771-88ef-af583d8c3c4f",
-      "projectId": "5e7f1513-1100-4e9f-b47f-c0ead2d47914",
+      "id": "195b21cb-dc78-4375-a014-9880e8f85248",
+      "projectId": "bde6db69-347a-421f-93c1-1c4e208b26ed",
       "type": "STORY",
       "title": "Parent Story",
       "description": "D",
       "status": "IN_PROGRESS",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:26:43.329Z",
-      "updatedAt": "2026-03-01T02:26:43.334Z",
+      "createdAt": "2026-03-01T02:27:03.558Z",
+      "updatedAt": "2026-03-01T02:27:03.565Z",
       "history": [
         {
-          "id": "46ea4dc7-7dc4-4352-803f-1437fe098c90",
+          "id": "a433fd13-25c5-4697-9b14-80dd2e23113f",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:26:43.329Z"
+          "timestamp": "2026-03-01T02:27:03.558Z"
         },
         {
-          "id": "abd5e470-902c-4bd8-a979-d6fb3adaef99",
+          "id": "72760780-3350-4560-82d3-f550b96f34da",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-01T02:26:43.334Z"
+          "timestamp": "2026-03-01T02:27:03.565Z"
         }
       ]
     },
     {
-      "id": "209d02cf-cc80-49d1-b481-2eb688db16a2",
-      "projectId": "5e7f1513-1100-4e9f-b47f-c0ead2d47914",
+      "id": "49545610-6927-4bbf-9300-367e4a01c79d",
+      "projectId": "bde6db69-347a-421f-93c1-1c4e208b26ed",
       "type": "TASK",
       "title": "Child Task",
       "description": "D",
       "status": "IN_PROGRESS",
-      "parentId": "65f29342-88b8-4771-88ef-af583d8c3c4f",
+      "parentId": "195b21cb-dc78-4375-a014-9880e8f85248",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:26:43.331Z",
-      "updatedAt": "2026-03-01T02:26:43.334Z",
+      "createdAt": "2026-03-01T02:27:03.560Z",
+      "updatedAt": "2026-03-01T02:27:03.564Z",
       "history": [
         {
-          "id": "7c8ce40f-19be-4fa1-99cf-72a2827f19bf",
+          "id": "36bc1959-3997-4a83-8d4e-d77f1cb6c360",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:26:43.332Z"
+          "timestamp": "2026-03-01T02:27:03.560Z"
         },
         {
-          "id": "b6a3fcfd-8aca-4ea6-8869-67d9dbafe41a",
+          "id": "1ead338d-43c0-4c42-a30f-37a5d8e5a142",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-01T02:26:43.334Z"
+          "timestamp": "2026-03-01T02:27:03.564Z"
         }
       ]
     },
     {
-      "id": "f3c20985-ecb0-4e12-8c94-4f8c7f726a48",
-      "projectId": "5e7f1513-1100-4e9f-b47f-c0ead2d47914",
+      "id": "ba818149-77ed-4ac2-a56f-f29f1bf42d2e",
+      "projectId": "bde6db69-347a-421f-93c1-1c4e208b26ed",
       "type": "TASK",
       "title": "Archive Me",
       "description": "D",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:26:43.337Z",
-      "updatedAt": "2026-03-01T02:26:43.341Z",
+      "createdAt": "2026-03-01T02:27:03.568Z",
+      "updatedAt": "2026-03-01T02:27:03.571Z",
       "history": [
         {
-          "id": "63bee8e4-2c8c-4e39-88a2-9ad05ccb222b",
+          "id": "4cee81b1-875c-40e9-bd73-3aacec9aa9bd",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:26:43.337Z"
+          "timestamp": "2026-03-01T02:27:03.568Z"
         },
         {
-          "id": "042b8f6c-855f-427d-9055-ce31f8c881bc",
+          "id": "64d31b30-2d8e-4c5c-8f6f-7331cef56a75",
           "fromStatus": "TODO",
           "toStatus": "ARCHIVED",
-          "timestamp": "2026-03-01T02:26:43.339Z"
+          "timestamp": "2026-03-01T02:27:03.569Z"
         },
         {
-          "id": "221335a4-0486-4a29-a655-de4183187987",
+          "id": "371d9664-8e21-4ce2-b729-ed6f9769c004",
           "fromStatus": "ARCHIVED",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:26:43.341Z"
+          "timestamp": "2026-03-01T02:27:03.571Z"
         }
       ]
     },
     {
-      "id": "b60728e3-2702-48cf-a2b4-4d4c3e6e6139",
-      "projectId": "5e7f1513-1100-4e9f-b47f-c0ead2d47914",
+      "id": "df6f96a1-cc99-4ed3-bf77-c636f084109d",
+      "projectId": "bde6db69-347a-421f-93c1-1c4e208b26ed",
       "type": "TASK",
       "title": "Delete Me",
       "description": "D",
       "status": "TRASHED",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:26:43.351Z",
-      "updatedAt": "2026-03-01T02:26:43.354Z",
+      "createdAt": "2026-03-01T02:27:03.573Z",
+      "updatedAt": "2026-03-01T02:27:03.575Z",
       "history": [
         {
-          "id": "fb3196a9-9355-486c-854d-50e0179d91f4",
+          "id": "95afcfa9-098c-4ee2-ab1e-5bc667d51c3f",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:26:43.352Z"
+          "timestamp": "2026-03-01T02:27:03.573Z"
         },
         {
-          "id": "e0f28a0d-4850-44f4-af0c-618b1b8f2119",
+          "id": "86591b7b-75d3-464a-86ae-839c1ab33455",
           "fromStatus": "TODO",
           "toStatus": "TRASHED",
-          "timestamp": "2026-03-01T02:26:43.354Z"
+          "timestamp": "2026-03-01T02:27:03.575Z"
         }
       ]
     },
     {
-      "id": "4873f691-f8b9-4812-8d59-6158c859756e",
-      "projectId": "5e7f1513-1100-4e9f-b47f-c0ead2d47914",
+      "id": "f421e500-6b7d-419b-88b8-ef2f7c636846",
+      "projectId": "bde6db69-347a-421f-93c1-1c4e208b26ed",
       "type": "TASK",
       "title": "Archived Task",
       "description": "",
       "status": "TRASHED",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:26:43.358Z",
-      "updatedAt": "2026-03-01T02:26:43.360Z",
+      "createdAt": "2026-03-01T02:27:03.579Z",
+      "updatedAt": "2026-03-01T02:27:03.582Z",
       "history": [
         {
-          "id": "eab60961-90b0-4afc-95a5-28a07d01c5f7",
+          "id": "b9498ea9-4874-4943-ba05-5554095506c4",
           "fromStatus": "TODO",
           "toStatus": "ARCHIVED",
-          "timestamp": "2026-03-01T02:26:43.358Z"
+          "timestamp": "2026-03-01T02:27:03.579Z"
         },
         {
-          "id": "0db8b575-e27d-40a3-8b2e-047475d0e6db",
+          "id": "4215830d-496f-4a3f-869d-ff0cf0a8ecd6",
           "fromStatus": "ARCHIVED",
           "toStatus": "TRASHED",
-          "timestamp": "2026-03-01T02:26:43.360Z"
+          "timestamp": "2026-03-01T02:27:03.582Z"
         }
       ]
     },
     {
-      "id": "ab1fbc61-6725-4d3d-a792-6d3edf61f803",
-      "projectId": "114fda9c-d880-4a82-85ca-e40e3df1446a",
+      "id": "7460d8c2-ac37-4381-9d91-778f1f8bc900",
+      "projectId": "18208e82-0f00-4ce3-89a0-254ec955cf43",
       "type": "BUG",
       "title": "[PROJ-1] Fix login bug",
       "description": "Imported from JIRA: PROJ-1",
@@ -260,14 +260,14 @@
       "implementationPlan": "",
       "externalId": "PROJ-1",
       "externalUrl": "https://test.atlassian.net/browse/PROJ-1",
-      "createdAt": "2026-03-01T02:26:43.399Z",
-      "updatedAt": "2026-03-01T02:26:43.399Z",
+      "createdAt": "2026-03-01T02:27:03.646Z",
+      "updatedAt": "2026-03-01T02:27:03.646Z",
       "history": [
         {
-          "id": "77d373a3-9a76-499c-bc3e-dfbb8bd80731",
+          "id": "a6026e0a-de7a-4d9b-b44d-48efae014a50",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:26:43.399Z"
+          "timestamp": "2026-03-01T02:27:03.646Z"
         }
       ]
     }

--- a/server-test-db.json
+++ b/server-test-db.json
@@ -1,258 +1,258 @@
 {
   "projects": [
     {
-      "id": "2ce65f57-8d43-4f7a-8254-cd28304b9b00",
+      "id": "55598749-9080-4a91-8cc0-8566f3fab251",
       "name": "P1 Updated",
       "description": "",
-      "createdAt": "2026-03-01T03:01:11.946Z",
-      "updatedAt": "2026-03-01T03:01:11.961Z"
+      "createdAt": "2026-03-01T03:05:03.138Z",
+      "updatedAt": "2026-03-01T03:05:03.152Z"
     },
     {
-      "id": "fa60734c-726e-47d9-829e-f7f05868ef98",
+      "id": "05cf87b1-6a87-418b-8f11-5794bb29e303",
       "name": "Item Test",
       "description": "",
-      "createdAt": "2026-03-01T03:01:11.972Z",
-      "updatedAt": "2026-03-01T03:01:11.972Z"
+      "createdAt": "2026-03-01T03:05:03.175Z",
+      "updatedAt": "2026-03-01T03:05:03.175Z"
     },
     {
-      "id": "c87259e3-c28c-4de0-9fc2-b74191f610d2",
+      "id": "33096a7a-3b51-4615-b074-43d8e48a3933",
       "name": "JIRA Import Test",
       "description": "",
-      "createdAt": "2026-03-01T03:01:12.107Z",
-      "updatedAt": "2026-03-01T03:01:12.107Z"
+      "createdAt": "2026-03-01T03:05:03.270Z",
+      "updatedAt": "2026-03-01T03:05:03.270Z"
     },
     {
-      "id": "9ffd0f4f-2d08-492b-a9ef-f9ae0f9b8aac",
+      "id": "951e3d75-ef1b-4bfc-b632-1ebab55bbc7f",
       "name": "JIRA Err Test",
       "description": "",
-      "createdAt": "2026-03-01T03:01:12.117Z",
-      "updatedAt": "2026-03-01T03:01:12.117Z"
+      "createdAt": "2026-03-01T03:05:03.274Z",
+      "updatedAt": "2026-03-01T03:05:03.274Z"
     }
   ],
   "items": [
     {
-      "id": "9c99206f-a62d-42c7-b324-2a14b3c13ccc",
-      "projectId": "fa60734c-726e-47d9-829e-f7f05868ef98",
+      "id": "fdfc3d4b-77ba-42de-a22b-eb5593c266f3",
+      "projectId": "05cf87b1-6a87-418b-8f11-5794bb29e303",
       "type": "TASK",
       "title": "T1",
       "description": "D1",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T03:01:11.974Z",
-      "updatedAt": "2026-03-01T03:01:11.974Z",
+      "createdAt": "2026-03-01T03:05:03.181Z",
+      "updatedAt": "2026-03-01T03:05:03.181Z",
       "history": [
         {
-          "id": "b75a5612-b41f-41f6-8325-bf0824ab2dff",
+          "id": "aac458bc-c1a9-43b2-b7f1-37d7c374ad3e",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T03:01:11.975Z"
+          "timestamp": "2026-03-01T03:05:03.182Z"
         }
       ]
     },
     {
-      "id": "4f67aa60-5489-4e48-9c52-628cb803f1b1",
-      "projectId": "fa60734c-726e-47d9-829e-f7f05868ef98",
+      "id": "4ae50b06-6c80-4934-adef-f868fe87dc04",
+      "projectId": "05cf87b1-6a87-418b-8f11-5794bb29e303",
       "type": "TASK",
       "title": "To Update",
       "description": "D",
       "status": "IN_PROGRESS",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T03:01:11.977Z",
-      "updatedAt": "2026-03-01T03:01:11.979Z",
+      "createdAt": "2026-03-01T03:05:03.184Z",
+      "updatedAt": "2026-03-01T03:05:03.187Z",
       "history": [
         {
-          "id": "83eba0d1-9836-4188-aa16-89ebfe562005",
+          "id": "2902d99a-773a-42f5-baec-9024d6ab471a",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T03:01:11.977Z"
+          "timestamp": "2026-03-01T03:05:03.184Z"
         },
         {
-          "id": "faf738c1-2548-4f6e-a9a5-e0d0048a44ae",
+          "id": "49eb6348-ddaf-4fc3-9779-15b333d0ddb8",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-01T03:01:11.979Z"
+          "timestamp": "2026-03-01T03:05:03.187Z"
         }
       ]
     },
     {
-      "id": "d854fde5-fd5b-4f09-8992-6ae6bad44f9b",
-      "projectId": "fa60734c-726e-47d9-829e-f7f05868ef98",
+      "id": "ebedc6bb-7e7a-42e9-8050-30bed9ad2fe3",
+      "projectId": "05cf87b1-6a87-418b-8f11-5794bb29e303",
       "type": "TASK",
       "title": "No Cheat",
       "description": "D",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T03:01:11.981Z",
-      "updatedAt": "2026-03-01T03:01:11.981Z",
+      "createdAt": "2026-03-01T03:05:03.189Z",
+      "updatedAt": "2026-03-01T03:05:03.189Z",
       "history": [
         {
-          "id": "7964f681-dd4a-4cba-a4de-0ca8ed7f7921",
+          "id": "44c3fd6a-8ca2-4d95-967b-b5d121b76eee",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T03:01:11.981Z"
+          "timestamp": "2026-03-01T03:05:03.190Z"
         }
       ]
     },
     {
-      "id": "8f885ed7-84ba-40cd-94ee-491156ee81f3",
-      "projectId": "fa60734c-726e-47d9-829e-f7f05868ef98",
+      "id": "ba604f0a-58d5-4742-b9a2-67f999ca0f9c",
+      "projectId": "05cf87b1-6a87-418b-8f11-5794bb29e303",
       "type": "TASK",
       "title": "Verify Me",
       "description": "D",
       "status": "DONE",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T03:01:11.985Z",
-      "updatedAt": "2026-03-01T03:01:11.988Z",
+      "createdAt": "2026-03-01T03:05:03.193Z",
+      "updatedAt": "2026-03-01T03:05:03.195Z",
       "history": [
         {
-          "id": "19efb4d6-2a76-4baa-a07a-c9741bc583f3",
+          "id": "27b8aab4-85f4-427e-8fdb-08ad2b90eb80",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T03:01:11.985Z"
+          "timestamp": "2026-03-01T03:05:03.193Z"
         },
         {
-          "id": "2e36e35d-5df1-481d-9c96-5d332d13f9e8",
+          "id": "1c235a10-789a-4429-91e8-fc1bd8ffb241",
           "fromStatus": "TODO",
           "toStatus": "DONE",
-          "timestamp": "2026-03-01T03:01:11.988Z"
+          "timestamp": "2026-03-01T03:05:03.195Z"
         }
       ]
     },
     {
-      "id": "bf4fc56b-dc82-40d4-b320-e1998f9a55ef",
-      "projectId": "fa60734c-726e-47d9-829e-f7f05868ef98",
+      "id": "2622b961-4369-4ab6-b391-03b41fd2f0e0",
+      "projectId": "05cf87b1-6a87-418b-8f11-5794bb29e303",
       "type": "STORY",
       "title": "Parent Story",
       "description": "D",
       "status": "IN_PROGRESS",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T03:01:11.990Z",
-      "updatedAt": "2026-03-01T03:01:11.994Z",
+      "createdAt": "2026-03-01T03:05:03.205Z",
+      "updatedAt": "2026-03-01T03:05:03.211Z",
       "history": [
         {
-          "id": "1611a0ab-e07b-41f6-914c-47ea220a1185",
+          "id": "d577d31e-0dbf-48b9-858f-ded9b679a0da",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T03:01:11.990Z"
+          "timestamp": "2026-03-01T03:05:03.205Z"
         },
         {
-          "id": "b5544f6c-4fb5-43ea-af31-d9ae387f98e0",
+          "id": "f4dc35ec-4d0e-4e36-9f6c-c94789e813f2",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-01T03:01:11.994Z"
+          "timestamp": "2026-03-01T03:05:03.211Z"
         }
       ]
     },
     {
-      "id": "abc7dd20-b850-4e5c-99da-e87767aa3f92",
-      "projectId": "fa60734c-726e-47d9-829e-f7f05868ef98",
+      "id": "5a91f33d-c87a-4d3f-86d3-985a21e33b65",
+      "projectId": "05cf87b1-6a87-418b-8f11-5794bb29e303",
       "type": "TASK",
       "title": "Child Task",
       "description": "D",
       "status": "IN_PROGRESS",
-      "parentId": "bf4fc56b-dc82-40d4-b320-e1998f9a55ef",
+      "parentId": "2622b961-4369-4ab6-b391-03b41fd2f0e0",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T03:01:11.992Z",
-      "updatedAt": "2026-03-01T03:01:11.993Z",
+      "createdAt": "2026-03-01T03:05:03.207Z",
+      "updatedAt": "2026-03-01T03:05:03.211Z",
       "history": [
         {
-          "id": "0fa4ad82-725d-48b8-b6a2-026206f2b18a",
+          "id": "4ecd60d7-a828-4668-a653-f91c677b84e9",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T03:01:11.992Z"
+          "timestamp": "2026-03-01T03:05:03.207Z"
         },
         {
-          "id": "1e8ad758-0ec0-484d-a16b-123f73497690",
+          "id": "faa077f1-ba23-43ee-8f49-e7596d373ec4",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-01T03:01:11.993Z"
+          "timestamp": "2026-03-01T03:05:03.211Z"
         }
       ]
     },
     {
-      "id": "958d74de-2956-4cd5-ae62-858419632ae9",
-      "projectId": "fa60734c-726e-47d9-829e-f7f05868ef98",
+      "id": "2898da74-ab5c-4035-9870-afa1d239510a",
+      "projectId": "05cf87b1-6a87-418b-8f11-5794bb29e303",
       "type": "TASK",
       "title": "Archive Me",
       "description": "D",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T03:01:11.996Z",
-      "updatedAt": "2026-03-01T03:01:12.001Z",
+      "createdAt": "2026-03-01T03:05:03.214Z",
+      "updatedAt": "2026-03-01T03:05:03.220Z",
       "history": [
         {
-          "id": "62f4b721-564b-47da-a822-94b078983009",
+          "id": "9b55a621-f7a4-42ed-96c6-4c657b2b7216",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T03:01:11.996Z"
+          "timestamp": "2026-03-01T03:05:03.214Z"
         },
         {
-          "id": "d823fe13-6180-4b9b-b34d-2ccba82c004e",
+          "id": "e378531a-16cb-411a-81e3-78119c709444",
           "fromStatus": "TODO",
           "toStatus": "ARCHIVED",
-          "timestamp": "2026-03-01T03:01:11.998Z"
+          "timestamp": "2026-03-01T03:05:03.217Z"
         },
         {
-          "id": "0ebd00e0-e55f-4e6c-9c33-08e673d0d7a9",
+          "id": "d567aa5b-a61b-408a-b4bd-81a763160718",
           "fromStatus": "ARCHIVED",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T03:01:12.000Z"
+          "timestamp": "2026-03-01T03:05:03.220Z"
         }
       ]
     },
     {
-      "id": "a7bac452-4f51-4219-a60e-5d18fc575eeb",
-      "projectId": "fa60734c-726e-47d9-829e-f7f05868ef98",
+      "id": "b34c7f6c-fc3c-4a19-b3bb-a6d800318769",
+      "projectId": "05cf87b1-6a87-418b-8f11-5794bb29e303",
       "type": "TASK",
       "title": "Delete Me",
       "description": "D",
       "status": "TRASHED",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T03:01:12.004Z",
-      "updatedAt": "2026-03-01T03:01:12.006Z",
+      "createdAt": "2026-03-01T03:05:03.222Z",
+      "updatedAt": "2026-03-01T03:05:03.225Z",
       "history": [
         {
-          "id": "b30ec59a-db0b-4930-bcda-01574823cfc3",
+          "id": "c3d72b90-adf9-4533-a67c-594338a6ab47",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T03:01:12.004Z"
+          "timestamp": "2026-03-01T03:05:03.223Z"
         },
         {
-          "id": "a0f4b89c-ad2f-4f7a-bce4-8a2f346136ce",
+          "id": "58707b18-e214-48e2-af1f-6dd900e5c80d",
           "fromStatus": "TODO",
           "toStatus": "TRASHED",
-          "timestamp": "2026-03-01T03:01:12.006Z"
+          "timestamp": "2026-03-01T03:05:03.225Z"
         }
       ]
     },
     {
-      "id": "c90423dc-224b-4354-98e2-82ace553bc3c",
-      "projectId": "fa60734c-726e-47d9-829e-f7f05868ef98",
+      "id": "d7674243-a38d-4bf2-b755-cf6bead7f664",
+      "projectId": "05cf87b1-6a87-418b-8f11-5794bb29e303",
       "type": "TASK",
       "title": "Archived Task",
       "description": "",
       "status": "TRASHED",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T03:01:12.010Z",
-      "updatedAt": "2026-03-01T03:01:12.012Z",
+      "createdAt": "2026-03-01T03:05:03.229Z",
+      "updatedAt": "2026-03-01T03:05:03.231Z",
       "history": [
         {
-          "id": "5891eea8-3a8a-49f2-884c-c527a13a0c53",
+          "id": "0005baed-97ed-49fe-904e-89d6e0c39f8b",
           "fromStatus": "TODO",
           "toStatus": "ARCHIVED",
-          "timestamp": "2026-03-01T03:01:12.010Z"
+          "timestamp": "2026-03-01T03:05:03.229Z"
         },
         {
-          "id": "b6c7e08d-923d-4b76-9af9-d25883f9f30a",
+          "id": "2d8e8752-34c6-4ff2-a286-bf68353475d8",
           "fromStatus": "ARCHIVED",
           "toStatus": "TRASHED",
-          "timestamp": "2026-03-01T03:01:12.012Z"
+          "timestamp": "2026-03-01T03:05:03.231Z"
         }
       ]
     },
     {
-      "id": "63b4e4d3-d871-4204-af6b-b3a8ec1df16f",
-      "projectId": "c87259e3-c28c-4de0-9fc2-b74191f610d2",
+      "id": "6541846e-3579-4c02-8af0-a87343e6f8b7",
+      "projectId": "33096a7a-3b51-4615-b074-43d8e48a3933",
       "type": "BUG",
       "title": "[PROJ-1] Fix login bug",
       "description": "Imported from JIRA: PROJ-1",
@@ -260,14 +260,14 @@
       "implementationPlan": "",
       "externalId": "PROJ-1",
       "externalUrl": "https://test.atlassian.net/browse/PROJ-1",
-      "createdAt": "2026-03-01T03:01:12.110Z",
-      "updatedAt": "2026-03-01T03:01:12.110Z",
+      "createdAt": "2026-03-01T03:05:03.272Z",
+      "updatedAt": "2026-03-01T03:05:03.272Z",
       "history": [
         {
-          "id": "abc3691b-f4d1-4452-b847-cd0239517f0a",
+          "id": "e106ac9d-5ea4-44bd-9b40-2f2a73ad9891",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T03:01:12.110Z"
+          "timestamp": "2026-03-01T03:05:03.272Z"
         }
       ]
     }

--- a/server-test-db.json
+++ b/server-test-db.json
@@ -1,258 +1,258 @@
 {
   "projects": [
     {
-      "id": "786fc24d-0ab7-4a4b-be06-63eefbbd8822",
+      "id": "b514dfac-9c54-4dca-a689-4305795c487d",
       "name": "P1 Updated",
       "description": "",
-      "createdAt": "2026-03-01T02:59:35.682Z",
-      "updatedAt": "2026-03-01T02:59:35.697Z"
+      "createdAt": "2026-03-01T02:59:59.767Z",
+      "updatedAt": "2026-03-01T02:59:59.785Z"
     },
     {
-      "id": "71d1a05b-3b79-4b8e-8aa4-2f3f2fef6890",
+      "id": "5182313c-04b5-4ce0-8e34-aa0a48c78ff3",
       "name": "Item Test",
       "description": "",
-      "createdAt": "2026-03-01T02:59:35.723Z",
-      "updatedAt": "2026-03-01T02:59:35.723Z"
+      "createdAt": "2026-03-01T02:59:59.798Z",
+      "updatedAt": "2026-03-01T02:59:59.798Z"
     },
     {
-      "id": "7778e0e1-e860-41ee-853f-d3618faf81b3",
+      "id": "bed7abe7-11c3-4d46-83e4-9fa2550f546a",
       "name": "JIRA Import Test",
       "description": "",
-      "createdAt": "2026-03-01T02:59:35.821Z",
-      "updatedAt": "2026-03-01T02:59:35.821Z"
+      "createdAt": "2026-03-01T02:59:59.918Z",
+      "updatedAt": "2026-03-01T02:59:59.918Z"
     },
     {
-      "id": "e8a2258d-1d9e-48e1-a3fe-b7d7f876a173",
+      "id": "4e1b27bd-ef12-4584-bb4b-93d41f950127",
       "name": "JIRA Err Test",
       "description": "",
-      "createdAt": "2026-03-01T02:59:35.826Z",
-      "updatedAt": "2026-03-01T02:59:35.826Z"
+      "createdAt": "2026-03-01T02:59:59.923Z",
+      "updatedAt": "2026-03-01T02:59:59.923Z"
     }
   ],
   "items": [
     {
-      "id": "49f14e5f-83c8-41ae-bfc0-96c96afe9667",
-      "projectId": "71d1a05b-3b79-4b8e-8aa4-2f3f2fef6890",
+      "id": "86ee42e4-72dd-4d71-90cb-dbce74d8b06a",
+      "projectId": "5182313c-04b5-4ce0-8e34-aa0a48c78ff3",
       "type": "TASK",
       "title": "T1",
       "description": "D1",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:59:35.726Z",
-      "updatedAt": "2026-03-01T02:59:35.726Z",
+      "createdAt": "2026-03-01T02:59:59.800Z",
+      "updatedAt": "2026-03-01T02:59:59.800Z",
       "history": [
         {
-          "id": "8596feb0-22d0-4804-87b2-e6347497bad8",
+          "id": "1180ff83-53b8-4d52-a0bf-d4208e0cd90f",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:59:35.726Z"
+          "timestamp": "2026-03-01T02:59:59.800Z"
         }
       ]
     },
     {
-      "id": "d7a586d2-1ae6-438f-be6a-8608466316e5",
-      "projectId": "71d1a05b-3b79-4b8e-8aa4-2f3f2fef6890",
+      "id": "8e703380-818a-4227-b0bd-a9f6c04143c9",
+      "projectId": "5182313c-04b5-4ce0-8e34-aa0a48c78ff3",
       "type": "TASK",
       "title": "To Update",
       "description": "D",
       "status": "IN_PROGRESS",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:59:35.728Z",
-      "updatedAt": "2026-03-01T02:59:35.733Z",
+      "createdAt": "2026-03-01T02:59:59.803Z",
+      "updatedAt": "2026-03-01T02:59:59.807Z",
       "history": [
         {
-          "id": "c4edf6d1-f3a8-4162-bd04-048a7610c8e3",
+          "id": "4e52412b-49d6-4908-88b5-1897faa44dc3",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:59:35.728Z"
+          "timestamp": "2026-03-01T02:59:59.803Z"
         },
         {
-          "id": "1a94b0b6-41d8-47f6-97b6-90f2490529cd",
+          "id": "41082b18-0350-4665-bb86-317a95b56352",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-01T02:59:35.733Z"
+          "timestamp": "2026-03-01T02:59:59.807Z"
         }
       ]
     },
     {
-      "id": "329c33c8-c60b-4bcd-919c-a16ae29b9221",
-      "projectId": "71d1a05b-3b79-4b8e-8aa4-2f3f2fef6890",
+      "id": "7da5b235-124c-4b80-a6dd-0d6af7492c85",
+      "projectId": "5182313c-04b5-4ce0-8e34-aa0a48c78ff3",
       "type": "TASK",
       "title": "No Cheat",
       "description": "D",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:59:35.736Z",
-      "updatedAt": "2026-03-01T02:59:35.736Z",
+      "createdAt": "2026-03-01T02:59:59.813Z",
+      "updatedAt": "2026-03-01T02:59:59.813Z",
       "history": [
         {
-          "id": "98914682-1d44-4640-8152-7edfbf739610",
+          "id": "04b4dace-c21e-4691-9179-f4caab3bc82e",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:59:35.736Z"
+          "timestamp": "2026-03-01T02:59:59.813Z"
         }
       ]
     },
     {
-      "id": "4c30d90f-6d5a-46f1-aece-93334224624b",
-      "projectId": "71d1a05b-3b79-4b8e-8aa4-2f3f2fef6890",
+      "id": "0cd616a7-a478-47a8-b3cb-dbd0a42310b1",
+      "projectId": "5182313c-04b5-4ce0-8e34-aa0a48c78ff3",
       "type": "TASK",
       "title": "Verify Me",
       "description": "D",
       "status": "DONE",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:59:35.739Z",
-      "updatedAt": "2026-03-01T02:59:35.742Z",
+      "createdAt": "2026-03-01T02:59:59.817Z",
+      "updatedAt": "2026-03-01T02:59:59.820Z",
       "history": [
         {
-          "id": "62be4608-f6af-421b-b280-a07569a11721",
+          "id": "5c37fa41-85dd-42b1-b503-4c9de49ad917",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:59:35.740Z"
+          "timestamp": "2026-03-01T02:59:59.817Z"
         },
         {
-          "id": "abfcbf96-8de7-4ccc-821e-8037731813c4",
+          "id": "9b018a83-af2b-4fa1-b4f4-be8217bb6d75",
           "fromStatus": "TODO",
           "toStatus": "DONE",
-          "timestamp": "2026-03-01T02:59:35.742Z"
+          "timestamp": "2026-03-01T02:59:59.820Z"
         }
       ]
     },
     {
-      "id": "d626d1da-4cd7-4186-ae39-318b156ebb7e",
-      "projectId": "71d1a05b-3b79-4b8e-8aa4-2f3f2fef6890",
+      "id": "64061e54-77ea-415f-a188-bb68f471832e",
+      "projectId": "5182313c-04b5-4ce0-8e34-aa0a48c78ff3",
       "type": "STORY",
       "title": "Parent Story",
       "description": "D",
       "status": "IN_PROGRESS",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:59:35.744Z",
-      "updatedAt": "2026-03-01T02:59:35.748Z",
+      "createdAt": "2026-03-01T02:59:59.822Z",
+      "updatedAt": "2026-03-01T02:59:59.829Z",
       "history": [
         {
-          "id": "a9e8dd14-f634-4cad-8256-f9038cc5c157",
+          "id": "8ad82d66-01f4-4aba-a9c4-5653e74e1941",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:59:35.744Z"
+          "timestamp": "2026-03-01T02:59:59.822Z"
         },
         {
-          "id": "787f14e4-a090-4128-92f5-489eced28861",
+          "id": "a16e686e-655a-4622-b7c0-611b8934af86",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-01T02:59:35.748Z"
+          "timestamp": "2026-03-01T02:59:59.829Z"
         }
       ]
     },
     {
-      "id": "ff601c44-8439-4d1a-becc-406f80c1a0f8",
-      "projectId": "71d1a05b-3b79-4b8e-8aa4-2f3f2fef6890",
+      "id": "3ed322a0-c89e-4a4e-8591-4371d5f08662",
+      "projectId": "5182313c-04b5-4ce0-8e34-aa0a48c78ff3",
       "type": "TASK",
       "title": "Child Task",
       "description": "D",
       "status": "IN_PROGRESS",
-      "parentId": "d626d1da-4cd7-4186-ae39-318b156ebb7e",
+      "parentId": "64061e54-77ea-415f-a188-bb68f471832e",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:59:35.746Z",
-      "updatedAt": "2026-03-01T02:59:35.748Z",
+      "createdAt": "2026-03-01T02:59:59.824Z",
+      "updatedAt": "2026-03-01T02:59:59.827Z",
       "history": [
         {
-          "id": "88d6c9fc-db0b-4b72-955d-97149d95140d",
+          "id": "f3fe6ad7-c6c3-49a7-9884-d403fa59c679",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:59:35.746Z"
+          "timestamp": "2026-03-01T02:59:59.825Z"
         },
         {
-          "id": "0fb87332-f8f9-479f-8bc0-673d6a5f118c",
+          "id": "af04731e-8fb4-4699-a217-066d00bf104e",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-01T02:59:35.748Z"
+          "timestamp": "2026-03-01T02:59:59.827Z"
         }
       ]
     },
     {
-      "id": "386317d4-362b-4fdf-b42a-e064b320e4b0",
-      "projectId": "71d1a05b-3b79-4b8e-8aa4-2f3f2fef6890",
+      "id": "e3e55e38-b59a-4ef4-a458-711830225fb0",
+      "projectId": "5182313c-04b5-4ce0-8e34-aa0a48c78ff3",
       "type": "TASK",
       "title": "Archive Me",
       "description": "D",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:59:35.751Z",
-      "updatedAt": "2026-03-01T02:59:35.756Z",
+      "createdAt": "2026-03-01T02:59:59.833Z",
+      "updatedAt": "2026-03-01T02:59:59.838Z",
       "history": [
         {
-          "id": "816289d0-17b5-4e6e-a7b8-e59cfb89d9e0",
+          "id": "ee789d78-af9e-4924-b3f3-404bae04f4b1",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:59:35.752Z"
+          "timestamp": "2026-03-01T02:59:59.834Z"
         },
         {
-          "id": "e498e5b3-ac60-476b-ab51-1ec2789448b5",
+          "id": "0894c7c6-9056-4f08-a1e5-4b7371121dd1",
           "fromStatus": "TODO",
           "toStatus": "ARCHIVED",
-          "timestamp": "2026-03-01T02:59:35.754Z"
+          "timestamp": "2026-03-01T02:59:59.836Z"
         },
         {
-          "id": "4144225e-d06f-4894-a302-4fe326ef53d7",
+          "id": "ca3a3d1c-0fba-4c09-a962-b5d6066927c1",
           "fromStatus": "ARCHIVED",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:59:35.756Z"
+          "timestamp": "2026-03-01T02:59:59.838Z"
         }
       ]
     },
     {
-      "id": "50b11ec9-807d-4080-8918-9d2035d58479",
-      "projectId": "71d1a05b-3b79-4b8e-8aa4-2f3f2fef6890",
+      "id": "358613a3-feec-45ea-8912-cdf8df58809e",
+      "projectId": "5182313c-04b5-4ce0-8e34-aa0a48c78ff3",
       "type": "TASK",
       "title": "Delete Me",
       "description": "D",
       "status": "TRASHED",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:59:35.758Z",
-      "updatedAt": "2026-03-01T02:59:35.761Z",
+      "createdAt": "2026-03-01T02:59:59.840Z",
+      "updatedAt": "2026-03-01T02:59:59.842Z",
       "history": [
         {
-          "id": "77acb82f-4fac-456f-aa81-5e0c0017b41d",
+          "id": "b24558b2-999f-45f6-9eac-65dd05f10476",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:59:35.759Z"
+          "timestamp": "2026-03-01T02:59:59.840Z"
         },
         {
-          "id": "61054ec6-8b69-496b-9af2-955e599ffa26",
+          "id": "53806899-b53f-4ac3-a2cc-1c15d57c5ca7",
           "fromStatus": "TODO",
           "toStatus": "TRASHED",
-          "timestamp": "2026-03-01T02:59:35.761Z"
+          "timestamp": "2026-03-01T02:59:59.842Z"
         }
       ]
     },
     {
-      "id": "5286765b-b849-4a7e-98a3-9a2000587f7e",
-      "projectId": "71d1a05b-3b79-4b8e-8aa4-2f3f2fef6890",
+      "id": "ba3a0999-38d1-49a3-b2e3-e0bf2b96551d",
+      "projectId": "5182313c-04b5-4ce0-8e34-aa0a48c78ff3",
       "type": "TASK",
       "title": "Archived Task",
       "description": "",
       "status": "TRASHED",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T02:59:35.766Z",
-      "updatedAt": "2026-03-01T02:59:35.768Z",
+      "createdAt": "2026-03-01T02:59:59.846Z",
+      "updatedAt": "2026-03-01T02:59:59.849Z",
       "history": [
         {
-          "id": "6b9ccf04-f677-41d3-b912-4ace78052a4f",
+          "id": "b77f95a7-c1d9-4859-8afd-e51c01e199ab",
           "fromStatus": "TODO",
           "toStatus": "ARCHIVED",
-          "timestamp": "2026-03-01T02:59:35.766Z"
+          "timestamp": "2026-03-01T02:59:59.846Z"
         },
         {
-          "id": "3feaccfb-fc4c-40ee-b6a8-eacfd4c67c9e",
+          "id": "febf8fad-e8ba-41b5-92b6-c3386faaae07",
           "fromStatus": "ARCHIVED",
           "toStatus": "TRASHED",
-          "timestamp": "2026-03-01T02:59:35.768Z"
+          "timestamp": "2026-03-01T02:59:59.849Z"
         }
       ]
     },
     {
-      "id": "89263aff-d0cf-4918-b0cb-022aa0c873c1",
-      "projectId": "7778e0e1-e860-41ee-853f-d3618faf81b3",
+      "id": "eb091889-0a4f-4ef1-b6bf-c4e846415b61",
+      "projectId": "bed7abe7-11c3-4d46-83e4-9fa2550f546a",
       "type": "BUG",
       "title": "[PROJ-1] Fix login bug",
       "description": "Imported from JIRA: PROJ-1",
@@ -260,14 +260,14 @@
       "implementationPlan": "",
       "externalId": "PROJ-1",
       "externalUrl": "https://test.atlassian.net/browse/PROJ-1",
-      "createdAt": "2026-03-01T02:59:35.823Z",
-      "updatedAt": "2026-03-01T02:59:35.823Z",
+      "createdAt": "2026-03-01T02:59:59.919Z",
+      "updatedAt": "2026-03-01T02:59:59.919Z",
       "history": [
         {
-          "id": "21c4ff8a-0b6e-4b5f-9806-a1abef491d92",
+          "id": "580511ea-f749-4e35-bc7f-424d4442462b",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T02:59:35.823Z"
+          "timestamp": "2026-03-01T02:59:59.919Z"
         }
       ]
     }

--- a/server-test-db.json
+++ b/server-test-db.json
@@ -1,258 +1,258 @@
 {
   "projects": [
     {
-      "id": "0fb7c152-9429-421c-83d9-e7cd1f016567",
+      "id": "365e5e64-db46-43b5-a62f-63ff61102359",
       "name": "P1 Updated",
       "description": "",
-      "createdAt": "2026-03-01T00:56:55.103Z",
-      "updatedAt": "2026-03-01T00:56:55.122Z"
+      "createdAt": "2026-03-01T02:25:58.825Z",
+      "updatedAt": "2026-03-01T02:25:58.840Z"
     },
     {
-      "id": "ec455103-7c48-43a4-80b7-33dc534b01dd",
+      "id": "fabc6488-cbdd-4a2e-a891-5bcf18ca6e23",
       "name": "Item Test",
       "description": "",
-      "createdAt": "2026-03-01T00:56:55.140Z",
-      "updatedAt": "2026-03-01T00:56:55.140Z"
+      "createdAt": "2026-03-01T02:25:58.872Z",
+      "updatedAt": "2026-03-01T02:25:58.872Z"
     },
     {
-      "id": "83b56a83-08d8-4826-89a5-70c151dcc343",
+      "id": "f715bf7d-c427-4642-9a52-3eb94ad4f2da",
       "name": "JIRA Import Test",
       "description": "",
-      "createdAt": "2026-03-01T00:56:55.270Z",
-      "updatedAt": "2026-03-01T00:56:55.270Z"
+      "createdAt": "2026-03-01T02:25:58.967Z",
+      "updatedAt": "2026-03-01T02:25:58.967Z"
     },
     {
-      "id": "e36312fd-dee6-49d9-b2bd-81a47663e275",
+      "id": "20cc3e0f-1d81-4d53-bd54-0406f87e61ff",
       "name": "JIRA Err Test",
       "description": "",
-      "createdAt": "2026-03-01T00:56:55.276Z",
-      "updatedAt": "2026-03-01T00:56:55.276Z"
+      "createdAt": "2026-03-01T02:25:58.972Z",
+      "updatedAt": "2026-03-01T02:25:58.972Z"
     }
   ],
   "items": [
     {
-      "id": "89c6d12f-3cbd-47f2-903c-2f6d951819f7",
-      "projectId": "ec455103-7c48-43a4-80b7-33dc534b01dd",
+      "id": "fdd5ea05-4384-4e55-86f2-cd471110bd8e",
+      "projectId": "fabc6488-cbdd-4a2e-a891-5bcf18ca6e23",
       "type": "TASK",
       "title": "T1",
       "description": "D1",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T00:56:55.143Z",
-      "updatedAt": "2026-03-01T00:56:55.143Z",
+      "createdAt": "2026-03-01T02:25:58.875Z",
+      "updatedAt": "2026-03-01T02:25:58.875Z",
       "history": [
         {
-          "id": "e290fb77-9510-42a7-8b05-ef0bab410f51",
+          "id": "158f7c82-9e10-4848-8b87-a8fb3058ab14",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T00:56:55.143Z"
+          "timestamp": "2026-03-01T02:25:58.875Z"
         }
       ]
     },
     {
-      "id": "0a66cac7-5b0f-494b-b2a4-1957ebcb3ce6",
-      "projectId": "ec455103-7c48-43a4-80b7-33dc534b01dd",
+      "id": "1035bbf5-f397-4617-8e7e-95e002e4bbe4",
+      "projectId": "fabc6488-cbdd-4a2e-a891-5bcf18ca6e23",
       "type": "TASK",
       "title": "To Update",
       "description": "D",
       "status": "IN_PROGRESS",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T00:56:55.148Z",
-      "updatedAt": "2026-03-01T00:56:55.153Z",
+      "createdAt": "2026-03-01T02:25:58.878Z",
+      "updatedAt": "2026-03-01T02:25:58.881Z",
       "history": [
         {
-          "id": "a396bc03-c38a-4912-bfee-853ac76f2f55",
+          "id": "c6a8c5bd-8af4-44e2-9b3b-7be687e0b1a2",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T00:56:55.149Z"
+          "timestamp": "2026-03-01T02:25:58.878Z"
         },
         {
-          "id": "e8577ecd-fed2-4fc1-b7dc-49dd27381a94",
+          "id": "fe5188e9-3610-443f-9274-75e8947bf8fe",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-01T00:56:55.153Z"
+          "timestamp": "2026-03-01T02:25:58.881Z"
         }
       ]
     },
     {
-      "id": "83fdeb5a-6dc4-42c5-882d-542e90eb49d6",
-      "projectId": "ec455103-7c48-43a4-80b7-33dc534b01dd",
+      "id": "f07c63e3-e38f-4b54-899a-5a7e7c428109",
+      "projectId": "fabc6488-cbdd-4a2e-a891-5bcf18ca6e23",
       "type": "TASK",
       "title": "No Cheat",
       "description": "D",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T00:56:55.157Z",
-      "updatedAt": "2026-03-01T00:56:55.157Z",
+      "createdAt": "2026-03-01T02:25:58.884Z",
+      "updatedAt": "2026-03-01T02:25:58.884Z",
       "history": [
         {
-          "id": "f27aa67f-ea3b-40e0-93a0-4eb4d90ecb47",
+          "id": "c7eceb0d-2105-4eb9-a1ec-6ee80fe02c86",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T00:56:55.158Z"
+          "timestamp": "2026-03-01T02:25:58.885Z"
         }
       ]
     },
     {
-      "id": "03357cbd-8e97-4de9-ba52-1ea97a8ac311",
-      "projectId": "ec455103-7c48-43a4-80b7-33dc534b01dd",
+      "id": "76bdf36e-6191-42f0-ac16-3adf4dbe778f",
+      "projectId": "fabc6488-cbdd-4a2e-a891-5bcf18ca6e23",
       "type": "TASK",
       "title": "Verify Me",
       "description": "D",
       "status": "DONE",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T00:56:55.162Z",
-      "updatedAt": "2026-03-01T00:56:55.164Z",
+      "createdAt": "2026-03-01T02:25:58.898Z",
+      "updatedAt": "2026-03-01T02:25:58.903Z",
       "history": [
         {
-          "id": "d0309d0c-f378-45bc-98c6-12c2eed1cbc1",
+          "id": "8775aee0-2b7a-4fbb-ab53-7db99ddd60a4",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T00:56:55.163Z"
+          "timestamp": "2026-03-01T02:25:58.899Z"
         },
         {
-          "id": "24fa8355-ebad-45f8-82ab-49858161729d",
+          "id": "2a1a2936-9071-48b0-9883-6935e8752517",
           "fromStatus": "TODO",
           "toStatus": "DONE",
-          "timestamp": "2026-03-01T00:56:55.164Z"
+          "timestamp": "2026-03-01T02:25:58.903Z"
         }
       ]
     },
     {
-      "id": "27a8bae0-45f9-434b-9d06-3de3ce2d0ab0",
-      "projectId": "ec455103-7c48-43a4-80b7-33dc534b01dd",
+      "id": "94ea4ddb-e459-4159-800f-55625789ef55",
+      "projectId": "fabc6488-cbdd-4a2e-a891-5bcf18ca6e23",
       "type": "STORY",
       "title": "Parent Story",
       "description": "D",
       "status": "IN_PROGRESS",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T00:56:55.167Z",
-      "updatedAt": "2026-03-01T00:56:55.177Z",
+      "createdAt": "2026-03-01T02:25:58.906Z",
+      "updatedAt": "2026-03-01T02:25:58.911Z",
       "history": [
         {
-          "id": "cf29c5dc-799e-4028-9869-7a932b8dfa84",
+          "id": "297a4e83-8b52-4aa9-ab29-5668628519bc",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T00:56:55.167Z"
+          "timestamp": "2026-03-01T02:25:58.906Z"
         },
         {
-          "id": "bdc46ec8-2ff4-4d37-8896-3afe75a4eace",
+          "id": "29ef1540-f2f4-4270-b9c2-567a3b32f4fd",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-01T00:56:55.177Z"
+          "timestamp": "2026-03-01T02:25:58.911Z"
         }
       ]
     },
     {
-      "id": "c4750ae6-7c27-4c24-95d6-86c596c1a7c6",
-      "projectId": "ec455103-7c48-43a4-80b7-33dc534b01dd",
+      "id": "391d2582-2f64-4fef-9e09-8a9a88e24bb0",
+      "projectId": "fabc6488-cbdd-4a2e-a891-5bcf18ca6e23",
       "type": "TASK",
       "title": "Child Task",
       "description": "D",
       "status": "IN_PROGRESS",
-      "parentId": "27a8bae0-45f9-434b-9d06-3de3ce2d0ab0",
+      "parentId": "94ea4ddb-e459-4159-800f-55625789ef55",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T00:56:55.172Z",
-      "updatedAt": "2026-03-01T00:56:55.176Z",
+      "createdAt": "2026-03-01T02:25:58.908Z",
+      "updatedAt": "2026-03-01T02:25:58.910Z",
       "history": [
         {
-          "id": "dbc512a7-eeec-4216-94fa-0639eda66793",
+          "id": "73d7bf39-b2fc-4736-a09d-052f657e6871",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T00:56:55.172Z"
+          "timestamp": "2026-03-01T02:25:58.908Z"
         },
         {
-          "id": "cf4a786a-b770-47d1-8866-c5eaae4df0a2",
+          "id": "d9adcb1b-8c84-435d-8594-47bafe28869b",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-01T00:56:55.176Z"
+          "timestamp": "2026-03-01T02:25:58.910Z"
         }
       ]
     },
     {
-      "id": "5319ac7a-076b-484d-9f38-550eb735d912",
-      "projectId": "ec455103-7c48-43a4-80b7-33dc534b01dd",
+      "id": "b67f028b-fd2f-4a11-81ba-898fb66f3fcb",
+      "projectId": "fabc6488-cbdd-4a2e-a891-5bcf18ca6e23",
       "type": "TASK",
       "title": "Archive Me",
       "description": "D",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T00:56:55.179Z",
-      "updatedAt": "2026-03-01T00:56:55.184Z",
+      "createdAt": "2026-03-01T02:25:58.914Z",
+      "updatedAt": "2026-03-01T02:25:58.918Z",
       "history": [
         {
-          "id": "665f9ac3-7868-4a0a-bb6e-02f357cebd3d",
+          "id": "40655c3d-368c-4ee6-aa04-df068ad346f6",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T00:56:55.180Z"
+          "timestamp": "2026-03-01T02:25:58.914Z"
         },
         {
-          "id": "c5965b7b-a6c8-4879-b08f-cbbee8db4fd2",
+          "id": "d7b0fc89-152a-46c2-a966-4bf76eacec44",
           "fromStatus": "TODO",
           "toStatus": "ARCHIVED",
-          "timestamp": "2026-03-01T00:56:55.181Z"
+          "timestamp": "2026-03-01T02:25:58.916Z"
         },
         {
-          "id": "0b0a2987-3ac8-451b-9861-c597ea207399",
+          "id": "6c0ba459-edfb-4bd2-862d-26a5080259ab",
           "fromStatus": "ARCHIVED",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T00:56:55.183Z"
+          "timestamp": "2026-03-01T02:25:58.918Z"
         }
       ]
     },
     {
-      "id": "4f5c8806-10e4-490f-b210-c902e6f4e8e9",
-      "projectId": "ec455103-7c48-43a4-80b7-33dc534b01dd",
+      "id": "492fa57f-c875-4caa-9418-84a7305a7bca",
+      "projectId": "fabc6488-cbdd-4a2e-a891-5bcf18ca6e23",
       "type": "TASK",
       "title": "Delete Me",
       "description": "D",
       "status": "TRASHED",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T00:56:55.185Z",
-      "updatedAt": "2026-03-01T00:56:55.193Z",
+      "createdAt": "2026-03-01T02:25:58.920Z",
+      "updatedAt": "2026-03-01T02:25:58.922Z",
       "history": [
         {
-          "id": "a2358582-9269-4a76-a0e5-c178b385ce85",
+          "id": "12cd1c94-fb93-410f-ac0c-b7d6e02bbf9f",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T00:56:55.186Z"
+          "timestamp": "2026-03-01T02:25:58.920Z"
         },
         {
-          "id": "72b90883-dedb-40b3-9300-6319d3af9b45",
+          "id": "6e74c0c4-e041-4971-8ba1-2119abcc1ff3",
           "fromStatus": "TODO",
           "toStatus": "TRASHED",
-          "timestamp": "2026-03-01T00:56:55.193Z"
+          "timestamp": "2026-03-01T02:25:58.922Z"
         }
       ]
     },
     {
-      "id": "a46e00e7-825f-4dc7-b1b7-69a566367849",
-      "projectId": "ec455103-7c48-43a4-80b7-33dc534b01dd",
+      "id": "08fd98a6-4e85-413f-b3e6-a22df1e1dcef",
+      "projectId": "fabc6488-cbdd-4a2e-a891-5bcf18ca6e23",
       "type": "TASK",
       "title": "Archived Task",
       "description": "",
       "status": "TRASHED",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T00:56:55.198Z",
-      "updatedAt": "2026-03-01T00:56:55.200Z",
+      "createdAt": "2026-03-01T02:25:58.926Z",
+      "updatedAt": "2026-03-01T02:25:58.928Z",
       "history": [
         {
-          "id": "c3837ba2-6785-49bc-9df8-d56d337eebdf",
+          "id": "fb26b7db-3bdc-4bfe-99d2-fc1b5374dbc1",
           "fromStatus": "TODO",
           "toStatus": "ARCHIVED",
-          "timestamp": "2026-03-01T00:56:55.198Z"
+          "timestamp": "2026-03-01T02:25:58.926Z"
         },
         {
-          "id": "db599b57-4558-48aa-ae6b-5494320de2dd",
+          "id": "e3ae3cfb-9b9f-4bd1-aebc-8b0ba56f3861",
           "fromStatus": "ARCHIVED",
           "toStatus": "TRASHED",
-          "timestamp": "2026-03-01T00:56:55.200Z"
+          "timestamp": "2026-03-01T02:25:58.928Z"
         }
       ]
     },
     {
-      "id": "331767b4-b97b-4645-a2c6-0103bf3ba25e",
-      "projectId": "83b56a83-08d8-4826-89a5-70c151dcc343",
+      "id": "9b82b0c8-8824-4e2a-aa8b-d6ad7ef7356b",
+      "projectId": "f715bf7d-c427-4642-9a52-3eb94ad4f2da",
       "type": "BUG",
       "title": "[PROJ-1] Fix login bug",
       "description": "Imported from JIRA: PROJ-1",
@@ -260,14 +260,14 @@
       "implementationPlan": "",
       "externalId": "PROJ-1",
       "externalUrl": "https://test.atlassian.net/browse/PROJ-1",
-      "createdAt": "2026-03-01T00:56:55.271Z",
-      "updatedAt": "2026-03-01T00:56:55.271Z",
+      "createdAt": "2026-03-01T02:25:58.969Z",
+      "updatedAt": "2026-03-01T02:25:58.969Z",
       "history": [
         {
-          "id": "ecf9def6-5a66-46b8-8526-3514e37235af",
+          "id": "ea909b7b-6dea-48b9-ad8e-51f0216d4cf4",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T00:56:55.272Z"
+          "timestamp": "2026-03-01T02:25:58.969Z"
         }
       ]
     }


### PR DESCRIPTION
Two bugs in install/uninstall scripts for Gemini CLI:
1. MCP registers at project scope (default) instead of user scope — server only visible from install directory
2. No slash commands installed for Gemini CLI — needs .toml files in ~/.gemini/commands/

Fix: Add -s user to gemini mcp add/remove, generate .toml wrappers referencing existing .md command files, and add cleanup to uninstall.