### PR TITLE
feat(cli): replace review/test with verify; move evidence logging to server

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1883,13 +1883,21 @@ program
   });
 
 program
-  .command('review <id> <command>')
-  .description('Run agent-chosen command and transition item IN_PROGRESS → REVIEW. MCP fallback: review_changes')
-  .action(async (id, command) => {
+  .command('verify <id> [command]')
+  .description('Log evidence and advance item to next flow step (MCP fallback: validate_progress)')
+  .option('--evidence <text>', 'REQUIRED: How you satisfied the current step\'s exit criteria')
+  .action(async (id, command, options) => {
+    if (!options.evidence) {
+      console.error(chalk.red('Error: --evidence is required. Describe how you satisfied the current step\'s exit criteria.'));
+      process.exit(1);
+      return;
+    }
+
     const tokenPath = path.join(os.homedir(), '.agenfk', 'verify-token');
     if (!fs.existsSync(tokenPath)) {
       console.error(chalk.red('Error: ~/.agenfk/verify-token not found.'));
       process.exit(1);
+      return;
     }
     const verifyToken = fs.readFileSync(tokenPath, 'utf8').trim();
 
@@ -1898,70 +1906,26 @@ program
       try {
         const { data: allItems } = await axios.get(`${API_URL}/items`);
         const found = allItems.filter((i: any) => i.id.startsWith(id));
-        if (found.length === 0) { console.error(chalk.red(`No item found starting with ${id}`)); process.exit(1); }
-        if (found.length > 1) { console.error(chalk.red(`Ambiguous ID ${id}`)); process.exit(1); }
+        if (found.length === 0) { console.error(chalk.red(`No item found starting with ${id}`)); process.exit(1); return; }
+        if (found.length > 1) { console.error(chalk.red(`Ambiguous ID ${id}`)); process.exit(1); return; }
         targetId = found[0].id;
       } catch (e: any) {
         console.error(chalk.red('Error resolving item:'), e.response?.data?.error || e.message);
         process.exit(1);
+        return;
       }
     }
 
-    console.log(chalk.blue(`Running review: ${command}`));
     try {
-      const { data } = await axios.post(
-        `${API_URL}/items/${targetId}/review`,
-        { command },
-        { headers: { 'x-agenfk-internal': verifyToken } }
-      );
+      const body: any = { evidence: options.evidence };
+      if (command) body.command = command;
+      const { data } = await axios.post(`${API_URL}/items/${targetId}/validate`, body, { headers: { 'x-agenfk-internal': verifyToken } });
       if (data.output) console.log(data.output);
-      console.log(chalk.green(`\n✅ Review passed. Item moved to ${data.status}.`));
+      console.log(chalk.green(data.message || `\n✅ Validation passed.`));
     } catch (error: any) {
       const errData = error.response?.data;
       if (errData?.output) console.error(errData.output);
-      console.error(chalk.red(`\n❌ ${errData?.message || error.message}`));
-      process.exit(1);
-    }
-  });
-
-program
-  .command('test <id>')
-  .description('Run project verifyCommand and transition item TEST → DONE. MCP fallback: test_changes')
-  .action(async (id) => {
-    const tokenPath = path.join(os.homedir(), '.agenfk', 'verify-token');
-    if (!fs.existsSync(tokenPath)) {
-      console.error(chalk.red('Error: ~/.agenfk/verify-token not found.'));
-      process.exit(1);
-    }
-    const verifyToken = fs.readFileSync(tokenPath, 'utf8').trim();
-
-    let targetId = id;
-    if (id.length < 36) {
-      try {
-        const { data: allItems } = await axios.get(`${API_URL}/items`);
-        const found = allItems.filter((i: any) => i.id.startsWith(id));
-        if (found.length === 0) { console.error(chalk.red(`No item found starting with ${id}`)); process.exit(1); }
-        if (found.length > 1) { console.error(chalk.red(`Ambiguous ID ${id}`)); process.exit(1); }
-        targetId = found[0].id;
-      } catch (e: any) {
-        console.error(chalk.red('Error resolving item:'), e.response?.data?.error || e.message);
-        process.exit(1);
-      }
-    }
-
-    console.log(chalk.blue(`Running project test suite...`));
-    try {
-      const { data } = await axios.post(
-        `${API_URL}/items/${targetId}/test`,
-        {},
-        { headers: { 'x-agenfk-internal': verifyToken } }
-      );
-      if (data.output) console.log(data.output);
-      console.log(chalk.green(`\n✅ Tests passed. Item moved to ${data.status}.`));
-    } catch (error: any) {
-      const errData = error.response?.data;
-      if (errData?.output) console.error(errData.output);
-      console.error(chalk.red(`\n❌ ${errData?.message || error.message}`));
+      console.error(chalk.red(`\n❌ ${errData?.message || errData?.error || error.message}`));
       process.exit(1);
     }
   });

--- a/packages/cli/src/test/verify-command.test.ts
+++ b/packages/cli/src/test/verify-command.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockExistsSync, mockReadFileSync } = vi.hoisted(() => ({
+  mockExistsSync: vi.fn(),
+  mockReadFileSync: vi.fn(),
+}));
+
+vi.mock('@agenfk/telemetry', () => ({
+  TelemetryClient: vi.fn(function (this: any) {
+    this.capture = vi.fn();
+    this.shutdown = vi.fn().mockResolvedValue(undefined);
+    this.isEnabled = true;
+    this.id = 'test-install-id';
+  }),
+  getInstallationId: vi.fn().mockReturnValue('test-install-id'),
+  isTelemetryEnabled: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock('fs', () => ({
+  existsSync: mockExistsSync,
+  readFileSync: mockReadFileSync,
+  writeFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  default: {
+    existsSync: mockExistsSync,
+    readFileSync: mockReadFileSync,
+    writeFileSync: vi.fn(),
+    mkdirSync: vi.fn(),
+  },
+}));
+
+vi.mock('axios');
+vi.mock('child_process', () => ({
+  execSync: vi.fn(),
+  spawn: vi.fn(),
+  spawnSync: vi.fn(),
+  default: { execSync: vi.fn(), spawn: vi.fn(), spawnSync: vi.fn() },
+}));
+vi.mock('figlet', () => ({
+  default: { textSync: vi.fn().mockReturnValue('AgEnFK') },
+}));
+
+import { program } from '../index';
+import axios from 'axios';
+
+const mockedAxios = vi.mocked(axios, true);
+
+const FULL_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+describe('verify command', () => {
+  function resetCommanderOptions(cmd: any) {
+    (cmd.options || []).forEach((opt: any) => cmd.setOptionValue(opt.attributeName(), undefined));
+    (cmd.commands || []).forEach(resetCommanderOptions);
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    program.commands.forEach(resetCommanderOptions);
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue('test-token');
+  });
+
+  it('should be registered as a command', () => {
+    expect(program.commands.map(c => c.name())).toContain('verify');
+  });
+
+  it('review and test commands should not exist', () => {
+    const names = program.commands.map(c => c.name());
+    expect(names).not.toContain('review');
+    expect(names).not.toContain('test');
+  });
+
+  it('should POST evidence to /validate without GET or PUT', async () => {
+    mockedAxios.post.mockResolvedValue({ data: { message: '✅ Validation Passed!\n\nItem moved to REVIEW.' } });
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await program.parseAsync(['node', 'agenfk', 'verify', FULL_ID, '--evidence', 'All tests pass']);
+
+    expect(mockedAxios.get).not.toHaveBeenCalled();
+    expect(mockedAxios.put).not.toHaveBeenCalled();
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      expect.stringContaining(`/items/${FULL_ID}/validate`),
+      expect.objectContaining({ evidence: 'All tests pass' }),
+      expect.objectContaining({ headers: expect.objectContaining({ 'x-agenfk-internal': 'test-token' }) })
+    );
+    logSpy.mockRestore();
+  });
+
+  it('should pass optional command alongside evidence to /validate', async () => {
+    mockedAxios.post.mockResolvedValue({ data: { message: '✅ Validation Passed!\n\nItem moved to DONE.' } });
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await program.parseAsync(['node', 'agenfk', 'verify', FULL_ID, '--evidence', 'Done', 'npm test']);
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      expect.stringContaining(`/items/${FULL_ID}/validate`),
+      expect.objectContaining({ evidence: 'Done', command: 'npm test' }),
+      expect.any(Object)
+    );
+    logSpy.mockRestore();
+  });
+
+  it('should resolve short IDs', async () => {
+    mockedAxios.get.mockResolvedValue({ data: [{ id: FULL_ID, title: 'Task' }] });
+    mockedAxios.post.mockResolvedValue({ data: { message: '✅ Validation Passed!' } });
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await program.parseAsync(['node', 'agenfk', 'verify', 'aaaaaaaa', '--evidence', 'done']);
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      expect.stringContaining(`/items/${FULL_ID}/validate`),
+      expect.any(Object),
+      expect.any(Object)
+    );
+    logSpy.mockRestore();
+  });
+
+  it('should error when --evidence is missing', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as any);
+
+    await program.parseAsync(['node', 'agenfk', 'verify', FULL_ID]);
+
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('--evidence'));
+    errSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('should error when verify-token file is missing', async () => {
+    mockExistsSync.mockReturnValue(false);
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as any);
+
+    await program.parseAsync(['node', 'agenfk', 'verify', FULL_ID, '--evidence', 'done']);
+
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('verify-token'));
+    errSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -456,21 +456,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request: any) => {
       case "validate_progress": {
         const { itemId, evidence, command } = z.object({ itemId: z.string(), evidence: z.string(), command: z.string().optional() }).parse(request.params.arguments);
         try {
-          // Fetch current item to tag comment with the step being completed
-          const { data: item } = await api.get(`/items/${itemId}`);
-          const currentStep = item.status;
-          // Log evidence as a tagged comment before advancing
-          const comments = item.comments || [];
-          comments.push({
-            id: uuidv4(),
-            content: `**Evidence [${currentStep}]:** ${evidence}`,
-            author: "agent",
-            timestamp: new Date(),
-            step: currentStep,
-          });
-          await api.put(`/items/${itemId}`, { comments });
-          // Advance the step
-          const { data } = await api.post(`/items/${itemId}/validate`, { command }, { headers: { 'x-agenfk-internal': VERIFY_TOKEN } });
+          const { data } = await api.post(`/items/${itemId}/validate`, { evidence, command }, { headers: { 'x-agenfk-internal': VERIFY_TOKEN } });
           return { content: [{ type: "text", text: data.message }] };
         } catch (error: any) {
           const msg = error.response?.data?.message || error.response?.data?.error || error.message;

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1215,9 +1215,17 @@ app.post("/items/:id/move", asyncHandler(async (req: any, res: any) => {
 // ── validate_progress: unified exit-criteria gate (flow-aware) ───────────────
 // command is optional; if omitted, project.verifyCommand is used.
 // Advances item to the next flow step. On failure, moves back to the coding step.
-async function handleValidateProgress(itemId: string, command: string | undefined, res: any) {
+async function handleValidateProgress(itemId: string, command: string | undefined, res: any, evidence?: string) {
   const item = await storage.getItem(itemId);
   if (!item) return res.status(404).json({ error: "Item not found" });
+
+  if (evidence) {
+    const evidenceComment = { id: uuidv4(), author: 'agent', content: `**Evidence [${item.status}]:** ${evidence}`, timestamp: new Date(), step: item.status };
+    await storage.updateItem(itemId, { comments: [...(item.comments || []), evidenceComment] });
+    // Reload item so subsequent comment appends don't lose the evidence comment
+    const refreshed = await storage.getItem(itemId);
+    if (refreshed) Object.assign(item, refreshed);
+  }
 
   const project = await storage.getProject(item.projectId);
   const projectFlows = await storage.listFlows();
@@ -1360,7 +1368,7 @@ app.post("/items/:id/validate", asyncHandler(async (req: any, res: any) => {
   if (req.headers['x-agenfk-internal'] !== VERIFY_TOKEN) {
     return res.status(403).json({ error: "Forbidden: validate endpoint requires internal token." });
   }
-  return handleValidateProgress(req.params.id, req.body.command || undefined, res);
+  return handleValidateProgress(req.params.id, req.body.command || undefined, res, req.body.evidence || undefined);
 }));
 
 // ── review_changes: DEPRECATED — delegates to validate_progress ──────────────

--- a/packages/server/src/test/server.supplemental.test.ts
+++ b/packages/server/src/test/server.supplemental.test.ts
@@ -558,6 +558,45 @@ describe('POST /items/:id/validate — command required only on final step', () 
   });
 });
 
+// ── validate_progress: evidence logging ──────────────────────────────────────
+
+describe('POST /items/:id/validate — evidence comment logging', () => {
+  beforeEach(async () => { await initStorage(); });
+
+  it('logs evidence as a tagged comment before advancing', async () => {
+    if (!VERIFY_TOKEN) return;
+    const p = (await request(app).post('/projects').send({ name: 'EV1' })).body;
+    const item = (await request(app).post('/items').send({ type: 'TASK', title: 'EV1', projectId: p.id })).body;
+    await request(app).put(`/items/${item.id}`).send({ status: 'IN_PROGRESS' });
+
+    const res = await request(app)
+      .post(`/items/${item.id}/validate`)
+      .set('x-agenfk-internal', VERIFY_TOKEN)
+      .send({ evidence: 'Wrote unit tests covering edge cases' });
+
+    expect(res.status).toBe(200);
+    const updated = (await request(app).get(`/items/${item.id}`)).body;
+    const evidenceComment = updated.comments.find((c: any) => c.content.includes('Wrote unit tests covering edge cases'));
+    expect(evidenceComment).toBeDefined();
+    expect(evidenceComment.step).toBe('IN_PROGRESS');
+  });
+
+  it('still advances without evidence when omitted', async () => {
+    if (!VERIFY_TOKEN) return;
+    const p = (await request(app).post('/projects').send({ name: 'EV2' })).body;
+    const item = (await request(app).post('/items').send({ type: 'TASK', title: 'EV2', projectId: p.id })).body;
+    await request(app).put(`/items/${item.id}`).send({ status: 'IN_PROGRESS' });
+
+    const res = await request(app)
+      .post(`/items/${item.id}/validate`)
+      .set('x-agenfk-internal', VERIFY_TOKEN)
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('REVIEW');
+  });
+});
+
 // ── Review success path ───────────────────────────────────────────────────────
 
 describe('POST /items/:id/review success paths', () => {


### PR DESCRIPTION
## Summary

- **Removed** `agenfk review` and `agenfk test` CLI commands — both were hardcoded to specific status names (IN_PROGRESS→REVIEW, TEST→DONE), breaking custom flows, and delegated to deprecated endpoints.
- **Added** `agenfk verify <id> [command] --evidence <text>` as the proper MCP fallback for `validate_progress`.
- **Server**: `handleValidateProgress` now accepts `evidence` and logs it as a tagged comment before advancing the step. The `/validate` endpoint passes `req.body.evidence` through.
- **MCP `validate_progress`**: simplified from PUT comment + POST validate to a single POST to `/validate` with `{ evidence, command }`.

## Result

CLI, MCP, and server all share the same evidence-logging path. No duplicate logic.

## Tests

- `verify-command.test.ts` (7 tests): registration, absence of review/test, evidence in POST body, optional command, short ID resolution, missing evidence error, missing token error.
- 2 new server tests: evidence comment logged on `/validate`, advances without evidence when omitted.
- 315/315 passing.