### PR TITLE
fix(release): include storage-sqlite and telemetry in dist bundle

### DIFF
--- a/scripts/package-dist.mjs
+++ b/scripts/package-dist.mjs
@@ -38,6 +38,10 @@ async function run() {
         'packages/server/dist/',
         'packages/storage-json/package.json',
         'packages/storage-json/dist/',
+        'packages/storage-sqlite/package.json',
+        'packages/storage-sqlite/dist/',
+        'packages/telemetry/package.json',
+        'packages/telemetry/dist/',
         'packages/ui/package.json',
         'packages/ui/dist/'
     ];


### PR DESCRIPTION
## Summary
- `scripts/package-dist.mjs` was missing `packages/storage-sqlite` and `packages/telemetry` from the tarball include list
- `scripts/install.mjs` requires both in its `requiredDists` check at step [1/14], causing upgrades to fail
- Both are runtime dependencies of `server` (`@agenfk/storage-sqlite`, `@agenfk/telemetry`) and `cli` (`@agenfk/telemetry`)

## Reproduction
`agenfk upgrade` → `Installation failed: pre-built dist bundles are missing and could not be downloaded. Missing: packages/storage-sqlite/dist, packages/telemetry/dist`

## Fix
Added both packages (`package.json` + `dist/`) to the `include` array in `package-dist.mjs`.

## Test plan
- [ ] Run `node scripts/package-dist.mjs` and verify `agenfk-dist.tar.gz` contains `packages/storage-sqlite/dist/` and `packages/telemetry/dist/`
- [ ] Extract the tarball and confirm install succeeds