### PR TITLE
feat(install): dist-bundle-only install with --debuglog diagnostics

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -272,7 +272,7 @@ program
   .description('Check for updates and upgrade to the latest version if available')
   .option('-f, --force', 'Force upgrade even if versions match')
   .option('-b, --beta', 'Include beta/pre-release versions')
-  .option('--rebuild', 'Force a full build from source after upgrading')
+  .option('--debuglog', 'Enable verbose diagnostic logging in the install script')
   .action(async (options) => {
     const REPO = 'cglab-public/agenfk';
     console.log(chalk.blue(`Checking for updates from https://github.com/${REPO}${options.beta ? ' (including betas)' : ''}...`));
@@ -343,12 +343,10 @@ program
           return;
         }
 
-        // With pre-built dist already extracted, install.mjs skips the build step.
-        // Only force rebuild when download failed or --rebuild flag is set.
-        const rebuildFlag = (!downloadedFromRelease || options.rebuild) ? ' --rebuild' : '';
-        console.log(chalk.gray(`Running install script${rebuildFlag ? ' (rebuild mode)' : ' (pre-built mode)'}...`));
+        const debuglogFlag = options.debuglog ? ' --debuglog' : '';
+        console.log(chalk.gray('Running install script (pre-built mode)...'));
         try {
-          execSync(`node scripts/install.mjs${rebuildFlag}`, { cwd: rootDir, stdio: 'inherit' });
+          execSync(`node scripts/install.mjs${debuglogFlag}`, { cwd: rootDir, stdio: 'inherit' });
         } catch (e) {
           console.error(chalk.red('Upgrade failed during installation.'));
           return;
@@ -384,7 +382,7 @@ program
 program
   .command('up')
   .description('Bootstrap and start AgEnFK Engineering Framework')
-  .option('--rebuild', 'Force a full build from source during bootstrap')
+  .option('--debuglog', 'Enable verbose diagnostic logging in the install script')
   .option('--easter-eggs', 'Enable easter egg animations')
   .action(async (options) => {
     const rootDir = path.resolve(__dirname, '../../..');
@@ -407,10 +405,11 @@ program
     ];
     const missingDist = requiredDists.some(d => !fs.existsSync(d));
 
-    if (!fs.existsSync(startScript) || missingDist || options.rebuild) {
-        console.log(chalk.yellow(options.rebuild ? '📦 Rebuild requested...' : '📦 Initial bootstrap required...'));
+    if (!fs.existsSync(startScript) || missingDist) {
+        console.log(chalk.yellow('📦 Initial bootstrap required...'));
         try {
-            execSync(`node scripts/install.mjs${options.rebuild ? ' --rebuild' : ''}`, { cwd: rootDir, stdio: 'inherit' });
+            const installFlags = options.debuglog ? ' --debuglog' : '';
+            execSync(`node scripts/install.mjs${installFlags}`, { cwd: rootDir, stdio: 'inherit' });
         } catch (e) {
             console.error(chalk.red('Bootstrap failed.'));
             return;
@@ -862,14 +861,9 @@ integrationCommand
 integrationCommand
   .command('install <platform>')
   .description('Install or refresh a single integration without running the full framework installer')
-  .option('--rebuild', 'Force a rebuild before installing the integration')
-  .action((platform, options) => {
+  .action((platform) => {
     const resolvedPlatform = resolveIntegrationPlatform(platform);
     const args = [`--only=${resolvedPlatform}`];
-
-    if (options.rebuild) {
-      args.push('--rebuild');
-    }
 
     console.log(chalk.blue(`Installing ${INTEGRATION_LABELS[resolvedPlatform]} integration...`));
     runIntegrationScript('install.mjs', args);

--- a/packages/cli/src/test/upgrade-skill.test.ts
+++ b/packages/cli/src/test/upgrade-skill.test.ts
@@ -128,40 +128,172 @@ describe('install.mjs auto-heal (broken upgrade loop recovery)', () => {
     expect(install).toMatch(/gh.*release.*download|release.*download.*gh/);
   });
 
-  it('should only trigger re-download in non-rebuild mode with missing dists', () => {
+  it('should always attempt re-download when dists are missing (no fallback to source build)', () => {
     const install = readInstall();
-    // The re-download logic must be guarded by !shouldRebuild
-    // Find the auto-heal block and verify it's not inside a shouldRebuild branch
     const healMatch = install.match(/auto.?heal|re.?download.*tar|tar.*re.?download/i);
     expect(healMatch).not.toBeNull();
   });
 });
 
 describe('install.mjs pre-built mode', () => {
-  it('should remove stale src/ directories when using pre-built dist (not rebuilding)', () => {
+  it('should remove stale src/ directories after dist-bundle extraction', () => {
     const install = readInstall();
-    // Must contain logic that removes src/ directories
     expect(install).toMatch(/src.*rmSync|rmSync.*src|cleanStaleSrc|stale.*src|src.*stale/i);
   });
 
   it('should cover server package src/ in the stale-src cleanup list', () => {
     const install = readInstall();
-    // The cleanup must reference packages/server/src
     expect(install).toMatch(/packages\/server\/src|packages.server.src/);
   });
+});
 
-  it('should only remove stale src/ when in pre-built mode (build artifacts found)', () => {
+describe('install.mjs dist-bundle-only (no source build)', () => {
+  it('should NOT contain runBuild or npm run build', () => {
     const install = readInstall();
-    // The stale-src cleanup must appear in or near the "build artifacts found" branch,
-    // not inside the rebuild branch (where src/ would be needed for compilation)
-    const rebuildBranchMatch = install.match(/if\s*\(shouldRebuild[\s\S]{0,500}runBuild\(\)/);
-    const staleSrcMatch = install.match(/cleanStaleSrc|stale.*src.*rmSync|packages\/server\/src/);
-    expect(staleSrcMatch).not.toBeNull();
+    expect(install).not.toMatch(/function runBuild|runBuild\(\)/);
+    expect(install).not.toMatch(/npm.*run.*build|'run',\s*'build'/);
+  });
 
-    // Verify stale-src cleanup does NOT appear inside the shouldRebuild-triggered build block
-    if (rebuildBranchMatch && staleSrcMatch) {
-      const rebuildBlock = rebuildBranchMatch[0];
-      expect(rebuildBlock).not.toMatch(/cleanStaleSrc/);
-    }
+  it('should NOT contain cleanDists function', () => {
+    const install = readInstall();
+    expect(install).not.toMatch(/function cleanDists|cleanDists\(\)/);
+  });
+
+  it('should NOT contain shouldRebuild flag', () => {
+    const install = readInstall();
+    expect(install).not.toMatch(/shouldRebuild/);
+  });
+
+  it('should NOT run npm install as part of a source build', () => {
+    const install = readInstall();
+    // npm install is only acceptable in a comment or string, not as a spawnSync call for building
+    expect(install).not.toMatch(/spawnSync\s*\([^)]*'install'[^)]*\)/);
+  });
+
+  it('should exit with an error when dists are still missing after re-download', () => {
+    const install = readInstall();
+    // Must call process.exit(1) in the failure path (after re-download fails)
+    expect(install).toMatch(/process\.exit\(1\)/);
+    // The exit must follow a re-download failure check
+    const redownloadIdx = install.search(/autoHeal|re.?download/i);
+    const exitIdx = install.indexOf('process.exit(1)');
+    expect(redownloadIdx).toBeGreaterThan(-1);
+    expect(exitIdx).toBeGreaterThan(redownloadIdx);
+  });
+
+  it('should NOT accept --rebuild flag', () => {
+    const install = readInstall();
+    expect(install).not.toMatch(/--rebuild/);
+  });
+});
+
+describe('install.mjs --debuglog flag', () => {
+  it('should parse --debuglog from process.argv', () => {
+    const install = readInstall();
+    expect(install).toMatch(/process\.argv.*debuglog|debuglog.*process\.argv|includes\(['"]--debuglog['"]\)/);
+  });
+
+  it('should define a debug logging helper that is gated on the debuglog flag', () => {
+    const install = readInstall();
+    // A debugLog / debug function that only emits when the flag is active
+    expect(install).toMatch(/debugLog|debuglog|function debug/i);
+    // The function must reference the debuglog flag
+    expect(install).toMatch(/debugLog\s*=.*debuglog|debuglog.*&&.*console|if.*debuglog.*console/i);
+  });
+
+  it('should log environment variables relevant to db resolution under --debuglog', () => {
+    const install = readInstall();
+    // Must log AGENFK_DB_PATH env var
+    expect(install).toMatch(/debugLog.*AGENFK_DB_PATH|AGENFK_DB_PATH.*debugLog/);
+  });
+
+  it('should log the resolved config.json path and its contents under --debuglog', () => {
+    const install = readInstall();
+    expect(install).toMatch(/debugLog.*config\.json|config\.json.*debugLog|debugLog.*agenfkConfigPath|agenfkConfigPath.*debugLog/);
+  });
+
+  it('should log rootDir and cwd under --debuglog', () => {
+    const install = readInstall();
+    expect(install).toMatch(/debugLog.*rootDir|rootDir.*debugLog|debugLog.*cwd|cwd.*debugLog/);
+  });
+
+  it('should log which dist directories are present or missing under --debuglog', () => {
+    const install = readInstall();
+    expect(install).toMatch(/debugLog.*missingDists|missingDists.*debugLog|debugLog.*dist.*missing|missing.*dist.*debugLog/i);
+  });
+
+  it('should log presence of src/ directories under --debuglog', () => {
+    const install = readInstall();
+    // Helps diagnose spurious source builds
+    expect(install).toMatch(/debugLog.*staleSrc|staleSrc.*debugLog|debugLog.*src.*exist|exist.*src.*debugLog/i);
+  });
+
+  it('should log platform and WSL detection info under --debuglog', () => {
+    const install = readInstall();
+    expect(install).toMatch(/debugLog.*platform|platform.*debugLog|debugLog.*WSL|WSL.*debugLog/i);
+  });
+
+  it('should log whether a running agenfk server was detected under --debuglog', () => {
+    const install = readInstall();
+    // Helps diagnose the "connected to another distro's server" scenario
+    expect(install).toMatch(/debugLog.*server|server.*debugLog|debugLog.*port|port.*debugLog/i);
+  });
+
+  it('should log the resolved dbPath after all resolution steps under --debuglog', () => {
+    const install = readInstall();
+    expect(install).toMatch(/debugLog.*dbPath|dbPath.*debugLog/);
+  });
+});
+
+describe('CLI upgrade/up -- no --rebuild', () => {
+  it('upgrade command should not have a --rebuild option', () => {
+    const cli = readCli();
+    const upgradeStart = cli.indexOf(".command('upgrade')");
+    const upgradeEnd = cli.indexOf(".command('up')", upgradeStart);
+    const upgradeSection = cli.slice(upgradeStart, upgradeEnd);
+    expect(upgradeSection).not.toMatch(/option.*--rebuild|--rebuild.*rebuild/);
+  });
+
+  it('upgrade command should not pass --rebuild to install.mjs', () => {
+    const cli = readCli();
+    const upgradeStart = cli.indexOf(".command('upgrade')");
+    const upgradeEnd = cli.indexOf(".command('up')", upgradeStart);
+    const upgradeSection = cli.slice(upgradeStart, upgradeEnd);
+    expect(upgradeSection).not.toMatch(/rebuildFlag|--rebuild/);
+  });
+
+  it('up command should not have a --rebuild option', () => {
+    const cli = readCli();
+    const upStart = cli.indexOf(".command('up')");
+    const upEnd = cli.indexOf(".command('down')", upStart);
+    const upSection = cli.slice(upStart, upEnd);
+    expect(upSection).not.toMatch(/option.*--rebuild|options\.rebuild/);
+  });
+
+  it('up command should not pass --rebuild to install.mjs', () => {
+    const cli = readCli();
+    const upStart = cli.indexOf(".command('up')");
+    const upEnd = cli.indexOf(".command('down')", upStart);
+    const upSection = cli.slice(upStart, upEnd);
+    expect(upSection).not.toMatch(/--rebuild/);
+  });
+});
+
+describe('CLI upgrade --debuglog flag', () => {
+  it('should accept --debuglog as a CLI option on the upgrade command', () => {
+    const cli = readCli();
+    const upgradeStart = cli.indexOf(".command('upgrade')");
+    const upgradeEnd = cli.indexOf(".command('up')", upgradeStart);
+    const upgradeSection = cli.slice(upgradeStart, upgradeEnd);
+    expect(upgradeSection).toMatch(/--debuglog/);
+  });
+
+  it('should forward --debuglog to install.mjs when set', () => {
+    const cli = readCli();
+    const upgradeStart = cli.indexOf(".command('upgrade')");
+    const upgradeEnd = cli.indexOf(".command('up')", upgradeStart);
+    const upgradeSection = cli.slice(upgradeStart, upgradeEnd);
+    // The install.mjs invocation must include --debuglog when the option is active
+    expect(upgradeSection).toMatch(/debuglog.*install\.mjs|install\.mjs.*debuglog/i);
   });
 });

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -62,9 +62,40 @@ function ask(rl, question) {
 async function run() {
     console.log(`${BLUE}=== AgenFK Framework Installation ===${NC}`);
 
-    const shouldRebuild = process.argv.includes('--rebuild');
+    const debuglog = process.argv.includes('--debuglog');
     const onlyPlatform = process.argv.find(arg => arg.startsWith('--only='))?.split('=')[1];
     const skipPlatform = process.argv.find(arg => arg.startsWith('--skip='))?.split('=')[1];
+
+    const debugLog = debuglog ? (...args) => console.log(`${YELLOW}[DEBUG]${NC}`, ...args) : () => {};
+
+    if (debuglog) {
+        debugLog('=== AgenFK Install Debug Log ===');
+        debugLog('argv:', process.argv.join(' '));
+        debugLog('cwd:', process.cwd());
+        debugLog('rootDir:', rootDir);
+        debugLog('platform:', os.platform(), '| arch:', os.arch(), '| node:', process.version);
+        debugLog('WSL_DISTRO_NAME:', process.env.WSL_DISTRO_NAME || '(not set)');
+        debugLog('WSL_INTEROP:', process.env.WSL_INTEROP || '(not set)');
+        debugLog('AGENFK_DB_PATH env:', process.env.AGENFK_DB_PATH || '(not set)');
+        debugLog('onlyPlatform:', onlyPlatform || '(none)');
+        const agenfkConfigPath_ = path.join(agenfkHome, 'config.json');
+        debugLog('~/.agenfk/config.json path:', agenfkConfigPath_);
+        if (existsSync(agenfkConfigPath_)) {
+            try {
+                const cfg = readFileSync(agenfkConfigPath_, 'utf8');
+                debugLog('~/.agenfk/config.json contents:', cfg.trim());
+            } catch (e) {
+                debugLog('~/.agenfk/config.json read error:', e.message);
+            }
+        } else {
+            debugLog('~/.agenfk/config.json: NOT FOUND');
+        }
+        // Check if an agenfk server is already reachable on the default port
+        const serverPort = process.env.AGENFK_PORT || '3000';
+        const serverCheck = spawnSync('curl', ['-s', '-o', '/dev/null', '-w', '%{http_code}', '--max-time', '1', `http://localhost:${serverPort}/`], { encoding: 'utf8' });
+        const serverReachable = serverCheck.status === 0 && serverCheck.stdout.trim() !== '000';
+        debugLog(`server on localhost:${serverPort}:`, serverReachable ? `REACHABLE (HTTP ${serverCheck.stdout.trim()})` : 'NOT REACHABLE');
+    }
 
     function shouldRun(platform) {
         if (onlyPlatform) return onlyPlatform.toLowerCase() === platform.toLowerCase();
@@ -72,8 +103,7 @@ async function run() {
         return true;
     }
 
-    // 1. Build the project
-    const npmCmd = getCliCommand('npm');
+    // 1. Verify pre-built dist bundles
     const requiredDists = [
         'packages/core/dist',
         'packages/storage-json/dist',
@@ -82,17 +112,6 @@ async function run() {
         'packages/cli/dist',
         'packages/server/dist',
     ];
-
-    // Clean stale dist/ directories to prevent type mismatches after upgrades
-    function cleanDists() {
-        for (const d of requiredDists) {
-            const fullPath = path.join(rootDir, d);
-            if (existsSync(fullPath)) {
-                rmSync(fullPath, { recursive: true, force: true });
-            }
-        }
-        console.log(`  Cleaned stale build artifacts.`);
-    }
 
     // Remove stale TypeScript source directories from installed packages.
     // The distributable tarball only ships pre-built dist/ — any src/ present is from
@@ -120,17 +139,7 @@ async function run() {
         if (cleaned > 0) console.log(`  Removed ${cleaned} stale source director${cleaned === 1 ? 'y' : 'ies'} (pre-built mode).`);
     }
 
-    function runBuild() {
-        const result = spawnSync(npmCmd, ['run', 'build'], { stdio: 'inherit', cwd: rootDir });
-        if (result.status !== 0) {
-            console.error(`${YELLOW}Build failed with exit code ${result.status}. Installation cannot continue.${NC}`);
-            process.exit(1);
-        }
-    }
-
-    // Auto-heal: when called without --rebuild but dist/ dirs are missing, it means the broken
-    // 0.2.8 upgrade code deleted them after extracting the tarball. Re-download the correct
-    // tarball for this version rather than rebuilding from potentially stale source.
+    // If dists are missing, attempt to re-download the release tarball for this version.
     async function autoHealRedownload() {
         let pkgVersion = '0.0.0';
         try {
@@ -168,29 +177,46 @@ async function run() {
     if (!onlyPlatform) {
         let missingDists = requiredDists.filter(d => !existsSync(path.join(rootDir, d)));
 
-        // Auto-heal: pre-built mode but dists are missing (broken 0.2.8 upgrade loop symptom).
-        // Re-download the tarball instead of rebuilding from potentially stale source.
-        if (!shouldRebuild && missingDists.length > 0) {
-            const healed = await autoHealRedownload();
-            if (healed) missingDists = requiredDists.filter(d => !existsSync(path.join(rootDir, d)));
+        if (debuglog) {
+            debugLog('--- Dist check ---');
+            for (const d of requiredDists) {
+                const full = path.join(rootDir, d);
+                debugLog(`  dist ${d}: ${existsSync(full) ? 'PRESENT' : 'MISSING'}`);
+            }
+            debugLog('missingDists count:', missingDists.length);
+            if (missingDists.length > 0) debugLog('missing:', missingDists.join(', '));
+            const presentStaleSrc = staleSrcDirs.filter(d => existsSync(path.join(rootDir, d)));
+            debugLog('staleSrcDirs present:', presentStaleSrc.length > 0 ? presentStaleSrc.join(', ') : '(none)');
         }
 
-        if (shouldRebuild || missingDists.length > 0) {
-            console.log(`${GREEN}[1/14] Building project...${NC}`);
-            spawnSync(npmCmd, ['install'], { stdio: 'inherit', cwd: rootDir });
-            if (shouldRebuild) cleanDists();
-            runBuild();
-        } else {
-            console.log(`${GREEN}[1/14] Build artifacts found, skipping rebuild.${NC}`);
-            cleanStaleSrc();
+        if (missingDists.length > 0) {
+            debugLog('trigger: missing dists → attempting auto-heal re-download');
+            const healed = await autoHealRedownload();
+            debugLog('auto-heal result:', healed ? 'SUCCESS' : 'FAILED');
+            if (healed) missingDists = requiredDists.filter(d => !existsSync(path.join(rootDir, d)));
+            debugLog('missingDists after heal:', missingDists.length);
         }
+
+        if (missingDists.length > 0) {
+            console.error(`${YELLOW}Installation failed: pre-built dist bundles are missing and could not be downloaded.`);
+            console.error(`  Missing: ${missingDists.join(', ')}`);
+            console.error(`  Download the latest release manually from https://github.com/cglab-public/agenfk/releases${NC}`);
+            process.exit(1);
+        }
+
+        debugLog('decision: all pre-built dists present');
+        console.log(`${GREEN}[1/14] Pre-built dist bundles verified.${NC}`);
+        cleanStaleSrc();
     } else {
         const missingDists = requiredDists.filter(d => !existsSync(path.join(rootDir, d)));
         if (missingDists.length > 0) {
-            console.log(`${GREEN}[1/14] Missing build artifacts for integration install. Rebuilding...${NC}`);
-            spawnSync(npmCmd, ['install'], { stdio: 'inherit', cwd: rootDir });
-            cleanDists();
-            runBuild();
+            debugLog('trigger (onlyPlatform mode): missing dists → attempting re-download');
+            const healed = await autoHealRedownload();
+            if (!healed || requiredDists.some(d => !existsSync(path.join(rootDir, d)))) {
+                console.error(`${YELLOW}Integration install failed: pre-built dist bundles are missing.`);
+                console.error(`  Download the latest release from https://github.com/cglab-public/agenfk/releases${NC}`);
+                process.exit(1);
+            }
         }
     }
 
@@ -248,6 +274,9 @@ async function run() {
         // Fallback for onlyPlatform if no config exists
         dbPath = path.join(rootDir, '.agenfk', 'db.sqlite');
     }
+
+    debugLog('dbPath resolved:', dbPath || '(empty — not yet set)');
+    debugLog('dbPath file exists:', dbPath ? existsSync(dbPath) : false);
 
     // 3b. Restore from backup (new install only)
     if (!onlyPlatform) {


### PR DESCRIPTION
## Summary

- **Remove source-build path** from `install.mjs` — `runBuild()`, `cleanDists()`, `shouldRebuild`, and `npm install` spawns are gone. Install is now dist-bundle-only: if pre-built dists are missing after the auto-heal re-download, it exits with a clear error message pointing to the releases page.
- **Add `--debuglog` flag** to `install.mjs`, `agenfk upgrade`, and `agenfk up`. Emits `[DEBUG]` lines covering: argv, cwd, rootDir, platform, WSL env vars, `AGENFK_DB_PATH`, `~/.agenfk/config.json` contents, server reachability on localhost, per-dist presence/absence, stale `src/` dirs, build-trigger reason, and resolved `dbPath`. Directly addresses the WSL2 distro-sharing diagnostic scenario.
- **Remove `--rebuild` option** from `upgrade`, `up`, and `integration install` CLI commands.

## Test plan

- [ ] `npx vitest run packages/cli/src/test/upgrade-skill.test.ts` — all 34 tests pass
- [ ] `npm run build` — clean build
- [ ] `agenfk upgrade --debuglog` prints `[DEBUG]` lines and completes without source build
- [ ] `agenfk up --debuglog` on a fresh distro with no dists triggers re-download (not `npm run build`)
- [ ] Missing dists after failed re-download prints error + release URL and exits 1