### PR TITLE
fix: always show PATH restart hint when ~/.local/bin not in current session

### DIFF
--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -571,25 +571,23 @@ process.exit(0);
                     path.join(os.homedir(), '.bashrc'),
                     path.join(os.homedir(), '.profile'),
                 ];
-                let added = false;
                 for (const rc of rcFiles) {
                     try {
                         const existing = existsSync(rc) ? readFileSync(rc, 'utf8') : '';
                         if (!existing.includes('.local/bin')) {
                             await fs.appendFile(rc, exportLine, 'utf8');
                             console.log(`  Added ~/.local/bin to PATH in ${path.basename(rc)}`);
-                            added = true;
                         }
                     } catch { /* skip unwritable files */ }
                 }
-                if (added) {
-                    const shell = path.basename(process.env.SHELL || '');
-                    const sourceHint = shell === 'zsh' ? 'source ~/.zshrc'
-                        : shell === 'bash' ? 'source ~/.bashrc'
-                        : shell === 'fish' ? 'source ~/.config/fish/config.fish'
-                        : 'source your shell rc file';
-                    console.log(`\n${YELLOW}  ⚠ Open a new terminal (or run: ${sourceHint}) for 'agenfk' to be available in your PATH.${NC}`);
-                }
+                // Always warn — even if rc files already referenced .local/bin,
+                // the current session doesn't have it yet.
+                const shell = path.basename(process.env.SHELL || '');
+                const sourceHint = shell === 'zsh' ? 'source ~/.zshrc'
+                    : shell === 'bash' ? 'source ~/.bashrc'
+                    : shell === 'fish' ? 'source ~/.config/fish/config.fish'
+                    : 'source your shell rc file';
+                console.log(`\n${YELLOW}  ⚠ Open a new terminal (or run: ${sourceHint}) for 'agenfk' to be available in your PATH.${NC}`);
             }
         }
     }


### PR DESCRIPTION
## Problem

The restart hint after symlinking the CLI was only shown if we actually appended to an rc file. Many distros ship `~/.bashrc` or `~/.profile` with a `.local/bin` block already (e.g. `if [ -d "$HOME/.local/bin" ]; then PATH=...`), so the append was skipped and no message appeared — even though the current shell session still lacked `~/.local/bin` in `$PATH`.

## Fix

Show the restart hint whenever `~/.local/bin` is absent from the current session's `$PATH`, regardless of rc file state.