### PR TITLE
feat(cli): agenfk upgrade without gh auth

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -114,6 +114,53 @@ function killPattern(pattern: string) {
   } catch (e) {}
 }
 
+async function fetchLatestReleaseTag(repo: string, beta: boolean): Promise<string> {
+  // Try GitHub REST API first — no auth required for public repos
+  try {
+    if (beta) {
+      const resp = await axios.get(`https://api.github.com/repos/${repo}/releases?per_page=1`, {
+        headers: { 'Accept': 'application/vnd.github+json', 'User-Agent': 'agenfk-cli' },
+        timeout: 10000,
+      });
+      const tag = resp.data?.[0]?.tag_name;
+      if (tag) return tag;
+    } else {
+      const resp = await axios.get(`https://api.github.com/repos/${repo}/releases/latest`, {
+        headers: { 'Accept': 'application/vnd.github+json', 'User-Agent': 'agenfk-cli' },
+        timeout: 10000,
+      });
+      const tag = resp.data?.tag_name;
+      if (tag) return tag;
+    }
+  } catch {
+    // Fall through to gh CLI
+  }
+  // Fallback: gh CLI (requires gh auth login)
+  if (beta) {
+    return execSync(`gh release list --repo ${repo} --limit 1 --json tagName --template '{{range .}}{{.tagName}}{{end}}'`, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  }
+  return execSync(`gh release view --repo ${repo} --json tagName --template '{{.tagName}}'`, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  }).trim();
+}
+
+function downloadReleaseAsset(repo: string, tag: string, pattern: string, outputPath: string): void {
+  const directUrl = `https://github.com/${repo}/releases/download/${tag}/${pattern}`;
+  // Try curl first — no auth required for public repos
+  try {
+    execSync(`curl -fsSL "${directUrl}" -o "${outputPath}"`, { stdio: 'inherit' });
+    return;
+  } catch {
+    // Fall through to gh CLI
+  }
+  // Fallback: gh release download (requires gh auth login)
+  execSync(`gh release download ${tag} --repo ${repo} --pattern '${pattern}' --output "${outputPath}"`, { stdio: 'inherit' });
+}
+
 function resolveIntegrationPlatform(platform: string): string {
   const normalized = platform.trim().toLowerCase();
   const resolved = INTEGRATION_ALIASES[normalized];
@@ -177,12 +224,9 @@ program
     // Check for updates silently
     try {
       const REPO = 'cglab-public/agenfk';
-      const latestTag = execSync(`gh release view --repo ${REPO} --json tagName --template '{{.tagName}}'`, {
-        encoding: 'utf8',
-        stdio: ['ignore', 'pipe', 'ignore'] 
-      }).trim();
+      const latestTag = await fetchLatestReleaseTag(REPO, false);
       const latestVersion = latestTag.replace(/^v/, '');
-      
+
       if (latestVersion !== CURRENT_VERSION) {
         console.log(chalk.yellow(`\nUpdate available: ${latestVersion} (current: ${CURRENT_VERSION})`));
         console.log(chalk.gray(`Run 'agenfk upgrade' to update.`));
@@ -244,24 +288,12 @@ program
         // Services not running
       }
 
-      // Use gh CLI to fetch the latest release tag
+      // Fetch latest release tag via GitHub REST API (no auth), falling back to gh CLI
       let latestTag = '';
       try {
-        if (options.beta) {
-          // Get the most recent release (could be a pre-release)
-          latestTag = execSync(`gh release list --repo ${REPO} --limit 1 --json tagName --template '{{range .}}{{.tagName}}{{end}}'`, { 
-            encoding: 'utf8',
-            stdio: ['ignore', 'pipe', 'ignore'] 
-          }).trim();
-        } else {
-          // Get the latest stable release
-          latestTag = execSync(`gh release view --repo ${REPO} --json tagName --template '{{.tagName}}'`, { 
-            encoding: 'utf8',
-            stdio: ['ignore', 'pipe', 'ignore'] 
-          }).trim();
-        }
+        latestTag = await fetchLatestReleaseTag(REPO, options.beta);
       } catch (e) {
-        throw new Error(`Failed to fetch latest ${options.beta ? 'beta ' : ''}release from GitHub. Ensure "gh" CLI is authenticated.`);
+        throw new Error(`Failed to fetch latest ${options.beta ? 'beta ' : ''}release from GitHub. Check your network connection or install the "gh" CLI and run "gh auth login".`);
       }
       
       const latestVersion = latestTag.replace(/^v/, '');
@@ -285,8 +317,8 @@ program
             const tempDir = path.join(os.tmpdir(), `agenfk-upgrade-${Date.now()}`);
             fs.mkdirSync(tempDir, { recursive: true });
             
-            // Download the tarball
-            execSync(`gh release download ${latestTag} --repo ${REPO} --pattern 'agenfk-dist.tar.gz' --output "${path.join(tempDir, 'agenfk-dist.tar.gz')}"`, { stdio: 'inherit' });
+            // Download the tarball (curl first, gh fallback)
+            downloadReleaseAsset(REPO, latestTag, 'agenfk-dist.tar.gz', path.join(tempDir, 'agenfk-dist.tar.gz'));
             
             // Extract the tarball
             console.log(chalk.gray('Extracting update...'));

--- a/packages/cli/src/test/cli.test.ts
+++ b/packages/cli/src/test/cli.test.ts
@@ -108,20 +108,119 @@ describe('CLI Commands', () => {
   });
 
   describe('upgrade command', () => {
-    it('should check for updates and run installer', async () => {
-      mockedAxios.get.mockRejectedValue(new Error('Down')); // services not running
+    it('should use GitHub REST API for version check (no gh auth required)', async () => {
+      // First get: services check (reject = not running)
+      // Second get: GitHub API returns same version → no upgrade needed
+      mockedAxios.get
+        .mockRejectedValueOnce(new Error('Down'))
+        .mockResolvedValueOnce({ data: { tag_name: 'v0.0.0' } });
+
+      mockedFs.existsSync.mockImplementation(() => true);
+      mockedFs.readFileSync.mockReturnValue('{"version":"0.0.0"}');
+
+      await program.parseAsync(['node', 'agenfk', 'upgrade']);
+
+      expect(mockedAxios.get).toHaveBeenCalledWith(
+        expect.stringContaining('api.github.com'),
+        expect.any(Object)
+      );
+      expect(mockedChildProcess.execSync).not.toHaveBeenCalledWith(
+        expect.stringContaining('gh release view'),
+        expect.any(Object)
+      );
+    });
+
+    it('should fall back to gh CLI when GitHub API is unavailable', async () => {
+      // First get: services check (reject)
+      // Second get: GitHub API fails
+      mockedAxios.get
+        .mockRejectedValueOnce(new Error('Down'))
+        .mockRejectedValueOnce(new Error('Network error'));
+
       mockedChildProcess.execSync.mockImplementation((cmd: any) => {
-        if (typeof cmd === 'string' && cmd.includes('gh release')) return 'v1.0.0';
+        if (typeof cmd === 'string' && cmd.includes('gh release view')) return 'v0.0.0';
         return Buffer.from('ok');
       });
-      
-      mockedFs.existsSync.mockImplementation(() => true);
-      mockedFs.readFileSync.mockReturnValue('{"version":"0.0.1"}');
 
-      await program.parseAsync(['node', 'agenfk', 'upgrade', '--force']);
-      
-      expect(mockedChildProcess.execSync).toHaveBeenCalledWith(expect.stringContaining('gh release view'), expect.any(Object));
-      expect(mockedChildProcess.execSync).toHaveBeenCalledWith(expect.stringContaining('install.mjs'), expect.any(Object));
+      mockedFs.existsSync.mockImplementation(() => true);
+      mockedFs.readFileSync.mockReturnValue('{"version":"0.0.0"}');
+
+      await program.parseAsync(['node', 'agenfk', 'upgrade']);
+
+      expect(mockedChildProcess.execSync).toHaveBeenCalledWith(
+        expect.stringContaining('gh release view'),
+        expect.any(Object)
+      );
+    });
+
+    it('should download release asset via curl without gh auth', async () => {
+      // First get: services check (reject = not running)
+      // Second get: GitHub API returns newer version
+      mockedAxios.get
+        .mockRejectedValueOnce(new Error('Down'))
+        .mockResolvedValueOnce({ data: { tag_name: 'v99.0.0' } });
+
+      mockedFs.existsSync.mockImplementation((p: any) => {
+        // Not a git repo, so it will try to download
+        if (typeof p === 'string' && p.endsWith('.git')) return false;
+        return true;
+      });
+      mockedFs.readFileSync.mockReturnValue('{"version":"0.0.0"}');
+      mockedChildProcess.execSync.mockReturnValue(Buffer.from('ok'));
+
+      await program.parseAsync(['node', 'agenfk', 'upgrade']);
+
+      expect(mockedChildProcess.execSync).toHaveBeenCalledWith(
+        expect.stringContaining('curl'),
+        expect.any(Object)
+      );
+      expect(mockedChildProcess.execSync).not.toHaveBeenCalledWith(
+        expect.stringContaining('gh release download'),
+        expect.any(Object)
+      );
+    });
+
+    it('should fall back to gh release download when curl fails', async () => {
+      mockedAxios.get
+        .mockRejectedValueOnce(new Error('Down'))
+        .mockResolvedValueOnce({ data: { tag_name: 'v99.0.0' } });
+
+      mockedFs.existsSync.mockImplementation((p: any) => {
+        if (typeof p === 'string' && p.endsWith('.git')) return false;
+        return true;
+      });
+      mockedFs.readFileSync.mockReturnValue('{"version":"0.0.0"}');
+      mockedChildProcess.execSync.mockImplementation((cmd: any) => {
+        if (typeof cmd === 'string' && cmd.includes('curl')) throw new Error('curl not found');
+        return Buffer.from('ok');
+      });
+
+      await program.parseAsync(['node', 'agenfk', 'upgrade']);
+
+      expect(mockedChildProcess.execSync).toHaveBeenCalledWith(
+        expect.stringContaining('gh release download'),
+        expect.any(Object)
+      );
+    });
+
+    it('should run installer after successful download', async () => {
+      mockedAxios.get
+        .mockRejectedValueOnce(new Error('Down'))
+        .mockResolvedValueOnce({ data: { tag_name: 'v99.0.0' } });
+
+      mockedFs.existsSync.mockImplementation((p: any) => {
+        if (typeof p === 'string' && p.endsWith('.git')) return false;
+        return true;
+      });
+      mockedFs.readFileSync.mockReturnValue('{"version":"0.0.0"}');
+      mockedChildProcess.execSync.mockReturnValue(Buffer.from('ok'));
+
+      await program.parseAsync(['node', 'agenfk', 'upgrade']);
+
+      expect(mockedChildProcess.execSync).toHaveBeenCalledWith(
+        expect.stringContaining('install.mjs'),
+        expect.any(Object)
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

- `agenfk upgrade` no longer requires `gh auth login`
- Version check now calls the GitHub REST API directly via `axios` (public endpoint, no auth needed)
- Release asset download now uses `curl -fsSL` with the direct GitHub release URL
- Silent fallback to `gh CLI` for both operations if the above fails (e.g. no network or curl unavailable)
- Updated error message to reflect that gh auth is a fallback, not a requirement

## Test plan

- [x] New test: GitHub REST API used for version check (no gh auth)
- [x] New test: falls back to gh CLI when GitHub API is unavailable
- [x] New test: uses curl for download without gh auth
- [x] New test: falls back to gh release download when curl fails
- [x] New test: install.mjs still called after successful download
- [x] All 31 CLI tests pass