### PR TITLE
Enforce main-branch checkout before new task branches

### DIFF
--- a/commands/agenfk.md
+++ b/commands/agenfk.md
@@ -51,6 +51,10 @@ Before creating any item, evaluate the request against these signals:
 
 ## Initialization
 
+0. **Main branch checkout** — Before creating or resuming work, ensure you're starting from the correct base:
+   - Run `git branch --show-current` to check the current branch.
+   - If you are NOT on `main` (or `master`), and the current branch does NOT belong to the item you're about to resume, run `git checkout main` (or `master`) followed by `git pull` first.
+   - This prevents new feature branches from being based on stale/unrelated feature branches and ensures you have the latest upstream changes.
 1. Call `list_items(projectId)` to check for any `IN_PROGRESS` task. If one exists, resume it. Otherwise create a new item with `create_item` (using the type determined in Step 0) and immediately set it to `IN_PROGRESS` with `update_item`.
 2. Call `workflow_gatekeeper(intent, role="coding", itemId)` before making any file changes.
 3. **Branch enforcement** — read the gatekeeper response carefully:

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -548,9 +548,20 @@ server.setRequestHandler(CallToolRequestSchema, async (request: any) => {
                   branchHint = `\n🔀 Already on branch '${task.branchName}'.`;
                 }
               } catch {
-                // Branch doesn't exist locally — create and checkout
+                // Branch doesn't exist locally — checkout main first, then create
+                const mainBranch = (() => {
+                  try {
+                    const ref = execSync('git symbolic-ref refs/remotes/origin/HEAD', { encoding: 'utf8' }).trim();
+                    return ref.replace('refs/remotes/origin/', '');
+                  } catch {}
+                  try { execSync('git rev-parse --verify main', { stdio: 'ignore' }); return 'main'; } catch {}
+                  try { execSync('git rev-parse --verify master', { stdio: 'ignore' }); return 'master'; } catch {}
+                  return execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf8' }).trim();
+                })();
+                execSync(`git checkout ${mainBranch}`, { stdio: 'ignore' });
+                try { execSync(`git pull`, { stdio: 'ignore' }); } catch {}
                 execSync(`git checkout -b ${task.branchName}`, { stdio: 'ignore' });
-                branchHint = `\n🔀 Created and switched to branch '${task.branchName}'.`;
+                branchHint = `\n🔀 Created branch '${task.branchName}' from '${mainBranch}'.`;
               }
             } catch (gitErr: any) {
               branchHint = `\n⚠️ Could not auto-checkout branch '${task.branchName}': ${gitErr.message}. You may need to handle this manually.`;
@@ -696,6 +707,16 @@ server.setRequestHandler(CallToolRequestSchema, async (request: any) => {
         return { content: [{ type: "text", text: "Comment added." }] };
       }
       case "create_branch": {
+        // Helper: detect the default branch (main/master)
+        function detectMainBranch(): string {
+          try {
+            const ref = execSync('git symbolic-ref refs/remotes/origin/HEAD', { encoding: 'utf8' }).trim();
+            return ref.replace('refs/remotes/origin/', '');
+          } catch {}
+          try { execSync('git rev-parse --verify main', { stdio: 'ignore' }); return 'main'; } catch {}
+          try { execSync('git rev-parse --verify master', { stdio: 'ignore' }); return 'master'; } catch {}
+          return execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf8' }).trim();
+        }
         const { itemId } = z.object({ itemId: z.string() }).parse(request.params.arguments);
         const { data: item } = await api.get(`/items/${itemId}`);
 
@@ -723,13 +744,17 @@ server.setRequestHandler(CallToolRequestSchema, async (request: any) => {
         const branchName = `${prefix}/${slug}`;
 
         try {
+          const mainBranch = detectMainBranch();
+          execSync(`git checkout ${mainBranch}`, { stdio: 'ignore' });
+          try { execSync(`git pull`, { stdio: 'ignore' }); } catch {}
           execSync(`git checkout -b ${branchName}`, { stdio: 'ignore' });
         } catch (gitErr: any) {
           return { isError: true, content: [{ type: "text", text: `❌ Failed to create branch '${branchName}': ${gitErr.message}` }] };
         }
 
         await api.put(`/items/${itemId}`, { branchName });
-        return { content: [{ type: "text", text: `🔀 Created and switched to branch '${branchName}'. Stored on item [${itemId.substring(0, 8)}].` }] };
+        const baseBranch = detectMainBranch();
+        return { content: [{ type: "text", text: `🔀 Created branch '${branchName}' from '${baseBranch}'. Stored on item [${itemId.substring(0, 8)}].` }] };
       }
       case "create_pr": {
         const { itemId, description: prBody, draft } = z.object({

--- a/server-test-db.json
+++ b/server-test-db.json
@@ -1,258 +1,258 @@
 {
   "projects": [
     {
-      "id": "9aa79a86-ab95-442c-8b21-9350ef17762e",
+      "id": "9b4d2f8a-fcb0-4134-b049-5d20fe665b35",
       "name": "P1 Updated",
       "description": "",
-      "createdAt": "2026-03-02T01:05:10.069Z",
-      "updatedAt": "2026-03-02T01:05:10.084Z"
+      "createdAt": "2026-03-02T01:16:25.948Z",
+      "updatedAt": "2026-03-02T01:16:25.961Z"
     },
     {
-      "id": "ba074844-446c-4562-b6a2-b6a5d057922d",
+      "id": "967567a7-6314-4eac-8a43-18d5921f8d09",
       "name": "Item Test",
       "description": "",
-      "createdAt": "2026-03-02T01:05:10.094Z",
-      "updatedAt": "2026-03-02T01:05:10.094Z"
+      "createdAt": "2026-03-02T01:16:25.969Z",
+      "updatedAt": "2026-03-02T01:16:25.969Z"
     },
     {
-      "id": "e0a6f3be-04f9-4efa-ab01-a359d682662d",
+      "id": "449aa765-cbe4-43ee-9fdc-a778c2897973",
       "name": "JIRA Import Test",
       "description": "",
-      "createdAt": "2026-03-02T01:05:10.175Z",
-      "updatedAt": "2026-03-02T01:05:10.175Z"
+      "createdAt": "2026-03-02T01:16:26.048Z",
+      "updatedAt": "2026-03-02T01:16:26.048Z"
     },
     {
-      "id": "a1cee432-430e-4751-af1d-b3e4a81730dc",
+      "id": "396aeb94-20bd-43bd-bf0b-958729783ab6",
       "name": "JIRA Err Test",
       "description": "",
-      "createdAt": "2026-03-02T01:05:10.180Z",
-      "updatedAt": "2026-03-02T01:05:10.180Z"
+      "createdAt": "2026-03-02T01:16:26.053Z",
+      "updatedAt": "2026-03-02T01:16:26.053Z"
     }
   ],
   "items": [
     {
-      "id": "d9764200-c930-4d64-919d-014dd33f7d05",
-      "projectId": "ba074844-446c-4562-b6a2-b6a5d057922d",
+      "id": "25ebb425-b1f7-4925-9d00-9ce32cf4352d",
+      "projectId": "967567a7-6314-4eac-8a43-18d5921f8d09",
       "type": "TASK",
       "title": "T1",
       "description": "D1",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:05:10.096Z",
-      "updatedAt": "2026-03-02T01:05:10.096Z",
+      "createdAt": "2026-03-02T01:16:25.972Z",
+      "updatedAt": "2026-03-02T01:16:25.972Z",
       "history": [
         {
-          "id": "6cfd189e-d88a-4309-a88b-6df46c2f9d45",
+          "id": "26f9a75d-265a-43b7-963b-dfbe8d26588d",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:05:10.096Z"
+          "timestamp": "2026-03-02T01:16:25.972Z"
         }
       ]
     },
     {
-      "id": "a9d5d779-c195-4827-b54f-3bd746d4d794",
-      "projectId": "ba074844-446c-4562-b6a2-b6a5d057922d",
+      "id": "b3b6af9d-eeec-4c39-8302-1a22d4ee2c66",
+      "projectId": "967567a7-6314-4eac-8a43-18d5921f8d09",
       "type": "TASK",
       "title": "To Update",
       "description": "D",
       "status": "IN_PROGRESS",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:05:10.099Z",
-      "updatedAt": "2026-03-02T01:05:10.101Z",
+      "createdAt": "2026-03-02T01:16:25.974Z",
+      "updatedAt": "2026-03-02T01:16:25.976Z",
       "history": [
         {
-          "id": "0866e1f4-31f8-43ca-8066-3e6bc2abc804",
+          "id": "a31ec551-fe6d-4e22-9d04-75901c482854",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:05:10.099Z"
+          "timestamp": "2026-03-02T01:16:25.974Z"
         },
         {
-          "id": "e747d409-7082-40d6-8330-393aa4e2e745",
+          "id": "d692791a-c694-4bdb-ae37-7111dff8a5e6",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-02T01:05:10.101Z"
+          "timestamp": "2026-03-02T01:16:25.976Z"
         }
       ]
     },
     {
-      "id": "972508f0-bbd2-4397-b4ba-0c669be2f1ef",
-      "projectId": "ba074844-446c-4562-b6a2-b6a5d057922d",
+      "id": "b9e59fd5-fc72-46e0-8680-8a730fa86cfa",
+      "projectId": "967567a7-6314-4eac-8a43-18d5921f8d09",
       "type": "TASK",
       "title": "No Cheat",
       "description": "D",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:05:10.103Z",
-      "updatedAt": "2026-03-02T01:05:10.103Z",
+      "createdAt": "2026-03-02T01:16:25.978Z",
+      "updatedAt": "2026-03-02T01:16:25.978Z",
       "history": [
         {
-          "id": "b522c66e-5a92-4a9d-b131-ade2e111bcb3",
+          "id": "9c388d9e-8f86-4b06-a6b3-f6f41810b44f",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:05:10.104Z"
+          "timestamp": "2026-03-02T01:16:25.979Z"
         }
       ]
     },
     {
-      "id": "104927c9-6f12-4754-9466-013a7391218e",
-      "projectId": "ba074844-446c-4562-b6a2-b6a5d057922d",
+      "id": "2d127bcf-756b-4f3b-b8b1-c6779dbb8a29",
+      "projectId": "967567a7-6314-4eac-8a43-18d5921f8d09",
       "type": "TASK",
       "title": "Verify Me",
       "description": "D",
       "status": "DONE",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:05:10.108Z",
-      "updatedAt": "2026-03-02T01:05:10.110Z",
+      "createdAt": "2026-03-02T01:16:25.981Z",
+      "updatedAt": "2026-03-02T01:16:25.983Z",
       "history": [
         {
-          "id": "a312d675-e9ef-4642-b390-933d82b8eac1",
+          "id": "5985b25e-64c0-4454-8c24-541c7368236b",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:05:10.108Z"
+          "timestamp": "2026-03-02T01:16:25.981Z"
         },
         {
-          "id": "59cd0e6d-b031-44ec-91bf-9dc3c2ed2949",
+          "id": "075dab2b-3705-44fb-98ba-0f7395cb5723",
           "fromStatus": "TODO",
           "toStatus": "DONE",
-          "timestamp": "2026-03-02T01:05:10.110Z"
+          "timestamp": "2026-03-02T01:16:25.983Z"
         }
       ]
     },
     {
-      "id": "b657e408-f579-4b40-a7da-1759c72caba9",
-      "projectId": "ba074844-446c-4562-b6a2-b6a5d057922d",
+      "id": "cb4a8c25-d50b-4933-90be-711fe30dcdef",
+      "projectId": "967567a7-6314-4eac-8a43-18d5921f8d09",
       "type": "STORY",
       "title": "Parent Story",
       "description": "D",
       "status": "IN_PROGRESS",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:05:10.112Z",
-      "updatedAt": "2026-03-02T01:05:10.116Z",
+      "createdAt": "2026-03-02T01:16:25.985Z",
+      "updatedAt": "2026-03-02T01:16:25.991Z",
       "history": [
         {
-          "id": "dad20b14-d37b-43ee-aeff-43212d94e041",
+          "id": "4fa6e08e-8202-4baa-b3b9-b700777ff378",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:05:10.112Z"
+          "timestamp": "2026-03-02T01:16:25.985Z"
         },
         {
-          "id": "aa531a04-df23-445f-95ba-e49992bcfa01",
+          "id": "3fd50554-f740-4e1c-829d-c5a33a1b6779",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-02T01:05:10.116Z"
+          "timestamp": "2026-03-02T01:16:25.991Z"
         }
       ]
     },
     {
-      "id": "51bceaef-fc27-47ba-8b9b-79f69711031c",
-      "projectId": "ba074844-446c-4562-b6a2-b6a5d057922d",
+      "id": "5b72848f-da2b-4a12-bef6-6b6e0a6c9ad5",
+      "projectId": "967567a7-6314-4eac-8a43-18d5921f8d09",
       "type": "TASK",
       "title": "Child Task",
       "description": "D",
       "status": "IN_PROGRESS",
-      "parentId": "b657e408-f579-4b40-a7da-1759c72caba9",
+      "parentId": "cb4a8c25-d50b-4933-90be-711fe30dcdef",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:05:10.113Z",
-      "updatedAt": "2026-03-02T01:05:10.115Z",
+      "createdAt": "2026-03-02T01:16:25.987Z",
+      "updatedAt": "2026-03-02T01:16:25.990Z",
       "history": [
         {
-          "id": "97532b87-8330-49fa-a72a-2e026326c3d1",
+          "id": "39d6bb37-ae4e-46c7-bf88-89b1a372433a",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:05:10.114Z"
+          "timestamp": "2026-03-02T01:16:25.987Z"
         },
         {
-          "id": "988cd55c-8045-41ae-833d-b368aa654405",
+          "id": "3acffbb8-55c3-48fd-94ab-609920a0109f",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-02T01:05:10.115Z"
+          "timestamp": "2026-03-02T01:16:25.990Z"
         }
       ]
     },
     {
-      "id": "92a44775-fc19-4618-abb0-5c0773ae9be0",
-      "projectId": "ba074844-446c-4562-b6a2-b6a5d057922d",
+      "id": "bbef9f54-e2bd-4a92-9b2c-665e715ef130",
+      "projectId": "967567a7-6314-4eac-8a43-18d5921f8d09",
       "type": "TASK",
       "title": "Archive Me",
       "description": "D",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:05:10.118Z",
-      "updatedAt": "2026-03-02T01:05:10.121Z",
+      "createdAt": "2026-03-02T01:16:25.994Z",
+      "updatedAt": "2026-03-02T01:16:25.997Z",
       "history": [
         {
-          "id": "2745bd86-7cef-4984-83e7-83ad5e5cd2de",
+          "id": "04c8dde1-7606-4687-aa65-dab943e13a14",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:05:10.118Z"
+          "timestamp": "2026-03-02T01:16:25.994Z"
         },
         {
-          "id": "118d084d-1bd1-4616-813a-4506da4bb2f6",
+          "id": "4fd3231b-a32f-401f-ad7f-52f6d741f993",
           "fromStatus": "TODO",
           "toStatus": "ARCHIVED",
-          "timestamp": "2026-03-02T01:05:10.119Z"
+          "timestamp": "2026-03-02T01:16:25.995Z"
         },
         {
-          "id": "594d8441-8240-409c-8cd3-ff10fa7865b3",
+          "id": "e08d9384-53ca-475a-a56a-f2abad3dbe9f",
           "fromStatus": "ARCHIVED",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:05:10.120Z"
+          "timestamp": "2026-03-02T01:16:25.997Z"
         }
       ]
     },
     {
-      "id": "436fa881-65ce-4cbc-b3ff-844cb2e3647a",
-      "projectId": "ba074844-446c-4562-b6a2-b6a5d057922d",
+      "id": "e9a3445f-1e07-48b1-90c3-ceeb3707288a",
+      "projectId": "967567a7-6314-4eac-8a43-18d5921f8d09",
       "type": "TASK",
       "title": "Delete Me",
       "description": "D",
       "status": "TRASHED",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:05:10.122Z",
-      "updatedAt": "2026-03-02T01:05:10.124Z",
+      "createdAt": "2026-03-02T01:16:25.999Z",
+      "updatedAt": "2026-03-02T01:16:26.000Z",
       "history": [
         {
-          "id": "e9cf2ee2-7035-4484-b04c-670454c849ab",
+          "id": "c1d73780-4d37-4d99-9e61-83c7b9d5e740",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:05:10.123Z"
+          "timestamp": "2026-03-02T01:16:25.999Z"
         },
         {
-          "id": "a68f05e9-1d03-43b0-842a-75ed0f40623e",
+          "id": "61394983-a2a7-4a76-94ae-3148f838a62e",
           "fromStatus": "TODO",
           "toStatus": "TRASHED",
-          "timestamp": "2026-03-02T01:05:10.124Z"
+          "timestamp": "2026-03-02T01:16:26.000Z"
         }
       ]
     },
     {
-      "id": "4fa893be-9649-41c4-b0ab-91a006699db2",
-      "projectId": "ba074844-446c-4562-b6a2-b6a5d057922d",
+      "id": "c72a66db-321a-4bff-a162-664a315fb6fd",
+      "projectId": "967567a7-6314-4eac-8a43-18d5921f8d09",
       "type": "TASK",
       "title": "Archived Task",
       "description": "",
       "status": "TRASHED",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:05:10.127Z",
-      "updatedAt": "2026-03-02T01:05:10.129Z",
+      "createdAt": "2026-03-02T01:16:26.005Z",
+      "updatedAt": "2026-03-02T01:16:26.013Z",
       "history": [
         {
-          "id": "beb66f56-77f5-44d7-b859-1c26777d0b7b",
+          "id": "cc7bc11a-e2d2-4a28-a430-755a43e540ad",
           "fromStatus": "TODO",
           "toStatus": "ARCHIVED",
-          "timestamp": "2026-03-02T01:05:10.127Z"
+          "timestamp": "2026-03-02T01:16:26.005Z"
         },
         {
-          "id": "1f0d4dfd-e55c-42cf-aa2b-7b1737753511",
+          "id": "f306a6da-755d-4c73-82c4-21e330702513",
           "fromStatus": "ARCHIVED",
           "toStatus": "TRASHED",
-          "timestamp": "2026-03-02T01:05:10.129Z"
+          "timestamp": "2026-03-02T01:16:26.013Z"
         }
       ]
     },
     {
-      "id": "a898fd3d-f499-449b-8b99-2af4c419fce2",
-      "projectId": "e0a6f3be-04f9-4efa-ab01-a359d682662d",
+      "id": "a1ebe394-f88e-467a-bcb2-bf5ed2f9478f",
+      "projectId": "449aa765-cbe4-43ee-9fdc-a778c2897973",
       "type": "BUG",
       "title": "[PROJ-1] Fix login bug",
       "description": "Imported from JIRA: PROJ-1",
@@ -260,14 +260,14 @@
       "implementationPlan": "",
       "externalId": "PROJ-1",
       "externalUrl": "https://test.atlassian.net/browse/PROJ-1",
-      "createdAt": "2026-03-02T01:05:10.176Z",
-      "updatedAt": "2026-03-02T01:05:10.176Z",
+      "createdAt": "2026-03-02T01:16:26.050Z",
+      "updatedAt": "2026-03-02T01:16:26.050Z",
       "history": [
         {
-          "id": "df30c845-a2ed-44fe-acc9-37f0f71b257a",
+          "id": "36b2d8f8-f550-4832-9e56-237e91624bea",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:05:10.177Z"
+          "timestamp": "2026-03-02T01:16:26.050Z"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- Added `detectMainBranch()` helper to auto-detect the default branch (origin/HEAD → main → master fallback)
- `create_branch` MCP tool now checks out main and pulls latest before creating new feature branches
- Gatekeeper fallback branch creation uses the same checkout-main-and-pull logic
- `/agenfk` skill Initialization now includes Step 0: pre-flight main branch checkout + pull

This prevents new task branches from being accidentally based on stale/unrelated feature branches when the agent hasn't returned to main between tasks.

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes
- [ ] Manual: verify `create_branch` checks out main before branching when on a feature branch