### PR TITLE
fix: health DB check via API + post-install PATH reminder

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -71,4 +71,4 @@ jobs:
             --title "v${VERSION}" \
             --generate-notes
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,74 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g. 0.2.4)'
+        required: true
+
+jobs:
+  release:
+    name: Bump, Build & Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+          cache: npm
+
+      - name: Bump version in all package.json files
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          node -e "
+            const fs = require('fs');
+            const { execSync } = require('child_process');
+            const files = execSync(
+              'find . -name package.json -not -path \"*/node_modules/*\" -not -path \"*/dist/*\"',
+              { encoding: 'utf8' }
+            ).trim().split('\n');
+            files.forEach(f => {
+              const pkg = JSON.parse(fs.readFileSync(f, 'utf8'));
+              pkg.version = process.env.VERSION;
+              fs.writeFileSync(f, JSON.stringify(pkg, null, 2) + '\n');
+            });
+          "
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+
+      - name: Commit and push version bump
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add package.json packages/*/package.json
+          git commit -m "chore: bump version to ${{ github.event.inputs.version }}"
+          git push
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Package distributable
+        run: node scripts/package-dist.mjs
+
+      - name: Create tag and GitHub release
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          git tag "v${VERSION}"
+          git push origin "v${VERSION}"
+          gh release create "v${VERSION}" agenfk-dist.tar.gz \
+            --title "v${VERSION}" \
+            --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/bin/agenfk.js
+++ b/bin/agenfk.js
@@ -114,3 +114,20 @@ if (isNpxCache) {
 
   execSync(`node scripts/install.mjs${shouldRebuild ? ' --rebuild' : ''}`, { cwd: REPO_ROOT, stdio: 'inherit' });
 }
+
+// Final reminder — always shown so it's visible at the end of install output
+if (process.platform !== 'win32') {
+  const shell = process.env.SHELL ? require('path').basename(process.env.SHELL) : '';
+  const sourceHint = shell === 'zsh' ? 'source ~/.zshrc'
+    : shell === 'bash' ? 'source ~/.bashrc'
+    : shell === 'fish' ? 'source ~/.config/fish/config.fish'
+    : 'source your shell rc file';
+  console.log(`\n${BLUE}╔══════════════════════════════════════════════════════╗`);
+  console.log(`║  ✅ AgEnFK installation complete!                    ║`);
+  console.log(`║                                                      ║`);
+  console.log(`║  To use the 'agenfk' command in this terminal, run: ║`);
+  console.log(`║    ${sourceHint.padEnd(49)}║`);
+  console.log(`║                                                      ║`);
+  console.log(`║  Then start services with: agenfk up                ║`);
+  console.log(`╚══════════════════════════════════════════════════════╝${RESET}\n`);
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1093,22 +1093,16 @@ program
       issues++;
     }
 
-    // 2. Configuration & DB Check
+    // 2. Database Check — query the running API server (source of truth)
     process.stdout.write('Checking Database... ');
-    const rootDir = path.resolve(__dirname, '../../..');
-    const dbPath = process.env.AGENFK_DB_PATH || path.join(rootDir, '.agenfk', 'db.json');
-    if (fs.existsSync(dbPath)) {
+    try {
+      const { data } = await axios.get(`${API_URL}/db/status`);
       console.log(chalk.green('OK'));
-      console.log(chalk.gray(`   - Path: ${dbPath}`));
-      try {
-        const db = JSON.parse(fs.readFileSync(dbPath, 'utf8'));
-        console.log(chalk.gray(`   - Items: ${db.items.length}`));
-      } catch (e) {
-        console.log(chalk.red('   - Error: Could not parse db.json'));
-        issues++;
-      }
-    } else {
-      console.log(chalk.red('MISSING'));
+      console.log(chalk.gray(`   - Path: ${data.dbPath}`));
+      console.log(chalk.gray(`   - Type: ${data.dbType}`));
+    } catch (e: any) {
+      console.log(chalk.red('FAILED'));
+      console.log(chalk.yellow(`   - Could not reach ${API_URL}/db/status`));
       issues++;
     }
 


### PR DESCRIPTION
## Summary

**health command**
- Replaced local `db.json` file-existence check with a `GET /db/status` API call
- Server already exposes this endpoint — it's the source of truth for DB state
- Fixes false `MISSING` for users on the same machine where the server runs as a different OS user

**bin/agenfk.js**  
- Added a boxed summary message at the very end of install output
- Always shows `source ~/.bashrc` (or equivalent) so users know how to activate `agenfk` in their current shell