### PR TITLE
fix(installer): curl download, Big font banner, AgEnFK branding

### DIFF
--- a/bin/agenfk.js
+++ b/bin/agenfk.js
@@ -16,26 +16,51 @@ const BLUE  = '\x1b[34m';
 const RESET = '\x1b[0m';
 
 console.log(`${CYAN}
-                         __ _
-                        / _| |
-  __ _  __ _  ___ _ __ | |_| | __
- / _\` |/ _\` |/ _ \\ '_ \\|  _| |/ /
-| (_| | (_| |  __/ | | | | |   <
- \\__,_|\\__, |\\___|_| |_|_| |_|\\_\\
-        __/ |
-       |___/
+                     ______           ______   _  __
+     /\\             |  ____|         |  ____| | |/ /
+    /  \\      __ _  | |__     _ __   | |__    | ' /
+   / /\\ \\    / _\` | |  __|   | '_ \\  |  __|   |  <
+  / ____ \\  | (_| | | |____  | | | | | |      | . \\
+ /_/    \\_\\  \\__, | |______| |_| |_| |_|      |_|\\_\\
+              __/ |
+             |___/
 ${RESET}`);
 
-console.log(`${BLUE}=== AgenFK Installer ===${RESET}\n`);
+console.log(`${BLUE}=== AgEnFK Installer ===${RESET}\n`);
 
 // Determine whether we're running from the npx cache or a real clone.
 // A real clone has a .git directory; the npx cache does not.
 const isNpxCache = !fs.existsSync(path.join(REPO_ROOT, '.git'));
 const shouldRebuild = process.argv.includes('--rebuild');
 
