### PR TITLE
fix: remove storage-json stragglers + fix release CI tag resolution

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,8 +13,7 @@
   },
   "dependencies": {
     "@agenfk/core": "*",
-    "@agenfk/storage-json": "*",
-    "@agenfk/telemetry": "*",
+"@agenfk/telemetry": "*",
     "axios": "^1.13.5",
     "chalk": "^4.1.2",
     "commander": "^12.0.0",

--- a/packages/server/src/test/no-storage-json.test.ts
+++ b/packages/server/src/test/no-storage-json.test.ts
@@ -53,4 +53,16 @@ describe('storage-json removal', () => {
     const content = fs.readFileSync(script, 'utf8');
     expect(content).not.toContain('storage-json');
   });
+
+  it('cli package.json should not depend on @agenfk/storage-json', () => {
+    const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'packages/cli/package.json'), 'utf8'));
+    const deps = { ...pkg.dependencies, ...pkg.devDependencies };
+    expect(deps['@agenfk/storage-json']).toBeUndefined();
+  });
+
+  it('enforce-coverage.ts should not reference storage-json dist', () => {
+    const script = path.join(ROOT, 'scripts/enforce-coverage.ts');
+    const content = fs.readFileSync(script, 'utf8');
+    expect(content).not.toContain('storage-json');
+  });
 });

--- a/scripts/enforce-coverage.ts
+++ b/scripts/enforce-coverage.ts
@@ -14,8 +14,7 @@ function run() {
     const rootDir = process.cwd();
     const dists = [
       path.join(rootDir, 'packages', 'core', 'dist'),
-      path.join(rootDir, 'packages', 'storage-json', 'dist'),
-      path.join(rootDir, 'packages', 'cli', 'dist'),
+path.join(rootDir, 'packages', 'cli', 'dist'),
       path.join(rootDir, 'packages', 'server', 'dist'),
       path.join(rootDir, 'packages', 'ui', 'dist'),
     ];


### PR DESCRIPTION
## Summary

- **Remove `@agenfk/storage-json` dep** from `packages/cli/package.json` — package no longer exists
- **Remove `storage-json/dist`** path from `scripts/enforce-coverage.ts` dist cleanup list
- **Fix release CI auto-bump** — add `fetch-depth: 0` to checkout step so `git describe --tags` can find the latest tag instead of falling back to `v0.0.0` (which caused every unversioned release to publish as `0.0.1`)
- Tests added for all three cases in `no-storage-json.test.ts` and `release-workflow.test.ts`

## Test plan

- [ ] `npm run build && npm test` passes
- [ ] `no-storage-json` and `release-workflow` test suites all green
- [ ] Trigger release workflow without a version input → confirm it bumps from the real latest tag