### PR TITLE
fix: move vite and @vitejs/plugin-react to dependencies

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -14,6 +14,8 @@
   "dependencies": {
     "@tailwindcss/postcss": "^4.2.0",
     "@tailwindcss/typography": "^0.5.19",
+    "@vitejs/plugin-react": "^5.1.1",
+    "vite": "^7.3.1",
     "@tanstack/react-query": "^5.90.21",
     "axios": "^1.13.5",
     "clsx": "^2.1.1",
@@ -33,7 +35,6 @@
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react": "^5.1.1",
     "autoprefixer": "^10.4.24",
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",
@@ -42,7 +43,6 @@
     "postcss": "^8.5.6",
     "tailwindcss": "^4.2.0",
     "typescript": "~5.9.3",
-    "typescript-eslint": "^8.48.0",
-    "vite": "^7.3.1"
+    "typescript-eslint": "^8.48.0"
   }
 }


### PR DESCRIPTION
## Problem
After a fresh `agenfk` install, `agenfk up` fails to start the UI:
```
sh: vite: not found
npm error code 127
```
Root cause: `install.mjs` runs `npm ci --omit=dev`, which skips devDependencies. But `vite` was only listed in `devDependencies` of `packages/ui`, and `npm run preview` (i.e. `vite preview`) is a runtime command needed to serve the UI.

## Fix
Move `vite` and `@vitejs/plugin-react` from `devDependencies` to `dependencies` in `packages/ui/package.json`.

## Test plan
- [ ] Run `agenfk up` on a fresh install and verify UI starts at `http://localhost:5173`
- [ ] Confirm `curl http://localhost:5173` returns HTTP 200