### PR TITLE
fix(installer): replace require('path') with path — ESM crash on install complete

### DIFF
--- a/bin/agenfk.js
+++ b/bin/agenfk.js
@@ -120,7 +120,7 @@ if (isNpxCache) {
 
 // Final reminder — always shown so it's visible at the end of install output
 if (process.platform !== 'win32') {
-  const shell = process.env.SHELL ? require('path').basename(process.env.SHELL) : '';
+  const shell = process.env.SHELL ? path.basename(process.env.SHELL) : '';
   const sourceHint = shell === 'zsh' ? 'source ~/.zshrc'
     : shell === 'bash' ? 'source ~/.bashrc'
     : shell === 'fish' ? 'source ~/.config/fish/config.fish'


### PR DESCRIPTION
bin/agenfk.js is an ES module but used require('path') in the final summary box. Replaced with the already-imported path module.