### PR TITLE
fix: always run npm ci --omit=dev on agenfk up

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -402,7 +402,16 @@ program
     killPattern('packages/server/dist/server.js');
     killPattern('packages/ui');
 
-    // 1. Only bootstrap if start-services.mjs or any required dist is missing
+    // 1. Always ensure production dependencies are installed
+    console.log(chalk.gray('📦 Ensuring dependencies are up to date...'));
+    const npmCmd = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+    try {
+        execSync(`${npmCmd} ci --omit=dev --ignore-scripts`, { cwd: rootDir, stdio: 'inherit' });
+    } catch (e) {
+        console.warn(chalk.yellow('Warning: npm ci failed. Continuing anyway...'));
+    }
+
+    // 2. Full bootstrap only if dist files are missing
     const startScript = path.join(rootDir, 'scripts', 'start-services.mjs');
     const requiredDists = [
         path.join(rootDir, 'packages/server/dist/server.js'),
@@ -420,8 +429,6 @@ program
             console.error(chalk.red('Bootstrap failed.'));
             return;
         }
-    } else {
-        console.log(chalk.green('Build artifacts found, skipping rebuild.'));
     }
     
     console.log(chalk.blue('⚡ Starting agenfk services...'));


### PR DESCRIPTION
## Problem
`agenfk up` only ran `install.mjs` (which includes `npm ci --omit=dev`) when dist files were missing. On existing installs with dists already present, it skipped the bootstrap entirely — leaving dependencies stale.

This was the root cause of `vite: not found` on existing installs after PR #51 moved vite to `dependencies`: even with the correct `package.json`, `npm ci` never ran to install the new dep.

## Fix
Always run `npm ci --omit=dev --ignore-scripts` at the start of `agenfk up`, regardless of dist file presence. Full bootstrap (`install.mjs`) is still only triggered when dist files are missing.

## Test plan
- [ ] On an existing install, run `agenfk up` and confirm `npm ci` runs (visible in output)
- [ ] Confirm a newly added production dependency is present in `node_modules` after `agenfk up`