### PR TITLE
Rewrite agenfk-pr command to use MCP tools instead of CLI

### DIFF
--- a/commands/agenfk-pr.md
+++ b/commands/agenfk-pr.md
@@ -1,0 +1,37 @@
+---
+description: Create a PR for the current item's branch and manage the PR lifecycle
+---
+
+You are executing the `/agenfk-pr <itemId>` command. Follow these steps precisely:
+
+**Step 1 — Verify branch and item state**
+- Call `get_item(itemId)` to read the current item.
+- Check `item.branchName`:
+  - If no branch is linked, call `create_branch(itemId)` to create and switch to a feature branch.
+  - If a branch exists, confirm you are on it.
+
+**Step 2 — Create the Pull Request**
+- Call `create_pr(itemId, "<summary of changes>")` — this pushes the branch to the remote and opens a GitHub PR in one step.
+- The tool stores `prUrl`, `prNumber`, and `prStatus` on the item automatically.
+- If the item already has a `prUrl`, skip creation — the PR already exists. Show the existing URL instead.
+
+**Step 3 — Confirm and wait**
+- Show the user the PR URL and instruct them:
+  > "Your PR is open. Once it has been reviewed and merged, run `/agenfk-release` to create a release."
+- Do NOT poll or wait. The user will trigger the next step manually.
+
+**Step 4 — (Optional) Check PR status**
+If the user asks whether the PR is ready:
+- Re-read the item with `get_item(itemId)` and check `prStatus`.
+- Alternatively, run `gh pr view <prNumber> --json state` for a live check.
+- If merged → tell the user to run `/agenfk-release`.
+- If still open or in draft → tell the user to wait for approval.
+- If closed without merge → warn the user and ask how they want to proceed.
+
+---
+
+**Key rules:**
+- Always use MCP tools (`get_item`, `create_branch`, `create_pr`) as the primary path.
+- Never poll in a loop. One check per user request.
+- `/agenfk-release` will automatically gate on merged PR status — the user does not need to do anything special before running it.
+- If `gh` CLI is not installed, `create_pr` will fail gracefully — inform the user and skip PR creation.

