### PR TITLE
fix(ui): use vite preview instead of vite dev in start-services

### DIFF
--- a/packages/cli/src/test/upgrade-skill.test.ts
+++ b/packages/cli/src/test/upgrade-skill.test.ts
@@ -297,3 +297,49 @@ describe('CLI upgrade --debuglog flag', () => {
     expect(upgradeSection).toMatch(/debuglog.*install\.mjs|install\.mjs.*debuglog/i);
   });
 });
+
+const START_SERVICES_PATH = path.resolve(__dirname, '../../../../scripts/start-services.mjs');
+const UI_PKG_PATH = path.resolve(__dirname, '../../../ui/package.json');
+const VITE_CONFIG_PATH = path.resolve(__dirname, '../../../ui/vite.config.ts');
+
+function readStartServices(): string {
+  if (!fs.existsSync(START_SERVICES_PATH)) return '';
+  return fs.readFileSync(START_SERVICES_PATH, 'utf8');
+}
+function readUiPkg(): Record<string, unknown> {
+  if (!fs.existsSync(UI_PKG_PATH)) return {};
+  return JSON.parse(fs.readFileSync(UI_PKG_PATH, 'utf8'));
+}
+function readViteConfig(): string {
+  if (!fs.existsSync(VITE_CONFIG_PATH)) return '';
+  return fs.readFileSync(VITE_CONFIG_PATH, 'utf8');
+}
+
+describe('UI vite preview fix', () => {
+  it('start-services.mjs should use npm run preview, not npm run dev', () => {
+    const content = readStartServices();
+    expect(content).not.toMatch(/'run',\s*'dev'|"run",\s*"dev"/);
+    expect(content).toMatch(/'run',\s*'preview'|"run",\s*"preview"/);
+  });
+
+  it('install.mjs start-services template should use npm run preview, not npm run dev', () => {
+    const install = readInstall();
+    const templateStart = install.indexOf('startScriptContent');
+    const templateEnd = install.indexOf('startScriptPath', templateStart + 1);
+    const template = install.slice(templateStart, templateEnd);
+    expect(template).not.toMatch(/['"]run['"]\s*,\s*['"]dev['"]/);
+    expect(template).toMatch(/['"]run['"]\s*,\s*['"]preview['"]/);
+  });
+
+  it('packages/ui/package.json should have a preview script', () => {
+    const pkg = readUiPkg() as { scripts?: Record<string, string> };
+    expect(pkg.scripts?.preview).toBeDefined();
+    expect(pkg.scripts?.preview).toMatch(/vite preview/);
+  });
+
+  it('vite.config.ts should configure preview.port from VITE_PORT', () => {
+    const config = readViteConfig();
+    expect(config).toMatch(/preview\s*:\s*\{[^}]*port/);
+    expect(config).toMatch(/VITE_PORT/);
+  });
+});

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -14,4 +14,7 @@ export default defineConfig({
   server: {
     port: parseInt(process.env.VITE_PORT || '5173'),
   },
+  preview: {
+    port: parseInt(process.env.VITE_PORT || '5173'),
+  },
 })

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -368,7 +368,7 @@ const uiLogPath = path.join(agenfkDir, 'ui.log');
 const uiLog = fs.openSync(uiLogPath, 'w');
 const isMinGW = !!(process.env.MSYSTEM || process.env.MINGW_PREFIX);
 const npmCmd = (os.platform() === 'win32' && !isMinGW) ? 'npm.cmd' : 'npm';
-const uiProcess = spawn(npmCmd, ['run', 'dev'], {
+const uiProcess = spawn(npmCmd, ['run', 'preview'], {
     cwd: path.join(rootDir, 'packages/ui'),
     env: { ...process.env, VITE_PORT: UI_PORT, VITE_API_URL: \`http://localhost:\${API_PORT}\` },
     detached: true,

--- a/scripts/start-services.mjs
+++ b/scripts/start-services.mjs
@@ -44,7 +44,7 @@ const uiLogPath = path.join(agenfkDir, 'ui.log');
 const uiLog = fs.openSync(uiLogPath, 'w');
 const isMinGW = !!(process.env.MSYSTEM || process.env.MINGW_PREFIX);
 const npmCmd = (os.platform() === 'win32' && !isMinGW) ? 'npm.cmd' : 'npm';
-const uiProcess = spawn(npmCmd, ['run', 'dev'], {
+const uiProcess = spawn(npmCmd, ['run', 'preview'], {
     cwd: path.join(rootDir, 'packages/ui'),
     env: { ...process.env, VITE_PORT: UI_PORT, VITE_API_URL: `http://localhost:${API_PORT}` },
     detached: true,


### PR DESCRIPTION
## Summary

- `cleanStaleSrc()` (introduced in #37) removes `packages/ui/src/` on installation, but `start-services.mjs` was still running `npm run dev` which needs `src/main.tsx` — causing `net::ERR_ABORTED 404` and a blank UI.
- Switch to `npm run preview` which serves the pre-built `dist/` folder.
- Add `preview.port` to `vite.config.ts` so it respects the `VITE_PORT` env var (same as the dev server).
- Fix applied to both the live `scripts/start-services.mjs` and the template inside `scripts/install.mjs` (used for future installs).

## Test plan

- [ ] `npx vitest run packages/cli/src/test/upgrade-skill.test.ts` — all 38 tests pass
- [ ] `agenfk up` on a fresh install (no `src/` dirs) — UI loads correctly at configured port
- [ ] `VITE_PORT=5180 agenfk up` — UI starts on port 5180