### PR TITLE
fix(test): fall back to repo commands/ when upgrade skill not installed

### DIFF
--- a/packages/cli/src/test/upgrade-skill.test.ts
+++ b/packages/cli/src/test/upgrade-skill.test.ts
@@ -10,11 +10,13 @@ import * as path from 'path';
 import * as os from 'os';
 
 const SKILL_PATH = path.join(os.homedir(), '.claude', 'commands', 'agenfk-upgrade.md');
+const SKILL_REPO_PATH = path.resolve(__dirname, '../../../../commands/agenfk-upgrade.md');
 const CLI_PATH = path.resolve(__dirname, '../../src/index.ts');
 
 function readSkill(): string {
-  if (!fs.existsSync(SKILL_PATH)) return '';
-  return fs.readFileSync(SKILL_PATH, 'utf8');
+  if (fs.existsSync(SKILL_PATH)) return fs.readFileSync(SKILL_PATH, 'utf8');
+  if (fs.existsSync(SKILL_REPO_PATH)) return fs.readFileSync(SKILL_REPO_PATH, 'utf8');
+  return '';
 }
 
 function readCli(): string {


### PR DESCRIPTION
## Summary
- `readSkill()` in `upgrade-skill.test.ts` returned `''` when `~/.claude/commands/agenfk-upgrade.md` didn't exist (e.g. in CI where AgenFK isn't installed globally)
- This caused the `should delegate to the agenfk upgrade CLI command` test to fail against an empty string
- Fix: fall back to `commands/agenfk-upgrade.md` in the repo root before returning `''`