### PR TITLE
fix(installer): skip rebuild when dists present, always fetch tarball on update

### DIFF
--- a/bin/agenfk.js
+++ b/bin/agenfk.js
@@ -59,7 +59,9 @@ function downloadAsset(repo, tag, pattern, outputPath) {
 }
 
 if (isNpxCache) {
-  if (fs.existsSync(INSTALL_DIR)) {
+  const isUpdate = fs.existsSync(INSTALL_DIR);
+
+  if (isUpdate) {
     console.log(`${GREEN}Updating AgEnFK at ${INSTALL_DIR}...${RESET}`);
     // Overlay new files from the npx cache onto the existing install
     if (fs.cpSync) {
@@ -77,7 +79,8 @@ if (isNpxCache) {
   }
 
   const distMissing = !fs.existsSync(path.join(INSTALL_DIR, 'packages/cli/dist')) || !fs.existsSync(path.join(INSTALL_DIR, 'packages/server/dist'));
-  if (!shouldRebuild && distMissing) {
+  // Always download on update (to replace stale binaries); on fresh install only if dist missing
+  if (!shouldRebuild && (isUpdate || distMissing)) {
     const REPO = 'cglab-public/agenfk';
     console.log(`${GREEN}Downloading pre-built binary from GitHub...${RESET}`);
     try {

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -103,10 +103,15 @@ async function run() {
     }
 
     if (!onlyPlatform) {
-        console.log(`${GREEN}[1/14] Building project...${NC}`);
-        spawnSync(npmCmd, ['install'], { stdio: 'inherit', cwd: rootDir });
-        cleanDists();
-        runBuild();
+        const missingDists = requiredDists.filter(d => !existsSync(path.join(rootDir, d)));
+        if (shouldRebuild || missingDists.length > 0) {
+            console.log(`${GREEN}[1/14] Building project...${NC}`);
+            spawnSync(npmCmd, ['install'], { stdio: 'inherit', cwd: rootDir });
+            if (shouldRebuild) cleanDists();
+            runBuild();
+        } else {
+            console.log(`${GREEN}[1/14] Build artifacts found, skipping rebuild.${NC}`);
+        }
     } else {
         const missingDists = requiredDists.filter(d => !existsSync(path.join(rootDir, d)));
         if (missingDists.length > 0) {


### PR DESCRIPTION
## Summary

Two related bugs in the npx install/update flow:

**install.mjs** — unconditionally ran `npm install + cleanDists + runBuild` even when pre-built dist files were already present (downloaded from release tarball). This caused a full source rebuild every time.
- Fix: only build when `shouldRebuild` is set or dist files are actually missing.

**bin/agenfk.js** — on update (existing `~/.agenfk-system`), skipped the tarball download because `distMissing` was false (old binaries still present). New version binaries were never fetched.
- Fix: always download the tarball on update; `distMissing` check only applies to fresh installs.