+// Fetch latest release tag — curl (no auth) first, gh CLI as fallback
+function fetchLatestTag(repo) {
+  try {
+    const json = execSync(
+      `curl -fsSL "https://api.github.com/repos/${repo}/releases/latest" -H "Accept: application/vnd.github+json" -H "User-Agent: agenfk-installer"`,
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }
+    );
+    const tag = JSON.parse(json).tag_name;
+    if (tag) return tag;
+  } catch {}
+  // Fallback: gh CLI
+  return execSync(`gh release view --repo ${repo} --json tagName --template '{{.tagName}}'`, { encoding: 'utf8' }).trim();
+}
+
+// Download release asset — direct curl URL (no auth) first, gh CLI as fallback
+function downloadAsset(repo, tag, pattern, outputPath) {
+  const url = `https://github.com/${repo}/releases/download/${tag}/${pattern}`;
+  try {
+    execSync(`curl -fsSL "${url}" -o "${outputPath}"`, { stdio: 'inherit' });
+    return;
+  } catch {}
+  // Fallback: gh CLI
+  execSync(`gh release download ${tag} --repo ${repo} --pattern '${pattern}' --output "${outputPath}"`, { stdio: 'inherit' });
+}
+
 if (isNpxCache) {
   if (fs.existsSync(INSTALL_DIR)) {
-    console.log(`${GREEN}Updating AgenFK at ${INSTALL_DIR}...${RESET}`);
+    console.log(`${GREEN}Updating AgEnFK at ${INSTALL_DIR}...${RESET}`);
     // Overlay new files from the npx cache onto the existing install
     if (fs.cpSync) {
       fs.cpSync(REPO_ROOT, INSTALL_DIR, { recursive: true });
@@ -43,7 +68,7 @@ if (isNpxCache) {
       execSync(`cp -r ${JSON.stringify(REPO_ROOT)}/. ${JSON.stringify(INSTALL_DIR)}/`, { stdio: 'inherit', shell: true });
     }
   } else {
-    console.log(`${GREEN}Installing AgenFK to ${INSTALL_DIR}...${RESET}`);
+    console.log(`${GREEN}Installing AgEnFK to ${INSTALL_DIR}...${RESET}`);
     if (fs.cpSync) {
       fs.cpSync(REPO_ROOT, INSTALL_DIR, { recursive: true });
     } else {
@@ -56,8 +81,8 @@ if (isNpxCache) {
     const REPO = 'cglab-public/agenfk';
     console.log(`${GREEN}Downloading pre-built binary from GitHub...${RESET}`);
     try {
-      const latestTag = execSync(`gh release view --repo ${REPO} --json tagName --template '{{.tagName}}'`, { encoding: 'utf8' }).trim();
-      execSync(`gh release download ${latestTag} --repo ${REPO} --pattern 'agenfk-dist.tar.gz' --output "${path.join(INSTALL_DIR, 'agenfk-dist.tar.gz')}"`, { stdio: 'inherit' });
+      const latestTag = fetchLatestTag(REPO);
+      downloadAsset(REPO, latestTag, 'agenfk-dist.tar.gz', path.join(INSTALL_DIR, 'agenfk-dist.tar.gz'));
       execSync(`tar -xzf "${path.join(INSTALL_DIR, 'agenfk-dist.tar.gz')}" -C "${INSTALL_DIR}"`, { stdio: 'inherit' });
       fs.unlinkSync(path.join(INSTALL_DIR, 'agenfk-dist.tar.gz'));
     } catch (e) {
@@ -71,14 +96,14 @@ if (isNpxCache) {
 } else {
   // Running from a real git clone — install in place
   console.log(`${GREEN}Running install from ${REPO_ROOT}...${RESET}\n`);
-  
+
   const distMissing = !fs.existsSync(path.join(REPO_ROOT, 'packages/cli/dist')) || !fs.existsSync(path.join(REPO_ROOT, 'packages/server/dist'));
   if (!shouldRebuild && distMissing) {
     const REPO = 'cglab-public/agenfk';
     console.log(`${GREEN}Downloading pre-built binary from GitHub...${RESET}`);
     try {
-      const latestTag = execSync(`gh release view --repo ${REPO} --json tagName --template '{{.tagName}}'`, { encoding: 'utf8' }).trim();
-      execSync(`gh release download ${latestTag} --repo ${REPO} --pattern 'agenfk-dist.tar.gz' --output "${path.join(REPO_ROOT, 'agenfk-dist.tar.gz')}"`, { stdio: 'inherit' });
+      const latestTag = fetchLatestTag(REPO);
+      downloadAsset(REPO, latestTag, 'agenfk-dist.tar.gz', path.join(REPO_ROOT, 'agenfk-dist.tar.gz'));
       execSync(`tar -xzf "${path.join(REPO_ROOT, 'agenfk-dist.tar.gz')}" -C "${REPO_ROOT}"`, { stdio: 'inherit' });
       fs.unlinkSync(path.join(REPO_ROOT, 'agenfk-dist.tar.gz'));
     } catch (e) {

--- a/packages/create/bin/agenfk.js
+++ b/packages/create/bin/agenfk.js
@@ -26,7 +26,7 @@ console.log(`${CYAN}
              |___/
 ${RESET}`);
 
-console.log(`${BLUE}=== AgenFK Installer ===${RESET}\n`);
+console.log(`${BLUE}=== AgEnFK Installer ===${RESET}\n`);
 
 // Check git is available
 const gitCheck = spawnSync('git', ['--version'], { encoding: 'utf8' });
@@ -64,7 +64,7 @@ function downloadAsset(repo, tag, pattern, outputPath) {
 }
 
 if (fs.existsSync(INSTALL_DIR)) {
-  console.log(`${GREEN}AgenFK already installed at ${INSTALL_DIR}${RESET}`);
+  console.log(`${GREEN}AgEnFK already installed at ${INSTALL_DIR}${RESET}`);
   const isGitRepo = fs.existsSync(path.join(INSTALL_DIR, '.git'));
 
   if (isGitRepo) {
@@ -83,7 +83,7 @@ if (fs.existsSync(INSTALL_DIR)) {
   }
 } else {
   if (!shouldRebuild) {
-    console.log(`Installing pre-built AgenFK to ${INSTALL_DIR} ...`);
+    console.log(`Installing pre-built AgEnFK to ${INSTALL_DIR} ...`);
     fs.mkdirSync(INSTALL_DIR, { recursive: true });
     try {
       const latestTag = fetchLatestTag(REPO_NAME);
@@ -96,7 +96,7 @@ if (fs.existsSync(INSTALL_DIR)) {
       execSync(`git clone ${REPO_URL} ${JSON.stringify(INSTALL_DIR)}`, { stdio: 'inherit', shell: true });
     }
   } else {
-    console.log(`Cloning AgenFK to ${INSTALL_DIR} ...`);
+    console.log(`Cloning AgEnFK to ${INSTALL_DIR} ...`);
     execSync(`git clone ${REPO_URL} ${JSON.stringify(INSTALL_DIR)}`, { stdio: 'inherit', shell: true });
   }
 }


### PR DESCRIPTION
## Summary

- `bin/agenfk.js` (the actual `npx github:cglab-public/agenfk` entry point) and `packages/create/bin/agenfk.js` no longer require `gh` CLI authentication
- Version lookup uses `curl` against the GitHub REST API; asset download uses the direct public release URL — `gh` used only as silent fallback
- Banner updated to Big font (matching README and CLI)
- Fixed capitalization: `AgenFK` → `AgEnFK` in all console messages

## Test plan
- [x] `npx github:cglab-public/agenfk` works without `gh` installed
- [x] Build passes