### PR TITLE
fix(ci): add fetch-depth: 0 so release auto-bump reads latest tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           fetch-tags: true
           token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 

--- a/packages/server/src/test/release-workflow.test.ts
+++ b/packages/server/src/test/release-workflow.test.ts
@@ -1,0 +1,16 @@
+/**
+ * Tests verifying the release workflow is correctly configured.
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(__dirname, '../../../..');
+const RELEASE_YML = path.join(ROOT, '.github/workflows/release.yml');
+
+describe('release workflow', () => {
+  it('checkout step includes fetch-depth: 0 so git describe can find tags', () => {
+    const content = fs.readFileSync(RELEASE_YML, 'utf8');
+    expect(content).toContain('fetch-depth: 0');
+  });
+});


### PR DESCRIPTION
## Summary

`actions/checkout@v4` defaults to a shallow clone (`fetch-depth: 1`). Even with `fetch-tags: true`, `git describe --tags --abbrev=0` can't walk back to a reachable tag, so it fails and falls back to `v0.0.0` — making every unversioned release publish as `0.0.1`.

Adding `fetch-depth: 0` gives the action a full clone so `git describe` resolves the latest tag correctly.

## Test plan

- [ ] `npm test` passes (new `release-workflow.test.ts` asserts `fetch-depth: 0` is present)
- [ ] Trigger release workflow without a version input → confirm it bumps from the real latest tag