### PR TITLE
Collapsed columns expand horizontally when a sibling column is expanded

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenfk-framework",
-  "version": "0.1.58",
+  "version": "0.1.61",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenfk-framework",
-      "version": "0.1.58",
+      "version": "0.1.61",
       "license": "ISC",
       "workspaces": [
         "packages/*"
@@ -10461,7 +10461,7 @@
     },
     "packages/cli": {
       "name": "@agenfk/cli",
-      "version": "0.1.58",
+      "version": "0.1.61",
       "license": "ISC",
       "dependencies": {
         "@agenfk/core": "*",
@@ -10486,7 +10486,7 @@
     },
     "packages/core": {
       "name": "@agenfk/core",
-      "version": "0.1.58",
+      "version": "0.1.61",
       "license": "ISC",
       "devDependencies": {
         "typescript": "^5.3.3"
@@ -10494,7 +10494,7 @@
     },
     "packages/create": {
       "name": "agenfk",
-      "version": "0.1.58",
+      "version": "0.1.61",
       "license": "ISC",
       "bin": {
         "agenfk": "bin/agenfk.js"
@@ -10505,7 +10505,7 @@
     },
     "packages/server": {
       "name": "@agenfk/server",
-      "version": "0.1.58",
+      "version": "0.1.61",
       "license": "ISC",
       "dependencies": {
         "@agenfk/core": "*",
@@ -10533,7 +10533,7 @@
     },
     "packages/storage-json": {
       "name": "@agenfk/storage-json",
-      "version": "0.1.58",
+      "version": "0.1.61",
       "license": "ISC",
       "dependencies": {
         "uuid": "^9.0.1"
@@ -10546,7 +10546,7 @@
     },
     "packages/storage-sqlite": {
       "name": "@agenfk/storage-sqlite",
-      "version": "0.1.58",
+      "version": "0.1.61",
       "license": "ISC",
       "dependencies": {
         "uuid": "^9.0.1"
@@ -10570,7 +10570,7 @@
     },
     "packages/telemetry": {
       "name": "@agenfk/telemetry",
-      "version": "0.1.58",
+      "version": "0.1.61",
       "license": "ISC",
       "dependencies": {
         "posthog-node": "^4.0.0"
@@ -10581,7 +10581,7 @@
       }
     },
     "packages/ui": {
-      "version": "0.1.58",
+      "version": "0.1.61",
       "dependencies": {
         "@tailwindcss/postcss": "^4.2.0",
         "@tailwindcss/typography": "^0.5.19",

--- a/packages/ui/src/components/KanbanBoard.tsx
+++ b/packages/ui/src/components/KanbanBoard.tsx
@@ -1183,7 +1183,7 @@ export const KanbanBoard: React.FC = () => {
         <LayoutGroup id="board">
           <div className="flex flex-col md:flex-row gap-2 h-full w-full relative z-0">
             {/* Ideas Section — hidden in drill-down view */}
-            {navPath.length === 0 && <div className={clsx("flex flex-col transition-all duration-300 h-full", !isIdeasCollapsed ? "w-80 shrink-0" : "w-12 shrink-0")}>
+            {navPath.length === 0 && <div className={clsx("flex flex-col transition-all duration-300 h-full", !isIdeasCollapsed ? "w-64 shrink min-w-0" : "w-12 shrink-0")}>
               {isIdeasCollapsed ? (
                 <button onClick={() => setIsIdeasCollapsed(false)} className="h-full w-full bg-indigo-50/50 dark:bg-indigo-900/10 rounded-xl flex flex-col items-center justify-center py-4 gap-3 hover:bg-indigo-100/50 dark:hover:bg-indigo-900/20 transition-colors group border border-dashed border-indigo-200 dark:border-indigo-900/30">
                   <Lightbulb size={16} className="text-indigo-400 group-hover:text-indigo-500 shrink-0" />
@@ -1303,27 +1303,12 @@ export const KanbanBoard: React.FC = () => {
           ))}
 
           {/* Paused + Blocked + Archived — hidden in drill-down view */}
-          {navPath.length === 0 && (() => {
-            const rightExpandedCount = [!isPausedCollapsed, !isBlockedCollapsed, !isArchiveCollapsed].filter(Boolean).length;
-            const rightAnyExpanded = rightExpandedCount > 0;
-            const collapsedClass = (isExpanded: boolean) => isExpanded ? "flex-1" : (rightAnyExpanded ? "h-12 shrink-0" : "flex-1");
-            return <div className={clsx("flex flex-col gap-4 transition-all duration-300 h-full", rightAnyExpanded ? "w-80 shrink-0" : "w-12 shrink-0")}>
-            {/* Paused Section */}
-            <div className={clsx("flex flex-col transition-all duration-300", collapsedClass(!isPausedCollapsed))}>
-              {isPausedCollapsed ? (
-                <button
-                  /* v8 ignore start */
-                  onClick={() => setIsPausedCollapsed(false)}
-                  /* v8 ignore stop */
-                  className="h-full w-full bg-orange-50/50 dark:bg-orange-900/10 rounded-xl flex flex-col items-center justify-center py-4 gap-3 hover:bg-orange-100/50 dark:hover:bg-orange-900/20 transition-colors group border border-dashed border-orange-200 dark:border-orange-900/30"
-                >
-                  <Pause size={16} className="text-orange-400 group-hover:text-orange-500 shrink-0" />
-                  {!rightAnyExpanded && <span className="[writing-mode:vertical-lr] font-bold text-[10px] uppercase tracking-widest text-orange-400 shrink-0 mt-2">Paused</span>}
-                  <span className={clsx("bg-white dark:bg-slate-800 text-orange-500 text-[10px] font-bold px-1.5 py-0.5 rounded-full border border-orange-100 dark:border-orange-900/30", !rightAnyExpanded && "mt-auto")}>{items?.filter((i: AgenFKItem) => i.status === Status.PAUSED).length || 0}</span>
-                </button>
-              ) : (
+          {navPath.length === 0 && (
+            <div className="flex flex-row gap-2 h-full shrink min-w-0 transition-all duration-300">
+              {/* Expanded sections render as full w-80 columns on the left */}
+              {!isPausedCollapsed && (
                 /* v8 ignore start */
-                <div className="flex flex-col h-full bg-slate-100/50 dark:bg-slate-950/20 rounded-xl p-4 border border-slate-200 dark:border-slate-800" onDrop={(e) => handleDrop(e, Status.PAUSED)} onDragOver={handleDragOver}>
+                <div className="flex flex-col w-64 shrink min-w-0 h-full bg-slate-100/50 dark:bg-slate-950/20 rounded-xl p-4 border border-slate-200 dark:border-slate-800 transition-all duration-300" onDrop={(e) => handleDrop(e, Status.PAUSED)} onDragOver={handleDragOver}>
                   <div className="flex items-center justify-between mb-3 px-1 border-t-4 border-t-orange-400 pt-2">
                     <div className="flex items-center gap-2">
                       <button onClick={() => setIsPausedCollapsed(true)} className="p-1 hover:bg-slate-200 dark:hover:bg-slate-800 rounded"><ChevronLeft size={14} className="text-slate-500" /></button>
@@ -1361,24 +1346,10 @@ export const KanbanBoard: React.FC = () => {
                 </div>
                 /* v8 ignore stop */
               )}
-            </div>
 
-            {/* Blocked Section */}
-            <div className={clsx("flex flex-col transition-all duration-300", collapsedClass(!isBlockedCollapsed))}>
-              {isBlockedCollapsed ? (
-                <button
-                  /* v8 ignore start */
-                  onClick={() => setIsBlockedCollapsed(false)}
-                  /* v8 ignore stop */
-                  className="h-full w-full bg-red-50/50 dark:bg-red-900/10 rounded-xl flex flex-col items-center justify-center py-4 gap-3 hover:bg-red-100/50 dark:hover:bg-red-900/20 transition-colors group border border-dashed border-red-200 dark:border-red-900/30"
-                >
-                  <AlertCircle size={16} className="text-red-400 group-hover:text-red-500 shrink-0" />
-                  {!rightAnyExpanded && <span className="[writing-mode:vertical-lr] font-bold text-[10px] uppercase tracking-widest text-red-400 shrink-0 mt-2">Blocked</span>}
-                  <span className={clsx("bg-white dark:bg-slate-800 text-red-500 text-[10px] font-bold px-1.5 py-0.5 rounded-full border border-red-100 dark:border-red-900/30", !rightAnyExpanded && "mt-auto")}>{items?.filter((i: AgenFKItem) => i.status === Status.BLOCKED).length || 0}</span>
-                </button>
-              ) : (
+              {!isBlockedCollapsed && (
                 /* v8 ignore start */
-                <div className="flex flex-col h-full bg-slate-100/50 dark:bg-slate-950/20 rounded-xl p-4 border border-slate-200 dark:border-slate-800" onDrop={(e) => handleDrop(e, Status.BLOCKED)} onDragOver={handleDragOver}>
+                <div className="flex flex-col w-64 shrink min-w-0 h-full bg-slate-100/50 dark:bg-slate-950/20 rounded-xl p-4 border border-slate-200 dark:border-slate-800 transition-all duration-300" onDrop={(e) => handleDrop(e, Status.BLOCKED)} onDragOver={handleDragOver}>
                   <div className="flex items-center justify-between mb-3 px-1 border-t-4 border-t-red-400 pt-2">
                     <div className="flex items-center gap-2">
                       <button onClick={() => setIsBlockedCollapsed(true)} className="p-1 hover:bg-slate-200 dark:hover:bg-slate-800 rounded"><ChevronLeft size={14} className="text-slate-500" /></button>
@@ -1419,18 +1390,9 @@ export const KanbanBoard: React.FC = () => {
                 </div>
                 /* v8 ignore stop */
               )}
-            </div>
 
-            {/* Archived Section */}
-            <div className={clsx("flex flex-col transition-all duration-300", collapsedClass(!isArchiveCollapsed))}>
-              {isArchiveCollapsed ? (
-                <button onClick={() => setIsArchiveCollapsed(false)} className="h-full w-full bg-slate-200/50 dark:bg-slate-900/50 rounded-xl flex flex-col items-center justify-center py-4 gap-3 hover:bg-slate-300 dark:hover:bg-slate-800 transition-colors group border border-dashed border-slate-300 dark:border-slate-800">
-                  <Archive size={16} className="text-slate-500 group-hover:text-indigo-600 shrink-0" />
-                  {isBlockedCollapsed && <span className="[writing-mode:vertical-lr] font-bold text-[10px] uppercase tracking-widest text-slate-500 shrink-0 mt-2">Archived</span>}
-                  <span className={clsx("bg-white dark:bg-slate-800 text-slate-500 text-[10px] font-bold px-1.5 py-0.5 rounded-full border border-slate-100 dark:border-slate-700", isBlockedCollapsed && "mt-auto")}>{items?.filter((i: AgenFKItem) => i.status === Status.ARCHIVED).length || 0}</span>
-                </button>
-              ) : (
-                <div className="flex flex-col h-full bg-slate-100/50 dark:bg-slate-950/20 rounded-xl p-4 border border-slate-200 dark:border-slate-800">
+              {!isArchiveCollapsed && (
+                <div className="flex flex-col w-64 shrink min-w-0 h-full bg-slate-100/50 dark:bg-slate-950/20 rounded-xl p-4 border border-slate-200 dark:border-slate-800 transition-all duration-300">
                   <div className="flex items-center justify-between mb-3 px-1 border-t-4 border-t-slate-300 pt-2">
                     <div className="flex items-center gap-2">
                       {/* v8 ignore start */}
@@ -1447,7 +1409,7 @@ export const KanbanBoard: React.FC = () => {
                             }
                           }}
                           /* v8 ignore stop */
-                          className="p-1 hover:bg-rose-50 dark:hover:bg-rose-900/20 rounded text-slate-400 hover:text-rose-500 transition-colors" 
+                          className="p-1 hover:bg-rose-50 dark:hover:bg-rose-900/20 rounded text-slate-400 hover:text-rose-500 transition-colors"
                           title="Trash All Archived"
                         >
                           <Trash2 size={12} />
@@ -1488,8 +1450,45 @@ export const KanbanBoard: React.FC = () => {
                 </div>
                 </div>
               )}
+
+              {/* Collapsed sections stacked vertically in a narrow column on the right */}
+              {(isPausedCollapsed || isBlockedCollapsed || isArchiveCollapsed) && (
+                <div className="w-12 shrink-0 flex flex-col gap-2 h-full">
+                  {isPausedCollapsed && (
+                    <button
+                      /* v8 ignore start */
+                      onClick={() => setIsPausedCollapsed(false)}
+                      /* v8 ignore stop */
+                      className="flex-1 w-full bg-orange-50/50 dark:bg-orange-900/10 rounded-xl flex flex-col items-center justify-center py-4 gap-3 hover:bg-orange-100/50 dark:hover:bg-orange-900/20 transition-colors group border border-dashed border-orange-200 dark:border-orange-900/30"
+                    >
+                      <Pause size={16} className="text-orange-400 group-hover:text-orange-500 shrink-0" />
+                      <span className="[writing-mode:vertical-lr] font-bold text-[10px] uppercase tracking-widest text-orange-400 shrink-0 mt-2">Paused</span>
+                      <span className="bg-white dark:bg-slate-800 text-orange-500 text-[10px] font-bold px-1.5 py-0.5 rounded-full border border-orange-100 dark:border-orange-900/30 mt-auto">{items?.filter((i: AgenFKItem) => i.status === Status.PAUSED).length || 0}</span>
+                    </button>
+                  )}
+                  {isBlockedCollapsed && (
+                    <button
+                      /* v8 ignore start */
+                      onClick={() => setIsBlockedCollapsed(false)}
+                      /* v8 ignore stop */
+                      className="flex-1 w-full bg-red-50/50 dark:bg-red-900/10 rounded-xl flex flex-col items-center justify-center py-4 gap-3 hover:bg-red-100/50 dark:hover:bg-red-900/20 transition-colors group border border-dashed border-red-200 dark:border-red-900/30"
+                    >
+                      <AlertCircle size={16} className="text-red-400 group-hover:text-red-500 shrink-0" />
+                      <span className="[writing-mode:vertical-lr] font-bold text-[10px] uppercase tracking-widest text-red-400 shrink-0 mt-2">Blocked</span>
+                      <span className="bg-white dark:bg-slate-800 text-red-500 text-[10px] font-bold px-1.5 py-0.5 rounded-full border border-red-100 dark:border-red-900/30 mt-auto">{items?.filter((i: AgenFKItem) => i.status === Status.BLOCKED).length || 0}</span>
+                    </button>
+                  )}
+                  {isArchiveCollapsed && (
+                    <button onClick={() => setIsArchiveCollapsed(false)} className="flex-1 w-full bg-slate-200/50 dark:bg-slate-900/50 rounded-xl flex flex-col items-center justify-center py-4 gap-3 hover:bg-slate-300 dark:hover:bg-slate-800 transition-colors group border border-dashed border-slate-300 dark:border-slate-800">
+                      <Archive size={16} className="text-slate-500 group-hover:text-indigo-600 shrink-0" />
+                      <span className="[writing-mode:vertical-lr] font-bold text-[10px] uppercase tracking-widest text-slate-500 shrink-0 mt-2">Archived</span>
+                      <span className="bg-white dark:bg-slate-800 text-slate-500 text-[10px] font-bold px-1.5 py-0.5 rounded-full border border-slate-100 dark:border-slate-700 mt-auto">{items?.filter((i: AgenFKItem) => i.status === Status.ARCHIVED).length || 0}</span>
+                    </button>
+                  )}
+                </div>
+              )}
             </div>
-            </div>})()}
+          )}
           </div>
         </LayoutGroup>
       </main>

--- a/packages/ui/src/components/KanbanBoard.tsx
+++ b/packages/ui/src/components/KanbanBoard.tsx
@@ -1304,20 +1304,19 @@ export const KanbanBoard: React.FC = () => {
 
           {/* Paused + Blocked + Archived — hidden in drill-down view */}
           {navPath.length === 0 && (
-            <div className="flex flex-row gap-2 h-full shrink min-w-0 transition-all duration-300">
-              {/* Expanded sections render as full w-80 columns on the left */}
+            <>
+              {/* Expanded sections render as independent columns side-by-side with main board */}
               {!isPausedCollapsed && (
-                /* v8 ignore start */
-                <div className="flex flex-col w-64 shrink min-w-0 h-full bg-slate-100/50 dark:bg-slate-950/20 rounded-xl p-4 border border-slate-200 dark:border-slate-800 transition-all duration-300" onDrop={(e) => handleDrop(e, Status.PAUSED)} onDragOver={handleDragOver}>
+                <div className="flex flex-col w-full md:flex-1 md:min-w-[180px] h-full bg-slate-100/50 dark:bg-slate-950/20 rounded-xl p-4 border border-slate-200 dark:border-slate-800 transition-all duration-300" onDrop={(e) => handleDrop(e, Status.PAUSED)} onDragOver={handleDragOver}>
                   <div className="flex items-center justify-between mb-3 px-1 border-t-4 border-t-orange-400 pt-2">
                     <div className="flex items-center gap-2">
-                      <button onClick={() => setIsPausedCollapsed(true)} className="p-1 hover:bg-slate-200 dark:hover:bg-slate-800 rounded"><ChevronLeft size={14} className="text-slate-500" /></button>
+                      <button onClick={() => setIsPausedCollapsed(true)} className="p-1 hover:bg-slate-200 dark:hover:bg-slate-800 rounded transition-colors" title="Collapse Column"><ChevronRight size={14} className="text-slate-500" /></button>
                       <Pause size={14} className="text-orange-500" />
-                      <h2 className="font-bold text-slate-700 dark:text-slate-300 text-sm uppercase tracking-wider text-xs">Paused</h2>
+                      <h2 className="font-bold text-slate-700 dark:text-slate-300 text-xs uppercase tracking-wider">Paused</h2>
                     </div>
                     <span className="bg-white dark:bg-slate-800 text-slate-500 dark:text-slate-400 text-xs font-bold px-2 py-1 rounded-full shadow-sm border border-slate-100 dark:border-slate-700">{items?.filter((i: AgenFKItem) => i.status === Status.PAUSED).length || 0}</span>
                   </div>
-                  <div className={clsx("flex-1 pr-2 pb-2 flex flex-col gap-3 relative scrollbar-thin scrollbar-thumb-slate-200 overflow-y-auto overflow-x-hidden")} style={{ scrollbarGutter: 'stable' }}>
+                  <div className={clsx("flex-1 pr-2 pb-2 flex flex-col gap-3 relative scrollbar-thin scrollbar-thumb-slate-200 dark:scrollbar-thumb-slate-800 overflow-y-auto overflow-x-hidden")} style={{ scrollbarGutter: 'stable' }}>
                     <AnimatePresence mode="popLayout" initial={false}>
                       {getItemsByStatus(Status.PAUSED).map((item: AgenFKItem) => (
                           <KanbanCard
@@ -1339,26 +1338,25 @@ export const KanbanBoard: React.FC = () => {
                             onDrillDown={handleDrillDown}
                             onArchive={(id) => updateMutation.mutate({ id, updates: { status: Status.ARCHIVED } })}
                             onCopyId={handleCopyId}
+                            disableLayoutAnimation={easterEggsEnabled}
                           />
                         ))}
                       </AnimatePresence>
                   </div>
                 </div>
-                /* v8 ignore stop */
               )}
 
               {!isBlockedCollapsed && (
-                /* v8 ignore start */
-                <div className="flex flex-col w-64 shrink min-w-0 h-full bg-slate-100/50 dark:bg-slate-950/20 rounded-xl p-4 border border-slate-200 dark:border-slate-800 transition-all duration-300" onDrop={(e) => handleDrop(e, Status.BLOCKED)} onDragOver={handleDragOver}>
+                <div className="flex flex-col w-full md:flex-1 md:min-w-[180px] h-full bg-slate-100/50 dark:bg-slate-950/20 rounded-xl p-4 border border-slate-200 dark:border-slate-800 transition-all duration-300" onDrop={(e) => handleDrop(e, Status.BLOCKED)} onDragOver={handleDragOver}>
                   <div className="flex items-center justify-between mb-3 px-1 border-t-4 border-t-red-400 pt-2">
                     <div className="flex items-center gap-2">
-                      <button onClick={() => setIsBlockedCollapsed(true)} className="p-1 hover:bg-slate-200 dark:hover:bg-slate-800 rounded"><ChevronLeft size={14} className="text-slate-500" /></button>
+                      <button onClick={() => setIsBlockedCollapsed(true)} className="p-1 hover:bg-slate-200 dark:hover:bg-slate-800 rounded transition-colors" title="Collapse Column"><ChevronRight size={14} className="text-slate-500" /></button>
                       <AlertCircle size={14} className="text-red-500" />
-                      <h2 className="font-bold text-slate-700 dark:text-slate-300 text-sm uppercase tracking-wider text-xs">Blocked</h2>
+                      <h2 className="font-bold text-slate-700 dark:text-slate-300 text-xs uppercase tracking-wider">Blocked</h2>
                     </div>
                     <span className="bg-white dark:bg-slate-800 text-slate-500 dark:text-slate-400 text-xs font-bold px-2 py-1 rounded-full shadow-sm border border-slate-100 dark:border-slate-700">{items?.filter((i: AgenFKItem) => i.status === Status.BLOCKED).length || 0}</span>
                   </div>
-                  <div className={clsx("flex-1 pr-2 pb-2 flex flex-col gap-3 relative scrollbar-thin scrollbar-thumb-slate-200 overflow-y-auto overflow-x-hidden")} style={{ scrollbarGutter: 'stable' }}>
+                  <div className={clsx("flex-1 pr-2 pb-2 flex flex-col gap-3 relative scrollbar-thin scrollbar-thumb-slate-200 dark:scrollbar-thumb-slate-800 overflow-y-auto overflow-x-hidden")} style={{ scrollbarGutter: 'stable' }}>
                     <AnimatePresence mode="popLayout" initial={false}>
                       {getItemsByStatus(Status.BLOCKED).map((item: AgenFKItem) => (
                           <KanbanCard
@@ -1380,35 +1378,31 @@ export const KanbanBoard: React.FC = () => {
                             onDrillDown={handleDrillDown}
                             onArchive={(id) => updateMutation.mutate({ id, updates: { status: Status.ARCHIVED } })}
                             onCopyId={handleCopyId}
+                            disableLayoutAnimation={easterEggsEnabled}
                           />
                         ))}
                       </AnimatePresence>
-                  <button onClick={() => setSelectedItem({ type: ItemType.TASK, status: Status.BLOCKED, title: '', description: '', projectId: selectedProjectId! } as any)} className="w-full py-1.5 border-2 border-dashed border-slate-200 dark:border-slate-800 rounded-lg text-slate-400 dark:text-slate-500 text-xs font-medium hover:border-red-300 dark:hover:border-red-700 hover:text-red-500 dark:hover:text-red-400 transition-all flex items-center justify-center gap-1.5">
-                    <Plus size={14} /> Add blocked
-                  </button>
+                    <button onClick={() => setSelectedItem({ type: ItemType.TASK, status: Status.BLOCKED, title: '', description: '', projectId: selectedProjectId! } as any)} className="w-full py-2 border-2 border-dashed border-slate-200 dark:border-slate-800 rounded-xl text-slate-400 dark:text-slate-500 text-xs font-medium hover:border-red-300 dark:hover:border-red-700 hover:text-red-500 dark:hover:text-red-400 transition-all flex items-center justify-center gap-2 mt-2">
+                      <Plus size={16} /> Add blocked
+                    </button>
+                  </div>
                 </div>
-                </div>
-                /* v8 ignore stop */
               )}
 
               {!isArchiveCollapsed && (
-                <div className="flex flex-col w-64 shrink min-w-0 h-full bg-slate-100/50 dark:bg-slate-950/20 rounded-xl p-4 border border-slate-200 dark:border-slate-800 transition-all duration-300">
+                <div className="flex flex-col w-full md:flex-1 md:min-w-[180px] h-full bg-slate-100/50 dark:bg-slate-950/20 rounded-xl p-4 border border-slate-200 dark:border-slate-800 transition-all duration-300" onDrop={(e) => handleDrop(e, Status.ARCHIVED)} onDragOver={handleDragOver}>
                   <div className="flex items-center justify-between mb-3 px-1 border-t-4 border-t-slate-300 pt-2">
                     <div className="flex items-center gap-2">
-                      {/* v8 ignore start */}
-                      <button onClick={() => setIsArchiveCollapsed(true)} className="p-1 hover:bg-slate-200 dark:hover:bg-slate-800 rounded"><ChevronLeft size={14} className="text-slate-500" /></button>
-                      {/* v8 ignore stop */}
+                      <button onClick={() => setIsArchiveCollapsed(true)} className="p-1 hover:bg-slate-200 dark:hover:bg-slate-800 rounded transition-colors" title="Collapse Column"><ChevronRight size={14} className="text-slate-500" /></button>
                       <Archive size={14} className="text-slate-500" />
-                      <h2 className="font-bold text-slate-700 dark:text-slate-300 text-sm uppercase tracking-wider text-xs">Archived</h2>
+                      <h2 className="font-bold text-slate-700 dark:text-slate-300 text-xs uppercase tracking-wider">Archived</h2>
                       {items?.some((i: AgenFKItem) => i.status === Status.ARCHIVED) && (
                         <button
-                          /* v8 ignore start */
                           onClick={() => {
                             if (window.confirm('Move all archived items to trash?')) {
                               trashArchivedMutation.mutate(selectedProjectId!);
                             }
                           }}
-                          /* v8 ignore stop */
                           className="p-1 hover:bg-rose-50 dark:hover:bg-rose-900/20 rounded text-slate-400 hover:text-rose-500 transition-colors"
                           title="Trash All Archived"
                         >
@@ -1418,36 +1412,33 @@ export const KanbanBoard: React.FC = () => {
                     </div>
                     <span className="bg-white dark:bg-slate-800 text-slate-500 dark:text-slate-400 text-xs font-bold px-2 py-1 rounded-full shadow-sm border border-slate-100 dark:border-slate-700">{items?.filter((i: AgenFKItem) => i.status === Status.ARCHIVED).length || 0}</span>
                   </div>
-                <div className={clsx("flex-1 pr-2 pb-2 flex flex-col gap-3 relative scrollbar-thin scrollbar-thumb-slate-200 overflow-y-auto overflow-x-hidden")} style={{ scrollbarGutter: 'stable' }}>
-                        <AnimatePresence mode="popLayout" initial={false}>
-                          {items?.filter((i: AgenFKItem) => i.status === Status.ARCHIVED).map((item: AgenFKItem) => (
-                          <KanbanCard
-                            key={item.id}
-                            item={item}
-                            items={items}
-                            highlightedId={highlightedId}
-                            dragId={dragId}
-                            dropTargetId={dropTargetId}
-                            dropPosition={dropPosition}
-                            copiedId={copiedId}
-                            pricesData={pricesData}
-                            isUserAction={isUserAction}
-                            onCardDragStart={handleDragStart}
-                            onCardDragEnd={handleDragEnd}
-                            onCardDragOver={handleCardDragOver}
-                            onCardDragLeave={handleCardDragLeave}
-                            /* v8 ignore start */
-                            onDoubleClick={() => setSelectedItem(item)}
-                            /* v8 ignore stop */
-                            onDrillDown={handleDrillDown}
-                            /* v8 ignore start */
-                            onArchive={(id) => updateMutation.mutate({ id, updates: { status: item.previousStatus || Status.TODO } })}
-                            /* v8 ignore stop */
-                            onCopyId={handleCopyId}
-                          />
-                        ))}
-                      </AnimatePresence>
-                </div>
+                  <div className={clsx("flex-1 pr-2 pb-2 flex flex-col gap-3 relative scrollbar-thin scrollbar-thumb-slate-200 dark:scrollbar-thumb-slate-800 overflow-y-auto overflow-x-hidden")} style={{ scrollbarGutter: 'stable' }}>
+                    <AnimatePresence mode="popLayout" initial={false}>
+                      {items?.filter((i: AgenFKItem) => i.status === Status.ARCHIVED).map((item: AgenFKItem) => (
+                        <KanbanCard
+                          key={item.id}
+                          item={item}
+                          items={items}
+                          highlightedId={highlightedId}
+                          dragId={dragId}
+                          dropTargetId={dropTargetId}
+                          dropPosition={dropPosition}
+                          copiedId={copiedId}
+                          pricesData={pricesData}
+                          isUserAction={isUserAction}
+                          onCardDragStart={handleDragStart}
+                          onCardDragEnd={handleDragEnd}
+                          onCardDragOver={handleCardDragOver}
+                          onCardDragLeave={handleCardDragLeave}
+                          onDoubleClick={() => setSelectedItem(item)}
+                          onDrillDown={handleDrillDown}
+                          onArchive={(id) => updateMutation.mutate({ id, updates: { status: item.previousStatus || Status.TODO } })}
+                          onCopyId={handleCopyId}
+                          disableLayoutAnimation={easterEggsEnabled}
+                        />
+                      ))}
+                    </AnimatePresence>
+                  </div>
                 </div>
               )}
 
@@ -1456,9 +1447,7 @@ export const KanbanBoard: React.FC = () => {
                 <div className="w-12 shrink-0 flex flex-col gap-2 h-full">
                   {isPausedCollapsed && (
                     <button
-                      /* v8 ignore start */
                       onClick={() => setIsPausedCollapsed(false)}
-                      /* v8 ignore stop */
                       className="flex-1 w-full bg-orange-50/50 dark:bg-orange-900/10 rounded-xl flex flex-col items-center justify-center py-4 gap-3 hover:bg-orange-100/50 dark:hover:bg-orange-900/20 transition-colors group border border-dashed border-orange-200 dark:border-orange-900/30"
                     >
                       <Pause size={16} className="text-orange-400 group-hover:text-orange-500 shrink-0" />
@@ -1468,9 +1457,7 @@ export const KanbanBoard: React.FC = () => {
                   )}
                   {isBlockedCollapsed && (
                     <button
-                      /* v8 ignore start */
                       onClick={() => setIsBlockedCollapsed(false)}
-                      /* v8 ignore stop */
                       className="flex-1 w-full bg-red-50/50 dark:bg-red-900/10 rounded-xl flex flex-col items-center justify-center py-4 gap-3 hover:bg-red-100/50 dark:hover:bg-red-900/20 transition-colors group border border-dashed border-red-200 dark:border-red-900/30"
                     >
                       <AlertCircle size={16} className="text-red-400 group-hover:text-red-500 shrink-0" />
@@ -1487,7 +1474,7 @@ export const KanbanBoard: React.FC = () => {
                   )}
                 </div>
               )}
-            </div>
+            </>
           )}
           </div>
         </LayoutGroup>

--- a/packages/ui/src/components/KanbanBoard.tsx
+++ b/packages/ui/src/components/KanbanBoard.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { motion, AnimatePresence, LayoutGroup, useAnimation } from 'framer-motion';
 import { api } from '../api';
@@ -9,7 +9,8 @@ import {
   Zap, ChevronRight, Home,
   Sun, Moon, Search, Archive, ArchiveRestore, ChevronLeft,
   FolderOpen, Briefcase, Clock, FlaskConical, ShieldCheck,
-  Copy, Check, Download, Pin, PinOff, ExternalLink, Trash2, Lightbulb, Book, Pause
+  Copy, Check, Download, Pin, PinOff, ExternalLink, Trash2, Lightbulb, Book, Pause,
+  ChevronUp, ChevronDown, X
 } from 'lucide-react';
 import { io } from 'socket.io-client';
 import { CardDetailModal } from './CardDetailModal';
@@ -193,7 +194,7 @@ const KanbanCard: React.FC<KanbanCardProps> = ({
       }}
       className={clsx(
         "group bg-white dark:bg-slate-900 rounded-xl p-3 border border-slate-200 dark:border-slate-800 cursor-move hover:shadow-lg dark:hover:shadow-indigo-900/20 hover:border-indigo-300 dark:hover:border-indigo-700 transition-colors duration-200",
-        highlightedId === item.id && "ring-2 ring-indigo-500 border-indigo-500 dark:border-indigo-500 bg-indigo-50/50 dark:bg-indigo-900/30",
+        highlightedId === item.id && "search-highlight border-indigo-500 dark:border-indigo-500",
         dragId === item.id && "opacity-40",
         isFlying ? "!z-[9999] isolate" : (highlightedId === item.id ? "z-20 relative" : "z-0 relative")
       )}
@@ -432,6 +433,9 @@ export const KanbanBoard: React.FC = () => {
 
   const [searchQuery, setSearchTerm] = useState('');
   const [highlightedId, setHighlightedId] = useState<string | null>(null);
+  const [searchMatches, setSearchMatches] = useState<AgenFKItem[]>([]);
+  const [currentMatchIndex, setCurrentMatchIndex] = useState(0);
+  const highlightTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [isIdeasCollapsed, setIsIdeasCollapsed] = useState(true);
   const [isArchiveCollapsed, setIsArchiveCollapsed] = useState(true);
   const [isBlockedCollapsed, setIsBlockedCollapsed] = useState(true);
@@ -760,57 +764,89 @@ export const KanbanBoard: React.FC = () => {
     });
   };
 
+  // Priority order for search results: active items first, archived last
+  const statusPriority: Record<string, number> = {
+    [Status.IN_PROGRESS]: 0,
+    [Status.TODO]: 1,
+    [Status.REVIEW]: 2,
+    [Status.TEST]: 3,
+    [Status.BLOCKED]: 4,
+    [Status.PAUSED]: 5,
+    [Status.IDEAS]: 6,
+    [Status.DONE]: 7,
+    [Status.ARCHIVED]: 8,
+  };
+
+  const navigateToMatch = (item: AgenFKItem) => {
+    if (item.status === Status.IDEAS) setIsIdeasCollapsed(false);
+    if (item.status === Status.ARCHIVED) setIsArchiveCollapsed(false);
+    if (item.status === Status.BLOCKED) setIsBlockedCollapsed(false);
+    if (item.status === Status.PAUSED) setIsPausedCollapsed(false);
+
+    const chain: NavItem[] = [];
+    let currentParentId = item.parentId;
+    while (currentParentId) {
+      const parent = items?.find((i: AgenFKItem) => i.id === currentParentId);
+      if (parent) {
+        chain.unshift({ id: parent.id, title: parent.title, type: parent.type });
+        currentParentId = parent.parentId;
+      } else break;
+    }
+    setNavPath(chain);
+    setHighlightedId(item.id);
+
+    setTimeout(() => {
+      const element = document.getElementById(`card-${item.id}`);
+      if (element) {
+        element.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }
+    }, item.status === Status.ARCHIVED || chain.length > 0 ? 400 : 100);
+
+    // Brief highlight: clear after 3s, cancelling any previous timer
+    if (highlightTimerRef.current) clearTimeout(highlightTimerRef.current);
+    highlightTimerRef.current = setTimeout(() => setHighlightedId(null), 3000);
+  };
+
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
     if (!searchQuery.trim() || !items) return;
 
     const term = searchQuery.toLowerCase();
-    const found = items.find((i: AgenFKItem) => 
-      i.id.toLowerCase().includes(term) || 
-      i.title.toLowerCase().includes(term)
-    );
+    const matches = items
+      .filter((i: AgenFKItem) =>
+        i.id.toLowerCase().includes(term) ||
+        i.title.toLowerCase().includes(term)
+      )
+      .sort((a: AgenFKItem, b: AgenFKItem) =>
+        (statusPriority[a.status] ?? 99) - (statusPriority[b.status] ?? 99)
+      );
 
-    if (found) {
-      if (found.status === Status.IDEAS) {
-        setIsIdeasCollapsed(false);
-      }
-      if (found.status === Status.ARCHIVED) {
-        setIsArchiveCollapsed(false);
-      }
-      if (found.status === Status.BLOCKED) {
-        setIsBlockedCollapsed(false);
-      }
-      if (found.status === Status.PAUSED) {
-        setIsPausedCollapsed(false);
-      }
-
-      const chain: NavItem[] = [];
-      let currentParentId = found.parentId;
-      while (currentParentId) {
-        const parent = items.find((i: AgenFKItem) => i.id === currentParentId);
-        if (parent) {
-          chain.unshift({ id: parent.id, title: parent.title, type: parent.type });
-          currentParentId = parent.parentId;
-        } else break;
-      }
-      setNavPath(chain);
-      setHighlightedId(found.id);
-      setSearchTerm('');
-      
-      // Give DOM time to update if we expanded archive or changed levels
-      setTimeout(() => {
-        const element = document.getElementById(`card-${found.id}`);
-        if (element) {
-          element.scrollIntoView({ behavior: 'smooth', block: 'center' });
-        }
-      }, found.status === Status.ARCHIVED || chain.length > 0 ? 400 : 100);
-      
-      setTimeout(() => setHighlightedId(null), 3000);
+    if (matches.length > 0) {
+      setSearchMatches(matches);
+      setCurrentMatchIndex(0);
+      navigateToMatch(matches[0]);
     } else {
-      // Temporary visual feedback for not found
+      setSearchMatches([]);
+      setCurrentMatchIndex(0);
       setSearchTerm('NOT FOUND');
       setTimeout(() => setSearchTerm(''), 1000);
     }
+  };
+
+  const handleSearchNav = (direction: 'prev' | 'next') => {
+    if (searchMatches.length === 0) return;
+    const newIndex = direction === 'next'
+      ? (currentMatchIndex + 1) % searchMatches.length
+      : (currentMatchIndex - 1 + searchMatches.length) % searchMatches.length;
+    setCurrentMatchIndex(newIndex);
+    navigateToMatch(searchMatches[newIndex]);
+  };
+
+  const clearSearch = () => {
+    setSearchMatches([]);
+    setCurrentMatchIndex(0);
+    setSearchTerm('');
+    setHighlightedId(null);
   };
 
   if (isLoadingProjects) {
@@ -997,15 +1033,32 @@ export const KanbanBoard: React.FC = () => {
             </div>
           </div>
 
-          <form onSubmit={handleSearch} className="relative flex-1 max-w-md hidden lg:block">
-            <input 
-              type="text"
-              placeholder="Search Item ID or Name..."
-              value={searchQuery}
-              onChange={(e) => setSearchTerm(e.target.value)}
-              className="w-full bg-slate-100 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl pl-10 pr-4 py-2 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-indigo-500/50 transition-all dark:text-slate-200 shadow-inner"
-            />
-            <Search size={16} className="absolute left-3.5 top-1/2 -translate-y-1/2 text-slate-400" />
+          <form onSubmit={handleSearch} className="relative flex-1 max-w-md hidden lg:flex items-center gap-1.5">
+            <div className="relative flex-1">
+              <input
+                type="text"
+                placeholder="Search Item ID or Name..."
+                value={searchQuery}
+                onChange={(e) => { setSearchTerm(e.target.value); if (!e.target.value.trim()) clearSearch(); }}
+                onKeyDown={(e) => { if (e.key === 'Escape') clearSearch(); }}
+                className="w-full bg-slate-100 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl pl-10 pr-4 py-2 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-indigo-500/50 transition-all dark:text-slate-200 shadow-inner"
+              />
+              <Search size={16} className="absolute left-3.5 top-1/2 -translate-y-1/2 text-slate-400" />
+            </div>
+            {searchMatches.length > 0 && (
+              <div className="flex items-center gap-0.5 text-xs font-medium text-slate-500 dark:text-slate-400 shrink-0">
+                <span className="tabular-nums whitespace-nowrap">{currentMatchIndex + 1}/{searchMatches.length}</span>
+                <button type="button" onClick={() => handleSearchNav('prev')} className="p-0.5 hover:bg-slate-200 dark:hover:bg-slate-700 rounded transition-colors" title="Previous match">
+                  <ChevronUp size={14} />
+                </button>
+                <button type="button" onClick={() => handleSearchNav('next')} className="p-0.5 hover:bg-slate-200 dark:hover:bg-slate-700 rounded transition-colors" title="Next match">
+                  <ChevronDown size={14} />
+                </button>
+                <button type="button" onClick={clearSearch} className="p-0.5 hover:bg-slate-200 dark:hover:bg-slate-700 rounded transition-colors ml-0.5" title="Clear search">
+                  <X size={14} />
+                </button>
+              </div>
+            )}
           </form>
 
           <div className="flex items-center gap-3">

--- a/packages/ui/src/components/KanbanBoard.tsx
+++ b/packages/ui/src/components/KanbanBoard.tsx
@@ -5,7 +5,7 @@ import { api } from '../api';
 import { AgenFKItem, ItemType, Status, Project } from '../types';
 import { clsx } from 'clsx';
 import {
-  Plus, Loader2, AlertCircle, Tag,
+  Plus, Loader2, AlertCircle,
   Zap, ChevronRight, Home,
   Sun, Moon, Search, Archive, ArchiveRestore, ChevronLeft,
   FolderOpen, Briefcase, Clock, FlaskConical, ShieldCheck,
@@ -429,7 +429,7 @@ export const KanbanBoard: React.FC = () => {
   }, [selectedItem?.id]);
 
   const [navPath, setNavPath] = useState<NavItem[]>([]);
-  const [selectedItemType, setSelectedItemType] = useState<ItemType | 'ALL'>('ALL');
+
   const [searchQuery, setSearchTerm] = useState('');
   const [highlightedId, setHighlightedId] = useState<string | null>(null);
   const [isIdeasCollapsed, setIsIdeasCollapsed] = useState(true);
@@ -594,9 +594,9 @@ export const KanbanBoard: React.FC = () => {
     capture('project_switched');
   };
 
-  const getItemsByStatus = (status: Status, ignoreFilter = false) => {
+  const getItemsByStatus = (status: Status) => {
     if (!items) return [];
-    
+
     let filtered = items.filter((i: AgenFKItem) => i.status === status);
 
     // Navigation Filtering
@@ -605,11 +605,6 @@ export const KanbanBoard: React.FC = () => {
     } else {
       const currentParent = navPath[navPath.length - 1];
       filtered = filtered.filter((i: AgenFKItem) => i.parentId === currentParent.id);
-    }
-
-    // Type Filtering
-    if (!ignoreFilter && selectedItemType !== 'ALL') {
-      filtered = filtered.filter((i: AgenFKItem) => i.type === selectedItemType);
     }
 
     // Sort by sortOrder, then by createdAt for stable ordering
@@ -692,7 +687,7 @@ export const KanbanBoard: React.FC = () => {
 
     // Reorder within same column or move to specific position in another column
     if (currentDropTargetId && currentDropTargetId !== id) {
-      const columnItemsBefore = getItemsByStatus(status, true);
+      const columnItemsBefore = getItemsByStatus(status);
       const columnItems = columnItemsBefore.filter((i: AgenFKItem) => i.id !== id);
       const targetIndex = columnItems.findIndex((i: AgenFKItem) => i.id === currentDropTargetId);
       
@@ -733,7 +728,7 @@ export const KanbanBoard: React.FC = () => {
 
     // Cross-column or drop on empty space: update status (append to end of target column)
     if (draggedItem.status !== status) {
-      const targetColumnItems = getItemsByStatus(status, true);
+      const targetColumnItems = getItemsByStatus(status);
       const newSortOrder = targetColumnItems.length;
 
       // Optimistic local UI update
@@ -799,7 +794,6 @@ export const KanbanBoard: React.FC = () => {
         } else break;
       }
       setNavPath(chain);
-      setSelectedItemType('ALL');
       setHighlightedId(found.id);
       setSearchTerm('');
       
@@ -1069,22 +1063,6 @@ export const KanbanBoard: React.FC = () => {
               >
                 {theme === 'dark' ? <Sun size={18} /> : <Moon size={18} />}
               </button>
-              
-              <div className="w-px h-4 bg-slate-200 dark:bg-slate-700 mx-1 hidden md:block" />
-
-              <div className="flex items-center gap-1 px-1">
-                <Tag size={14} className="text-slate-400" />
-                <select 
-                  value={selectedItemType} 
-                  onChange={(e) => setSelectedItemType(e.target.value as ItemType | 'ALL')}
-                  className="bg-transparent text-xs font-bold text-slate-600 dark:text-slate-300 focus:outline-none cursor-pointer hover:text-indigo-600 transition-colors py-1"
-                >
-                  <option value="ALL">All Types</option>
-                  {Object.values(ItemType).map(type => (
-                    <option key={type} value={type}>{type}</option>
-                  ))}
-                </select>
-              </div>
             </div>
 
             <button 

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -2,3 +2,19 @@
 @plugin "@tailwindcss/typography";
 
 @variant dark (&:where(.dark, .dark *, [data-theme="dark"], [data-theme="dark"] *));
+
+@keyframes search-highlight {
+  0% { box-shadow: inset 0 0 0 2px rgb(99 102 241), 0 0 12px 2px rgba(99, 102, 241, 0.4); }
+  50% { box-shadow: inset 0 0 0 2px rgb(99 102 241), 0 0 20px 4px rgba(99, 102, 241, 0.6); }
+  100% { box-shadow: inset 0 0 0 2px rgb(99 102 241), 0 0 12px 2px rgba(99, 102, 241, 0.4); }
+}
+
+.search-highlight {
+  animation: search-highlight 1s ease-in-out 2;
+  box-shadow: inset 0 0 0 2px rgb(99 102 241);
+  background-color: rgba(238, 242, 255, 0.6) !important;
+}
+
+:is(.dark) .search-highlight {
+  background-color: rgba(49, 46, 129, 0.4) !important;
+}

--- a/packages/ui/src/test/KanbanBoard.test.tsx
+++ b/packages/ui/src/test/KanbanBoard.test.tsx
@@ -359,9 +359,10 @@ describe('KanbanBoard', () => {
     const form = searchInput.closest('form');
     if (form) fireEvent.submit(form);
 
-    // The item should still be visible (highlights it)
+    // The item should still be visible and match counter should appear
     await waitFor(() => {
       expect(screen.queryByText('SearchableTask')).toBeDefined();
+      expect(screen.getByText('1/1')).toBeDefined();
     });
   });
 
@@ -384,6 +385,48 @@ describe('KanbanBoard', () => {
     // Just verify no crash
     await waitFor(() => {
       expect(true).toBe(true);
+    });
+  });
+
+  it('should prioritize active items over archived in search and allow navigation', async () => {
+    const project = { id: 'p1', name: 'P1', createdAt: new Date(), updatedAt: new Date() };
+    const items = [
+      { id: 'archived-1', projectId: 'p1', type: ItemType.TASK, title: 'Widget Config', status: Status.ARCHIVED, createdAt: new Date(), updatedAt: new Date(), history: [] },
+      { id: 'active-1', projectId: 'p1', type: ItemType.TASK, title: 'Widget Feature', status: Status.TODO, createdAt: new Date(), updatedAt: new Date(), history: [] },
+      { id: 'active-2', projectId: 'p1', type: ItemType.TASK, title: 'Widget Bug', status: Status.IN_PROGRESS, createdAt: new Date(), updatedAt: new Date(), history: [] },
+    ];
+    vi.mocked(api.listProjects).mockResolvedValue([project as any]);
+    vi.mocked(api.listItems).mockResolvedValue(items as any);
+    localStorage.setItem('agenfk_project_id', 'p1');
+
+    render(<KanbanBoard />, { wrapper });
+    await screen.findByText('Widget Feature');
+
+    const searchInput = screen.getByPlaceholderText(/Search Item ID or Name/i);
+    fireEvent.change(searchInput, { target: { value: 'Widget' } });
+
+    const form = searchInput.closest('form');
+    if (form) fireEvent.submit(form);
+
+    // Should show match counter with 3 matches, starting at first (active item)
+    await waitFor(() => {
+      expect(screen.getByText('1/3')).toBeDefined();
+    });
+
+    // Click next match button
+    const nextButton = screen.getByTitle('Next match');
+    fireEvent.click(nextButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('2/3')).toBeDefined();
+    });
+
+    // Click previous match button
+    const prevButton = screen.getByTitle('Previous match');
+    fireEvent.click(prevButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('1/3')).toBeDefined();
     });
   });
 

--- a/server-test-db.json
+++ b/server-test-db.json
@@ -1,258 +1,258 @@
 {
   "projects": [
     {
-      "id": "e9a0ad6c-2e34-451d-bea0-046aa6268ab6",
+      "id": "8c97729c-ac6b-430c-9600-d2d7bbcebef4",
       "name": "P1 Updated",
       "description": "",
-      "createdAt": "2026-03-02T01:37:06.496Z",
-      "updatedAt": "2026-03-02T01:37:06.509Z"
+      "createdAt": "2026-03-02T01:37:55.604Z",
+      "updatedAt": "2026-03-02T01:37:55.618Z"
     },
     {
-      "id": "ef345c32-2875-4775-91cc-291f1815f6c5",
+      "id": "953c3e7e-3f23-47bf-b36e-7febcbfdfb00",
       "name": "Item Test",
       "description": "",
-      "createdAt": "2026-03-02T01:37:06.518Z",
-      "updatedAt": "2026-03-02T01:37:06.518Z"
+      "createdAt": "2026-03-02T01:37:55.627Z",
+      "updatedAt": "2026-03-02T01:37:55.627Z"
     },
     {
-      "id": "13cc6294-bcb6-4dcf-9a2f-5b5f2d05d959",
+      "id": "3083b291-065b-490c-baa5-418d604e1b5b",
       "name": "JIRA Import Test",
       "description": "",
-      "createdAt": "2026-03-02T01:37:06.606Z",
-      "updatedAt": "2026-03-02T01:37:06.606Z"
+      "createdAt": "2026-03-02T01:37:55.704Z",
+      "updatedAt": "2026-03-02T01:37:55.704Z"
     },
     {
-      "id": "03816ce9-4e01-42c9-9c1a-f26330a4c872",
+      "id": "fddd27d3-fe1d-4ca8-a4d5-d5cf1d4a080a",
       "name": "JIRA Err Test",
       "description": "",
-      "createdAt": "2026-03-02T01:37:06.611Z",
-      "updatedAt": "2026-03-02T01:37:06.611Z"
+      "createdAt": "2026-03-02T01:37:55.708Z",
+      "updatedAt": "2026-03-02T01:37:55.708Z"
     }
   ],
   "items": [
     {
-      "id": "c83cdee6-cf25-4382-bc0f-3f6e1a8a4516",
-      "projectId": "ef345c32-2875-4775-91cc-291f1815f6c5",
+      "id": "1fe47b02-8e03-4804-a68a-923e78e4cb9d",
+      "projectId": "953c3e7e-3f23-47bf-b36e-7febcbfdfb00",
       "type": "TASK",
       "title": "T1",
       "description": "D1",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:37:06.521Z",
-      "updatedAt": "2026-03-02T01:37:06.521Z",
+      "createdAt": "2026-03-02T01:37:55.629Z",
+      "updatedAt": "2026-03-02T01:37:55.629Z",
       "history": [
         {
-          "id": "548b6b90-20d4-4895-a4f0-c8307985c2c6",
+          "id": "2ce4cf23-8656-4805-9f2c-f781b13d63b4",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:37:06.521Z"
+          "timestamp": "2026-03-02T01:37:55.629Z"
         }
       ]
     },
     {
-      "id": "76fd6e2e-cbe5-4ba3-980d-21f174d21ed5",
-      "projectId": "ef345c32-2875-4775-91cc-291f1815f6c5",
+      "id": "f934000f-c5b3-4843-86d5-c14a10fae4b2",
+      "projectId": "953c3e7e-3f23-47bf-b36e-7febcbfdfb00",
       "type": "TASK",
       "title": "To Update",
       "description": "D",
       "status": "IN_PROGRESS",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:37:06.524Z",
-      "updatedAt": "2026-03-02T01:37:06.526Z",
+      "createdAt": "2026-03-02T01:37:55.632Z",
+      "updatedAt": "2026-03-02T01:37:55.634Z",
       "history": [
         {
-          "id": "ec3c403a-9d0a-49a3-85d1-cd39e045001e",
+          "id": "9759b738-8e1b-4bbf-a765-e3725e70d99a",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:37:06.524Z"
+          "timestamp": "2026-03-02T01:37:55.632Z"
         },
         {
-          "id": "35ed953f-359c-4f33-8240-f90a7538bf9b",
+          "id": "6b2126c3-be41-4371-801d-e0898ec151e3",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-02T01:37:06.526Z"
+          "timestamp": "2026-03-02T01:37:55.634Z"
         }
       ]
     },
     {
-      "id": "81a66eda-8880-4a14-b78f-a4d0b2f899e0",
-      "projectId": "ef345c32-2875-4775-91cc-291f1815f6c5",
+      "id": "45f4b33f-bd63-47bc-8c5a-759aefae4c67",
+      "projectId": "953c3e7e-3f23-47bf-b36e-7febcbfdfb00",
       "type": "TASK",
       "title": "No Cheat",
       "description": "D",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:37:06.528Z",
-      "updatedAt": "2026-03-02T01:37:06.528Z",
+      "createdAt": "2026-03-02T01:37:55.643Z",
+      "updatedAt": "2026-03-02T01:37:55.643Z",
       "history": [
         {
-          "id": "05a9090c-4817-41cd-8594-176a110b0eb0",
+          "id": "8749e551-e7ba-482a-b5f4-9c118a8ee8e5",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:37:06.528Z"
+          "timestamp": "2026-03-02T01:37:55.643Z"
         }
       ]
     },
     {
-      "id": "ed1a78d8-59f3-4d41-832f-900678487df9",
-      "projectId": "ef345c32-2875-4775-91cc-291f1815f6c5",
+      "id": "e3697eac-d1f0-4864-bab2-436df0762296",
+      "projectId": "953c3e7e-3f23-47bf-b36e-7febcbfdfb00",
       "type": "TASK",
       "title": "Verify Me",
       "description": "D",
       "status": "DONE",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:37:06.531Z",
-      "updatedAt": "2026-03-02T01:37:06.533Z",
+      "createdAt": "2026-03-02T01:37:55.647Z",
+      "updatedAt": "2026-03-02T01:37:55.649Z",
       "history": [
         {
-          "id": "a49cd8ff-66a1-4825-a927-e500fc507f44",
+          "id": "5664fc26-635a-4504-8804-5c55a0373f03",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:37:06.531Z"
+          "timestamp": "2026-03-02T01:37:55.647Z"
         },
         {
-          "id": "a1063921-2ee6-4f20-920a-f02eb4a345c7",
+          "id": "1f890ebc-c40c-470b-8897-8e246aa41d8b",
           "fromStatus": "TODO",
           "toStatus": "DONE",
-          "timestamp": "2026-03-02T01:37:06.533Z"
+          "timestamp": "2026-03-02T01:37:55.649Z"
         }
       ]
     },
     {
-      "id": "263d1168-ba5a-4114-be39-b7b9fa4b3fee",
-      "projectId": "ef345c32-2875-4775-91cc-291f1815f6c5",
+      "id": "731fe311-db3f-450c-bcb6-f63684ddb057",
+      "projectId": "953c3e7e-3f23-47bf-b36e-7febcbfdfb00",
       "type": "STORY",
       "title": "Parent Story",
       "description": "D",
       "status": "IN_PROGRESS",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:37:06.537Z",
-      "updatedAt": "2026-03-02T01:37:06.549Z",
+      "createdAt": "2026-03-02T01:37:55.651Z",
+      "updatedAt": "2026-03-02T01:37:55.655Z",
       "history": [
         {
-          "id": "1801dabe-3054-4051-a3c4-d02e565b4cab",
+          "id": "5d7a9db9-388a-472f-b0a6-f4f08016ec72",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:37:06.537Z"
+          "timestamp": "2026-03-02T01:37:55.651Z"
         },
         {
-          "id": "a16e9177-3fff-4ebc-bc96-d912d79f2401",
+          "id": "8457d900-e55c-4273-a3f6-3fe1f9a036b3",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-02T01:37:06.549Z"
+          "timestamp": "2026-03-02T01:37:55.655Z"
         }
       ]
     },
     {
-      "id": "cef9522b-58fe-466c-bb26-f989269a7146",
-      "projectId": "ef345c32-2875-4775-91cc-291f1815f6c5",
+      "id": "5a930b91-0be6-4c9b-97ca-1d00fad6530e",
+      "projectId": "953c3e7e-3f23-47bf-b36e-7febcbfdfb00",
       "type": "TASK",
       "title": "Child Task",
       "description": "D",
       "status": "IN_PROGRESS",
-      "parentId": "263d1168-ba5a-4114-be39-b7b9fa4b3fee",
+      "parentId": "731fe311-db3f-450c-bcb6-f63684ddb057",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:37:06.546Z",
-      "updatedAt": "2026-03-02T01:37:06.548Z",
+      "createdAt": "2026-03-02T01:37:55.653Z",
+      "updatedAt": "2026-03-02T01:37:55.655Z",
       "history": [
         {
-          "id": "bc91d6e0-bfdd-4b75-be4b-d26730ee241b",
+          "id": "beb494fa-3f2f-46ca-b61e-f760d863a119",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:37:06.546Z"
+          "timestamp": "2026-03-02T01:37:55.653Z"
         },
         {
-          "id": "a78efd46-bfb0-4780-9a50-ffc2133072d6",
+          "id": "178268db-9e8a-49a2-94d8-e51305e87ea9",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-02T01:37:06.548Z"
+          "timestamp": "2026-03-02T01:37:55.655Z"
         }
       ]
     },
     {
-      "id": "83fe16d4-8bae-41cd-b7ac-95b6e893f462",
-      "projectId": "ef345c32-2875-4775-91cc-291f1815f6c5",
+      "id": "4edeb421-808a-44b1-b8e5-fba6dd0ce26f",
+      "projectId": "953c3e7e-3f23-47bf-b36e-7febcbfdfb00",
       "type": "TASK",
       "title": "Archive Me",
       "description": "D",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:37:06.552Z",
-      "updatedAt": "2026-03-02T01:37:06.556Z",
+      "createdAt": "2026-03-02T01:37:55.657Z",
+      "updatedAt": "2026-03-02T01:37:55.661Z",
       "history": [
         {
-          "id": "dc73c65f-ecbc-476d-ba9e-41cf49faae5d",
+          "id": "06f44e0c-6b07-4de2-87dd-e0b50fea3cde",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:37:06.552Z"
+          "timestamp": "2026-03-02T01:37:55.657Z"
         },
         {
-          "id": "1b3872c8-c78f-43d7-8437-8962f0c2c945",
+          "id": "3b8bcb65-7d38-4c14-aec0-9349b5e64e77",
           "fromStatus": "TODO",
           "toStatus": "ARCHIVED",
-          "timestamp": "2026-03-02T01:37:06.554Z"
+          "timestamp": "2026-03-02T01:37:55.659Z"
         },
         {
-          "id": "436444ef-46ed-4d06-9514-0aeb6bc398de",
+          "id": "bf5de0cb-e998-445e-ae30-662a63db9630",
           "fromStatus": "ARCHIVED",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:37:06.556Z"
+          "timestamp": "2026-03-02T01:37:55.660Z"
         }
       ]
     },
     {
-      "id": "f57dbcb2-56b1-4673-8258-0fe1972f6299",
-      "projectId": "ef345c32-2875-4775-91cc-291f1815f6c5",
+      "id": "c208fac4-ea74-4f44-b412-8c6fc3105c7e",
+      "projectId": "953c3e7e-3f23-47bf-b36e-7febcbfdfb00",
       "type": "TASK",
       "title": "Delete Me",
       "description": "D",
       "status": "TRASHED",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:37:06.558Z",
-      "updatedAt": "2026-03-02T01:37:06.560Z",
+      "createdAt": "2026-03-02T01:37:55.663Z",
+      "updatedAt": "2026-03-02T01:37:55.665Z",
       "history": [
         {
-          "id": "57f182d0-662a-4ff3-a1a0-81c13d9903db",
+          "id": "063f7ff6-d720-402b-a9ba-782cc2e016e0",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:37:06.558Z"
+          "timestamp": "2026-03-02T01:37:55.663Z"
         },
         {
-          "id": "189aa27e-1c77-4840-83dc-2f5b4ad7446b",
+          "id": "5830f174-1a42-4831-bab9-ced27c66c6dc",
           "fromStatus": "TODO",
           "toStatus": "TRASHED",
-          "timestamp": "2026-03-02T01:37:06.560Z"
+          "timestamp": "2026-03-02T01:37:55.665Z"
         }
       ]
     },
     {
-      "id": "e622c368-e957-4458-9ec6-d9d6012caea0",
-      "projectId": "ef345c32-2875-4775-91cc-291f1815f6c5",
+      "id": "eb936a01-2554-45c6-b8c2-2a34a383c5bb",
+      "projectId": "953c3e7e-3f23-47bf-b36e-7febcbfdfb00",
       "type": "TASK",
       "title": "Archived Task",
       "description": "",
       "status": "TRASHED",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:37:06.563Z",
-      "updatedAt": "2026-03-02T01:37:06.565Z",
+      "createdAt": "2026-03-02T01:37:55.669Z",
+      "updatedAt": "2026-03-02T01:37:55.670Z",
       "history": [
         {
-          "id": "d7f2d969-2e66-4370-b05c-4f338cb423a2",
+          "id": "111a70bd-d089-4780-aa05-9b3832632b00",
           "fromStatus": "TODO",
           "toStatus": "ARCHIVED",
-          "timestamp": "2026-03-02T01:37:06.563Z"
+          "timestamp": "2026-03-02T01:37:55.669Z"
         },
         {
-          "id": "5f5b1f75-403f-45f6-b2b7-0b3d1811cd5d",
+          "id": "8438f5d4-f0d1-4213-9bfb-a4ffe8165006",
           "fromStatus": "ARCHIVED",
           "toStatus": "TRASHED",
-          "timestamp": "2026-03-02T01:37:06.565Z"
+          "timestamp": "2026-03-02T01:37:55.670Z"
         }
       ]
     },
     {
-      "id": "e9930bce-8ad5-4af1-916d-fbd11be318d6",
-      "projectId": "13cc6294-bcb6-4dcf-9a2f-5b5f2d05d959",
+      "id": "9f4cd6f6-7478-4ec5-9011-28f6b7248a76",
+      "projectId": "3083b291-065b-490c-baa5-418d604e1b5b",
       "type": "BUG",
       "title": "[PROJ-1] Fix login bug",
       "description": "Imported from JIRA: PROJ-1",
@@ -260,14 +260,14 @@
       "implementationPlan": "",
       "externalId": "PROJ-1",
       "externalUrl": "https://test.atlassian.net/browse/PROJ-1",
-      "createdAt": "2026-03-02T01:37:06.607Z",
-      "updatedAt": "2026-03-02T01:37:06.607Z",
+      "createdAt": "2026-03-02T01:37:55.705Z",
+      "updatedAt": "2026-03-02T01:37:55.705Z",
       "history": [
         {
-          "id": "d0da4389-50e0-4e43-be0f-e27a5f324b8d",
+          "id": "dc55811f-a812-4994-a5ba-f963b1198ec2",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:37:06.608Z"
+          "timestamp": "2026-03-02T01:37:55.705Z"
         }
       ]
     }

--- a/server-test-db.json
+++ b/server-test-db.json
@@ -1,258 +1,258 @@
 {
   "projects": [
     {
-      "id": "9b4d2f8a-fcb0-4134-b049-5d20fe665b35",
+      "id": "c7b0019f-5648-4d9f-bb49-1c2d6554c360",
       "name": "P1 Updated",
       "description": "",
-      "createdAt": "2026-03-02T01:16:25.948Z",
-      "updatedAt": "2026-03-02T01:16:25.961Z"
+      "createdAt": "2026-03-02T01:24:01.892Z",
+      "updatedAt": "2026-03-02T01:24:01.906Z"
     },
     {
-      "id": "967567a7-6314-4eac-8a43-18d5921f8d09",
+      "id": "fa18a70b-9231-40b7-9714-981f5d2080c1",
       "name": "Item Test",
       "description": "",
-      "createdAt": "2026-03-02T01:16:25.969Z",
-      "updatedAt": "2026-03-02T01:16:25.969Z"
+      "createdAt": "2026-03-02T01:24:01.915Z",
+      "updatedAt": "2026-03-02T01:24:01.915Z"
     },
     {
-      "id": "449aa765-cbe4-43ee-9fdc-a778c2897973",
+      "id": "a0af150a-61f3-4fe9-bab5-566878ec5669",
       "name": "JIRA Import Test",
       "description": "",
-      "createdAt": "2026-03-02T01:16:26.048Z",
-      "updatedAt": "2026-03-02T01:16:26.048Z"
+      "createdAt": "2026-03-02T01:24:01.995Z",
+      "updatedAt": "2026-03-02T01:24:01.995Z"
     },
     {
-      "id": "396aeb94-20bd-43bd-bf0b-958729783ab6",
+      "id": "12943577-c249-4707-b5d8-d25b5cede536",
       "name": "JIRA Err Test",
       "description": "",
-      "createdAt": "2026-03-02T01:16:26.053Z",
-      "updatedAt": "2026-03-02T01:16:26.053Z"
+      "createdAt": "2026-03-02T01:24:01.999Z",
+      "updatedAt": "2026-03-02T01:24:01.999Z"
     }
   ],
   "items": [
     {
-      "id": "25ebb425-b1f7-4925-9d00-9ce32cf4352d",
-      "projectId": "967567a7-6314-4eac-8a43-18d5921f8d09",
+      "id": "773be8cc-7dce-4ce7-a11b-737a65569ba8",
+      "projectId": "fa18a70b-9231-40b7-9714-981f5d2080c1",
       "type": "TASK",
       "title": "T1",
       "description": "D1",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:16:25.972Z",
-      "updatedAt": "2026-03-02T01:16:25.972Z",
+      "createdAt": "2026-03-02T01:24:01.918Z",
+      "updatedAt": "2026-03-02T01:24:01.918Z",
       "history": [
         {
-          "id": "26f9a75d-265a-43b7-963b-dfbe8d26588d",
+          "id": "f54bfb18-bbdb-448c-a9fa-9e018678b8e5",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:16:25.972Z"
+          "timestamp": "2026-03-02T01:24:01.918Z"
         }
       ]
     },
     {
-      "id": "b3b6af9d-eeec-4c39-8302-1a22d4ee2c66",
-      "projectId": "967567a7-6314-4eac-8a43-18d5921f8d09",
+      "id": "8084473b-fafb-4163-811f-9e9000f9b962",
+      "projectId": "fa18a70b-9231-40b7-9714-981f5d2080c1",
       "type": "TASK",
       "title": "To Update",
       "description": "D",
       "status": "IN_PROGRESS",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:16:25.974Z",
-      "updatedAt": "2026-03-02T01:16:25.976Z",
+      "createdAt": "2026-03-02T01:24:01.920Z",
+      "updatedAt": "2026-03-02T01:24:01.923Z",
       "history": [
         {
-          "id": "a31ec551-fe6d-4e22-9d04-75901c482854",
+          "id": "cad22f27-bcb6-45fa-8b62-1523d49797ce",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:16:25.974Z"
+          "timestamp": "2026-03-02T01:24:01.920Z"
         },
         {
-          "id": "d692791a-c694-4bdb-ae37-7111dff8a5e6",
+          "id": "b064773f-602a-4307-a75e-41e0f296a4f6",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-02T01:16:25.976Z"
+          "timestamp": "2026-03-02T01:24:01.923Z"
         }
       ]
     },
     {
-      "id": "b9e59fd5-fc72-46e0-8680-8a730fa86cfa",
-      "projectId": "967567a7-6314-4eac-8a43-18d5921f8d09",
+      "id": "02cff57e-f699-4f09-afb0-19fba35ba638",
+      "projectId": "fa18a70b-9231-40b7-9714-981f5d2080c1",
       "type": "TASK",
       "title": "No Cheat",
       "description": "D",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:16:25.978Z",
-      "updatedAt": "2026-03-02T01:16:25.978Z",
+      "createdAt": "2026-03-02T01:24:01.925Z",
+      "updatedAt": "2026-03-02T01:24:01.925Z",
       "history": [
         {
-          "id": "9c388d9e-8f86-4b06-a6b3-f6f41810b44f",
+          "id": "45a9580c-9576-4ac7-941c-fe75f327339f",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:16:25.979Z"
+          "timestamp": "2026-03-02T01:24:01.926Z"
         }
       ]
     },
     {
-      "id": "2d127bcf-756b-4f3b-b8b1-c6779dbb8a29",
-      "projectId": "967567a7-6314-4eac-8a43-18d5921f8d09",
+      "id": "720d37b8-e7a0-4458-b478-243dc1ae90ff",
+      "projectId": "fa18a70b-9231-40b7-9714-981f5d2080c1",
       "type": "TASK",
       "title": "Verify Me",
       "description": "D",
       "status": "DONE",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:16:25.981Z",
-      "updatedAt": "2026-03-02T01:16:25.983Z",
+      "createdAt": "2026-03-02T01:24:01.929Z",
+      "updatedAt": "2026-03-02T01:24:01.930Z",
       "history": [
         {
-          "id": "5985b25e-64c0-4454-8c24-541c7368236b",
+          "id": "75f1249a-45ef-4232-8566-b12e9ffe2659",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:16:25.981Z"
+          "timestamp": "2026-03-02T01:24:01.929Z"
         },
         {
-          "id": "075dab2b-3705-44fb-98ba-0f7395cb5723",
+          "id": "aebf38b7-ea6c-4bfc-a7d2-160c97c06473",
           "fromStatus": "TODO",
           "toStatus": "DONE",
-          "timestamp": "2026-03-02T01:16:25.983Z"
+          "timestamp": "2026-03-02T01:24:01.930Z"
         }
       ]
     },
     {
-      "id": "cb4a8c25-d50b-4933-90be-711fe30dcdef",
-      "projectId": "967567a7-6314-4eac-8a43-18d5921f8d09",
+      "id": "c81e7748-8b2b-4e9d-b747-6b7e831ec69e",
+      "projectId": "fa18a70b-9231-40b7-9714-981f5d2080c1",
       "type": "STORY",
       "title": "Parent Story",
       "description": "D",
       "status": "IN_PROGRESS",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:16:25.985Z",
-      "updatedAt": "2026-03-02T01:16:25.991Z",
+      "createdAt": "2026-03-02T01:24:01.932Z",
+      "updatedAt": "2026-03-02T01:24:01.944Z",
       "history": [
         {
-          "id": "4fa6e08e-8202-4baa-b3b9-b700777ff378",
+          "id": "3851d9fd-eddb-46d3-986a-5dc6df15377d",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:16:25.985Z"
+          "timestamp": "2026-03-02T01:24:01.932Z"
         },
         {
-          "id": "3fd50554-f740-4e1c-829d-c5a33a1b6779",
+          "id": "3a110d86-c3b2-49bc-8c66-37debb1ea413",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-02T01:16:25.991Z"
+          "timestamp": "2026-03-02T01:24:01.944Z"
         }
       ]
     },
     {
-      "id": "5b72848f-da2b-4a12-bef6-6b6e0a6c9ad5",
-      "projectId": "967567a7-6314-4eac-8a43-18d5921f8d09",
+      "id": "8bb335c4-a412-4df0-805d-238e82b7b239",
+      "projectId": "fa18a70b-9231-40b7-9714-981f5d2080c1",
       "type": "TASK",
       "title": "Child Task",
       "description": "D",
       "status": "IN_PROGRESS",
-      "parentId": "cb4a8c25-d50b-4933-90be-711fe30dcdef",
+      "parentId": "c81e7748-8b2b-4e9d-b747-6b7e831ec69e",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:16:25.987Z",
-      "updatedAt": "2026-03-02T01:16:25.990Z",
+      "createdAt": "2026-03-02T01:24:01.941Z",
+      "updatedAt": "2026-03-02T01:24:01.943Z",
       "history": [
         {
-          "id": "39d6bb37-ae4e-46c7-bf88-89b1a372433a",
+          "id": "951291fa-4cc7-4def-8f06-e81a7172dc86",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:16:25.987Z"
+          "timestamp": "2026-03-02T01:24:01.942Z"
         },
         {
-          "id": "3acffbb8-55c3-48fd-94ab-609920a0109f",
+          "id": "053b8107-52d8-4037-8688-8488c92b2ebe",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-02T01:16:25.990Z"
+          "timestamp": "2026-03-02T01:24:01.943Z"
         }
       ]
     },
     {
-      "id": "bbef9f54-e2bd-4a92-9b2c-665e715ef130",
-      "projectId": "967567a7-6314-4eac-8a43-18d5921f8d09",
+      "id": "5693b183-f4d4-462a-bd7d-ab985818d13e",
+      "projectId": "fa18a70b-9231-40b7-9714-981f5d2080c1",
       "type": "TASK",
       "title": "Archive Me",
       "description": "D",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:16:25.994Z",
-      "updatedAt": "2026-03-02T01:16:25.997Z",
+      "createdAt": "2026-03-02T01:24:01.946Z",
+      "updatedAt": "2026-03-02T01:24:01.949Z",
       "history": [
         {
-          "id": "04c8dde1-7606-4687-aa65-dab943e13a14",
+          "id": "2a3e7d4c-7f62-4ee4-9d5f-49ba697a714c",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:16:25.994Z"
+          "timestamp": "2026-03-02T01:24:01.946Z"
         },
         {
-          "id": "4fd3231b-a32f-401f-ad7f-52f6d741f993",
+          "id": "f2d9bc43-4a1e-4eff-95c6-73d82bd64aec",
           "fromStatus": "TODO",
           "toStatus": "ARCHIVED",
-          "timestamp": "2026-03-02T01:16:25.995Z"
+          "timestamp": "2026-03-02T01:24:01.947Z"
         },
         {
-          "id": "e08d9384-53ca-475a-a56a-f2abad3dbe9f",
+          "id": "7807d5b2-06b8-49d8-948c-0e027a8ec83e",
           "fromStatus": "ARCHIVED",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:16:25.997Z"
+          "timestamp": "2026-03-02T01:24:01.949Z"
         }
       ]
     },
     {
-      "id": "e9a3445f-1e07-48b1-90c3-ceeb3707288a",
-      "projectId": "967567a7-6314-4eac-8a43-18d5921f8d09",
+      "id": "f52d5af8-e393-4f5f-9759-55e503923244",
+      "projectId": "fa18a70b-9231-40b7-9714-981f5d2080c1",
       "type": "TASK",
       "title": "Delete Me",
       "description": "D",
       "status": "TRASHED",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:16:25.999Z",
-      "updatedAt": "2026-03-02T01:16:26.000Z",
+      "createdAt": "2026-03-02T01:24:01.950Z",
+      "updatedAt": "2026-03-02T01:24:01.952Z",
       "history": [
         {
-          "id": "c1d73780-4d37-4d99-9e61-83c7b9d5e740",
+          "id": "f5858409-fc40-4c6e-8a00-21f362fa3ec6",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:16:25.999Z"
+          "timestamp": "2026-03-02T01:24:01.951Z"
         },
         {
-          "id": "61394983-a2a7-4a76-94ae-3148f838a62e",
+          "id": "7c425ec7-959d-49f8-8d1b-49593cca5fc3",
           "fromStatus": "TODO",
           "toStatus": "TRASHED",
-          "timestamp": "2026-03-02T01:16:26.000Z"
+          "timestamp": "2026-03-02T01:24:01.952Z"
         }
       ]
     },
     {
-      "id": "c72a66db-321a-4bff-a162-664a315fb6fd",
-      "projectId": "967567a7-6314-4eac-8a43-18d5921f8d09",
+      "id": "bbe7f32c-0d16-464b-a86f-e3b1a440502b",
+      "projectId": "fa18a70b-9231-40b7-9714-981f5d2080c1",
       "type": "TASK",
       "title": "Archived Task",
       "description": "",
       "status": "TRASHED",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:16:26.005Z",
-      "updatedAt": "2026-03-02T01:16:26.013Z",
+      "createdAt": "2026-03-02T01:24:01.956Z",
+      "updatedAt": "2026-03-02T01:24:01.958Z",
       "history": [
         {
-          "id": "cc7bc11a-e2d2-4a28-a430-755a43e540ad",
+          "id": "55d33972-3444-49c3-a15f-02251bfba2e7",
           "fromStatus": "TODO",
           "toStatus": "ARCHIVED",
-          "timestamp": "2026-03-02T01:16:26.005Z"
+          "timestamp": "2026-03-02T01:24:01.956Z"
         },
         {
-          "id": "f306a6da-755d-4c73-82c4-21e330702513",
+          "id": "a2ed6ace-f825-4770-8569-0e073046cd6e",
           "fromStatus": "ARCHIVED",
           "toStatus": "TRASHED",
-          "timestamp": "2026-03-02T01:16:26.013Z"
+          "timestamp": "2026-03-02T01:24:01.958Z"
         }
       ]
     },
     {
-      "id": "a1ebe394-f88e-467a-bcb2-bf5ed2f9478f",
-      "projectId": "449aa765-cbe4-43ee-9fdc-a778c2897973",
+      "id": "87cd4c91-f3e3-4be8-8a6e-bace15fff432",
+      "projectId": "a0af150a-61f3-4fe9-bab5-566878ec5669",
       "type": "BUG",
       "title": "[PROJ-1] Fix login bug",
       "description": "Imported from JIRA: PROJ-1",
@@ -260,14 +260,14 @@
       "implementationPlan": "",
       "externalId": "PROJ-1",
       "externalUrl": "https://test.atlassian.net/browse/PROJ-1",
-      "createdAt": "2026-03-02T01:16:26.050Z",
-      "updatedAt": "2026-03-02T01:16:26.050Z",
+      "createdAt": "2026-03-02T01:24:01.996Z",
+      "updatedAt": "2026-03-02T01:24:01.996Z",
       "history": [
         {
-          "id": "36b2d8f8-f550-4832-9e56-237e91624bea",
+          "id": "f34f4827-06df-4f3e-94ca-53f1feeae976",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:16:26.050Z"
+          "timestamp": "2026-03-02T01:24:01.996Z"
         }
       ]
     }

--- a/server-test-db.json
+++ b/server-test-db.json
@@ -1,258 +1,258 @@
 {
   "projects": [
     {
-      "id": "c7b0019f-5648-4d9f-bb49-1c2d6554c360",
+      "id": "e9a0ad6c-2e34-451d-bea0-046aa6268ab6",
       "name": "P1 Updated",
       "description": "",
-      "createdAt": "2026-03-02T01:24:01.892Z",
-      "updatedAt": "2026-03-02T01:24:01.906Z"
+      "createdAt": "2026-03-02T01:37:06.496Z",
+      "updatedAt": "2026-03-02T01:37:06.509Z"
     },
     {
-      "id": "fa18a70b-9231-40b7-9714-981f5d2080c1",
+      "id": "ef345c32-2875-4775-91cc-291f1815f6c5",
       "name": "Item Test",
       "description": "",
-      "createdAt": "2026-03-02T01:24:01.915Z",
-      "updatedAt": "2026-03-02T01:24:01.915Z"
+      "createdAt": "2026-03-02T01:37:06.518Z",
+      "updatedAt": "2026-03-02T01:37:06.518Z"
     },
     {
-      "id": "a0af150a-61f3-4fe9-bab5-566878ec5669",
+      "id": "13cc6294-bcb6-4dcf-9a2f-5b5f2d05d959",
       "name": "JIRA Import Test",
       "description": "",
-      "createdAt": "2026-03-02T01:24:01.995Z",
-      "updatedAt": "2026-03-02T01:24:01.995Z"
+      "createdAt": "2026-03-02T01:37:06.606Z",
+      "updatedAt": "2026-03-02T01:37:06.606Z"
     },
     {
-      "id": "12943577-c249-4707-b5d8-d25b5cede536",
+      "id": "03816ce9-4e01-42c9-9c1a-f26330a4c872",
       "name": "JIRA Err Test",
       "description": "",
-      "createdAt": "2026-03-02T01:24:01.999Z",
-      "updatedAt": "2026-03-02T01:24:01.999Z"
+      "createdAt": "2026-03-02T01:37:06.611Z",
+      "updatedAt": "2026-03-02T01:37:06.611Z"
     }
   ],
   "items": [
     {
-      "id": "773be8cc-7dce-4ce7-a11b-737a65569ba8",
-      "projectId": "fa18a70b-9231-40b7-9714-981f5d2080c1",
+      "id": "c83cdee6-cf25-4382-bc0f-3f6e1a8a4516",
+      "projectId": "ef345c32-2875-4775-91cc-291f1815f6c5",
       "type": "TASK",
       "title": "T1",
       "description": "D1",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:24:01.918Z",
-      "updatedAt": "2026-03-02T01:24:01.918Z",
+      "createdAt": "2026-03-02T01:37:06.521Z",
+      "updatedAt": "2026-03-02T01:37:06.521Z",
       "history": [
         {
-          "id": "f54bfb18-bbdb-448c-a9fa-9e018678b8e5",
+          "id": "548b6b90-20d4-4895-a4f0-c8307985c2c6",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:24:01.918Z"
+          "timestamp": "2026-03-02T01:37:06.521Z"
         }
       ]
     },
     {
-      "id": "8084473b-fafb-4163-811f-9e9000f9b962",
-      "projectId": "fa18a70b-9231-40b7-9714-981f5d2080c1",
+      "id": "76fd6e2e-cbe5-4ba3-980d-21f174d21ed5",
+      "projectId": "ef345c32-2875-4775-91cc-291f1815f6c5",
       "type": "TASK",
       "title": "To Update",
       "description": "D",
       "status": "IN_PROGRESS",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:24:01.920Z",
-      "updatedAt": "2026-03-02T01:24:01.923Z",
+      "createdAt": "2026-03-02T01:37:06.524Z",
+      "updatedAt": "2026-03-02T01:37:06.526Z",
       "history": [
         {
-          "id": "cad22f27-bcb6-45fa-8b62-1523d49797ce",
+          "id": "ec3c403a-9d0a-49a3-85d1-cd39e045001e",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:24:01.920Z"
+          "timestamp": "2026-03-02T01:37:06.524Z"
         },
         {
-          "id": "b064773f-602a-4307-a75e-41e0f296a4f6",
+          "id": "35ed953f-359c-4f33-8240-f90a7538bf9b",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-02T01:24:01.923Z"
+          "timestamp": "2026-03-02T01:37:06.526Z"
         }
       ]
     },
     {
-      "id": "02cff57e-f699-4f09-afb0-19fba35ba638",
-      "projectId": "fa18a70b-9231-40b7-9714-981f5d2080c1",
+      "id": "81a66eda-8880-4a14-b78f-a4d0b2f899e0",
+      "projectId": "ef345c32-2875-4775-91cc-291f1815f6c5",
       "type": "TASK",
       "title": "No Cheat",
       "description": "D",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:24:01.925Z",
-      "updatedAt": "2026-03-02T01:24:01.925Z",
+      "createdAt": "2026-03-02T01:37:06.528Z",
+      "updatedAt": "2026-03-02T01:37:06.528Z",
       "history": [
         {
-          "id": "45a9580c-9576-4ac7-941c-fe75f327339f",
+          "id": "05a9090c-4817-41cd-8594-176a110b0eb0",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:24:01.926Z"
+          "timestamp": "2026-03-02T01:37:06.528Z"
         }
       ]
     },
     {
-      "id": "720d37b8-e7a0-4458-b478-243dc1ae90ff",
-      "projectId": "fa18a70b-9231-40b7-9714-981f5d2080c1",
+      "id": "ed1a78d8-59f3-4d41-832f-900678487df9",
+      "projectId": "ef345c32-2875-4775-91cc-291f1815f6c5",
       "type": "TASK",
       "title": "Verify Me",
       "description": "D",
       "status": "DONE",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:24:01.929Z",
-      "updatedAt": "2026-03-02T01:24:01.930Z",
+      "createdAt": "2026-03-02T01:37:06.531Z",
+      "updatedAt": "2026-03-02T01:37:06.533Z",
       "history": [
         {
-          "id": "75f1249a-45ef-4232-8566-b12e9ffe2659",
+          "id": "a49cd8ff-66a1-4825-a927-e500fc507f44",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:24:01.929Z"
+          "timestamp": "2026-03-02T01:37:06.531Z"
         },
         {
-          "id": "aebf38b7-ea6c-4bfc-a7d2-160c97c06473",
+          "id": "a1063921-2ee6-4f20-920a-f02eb4a345c7",
           "fromStatus": "TODO",
           "toStatus": "DONE",
-          "timestamp": "2026-03-02T01:24:01.930Z"
+          "timestamp": "2026-03-02T01:37:06.533Z"
         }
       ]
     },
     {
-      "id": "c81e7748-8b2b-4e9d-b747-6b7e831ec69e",
-      "projectId": "fa18a70b-9231-40b7-9714-981f5d2080c1",
+      "id": "263d1168-ba5a-4114-be39-b7b9fa4b3fee",
+      "projectId": "ef345c32-2875-4775-91cc-291f1815f6c5",
       "type": "STORY",
       "title": "Parent Story",
       "description": "D",
       "status": "IN_PROGRESS",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:24:01.932Z",
-      "updatedAt": "2026-03-02T01:24:01.944Z",
+      "createdAt": "2026-03-02T01:37:06.537Z",
+      "updatedAt": "2026-03-02T01:37:06.549Z",
       "history": [
         {
-          "id": "3851d9fd-eddb-46d3-986a-5dc6df15377d",
+          "id": "1801dabe-3054-4051-a3c4-d02e565b4cab",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:24:01.932Z"
+          "timestamp": "2026-03-02T01:37:06.537Z"
         },
         {
-          "id": "3a110d86-c3b2-49bc-8c66-37debb1ea413",
+          "id": "a16e9177-3fff-4ebc-bc96-d912d79f2401",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-02T01:24:01.944Z"
+          "timestamp": "2026-03-02T01:37:06.549Z"
         }
       ]
     },
     {
-      "id": "8bb335c4-a412-4df0-805d-238e82b7b239",
-      "projectId": "fa18a70b-9231-40b7-9714-981f5d2080c1",
+      "id": "cef9522b-58fe-466c-bb26-f989269a7146",
+      "projectId": "ef345c32-2875-4775-91cc-291f1815f6c5",
       "type": "TASK",
       "title": "Child Task",
       "description": "D",
       "status": "IN_PROGRESS",
-      "parentId": "c81e7748-8b2b-4e9d-b747-6b7e831ec69e",
+      "parentId": "263d1168-ba5a-4114-be39-b7b9fa4b3fee",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:24:01.941Z",
-      "updatedAt": "2026-03-02T01:24:01.943Z",
+      "createdAt": "2026-03-02T01:37:06.546Z",
+      "updatedAt": "2026-03-02T01:37:06.548Z",
       "history": [
         {
-          "id": "951291fa-4cc7-4def-8f06-e81a7172dc86",
+          "id": "bc91d6e0-bfdd-4b75-be4b-d26730ee241b",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:24:01.942Z"
+          "timestamp": "2026-03-02T01:37:06.546Z"
         },
         {
-          "id": "053b8107-52d8-4037-8688-8488c92b2ebe",
+          "id": "a78efd46-bfb0-4780-9a50-ffc2133072d6",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-02T01:24:01.943Z"
+          "timestamp": "2026-03-02T01:37:06.548Z"
         }
       ]
     },
     {
-      "id": "5693b183-f4d4-462a-bd7d-ab985818d13e",
-      "projectId": "fa18a70b-9231-40b7-9714-981f5d2080c1",
+      "id": "83fe16d4-8bae-41cd-b7ac-95b6e893f462",
+      "projectId": "ef345c32-2875-4775-91cc-291f1815f6c5",
       "type": "TASK",
       "title": "Archive Me",
       "description": "D",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:24:01.946Z",
-      "updatedAt": "2026-03-02T01:24:01.949Z",
+      "createdAt": "2026-03-02T01:37:06.552Z",
+      "updatedAt": "2026-03-02T01:37:06.556Z",
       "history": [
         {
-          "id": "2a3e7d4c-7f62-4ee4-9d5f-49ba697a714c",
+          "id": "dc73c65f-ecbc-476d-ba9e-41cf49faae5d",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:24:01.946Z"
+          "timestamp": "2026-03-02T01:37:06.552Z"
         },
         {
-          "id": "f2d9bc43-4a1e-4eff-95c6-73d82bd64aec",
+          "id": "1b3872c8-c78f-43d7-8437-8962f0c2c945",
           "fromStatus": "TODO",
           "toStatus": "ARCHIVED",
-          "timestamp": "2026-03-02T01:24:01.947Z"
+          "timestamp": "2026-03-02T01:37:06.554Z"
         },
         {
-          "id": "7807d5b2-06b8-49d8-948c-0e027a8ec83e",
+          "id": "436444ef-46ed-4d06-9514-0aeb6bc398de",
           "fromStatus": "ARCHIVED",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:24:01.949Z"
+          "timestamp": "2026-03-02T01:37:06.556Z"
         }
       ]
     },
     {
-      "id": "f52d5af8-e393-4f5f-9759-55e503923244",
-      "projectId": "fa18a70b-9231-40b7-9714-981f5d2080c1",
+      "id": "f57dbcb2-56b1-4673-8258-0fe1972f6299",
+      "projectId": "ef345c32-2875-4775-91cc-291f1815f6c5",
       "type": "TASK",
       "title": "Delete Me",
       "description": "D",
       "status": "TRASHED",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:24:01.950Z",
-      "updatedAt": "2026-03-02T01:24:01.952Z",
+      "createdAt": "2026-03-02T01:37:06.558Z",
+      "updatedAt": "2026-03-02T01:37:06.560Z",
       "history": [
         {
-          "id": "f5858409-fc40-4c6e-8a00-21f362fa3ec6",
+          "id": "57f182d0-662a-4ff3-a1a0-81c13d9903db",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:24:01.951Z"
+          "timestamp": "2026-03-02T01:37:06.558Z"
         },
         {
-          "id": "7c425ec7-959d-49f8-8d1b-49593cca5fc3",
+          "id": "189aa27e-1c77-4840-83dc-2f5b4ad7446b",
           "fromStatus": "TODO",
           "toStatus": "TRASHED",
-          "timestamp": "2026-03-02T01:24:01.952Z"
+          "timestamp": "2026-03-02T01:37:06.560Z"
         }
       ]
     },
     {
-      "id": "bbe7f32c-0d16-464b-a86f-e3b1a440502b",
-      "projectId": "fa18a70b-9231-40b7-9714-981f5d2080c1",
+      "id": "e622c368-e957-4458-9ec6-d9d6012caea0",
+      "projectId": "ef345c32-2875-4775-91cc-291f1815f6c5",
       "type": "TASK",
       "title": "Archived Task",
       "description": "",
       "status": "TRASHED",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:24:01.956Z",
-      "updatedAt": "2026-03-02T01:24:01.958Z",
+      "createdAt": "2026-03-02T01:37:06.563Z",
+      "updatedAt": "2026-03-02T01:37:06.565Z",
       "history": [
         {
-          "id": "55d33972-3444-49c3-a15f-02251bfba2e7",
+          "id": "d7f2d969-2e66-4370-b05c-4f338cb423a2",
           "fromStatus": "TODO",
           "toStatus": "ARCHIVED",
-          "timestamp": "2026-03-02T01:24:01.956Z"
+          "timestamp": "2026-03-02T01:37:06.563Z"
         },
         {
-          "id": "a2ed6ace-f825-4770-8569-0e073046cd6e",
+          "id": "5f5b1f75-403f-45f6-b2b7-0b3d1811cd5d",
           "fromStatus": "ARCHIVED",
           "toStatus": "TRASHED",
-          "timestamp": "2026-03-02T01:24:01.958Z"
+          "timestamp": "2026-03-02T01:37:06.565Z"
         }
       ]
     },
     {
-      "id": "87cd4c91-f3e3-4be8-8a6e-bace15fff432",
-      "projectId": "a0af150a-61f3-4fe9-bab5-566878ec5669",
+      "id": "e9930bce-8ad5-4af1-916d-fbd11be318d6",
+      "projectId": "13cc6294-bcb6-4dcf-9a2f-5b5f2d05d959",
       "type": "BUG",
       "title": "[PROJ-1] Fix login bug",
       "description": "Imported from JIRA: PROJ-1",
@@ -260,14 +260,14 @@
       "implementationPlan": "",
       "externalId": "PROJ-1",
       "externalUrl": "https://test.atlassian.net/browse/PROJ-1",
-      "createdAt": "2026-03-02T01:24:01.996Z",
-      "updatedAt": "2026-03-02T01:24:01.996Z",
+      "createdAt": "2026-03-02T01:37:06.607Z",
+      "updatedAt": "2026-03-02T01:37:06.607Z",
       "history": [
         {
-          "id": "f34f4827-06df-4f3e-94ca-53f1feeae976",
+          "id": "d0da4389-50e0-4e43-be0f-e27a5f324b8d",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:24:01.996Z"
+          "timestamp": "2026-03-02T01:37:06.608Z"
         }
       ]
     }

--- a/server-test-db.json
+++ b/server-test-db.json
@@ -1,258 +1,258 @@
 {
   "projects": [
     {
-      "id": "8ece8a24-12c9-423b-af70-d6cd6ff69e5a",
+      "id": "58085ec9-c6e6-436f-ad97-29c7273c28b6",
       "name": "P1 Updated",
       "description": "",
-      "createdAt": "2026-03-02T01:45:36.790Z",
-      "updatedAt": "2026-03-02T01:45:36.804Z"
+      "createdAt": "2026-03-02T01:51:21.311Z",
+      "updatedAt": "2026-03-02T01:51:21.325Z"
     },
     {
-      "id": "19c5b908-2762-4960-b38c-cc0c10443f71",
+      "id": "c37991f3-f870-40ce-a194-9033e5339147",
       "name": "Item Test",
       "description": "",
-      "createdAt": "2026-03-02T01:45:36.814Z",
-      "updatedAt": "2026-03-02T01:45:36.814Z"
+      "createdAt": "2026-03-02T01:51:21.335Z",
+      "updatedAt": "2026-03-02T01:51:21.335Z"
     },
     {
-      "id": "2638f456-4788-4b80-89f1-6416ab5356a2",
+      "id": "1e8370b4-9561-41bf-afc1-3d5064538f10",
       "name": "JIRA Import Test",
       "description": "",
-      "createdAt": "2026-03-02T01:45:36.888Z",
-      "updatedAt": "2026-03-02T01:45:36.888Z"
+      "createdAt": "2026-03-02T01:51:21.420Z",
+      "updatedAt": "2026-03-02T01:51:21.420Z"
     },
     {
-      "id": "294c0dfc-54dd-49bb-965f-c78b9dc517a1",
+      "id": "5b4524a9-dada-4423-a00a-8818e47ea7a1",
       "name": "JIRA Err Test",
       "description": "",
-      "createdAt": "2026-03-02T01:45:36.892Z",
-      "updatedAt": "2026-03-02T01:45:36.892Z"
+      "createdAt": "2026-03-02T01:51:21.425Z",
+      "updatedAt": "2026-03-02T01:51:21.425Z"
     }
   ],
   "items": [
     {
-      "id": "7fcbc640-65ed-41aa-b160-f451313f9317",
-      "projectId": "19c5b908-2762-4960-b38c-cc0c10443f71",
+      "id": "6686629a-d900-46e0-9ec6-b54b4d889184",
+      "projectId": "c37991f3-f870-40ce-a194-9033e5339147",
       "type": "TASK",
       "title": "T1",
       "description": "D1",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:45:36.816Z",
-      "updatedAt": "2026-03-02T01:45:36.816Z",
+      "createdAt": "2026-03-02T01:51:21.337Z",
+      "updatedAt": "2026-03-02T01:51:21.337Z",
       "history": [
         {
-          "id": "c43a4b68-4b14-4b70-829b-dffbe33d4332",
+          "id": "576f0eb1-fbfe-44a7-bb1e-5302f83dd31b",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:45:36.816Z"
+          "timestamp": "2026-03-02T01:51:21.338Z"
         }
       ]
     },
     {
-      "id": "c01033a6-f5bd-4e0d-a303-229cc53e80bd",
-      "projectId": "19c5b908-2762-4960-b38c-cc0c10443f71",
+      "id": "8db42ae0-8a68-438f-83b2-e6ca46368dac",
+      "projectId": "c37991f3-f870-40ce-a194-9033e5339147",
       "type": "TASK",
       "title": "To Update",
       "description": "D",
       "status": "IN_PROGRESS",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:45:36.818Z",
-      "updatedAt": "2026-03-02T01:45:36.820Z",
+      "createdAt": "2026-03-02T01:51:21.340Z",
+      "updatedAt": "2026-03-02T01:51:21.342Z",
       "history": [
         {
-          "id": "2e7d3e31-cab6-43a5-80d7-5d13c111084f",
+          "id": "852004a3-fafe-4da6-b94b-fda8968da35b",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:45:36.818Z"
+          "timestamp": "2026-03-02T01:51:21.340Z"
         },
         {
-          "id": "1bd0e5fb-1af6-4c6d-9401-0290db2e9fcb",
+          "id": "0ea69c27-9a38-489d-90c8-49e359adfef9",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-02T01:45:36.820Z"
+          "timestamp": "2026-03-02T01:51:21.342Z"
         }
       ]
     },
     {
-      "id": "62da7ab4-d734-4231-87c6-469d41069c6c",
-      "projectId": "19c5b908-2762-4960-b38c-cc0c10443f71",
+      "id": "85d3f405-5d0e-4970-85e3-468c49653652",
+      "projectId": "c37991f3-f870-40ce-a194-9033e5339147",
       "type": "TASK",
       "title": "No Cheat",
       "description": "D",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:45:36.822Z",
-      "updatedAt": "2026-03-02T01:45:36.822Z",
+      "createdAt": "2026-03-02T01:51:21.344Z",
+      "updatedAt": "2026-03-02T01:51:21.344Z",
       "history": [
         {
-          "id": "6350008e-d602-4524-8b8d-c9d603783374",
+          "id": "4e39b142-ebf3-49dd-aa2b-de3423f3b33d",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:45:36.823Z"
+          "timestamp": "2026-03-02T01:51:21.345Z"
         }
       ]
     },
     {
-      "id": "716506fc-402e-4934-8d2d-7e84598dac31",
-      "projectId": "19c5b908-2762-4960-b38c-cc0c10443f71",
+      "id": "f28a31a9-27a8-4531-9f8a-8a72765935b7",
+      "projectId": "c37991f3-f870-40ce-a194-9033e5339147",
       "type": "TASK",
       "title": "Verify Me",
       "description": "D",
       "status": "DONE",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:45:36.826Z",
-      "updatedAt": "2026-03-02T01:45:36.828Z",
+      "createdAt": "2026-03-02T01:51:21.350Z",
+      "updatedAt": "2026-03-02T01:51:21.354Z",
       "history": [
         {
-          "id": "64610920-7ab2-4b48-9855-d4202b8e0442",
+          "id": "2593f3f7-0b49-4092-8dc5-3bb7208e648b",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:45:36.826Z"
+          "timestamp": "2026-03-02T01:51:21.350Z"
         },
         {
-          "id": "e0f63b9a-f105-438a-bdc9-04bb7b20a402",
+          "id": "04bcd8a3-4e5c-44d2-b27a-23bc1f5c7c31",
           "fromStatus": "TODO",
           "toStatus": "DONE",
-          "timestamp": "2026-03-02T01:45:36.828Z"
+          "timestamp": "2026-03-02T01:51:21.354Z"
         }
       ]
     },
     {
-      "id": "cab0f343-f3c7-4eff-b4ba-0af7e9871025",
-      "projectId": "19c5b908-2762-4960-b38c-cc0c10443f71",
+      "id": "5854f364-1728-4bbc-8795-c26057424185",
+      "projectId": "c37991f3-f870-40ce-a194-9033e5339147",
       "type": "STORY",
       "title": "Parent Story",
       "description": "D",
       "status": "IN_PROGRESS",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:45:36.830Z",
-      "updatedAt": "2026-03-02T01:45:36.840Z",
+      "createdAt": "2026-03-02T01:51:21.356Z",
+      "updatedAt": "2026-03-02T01:51:21.360Z",
       "history": [
         {
-          "id": "f468ad36-fa5f-4d58-a38c-62d8c2db9e8d",
+          "id": "88aef2e2-9a6d-443b-a5c2-5c3e0c413a9c",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:45:36.830Z"
+          "timestamp": "2026-03-02T01:51:21.356Z"
         },
         {
-          "id": "784c48da-7062-4485-9c19-9b28c8305a91",
+          "id": "4de8adb5-609b-4d8b-8d20-fe685e09e4ed",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-02T01:45:36.840Z"
+          "timestamp": "2026-03-02T01:51:21.360Z"
         }
       ]
     },
     {
-      "id": "9f571712-7390-4c85-a850-7628e29ac7f1",
-      "projectId": "19c5b908-2762-4960-b38c-cc0c10443f71",
+      "id": "9ef6b69c-ad5a-465f-af12-d61c5b975905",
+      "projectId": "c37991f3-f870-40ce-a194-9033e5339147",
       "type": "TASK",
       "title": "Child Task",
       "description": "D",
       "status": "IN_PROGRESS",
-      "parentId": "cab0f343-f3c7-4eff-b4ba-0af7e9871025",
+      "parentId": "5854f364-1728-4bbc-8795-c26057424185",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:45:36.837Z",
-      "updatedAt": "2026-03-02T01:45:36.840Z",
+      "createdAt": "2026-03-02T01:51:21.358Z",
+      "updatedAt": "2026-03-02T01:51:21.360Z",
       "history": [
         {
-          "id": "e1905275-d0d1-47ba-b876-d32f6b373ce9",
+          "id": "67b53318-290d-42bd-93de-ef9ae483b0d3",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:45:36.838Z"
+          "timestamp": "2026-03-02T01:51:21.358Z"
         },
         {
-          "id": "630f0e50-0f8b-4fb0-b980-f75e85ccd414",
+          "id": "4a8f3beb-af9d-4dba-91b0-32da433ba7b0",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-02T01:45:36.840Z"
+          "timestamp": "2026-03-02T01:51:21.360Z"
         }
       ]
     },
     {
-      "id": "9babd873-9e0b-4328-9435-642e5ecfb1b8",
-      "projectId": "19c5b908-2762-4960-b38c-cc0c10443f71",
+      "id": "3d944c13-be60-48ad-bec9-2fecba22a3df",
+      "projectId": "c37991f3-f870-40ce-a194-9033e5339147",
       "type": "TASK",
       "title": "Archive Me",
       "description": "D",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:45:36.843Z",
-      "updatedAt": "2026-03-02T01:45:36.846Z",
+      "createdAt": "2026-03-02T01:51:21.363Z",
+      "updatedAt": "2026-03-02T01:51:21.368Z",
       "history": [
         {
-          "id": "a5f0ad35-d901-44a7-9dd2-08d3a2e9f2ae",
+          "id": "19369269-0d81-4a20-9721-958831836021",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:45:36.843Z"
+          "timestamp": "2026-03-02T01:51:21.363Z"
         },
         {
-          "id": "a240d128-7e49-439b-9818-126452c82a6c",
+          "id": "ba01ca43-4a19-43ae-a297-d8224a2addf4",
           "fromStatus": "TODO",
           "toStatus": "ARCHIVED",
-          "timestamp": "2026-03-02T01:45:36.844Z"
+          "timestamp": "2026-03-02T01:51:21.366Z"
         },
         {
-          "id": "62fb9bf9-9c21-4605-962d-81aef7be8a92",
+          "id": "e15bdc47-7ade-4424-ba6b-882b3fab42ed",
           "fromStatus": "ARCHIVED",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:45:36.846Z"
+          "timestamp": "2026-03-02T01:51:21.368Z"
         }
       ]
     },
     {
-      "id": "9d67ada0-eb9b-4e8c-884d-f268a653110d",
-      "projectId": "19c5b908-2762-4960-b38c-cc0c10443f71",
+      "id": "02e4513b-4a09-47da-ab30-2258049e1b93",
+      "projectId": "c37991f3-f870-40ce-a194-9033e5339147",
       "type": "TASK",
       "title": "Delete Me",
       "description": "D",
       "status": "TRASHED",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:45:36.847Z",
-      "updatedAt": "2026-03-02T01:45:36.849Z",
+      "createdAt": "2026-03-02T01:51:21.376Z",
+      "updatedAt": "2026-03-02T01:51:21.378Z",
       "history": [
         {
-          "id": "dfc604c7-d5fa-41af-ad59-fef829395d88",
+          "id": "f4e37f0c-526d-4c6f-ba68-444b5290ed42",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:45:36.848Z"
+          "timestamp": "2026-03-02T01:51:21.376Z"
         },
         {
-          "id": "791338cc-e44b-4816-a680-70ac849c3963",
+          "id": "3a054f8a-efde-47e6-ae4b-e93c86718127",
           "fromStatus": "TODO",
           "toStatus": "TRASHED",
-          "timestamp": "2026-03-02T01:45:36.849Z"
+          "timestamp": "2026-03-02T01:51:21.378Z"
         }
       ]
     },
     {
-      "id": "16864f1c-9349-4be7-a841-23b30d91474c",
-      "projectId": "19c5b908-2762-4960-b38c-cc0c10443f71",
+      "id": "1651b5b0-2525-4c90-bec6-7fd9761b504d",
+      "projectId": "c37991f3-f870-40ce-a194-9033e5339147",
       "type": "TASK",
       "title": "Archived Task",
       "description": "",
       "status": "TRASHED",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:45:36.852Z",
-      "updatedAt": "2026-03-02T01:45:36.853Z",
+      "createdAt": "2026-03-02T01:51:21.382Z",
+      "updatedAt": "2026-03-02T01:51:21.384Z",
       "history": [
         {
-          "id": "97696ae4-7512-4228-a813-dfe60c47ac05",
+          "id": "d8711f65-1425-4174-9836-e56b51cf41d7",
           "fromStatus": "TODO",
           "toStatus": "ARCHIVED",
-          "timestamp": "2026-03-02T01:45:36.852Z"
+          "timestamp": "2026-03-02T01:51:21.382Z"
         },
         {
-          "id": "4999a3f2-5e41-47b0-8463-ae96242d84e8",
+          "id": "96561d7c-6fdd-4bef-890b-a424d1870ddf",
           "fromStatus": "ARCHIVED",
           "toStatus": "TRASHED",
-          "timestamp": "2026-03-02T01:45:36.853Z"
+          "timestamp": "2026-03-02T01:51:21.384Z"
         }
       ]
     },
     {
-      "id": "c1c1834a-94e3-4906-ba6c-c184f205a898",
-      "projectId": "2638f456-4788-4b80-89f1-6416ab5356a2",
+      "id": "0d65f57f-ac0c-4cb0-9a40-06431b4ca3bb",
+      "projectId": "1e8370b4-9561-41bf-afc1-3d5064538f10",
       "type": "BUG",
       "title": "[PROJ-1] Fix login bug",
       "description": "Imported from JIRA: PROJ-1",
@@ -260,14 +260,14 @@
       "implementationPlan": "",
       "externalId": "PROJ-1",
       "externalUrl": "https://test.atlassian.net/browse/PROJ-1",
-      "createdAt": "2026-03-02T01:45:36.889Z",
-      "updatedAt": "2026-03-02T01:45:36.889Z",
+      "createdAt": "2026-03-02T01:51:21.421Z",
+      "updatedAt": "2026-03-02T01:51:21.421Z",
       "history": [
         {
-          "id": "9038f3fe-85fa-46c3-b43b-a60c72f11d5f",
+          "id": "af0bc1f9-4fbd-4e96-bb48-843a217ae1cf",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:45:36.889Z"
+          "timestamp": "2026-03-02T01:51:21.421Z"
         }
       ]
     }

--- a/server-test-db.json
+++ b/server-test-db.json
@@ -1,258 +1,258 @@
 {
   "projects": [
     {
-      "id": "8c97729c-ac6b-430c-9600-d2d7bbcebef4",
+      "id": "8ece8a24-12c9-423b-af70-d6cd6ff69e5a",
       "name": "P1 Updated",
       "description": "",
-      "createdAt": "2026-03-02T01:37:55.604Z",
-      "updatedAt": "2026-03-02T01:37:55.618Z"
+      "createdAt": "2026-03-02T01:45:36.790Z",
+      "updatedAt": "2026-03-02T01:45:36.804Z"
     },
     {
-      "id": "953c3e7e-3f23-47bf-b36e-7febcbfdfb00",
+      "id": "19c5b908-2762-4960-b38c-cc0c10443f71",
       "name": "Item Test",
       "description": "",
-      "createdAt": "2026-03-02T01:37:55.627Z",
-      "updatedAt": "2026-03-02T01:37:55.627Z"
+      "createdAt": "2026-03-02T01:45:36.814Z",
+      "updatedAt": "2026-03-02T01:45:36.814Z"
     },
     {
-      "id": "3083b291-065b-490c-baa5-418d604e1b5b",
+      "id": "2638f456-4788-4b80-89f1-6416ab5356a2",
       "name": "JIRA Import Test",
       "description": "",
-      "createdAt": "2026-03-02T01:37:55.704Z",
-      "updatedAt": "2026-03-02T01:37:55.704Z"
+      "createdAt": "2026-03-02T01:45:36.888Z",
+      "updatedAt": "2026-03-02T01:45:36.888Z"
     },
     {
-      "id": "fddd27d3-fe1d-4ca8-a4d5-d5cf1d4a080a",
+      "id": "294c0dfc-54dd-49bb-965f-c78b9dc517a1",
       "name": "JIRA Err Test",
       "description": "",
-      "createdAt": "2026-03-02T01:37:55.708Z",
-      "updatedAt": "2026-03-02T01:37:55.708Z"
+      "createdAt": "2026-03-02T01:45:36.892Z",
+      "updatedAt": "2026-03-02T01:45:36.892Z"
     }
   ],
   "items": [
     {
-      "id": "1fe47b02-8e03-4804-a68a-923e78e4cb9d",
-      "projectId": "953c3e7e-3f23-47bf-b36e-7febcbfdfb00",
+      "id": "7fcbc640-65ed-41aa-b160-f451313f9317",
+      "projectId": "19c5b908-2762-4960-b38c-cc0c10443f71",
       "type": "TASK",
       "title": "T1",
       "description": "D1",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:37:55.629Z",
-      "updatedAt": "2026-03-02T01:37:55.629Z",
+      "createdAt": "2026-03-02T01:45:36.816Z",
+      "updatedAt": "2026-03-02T01:45:36.816Z",
       "history": [
         {
-          "id": "2ce4cf23-8656-4805-9f2c-f781b13d63b4",
+          "id": "c43a4b68-4b14-4b70-829b-dffbe33d4332",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:37:55.629Z"
+          "timestamp": "2026-03-02T01:45:36.816Z"
         }
       ]
     },
     {
-      "id": "f934000f-c5b3-4843-86d5-c14a10fae4b2",
-      "projectId": "953c3e7e-3f23-47bf-b36e-7febcbfdfb00",
+      "id": "c01033a6-f5bd-4e0d-a303-229cc53e80bd",
+      "projectId": "19c5b908-2762-4960-b38c-cc0c10443f71",
       "type": "TASK",
       "title": "To Update",
       "description": "D",
       "status": "IN_PROGRESS",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:37:55.632Z",
-      "updatedAt": "2026-03-02T01:37:55.634Z",
+      "createdAt": "2026-03-02T01:45:36.818Z",
+      "updatedAt": "2026-03-02T01:45:36.820Z",
       "history": [
         {
-          "id": "9759b738-8e1b-4bbf-a765-e3725e70d99a",
+          "id": "2e7d3e31-cab6-43a5-80d7-5d13c111084f",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:37:55.632Z"
+          "timestamp": "2026-03-02T01:45:36.818Z"
         },
         {
-          "id": "6b2126c3-be41-4371-801d-e0898ec151e3",
+          "id": "1bd0e5fb-1af6-4c6d-9401-0290db2e9fcb",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-02T01:37:55.634Z"
+          "timestamp": "2026-03-02T01:45:36.820Z"
         }
       ]
     },
     {
-      "id": "45f4b33f-bd63-47bc-8c5a-759aefae4c67",
-      "projectId": "953c3e7e-3f23-47bf-b36e-7febcbfdfb00",
+      "id": "62da7ab4-d734-4231-87c6-469d41069c6c",
+      "projectId": "19c5b908-2762-4960-b38c-cc0c10443f71",
       "type": "TASK",
       "title": "No Cheat",
       "description": "D",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:37:55.643Z",
-      "updatedAt": "2026-03-02T01:37:55.643Z",
+      "createdAt": "2026-03-02T01:45:36.822Z",
+      "updatedAt": "2026-03-02T01:45:36.822Z",
       "history": [
         {
-          "id": "8749e551-e7ba-482a-b5f4-9c118a8ee8e5",
+          "id": "6350008e-d602-4524-8b8d-c9d603783374",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:37:55.643Z"
+          "timestamp": "2026-03-02T01:45:36.823Z"
         }
       ]
     },
     {
-      "id": "e3697eac-d1f0-4864-bab2-436df0762296",
-      "projectId": "953c3e7e-3f23-47bf-b36e-7febcbfdfb00",
+      "id": "716506fc-402e-4934-8d2d-7e84598dac31",
+      "projectId": "19c5b908-2762-4960-b38c-cc0c10443f71",
       "type": "TASK",
       "title": "Verify Me",
       "description": "D",
       "status": "DONE",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:37:55.647Z",
-      "updatedAt": "2026-03-02T01:37:55.649Z",
+      "createdAt": "2026-03-02T01:45:36.826Z",
+      "updatedAt": "2026-03-02T01:45:36.828Z",
       "history": [
         {
-          "id": "5664fc26-635a-4504-8804-5c55a0373f03",
+          "id": "64610920-7ab2-4b48-9855-d4202b8e0442",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:37:55.647Z"
+          "timestamp": "2026-03-02T01:45:36.826Z"
         },
         {
-          "id": "1f890ebc-c40c-470b-8897-8e246aa41d8b",
+          "id": "e0f63b9a-f105-438a-bdc9-04bb7b20a402",
           "fromStatus": "TODO",
           "toStatus": "DONE",
-          "timestamp": "2026-03-02T01:37:55.649Z"
+          "timestamp": "2026-03-02T01:45:36.828Z"
         }
       ]
     },
     {
-      "id": "731fe311-db3f-450c-bcb6-f63684ddb057",
-      "projectId": "953c3e7e-3f23-47bf-b36e-7febcbfdfb00",
+      "id": "cab0f343-f3c7-4eff-b4ba-0af7e9871025",
+      "projectId": "19c5b908-2762-4960-b38c-cc0c10443f71",
       "type": "STORY",
       "title": "Parent Story",
       "description": "D",
       "status": "IN_PROGRESS",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:37:55.651Z",
-      "updatedAt": "2026-03-02T01:37:55.655Z",
+      "createdAt": "2026-03-02T01:45:36.830Z",
+      "updatedAt": "2026-03-02T01:45:36.840Z",
       "history": [
         {
-          "id": "5d7a9db9-388a-472f-b0a6-f4f08016ec72",
+          "id": "f468ad36-fa5f-4d58-a38c-62d8c2db9e8d",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:37:55.651Z"
+          "timestamp": "2026-03-02T01:45:36.830Z"
         },
         {
-          "id": "8457d900-e55c-4273-a3f6-3fe1f9a036b3",
+          "id": "784c48da-7062-4485-9c19-9b28c8305a91",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-02T01:37:55.655Z"
+          "timestamp": "2026-03-02T01:45:36.840Z"
         }
       ]
     },
     {
-      "id": "5a930b91-0be6-4c9b-97ca-1d00fad6530e",
-      "projectId": "953c3e7e-3f23-47bf-b36e-7febcbfdfb00",
+      "id": "9f571712-7390-4c85-a850-7628e29ac7f1",
+      "projectId": "19c5b908-2762-4960-b38c-cc0c10443f71",
       "type": "TASK",
       "title": "Child Task",
       "description": "D",
       "status": "IN_PROGRESS",
-      "parentId": "731fe311-db3f-450c-bcb6-f63684ddb057",
+      "parentId": "cab0f343-f3c7-4eff-b4ba-0af7e9871025",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:37:55.653Z",
-      "updatedAt": "2026-03-02T01:37:55.655Z",
+      "createdAt": "2026-03-02T01:45:36.837Z",
+      "updatedAt": "2026-03-02T01:45:36.840Z",
       "history": [
         {
-          "id": "beb494fa-3f2f-46ca-b61e-f760d863a119",
+          "id": "e1905275-d0d1-47ba-b876-d32f6b373ce9",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:37:55.653Z"
+          "timestamp": "2026-03-02T01:45:36.838Z"
         },
         {
-          "id": "178268db-9e8a-49a2-94d8-e51305e87ea9",
+          "id": "630f0e50-0f8b-4fb0-b980-f75e85ccd414",
           "fromStatus": "TODO",
           "toStatus": "IN_PROGRESS",
-          "timestamp": "2026-03-02T01:37:55.655Z"
+          "timestamp": "2026-03-02T01:45:36.840Z"
         }
       ]
     },
     {
-      "id": "4edeb421-808a-44b1-b8e5-fba6dd0ce26f",
-      "projectId": "953c3e7e-3f23-47bf-b36e-7febcbfdfb00",
+      "id": "9babd873-9e0b-4328-9435-642e5ecfb1b8",
+      "projectId": "19c5b908-2762-4960-b38c-cc0c10443f71",
       "type": "TASK",
       "title": "Archive Me",
       "description": "D",
       "status": "TODO",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:37:55.657Z",
-      "updatedAt": "2026-03-02T01:37:55.661Z",
+      "createdAt": "2026-03-02T01:45:36.843Z",
+      "updatedAt": "2026-03-02T01:45:36.846Z",
       "history": [
         {
-          "id": "06f44e0c-6b07-4de2-87dd-e0b50fea3cde",
+          "id": "a5f0ad35-d901-44a7-9dd2-08d3a2e9f2ae",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:37:55.657Z"
+          "timestamp": "2026-03-02T01:45:36.843Z"
         },
         {
-          "id": "3b8bcb65-7d38-4c14-aec0-9349b5e64e77",
+          "id": "a240d128-7e49-439b-9818-126452c82a6c",
           "fromStatus": "TODO",
           "toStatus": "ARCHIVED",
-          "timestamp": "2026-03-02T01:37:55.659Z"
+          "timestamp": "2026-03-02T01:45:36.844Z"
         },
         {
-          "id": "bf5de0cb-e998-445e-ae30-662a63db9630",
+          "id": "62fb9bf9-9c21-4605-962d-81aef7be8a92",
           "fromStatus": "ARCHIVED",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:37:55.660Z"
+          "timestamp": "2026-03-02T01:45:36.846Z"
         }
       ]
     },
     {
-      "id": "c208fac4-ea74-4f44-b412-8c6fc3105c7e",
-      "projectId": "953c3e7e-3f23-47bf-b36e-7febcbfdfb00",
+      "id": "9d67ada0-eb9b-4e8c-884d-f268a653110d",
+      "projectId": "19c5b908-2762-4960-b38c-cc0c10443f71",
       "type": "TASK",
       "title": "Delete Me",
       "description": "D",
       "status": "TRASHED",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:37:55.663Z",
-      "updatedAt": "2026-03-02T01:37:55.665Z",
+      "createdAt": "2026-03-02T01:45:36.847Z",
+      "updatedAt": "2026-03-02T01:45:36.849Z",
       "history": [
         {
-          "id": "063f7ff6-d720-402b-a9ba-782cc2e016e0",
+          "id": "dfc604c7-d5fa-41af-ad59-fef829395d88",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:37:55.663Z"
+          "timestamp": "2026-03-02T01:45:36.848Z"
         },
         {
-          "id": "5830f174-1a42-4831-bab9-ced27c66c6dc",
+          "id": "791338cc-e44b-4816-a680-70ac849c3963",
           "fromStatus": "TODO",
           "toStatus": "TRASHED",
-          "timestamp": "2026-03-02T01:37:55.665Z"
+          "timestamp": "2026-03-02T01:45:36.849Z"
         }
       ]
     },
     {
-      "id": "eb936a01-2554-45c6-b8c2-2a34a383c5bb",
-      "projectId": "953c3e7e-3f23-47bf-b36e-7febcbfdfb00",
+      "id": "16864f1c-9349-4be7-a841-23b30d91474c",
+      "projectId": "19c5b908-2762-4960-b38c-cc0c10443f71",
       "type": "TASK",
       "title": "Archived Task",
       "description": "",
       "status": "TRASHED",
       "implementationPlan": "",
-      "createdAt": "2026-03-02T01:37:55.669Z",
-      "updatedAt": "2026-03-02T01:37:55.670Z",
+      "createdAt": "2026-03-02T01:45:36.852Z",
+      "updatedAt": "2026-03-02T01:45:36.853Z",
       "history": [
         {
-          "id": "111a70bd-d089-4780-aa05-9b3832632b00",
+          "id": "97696ae4-7512-4228-a813-dfe60c47ac05",
           "fromStatus": "TODO",
           "toStatus": "ARCHIVED",
-          "timestamp": "2026-03-02T01:37:55.669Z"
+          "timestamp": "2026-03-02T01:45:36.852Z"
         },
         {
-          "id": "8438f5d4-f0d1-4213-9bfb-a4ffe8165006",
+          "id": "4999a3f2-5e41-47b0-8463-ae96242d84e8",
           "fromStatus": "ARCHIVED",
           "toStatus": "TRASHED",
-          "timestamp": "2026-03-02T01:37:55.670Z"
+          "timestamp": "2026-03-02T01:45:36.853Z"
         }
       ]
     },
     {
-      "id": "9f4cd6f6-7478-4ec5-9011-28f6b7248a76",
-      "projectId": "3083b291-065b-490c-baa5-418d604e1b5b",
+      "id": "c1c1834a-94e3-4906-ba6c-c184f205a898",
+      "projectId": "2638f456-4788-4b80-89f1-6416ab5356a2",
       "type": "BUG",
       "title": "[PROJ-1] Fix login bug",
       "description": "Imported from JIRA: PROJ-1",
@@ -260,14 +260,14 @@
       "implementationPlan": "",
       "externalId": "PROJ-1",
       "externalUrl": "https://test.atlassian.net/browse/PROJ-1",
-      "createdAt": "2026-03-02T01:37:55.705Z",
-      "updatedAt": "2026-03-02T01:37:55.705Z",
+      "createdAt": "2026-03-02T01:45:36.889Z",
+      "updatedAt": "2026-03-02T01:45:36.889Z",
       "history": [
         {
-          "id": "dc55811f-a812-4994-a5ba-f963b1198ec2",
+          "id": "9038f3fe-85fa-46c3-b43b-a60c72f11d5f",
           "fromStatus": "TODO",
           "toStatus": "TODO",
-          "timestamp": "2026-03-02T01:37:55.705Z"
+          "timestamp": "2026-03-02T01:45:36.889Z"
         }
       ]
     }


### PR DESCRIPTION
This PR fixes a layout regression in the Kanban board where expanded "Paused", "Blocked", or "Archived" columns would stack vertically or squeeze each other when multiple were expanded.

Key changes:
- Decoupled these columns from their shared grouping container.
- Promoted each expanded section to a first-class board column using `md:flex-1` and `md:min-w-[180px]`.
- Collapsed sections continue to aggregate into a single vertical stack on the right.
- Simplified the DOM structure to align with the proven patterns used by the "Ideas" and main board columns.