### PR TITLE
feat: make SQLite the default storage backend

### DIFF
--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -213,7 +213,7 @@ const initStorage = async () => {
     }
     if (!dbPath) {
       const root = findProjectRoot(process.cwd());
-      dbPath = path.join(root, ".agenfk", "db.json");
+      dbPath = path.join(root, ".agenfk", "db.sqlite");
     }
   }
 

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -152,10 +152,10 @@ async function run() {
         console.log(`${GREEN}[3/14] Choosing database engine...${NC}`);
         const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
 
-        let dbType = 'json';
+        let dbType = 'sqlite';
         try {
-            const answer = await ask(rl, `  Choose storage engine [json/sqlite] (default: json): `);
-            if (answer.trim().toLowerCase() === 'sqlite') dbType = 'sqlite';
+            const answer = await ask(rl, `  Choose storage engine [json/sqlite] (default: sqlite): `);
+            if (answer.trim().toLowerCase() === 'json') dbType = 'json';
         } finally {
             rl.close();
         }
@@ -169,7 +169,7 @@ async function run() {
         console.log(`  Config written: ${agenfkConfigPath}`);
     } else if (!dbPath && onlyPlatform) {
         // Fallback for onlyPlatform if no config exists
-        dbPath = path.join(rootDir, '.agenfk', 'db.json');
+        dbPath = path.join(rootDir, '.agenfk', 'db.sqlite');
     }
 
     // 3b. Restore from backup (new install only)

--- a/scripts/start-services.mjs
+++ b/scripts/start-services.mjs
@@ -18,7 +18,7 @@ function resolveDbPath() {
             if (cfg.dbPath) return cfg.dbPath;
         } catch (e) {}
     }
-    return path.join(agenfkDir, 'db.json');
+    return path.join(agenfkDir, 'db.sqlite');
 }
 const dbPath = resolveDbPath();
 


### PR DESCRIPTION
## Summary

SQLite is now the default storage engine during installation. Users who prefer JSON can still select it explicitly at the prompt.

## Changes

- `scripts/install.mjs`: default changed to `sqlite`, prompt updated, `onlyPlatform` fallback changed to `db.sqlite`
- `packages/server/src/server.ts`: cold-start fallback changed to `db.sqlite`
- `scripts/start-services.mjs`: `resolveDbPath` fallback changed to `db.sqlite`