--- a/server-test-db.json
+++ b/server-test-db.json
@@ -1,258 +1,258 @@
 {
   "projects": [
     {
-      "id": "ec409368-cf67-4bba-8e74-6534e35a1d07",
+      "id": "8638495b-faab-44d3-944e-6c7412c71abc",
       "name": "P1 Updated",
       "description": "",
-      "createdAt": "2026-03-01T03:24:49.508Z",
-      "updatedAt": "2026-03-01T03:24:49.526Z"
+      "createdAt": "2026-03-01T03:29:35.800Z",
+      "updatedAt": "2026-03-01T03:29:35.815Z"
     },
     {
-      "id": "088f4657-e816-4dfe-8e0e-b129f3a47c5e",
+      "id": "81f468e0-1d62-4c74-a993-b71a57697f68",
       "name": "Item Test",
       "description": "",
-      "createdAt": "2026-03-01T03:24:49.537Z",
-      "updatedAt": "2026-03-01T03:24:49.537Z"
+      "createdAt": "2026-03-01T03:29:35.840Z",
+      "updatedAt": "2026-03-01T03:29:35.840Z"
     },
     {
-      "id": "476277cd-8869-4753-8f83-c427b51110a1",
+      "id": "08366fdd-03ee-418f-b1ff-b93d41266cd4",
       "name": "JIRA Import Test",
       "description": "",
-      "createdAt": "2026-03-01T03:24:49.633Z",
-      "updatedAt": "2026-03-01T03:24:49.633Z"
+      "createdAt": "2026-03-01T03:29:35.927Z",
+      "updatedAt": "2026-03-01T03:29:35.927Z"
     },
     {
-      "id": "6a0e8342-ed79-4230-b371-5cb7bf1926aa",
+      "id": "15ae2555-ef4a-410c-b244-05fd85ac537d",
       "name": "JIRA Err Test",
       "description": "",
-      "createdAt": "2026-03-01T03:24:49.638Z",
-      "updatedAt": "2026-03-01T03:24:49.638Z"
+      "createdAt": "2026-03-01T03:29:35.933Z",
+      "updatedAt": "2026-03-01T03:29:35.933Z"
     }
   ],
   "items": [
     {
-      "id": "36855d01-acd9-4850-b059-76419b262263",
-      "projectId": "088f4657-e816-4dfe-8e0e-b129f3a47c5e",
+      "id": "51b98666-d99f-4580-8535-7ac5b9a4a9cf",
+      "projectId": "81f468e0-1d62-4c74-a993-b71a57697f68",
       "type": "TASK",
       "title": "T1",
       "description": "D1",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T03:24:49.539Z",
-      "updatedAt": "2026-03-01T03:24:49.539Z",
+      "createdAt": "2026-03-01T03:29:35.843Z",
+      "updatedAt": "2026-03-01T03:29:35.843Z",
       "history": [
         {
-          "id": "8882ceae-e7df-433b-bba5-590dac003e28",
+          "id": "88fa3faa-4c85-4e0c-bb61-f3a99d6dbf46",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T03:24:49.539Z"
+          "timestamp": "2026-03-01T03:29:35.844Z"
         }
       ]
     },
     {
-      "id": "5ff3c8e6-3626-49f2-83b6-7214214ba8fe",
-      "projectId": "088f4657-e816-4dfe-8e0e-b129f3a47c5e",
+      "id": "d209ca38-5104-4ebb-87ef-7fd4071d3057",
+      "projectId": "81f468e0-1d62-4c74-a993-b71a57697f68",
       "type": "TASK",
       "title": "To Update",
       "description": "D",
       "status": "IN_PROGRESS",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T03:24:49.542Z",
-      "updatedAt": "2026-03-01T03:24:49.546Z",
+      "createdAt": "2026-03-01T03:29:35.853Z",
+      "updatedAt": "2026-03-01T03:29:35.855Z",
       "history": [
         {
-          "id": "15fb8957-60f7-4474-994d-5156862a255b",
+          "id": "55a9f333-d22c-4f3c-a41c-0b67ca1d8974",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T03:24:49.542Z"
+          "timestamp": "2026-03-01T03:29:35.853Z"
         },
         {
-          "id": "199080cc-96e2-413c-964f-137f7c6b3330",
+          "id": "fe33894c-1809-4472-927e-861d687efa76",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-01T03:24:49.546Z"
+          "timestamp": "2026-03-01T03:29:35.855Z"
         }
       ]
     },
     {
-      "id": "70512404-e1c4-4e69-b606-a601a449e35b",
-      "projectId": "088f4657-e816-4dfe-8e0e-b129f3a47c5e",
+      "id": "8a3f1ebc-03b3-4e59-918b-3dbdc5b738a3",
+      "projectId": "81f468e0-1d62-4c74-a993-b71a57697f68",
       "type": "TASK",
       "title": "No Cheat",
       "description": "D",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T03:24:49.549Z",
-      "updatedAt": "2026-03-01T03:24:49.549Z",
+      "createdAt": "2026-03-01T03:29:35.858Z",
+      "updatedAt": "2026-03-01T03:29:35.858Z",
       "history": [
         {
-          "id": "e1d4e7ec-accc-456c-a610-26f7eddcd88a",
+          "id": "7d26dd59-0a38-436e-abe9-2c27decbc96f",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T03:24:49.550Z"
+          "timestamp": "2026-03-01T03:29:35.858Z"
         }
       ]
     },
     {
-      "id": "3cb31495-e944-4022-995e-55e4b5ea0df2",
-      "projectId": "088f4657-e816-4dfe-8e0e-b129f3a47c5e",
+      "id": "9a64ba13-aca3-483c-99c2-4c5842245b42",
+      "projectId": "81f468e0-1d62-4c74-a993-b71a57697f68",
       "type": "TASK",
       "title": "Verify Me",
       "description": "D",
       "status": "DONE",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T03:24:49.554Z",
-      "updatedAt": "2026-03-01T03:24:49.556Z",
+      "createdAt": "2026-03-01T03:29:35.862Z",
+      "updatedAt": "2026-03-01T03:29:35.864Z",
       "history": [
         {
-          "id": "5bc39dfd-cc6b-4d29-88e0-41182d176a8a",
+          "id": "684193cc-f95e-4c7f-8fa7-5dd2367fc8d2",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T03:24:49.554Z"
+          "timestamp": "2026-03-01T03:29:35.862Z"
         },
         {
-          "id": "757de4d2-b54a-41a8-abd3-cab7be9e1998",
+          "id": "47a92c5c-6e4b-4ec4-8b16-0cb4eb85071a",
           "fromStatus": "TODO",
           "toStatus": "DONE",
-          "timestamp": "2026-03-01T03:24:49.556Z"
+          "timestamp": "2026-03-01T03:29:35.864Z"
         }
       ]
     },
     {
-      "id": "eba0edd6-58d6-4dc8-9a13-d066f14cf10d",
-      "projectId": "088f4657-e816-4dfe-8e0e-b129f3a47c5e",
+      "id": "8f8a28ea-3b3a-4ce1-b10f-baf7a0df81e8",
+      "projectId": "81f468e0-1d62-4c74-a993-b71a57697f68",
       "type": "STORY",
       "title": "Parent Story",
       "description": "D",
       "status": "IN_PROGRESS",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T03:24:49.567Z",
-      "updatedAt": "2026-03-01T03:24:49.573Z",
+      "createdAt": "2026-03-01T03:29:35.866Z",
+      "updatedAt": "2026-03-01T03:29:35.871Z",
       "history": [
         {
-          "id": "577ec98c-363d-41bc-bcab-444c0d279cdd",
+          "id": "85cf053d-11ba-4bcf-ac7a-f1284d6c2c98",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T03:24:49.567Z"
+          "timestamp": "2026-03-01T03:29:35.867Z"
         },
         {
-          "id": "d9d69dd7-adab-4097-b8d3-642b4964f1b9",
+          "id": "7fbf85ab-de58-4cc1-853a-f154bb28dbd5",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-01T03:24:49.573Z"
+          "timestamp": "2026-03-01T03:29:35.871Z"
         }
       ]
     },
     {
-      "id": "9ef08570-4933-4df3-82e9-3fc7c972882b",
-      "projectId": "088f4657-e816-4dfe-8e0e-b129f3a47c5e",
+      "id": "0d3b7645-a3dd-4da8-99ca-b7199c023b6c",
+      "projectId": "81f468e0-1d62-4c74-a993-b71a57697f68",
       "type": "TASK",
       "title": "Child Task",
       "description": "D",
       "status": "IN_PROGRESS",
-      "parentId": "eba0edd6-58d6-4dc8-9a13-d066f14cf10d",
+      "parentId": "8f8a28ea-3b3a-4ce1-b10f-baf7a0df81e8",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T03:24:49.569Z",
-      "updatedAt": "2026-03-01T03:24:49.572Z",
+      "createdAt": "2026-03-01T03:29:35.868Z",
+      "updatedAt": "2026-03-01T03:29:35.870Z",
       "history": [
         {
-          "id": "1a362fad-0361-405d-b417-b6d74cbaeaae",
+          "id": "f7744cbc-c758-443d-87c3-092412339fe0",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T03:24:49.569Z"
+          "timestamp": "2026-03-01T03:29:35.868Z"
         },
         {
-          "id": "bb36aa6c-cd13-4617-8d52-5d54c094ee68",
+          "id": "89254522-5dd7-430f-9c84-43694c823861",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-01T03:24:49.572Z"
+          "timestamp": "2026-03-01T03:29:35.870Z"
         }
       ]
     },
     {
-      "id": "94b3386f-a132-4845-be3c-0f8d25a1089b",
-      "projectId": "088f4657-e816-4dfe-8e0e-b129f3a47c5e",
+      "id": "5088a787-998e-4f99-b087-8467978b317c",
+      "projectId": "81f468e0-1d62-4c74-a993-b71a57697f68",
       "type": "TASK",
       "title": "Archive Me",
       "description": "D",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T03:24:49.575Z",
-      "updatedAt": "2026-03-01T03:24:49.579Z",
+      "createdAt": "2026-03-01T03:29:35.874Z",
+      "updatedAt": "2026-03-01T03:29:35.880Z",
       "history": [
         {
-          "id": "719e2af8-1307-4ee5-8af5-51c6f8df98ff",
+          "id": "21fbce9a-4685-41b0-8e45-8639aa782186",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T03:24:49.575Z"
+          "timestamp": "2026-03-01T03:29:35.874Z"
         },
         {
-          "id": "4dbc5f30-7ccc-49f4-8774-d234c3b1161c",
+          "id": "ecfbef34-0b78-4889-b910-c76462de1b7e",
           "fromStatus": "TODO",
           "toStatus": "ARCHIVED",
-          "timestamp": "2026-03-01T03:24:49.577Z"
+          "timestamp": "2026-03-01T03:29:35.878Z"
         },
         {
-          "id": "a0225ac6-9a58-4661-9e54-33370eca6286",
+          "id": "7dfa95c7-105c-4f52-bd2e-25e5df8b13c1",
           "fromStatus": "ARCHIVED",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T03:24:49.579Z"
+          "timestamp": "2026-03-01T03:29:35.880Z"
         }
       ]
     },
     {
-      "id": "39d464d9-49c3-413b-83a8-2e8d4b044b80",
-      "projectId": "088f4657-e816-4dfe-8e0e-b129f3a47c5e",
+      "id": "d9a676cb-85f9-44e0-ba36-56e8721b7258",
+      "projectId": "81f468e0-1d62-4c74-a993-b71a57697f68",
       "type": "TASK",
       "title": "Delete Me",
       "description": "D",
       "status": "TRASHED",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T03:24:49.581Z",
-      "updatedAt": "2026-03-01T03:24:49.584Z",
+      "createdAt": "2026-03-01T03:29:35.882Z",
+      "updatedAt": "2026-03-01T03:29:35.884Z",
       "history": [
         {
-          "id": "4d7abb4c-37f9-4545-ab81-87c2539fdf80",
+          "id": "ab575258-c48a-44a1-b3ed-558b951cbbca",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T03:24:49.582Z"
+          "timestamp": "2026-03-01T03:29:35.882Z"
         },
         {
-          "id": "3ea2d18e-bb8d-4c31-a36a-185ad6c62042",
+          "id": "793b1c4f-63b7-4f2a-b227-e7b2ac852081",
           "fromStatus": "TODO",
           "toStatus": "TRASHED",
-          "timestamp": "2026-03-01T03:24:49.584Z"
+          "timestamp": "2026-03-01T03:29:35.884Z"
         }
       ]
     },
     {
-      "id": "a23730bf-7bdb-4981-9ee4-9cc0a6c33540",
-      "projectId": "088f4657-e816-4dfe-8e0e-b129f3a47c5e",
+      "id": "b582a0ab-4ed5-4907-9aa9-71318a353aeb",
+      "projectId": "81f468e0-1d62-4c74-a993-b71a57697f68",
       "type": "TASK",
       "title": "Archived Task",
       "description": "",
       "status": "TRASHED",
       "implementationPlan": "",
-      "createdAt": "2026-03-01T03:24:49.589Z",
-      "updatedAt": "2026-03-01T03:24:49.591Z",
+      "createdAt": "2026-03-01T03:29:35.888Z",
+      "updatedAt": "2026-03-01T03:29:35.889Z",
       "history": [
         {
-          "id": "0bec646b-b551-4ff3-b858-eb4126eef5fb",
+          "id": "29dfe4a1-18ca-41a1-989a-1619db1c3c06",
           "fromStatus": "TODO",
           "toStatus": "ARCHIVED",
-          "timestamp": "2026-03-01T03:24:49.589Z"
+          "timestamp": "2026-03-01T03:29:35.888Z"
         },
         {
-          "id": "3788ae6b-d997-4a5f-9ea6-82a7311446ee",
+          "id": "f8a549ae-a497-447f-9b38-5db8a05f7857",
           "fromStatus": "ARCHIVED",
           "toStatus": "TRASHED",
-          "timestamp": "2026-03-01T03:24:49.591Z"
+          "timestamp": "2026-03-01T03:29:35.889Z"
         }
       ]
     },
     {
-      "id": "99696072-9378-41c4-8bcd-09679c5debb2",
-      "projectId": "476277cd-8869-4753-8f83-c427b51110a1",
+      "id": "6df7438f-1291-4a83-96cb-d64e176d89c7",
+      "projectId": "08366fdd-03ee-418f-b1ff-b93d41266cd4",
       "type": "BUG",
       "title": "[PROJ-1] Fix login bug",
       "description": "Imported from JIRA: PROJ-1",
@@ -260,14 +260,14 @@
       "implementationPlan": "",
       "externalId": "PROJ-1",
       "externalUrl": "https://test.atlassian.net/browse/PROJ-1",
-      "createdAt": "2026-03-01T03:24:49.634Z",
-      "updatedAt": "2026-03-01T03:24:49.634Z",
+      "createdAt": "2026-03-01T03:29:35.928Z",
+      "updatedAt": "2026-03-01T03:29:35.928Z",
       "history": [
         {
-          "id": "414abb3b-6271-439d-a510-7337e3e01486",
+          "id": "a6cc3aa1-a5e6-4829-bf89-e353bf27bb4f",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-01T03:24:49.634Z"
+          "timestamp": "2026-03-01T03:29:35.928Z"
         }
       ]
     }


### PR DESCRIPTION
Rewrites the /agenfk-pr slash command to use MCP tools (get_item, create_branch, create_pr) as the primary path instead of CLI commands. Adds the command file to the repo's commands/ directory so it gets installed alongside other commands during `agenfk upgrade`.