### PR TITLE
revert: remove npm ci on every agenfk up

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -402,16 +402,7 @@ program
     killPattern('packages/server/dist/server.js');
     killPattern('packages/ui');
 
-    // 1. Always ensure production dependencies are installed
-    console.log(chalk.gray('📦 Ensuring dependencies are up to date...'));
-    const npmCmd = process.platform === 'win32' ? 'npm.cmd' : 'npm';
-    try {
-        execSync(`${npmCmd} ci --omit=dev --ignore-scripts`, { cwd: rootDir, stdio: 'inherit' });
-    } catch (e) {
-        console.warn(chalk.yellow('Warning: npm ci failed. Continuing anyway...'));
-    }
-
-    // 2. Full bootstrap only if dist files are missing
+    // 1. Only bootstrap if start-services.mjs or any required dist is missing
     const startScript = path.join(rootDir, 'scripts', 'start-services.mjs');
     const requiredDists = [
         path.join(rootDir, 'packages/server/dist/server.js'),
@@ -429,6 +420,8 @@ program
             console.error(chalk.red('Bootstrap failed.'));
             return;
         }
+    } else {
+        console.log(chalk.green('Build artifacts found, skipping rebuild.'));
     }
     
     console.log(chalk.blue('⚡ Starting agenfk services...'));


### PR DESCRIPTION
## Summary
Reverts commit 0c202304 ("fix: always run npm ci --omit=dev on agenfk up").

Running `npm ci` on every `agenfk up` adds ~8s of unnecessary overhead. The actual root cause (stale `package-lock.json` with `"dev": true` on vite) was fixed in the same PR, so install and upgrade already handle dependency installation correctly.

## Test plan
- [ ] `agenfk up` starts quickly without running npm ci
- [ ] Fresh install still works (install.mjs runs npm ci)
- [ ] Upgrade still works (install.mjs runs npm ci)