### PR TITLE
feat: pause/resume integrations, upgrade tiers, README index

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,29 @@
 
 Welcome to **AgEnFK**, a high-reliability, measurable, and visual framework designed to turn "Vibe Coding" into rigorous **Agentic Engineering**. AgEnFK enforces a structured workflow that bridges the gap between autonomous AI agents and professional software engineering practices.
 
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [How do I use AgEnFK?](#how-do-i-use-agenfk)
+- [Supported Platforms](#supported-platforms)
+- [Installation & Setup](#installation--setup)
+  - [Post-Install Steps](#post-install-steps)
+  - [Rules Scope — Global vs Project](#rules-scope--global-vs-project)
+  - [Pausing & Resuming Integrations](#pausing--resuming-integrations)
+  - [Uninstalling AgEnFK](#uninstalling-agenfk)
+- [Multi-Project Support](#multi-project-support)
+- [GitHub Issues Sync](#github-issues-sync)
+- [Architecture Deep Dive](#architecture-deep-dive)
+- [Custom Workflow Flows](#custom-workflow-flows)
+- [Quick Start](#quick-start)
+- [Operation Modes](#operation-modes)
+- [Telemetry](#telemetry)
+- [FAQ](#faq)
+
+---
+
 ## Overview
 
 AgEnFK is built on six core mandates to ensure your AI-assisted development is consistent and high-quality:
@@ -113,23 +136,9 @@ After installation, complete the setup:
     *   `agenfk down`: Stop all running AgEnFK processes.
     *   `agenfk health`: Verify configuration, database, and connectivity.
     *   `agenfk integration list`: Show the supported editor and agent integrations.
-    *   `agenfk integration install <platform>`: Reinstall one integration without rerunning the full framework installer.
-    *   `agenfk integration uninstall <platform>`: Remove one integration without uninstalling the full framework.
-    *   `npm run uninstall:framework`: Fully remove AgEnFK from your system.
+    *   `agenfk pause <platform>`: Temporarily disable a specific integration (removes MCP config and skills). Use `all` to pause every integration.
+    *   `agenfk resume <platform>`: Re-enable a previously paused integration. Use `all` to resume everything.
 4.  **Initialize a project** — go to any repository and type `/agenfk` in your AI editor to link it to the framework.
-
-### Managing Individual Integrations
-
-If you only need to repair or refresh one editor integration, use the `agenfk integration` command group instead of rerunning the full installer.
-
-```bash
-agenfk integration list
-agenfk integration install claude
-agenfk integration install codex --rebuild
-agenfk integration uninstall cursor
-```
-
-Supported platform IDs are `claude`, `opencode`, `cursor`, `codex`, and `gemini`.
 
 ### Rules Scope — Global vs Project
 
@@ -150,9 +159,81 @@ agenfk skills status             # show current scope (global, project, or none)
 
 Switching automatically removes rules from the old location and installs them in the new one.
 
+### Pausing & Resuming Integrations
+
+You can temporarily disable one or all editor integrations without fully uninstalling AgEnFK. This is useful when you want to stop AgEnFK from appearing in a specific AI editor without losing your configuration or workflow data.
+
+**Pause** removes the MCP server registration and all AgEnFK skills/slash commands from the target editor. The framework itself (server, database, CLI) continues running normally.
+
+```bash
+# Pause a single integration
+agenfk pause claude
+agenfk pause opencode
+agenfk pause cursor
+agenfk pause codex
+agenfk pause gemini
+
+# Pause all integrations at once
+agenfk pause all
+
+# Use --yes to skip the confirmation prompt
+agenfk pause claude --yes
+```
+
+**Resume** re-installs the MCP registration and skills for the target editor, restoring it to fully operational state.
+
+```bash
+# Resume a single integration
+agenfk resume claude
+agenfk resume opencode
+
+# Resume all previously paused integrations
+agenfk resume all
+
+# Use --yes to skip the confirmation prompt
+agenfk resume all --yes
+```
+
+Paused integrations are tracked in `~/.agenfk/config.json` under `pausedIntegrations`. Resume respects your configured `rulesScope` (global or project) so rules are reinstalled in the correct location.
+
+> **Supported platform IDs:** `claude`, `opencode`, `cursor`, `codex`, `gemini`. You can also use the alias `claude-code` for `claude`.
+
+### Uninstalling AgEnFK
+
+To fully remove AgEnFK from your system:
+
+```bash
+agenfk uninstall
+```
+
+This removes:
+- All slash commands and skills from Claude Code, Opencode, and Gemini CLI
+- MCP server configuration from all editors (Claude Code, Opencode, Cursor, Codex CLI, Gemini CLI)
+- Cursor workflow rules (`agenfk.mdc`)
+- Workflow rules from all scopes (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`)
+- The AgEnFK PreToolUse hook from `~/.claude/settings.json`
+- The `~/.agenfk-system` framework files
+- The `agenfk` CLI symlink from `~/.local/bin`
+
+Your project data (`~/.agenfk/db.sqlite`, `~/.agenfk/config.json`) is **not** deleted by default, so you can reinstall later without losing your boards and history.
+
+**To uninstall only a specific editor integration** (leaving all others intact):
+
+```bash
+agenfk pause claude    # removes Claude Code MCP + skills only
+agenfk pause cursor    # removes Cursor MCP + rules only
+```
+
+**To uninstall framework files only** (rules and skills, without removing the CLI or database):
+
+```bash
+agenfk skills uninstall          # remove global rules & skills
+agenfk skills uninstall --project  # remove project-scoped rules & skills
+```
+
 ## Multi-Project Support
 
-AgEnFK supports managing multiple distinct projects from a single unified backend. 
+AgEnFK supports managing multiple distinct projects from a single unified backend.
 
 *   **Local Linking**: Each local repository is linked to a database project via a `.agenfk/project.json` file.
 *   **Automatic Context Switching**: When an AI Agent (via MCP) or a developer (via CLI) starts working on a task, the API server automatically detects the project context and broadcasts an event via WebSockets.
@@ -388,6 +469,12 @@ Yes. Projects are independent records in the database. You can switch between th
 ### Is my code or project data sent anywhere?
 
 No. Your source code and project data never leave your machine. The only outbound data is anonymous usage telemetry (see [Telemetry](#telemetry)), which can be disabled with `agenfk config set telemetry false`.
+
+---
+
+### How do I pause AgEnFK in one editor without affecting others?
+
+Use `agenfk pause <platform>` to disable a specific integration. For example, `agenfk pause cursor` removes AgEnFK's MCP config and rules from Cursor while leaving Claude Code, Opencode, and others untouched. Run `agenfk resume cursor` to re-enable it. See [Pausing & Resuming Integrations](#pausing--resuming-integrations) for full details.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk-framework",
-  "version": "0.2.22",
+  "version": "0.2.23-beta.1",
   "description": "AgenFK Engineering Framework",
   "private": true,
   "workspaces": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/cli",
-  "version": "0.2.22",
+  "version": "0.2.23-beta.1",
   "description": "CLI for AgenFK Engineering Framework",
   "main": "dist/index.js",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,5 +32,6 @@
     "cli"
   ],
   "author": "",
-  "license": "ISC"
+  "license": "ISC",
+  "agenfkUpgradeTier": "recommended"
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -210,6 +210,86 @@ try {
   // In some environments this might fail
 }
 
+// ── Upgrade tier startup check ────────────────────────────────────────────────
+
+const UPGRADE_TIER_CACHE_TTL = 60 * 60 * 1000; // 1 hour
+
+async function checkUpgradeTier(): Promise<void> {
+  const cacheFile = path.join(os.homedir(), '.agenfk', 'upgrade-tier-cache.json');
+
+  // Try the local cache first
+  try {
+    if (fs.existsSync(cacheFile)) {
+      const cached = JSON.parse(fs.readFileSync(cacheFile, 'utf8'));
+      if (cached.fetchedAt && (Date.now() - cached.fetchedAt) < UPGRADE_TIER_CACHE_TTL) {
+        applyUpgradeTierAction(cached.tier ?? 'optional', cached.version ?? '');
+        return;
+      }
+    }
+  } catch {
+    // Cache read failed — proceed to live fetch
+  }
+
+  let tier: 'mandatory' | 'recommended' | 'optional' = 'optional';
+  let latestVersion = '';
+
+  try {
+    // Try the local server first (it already caches the result)
+    const resp = await axios.get(`${API_URL}/releases/latest`, { timeout: 3000 });
+    tier = resp.data?.upgradeTier ?? 'optional';
+    latestVersion = resp.data?.version ?? '';
+  } catch {
+    // Server unavailable — fall back to GitHub API directly
+    try {
+      const repo = 'cglab-public/agenfk';
+      const releaseResp = await axios.get(
+        `https://api.github.com/repos/${repo}/releases/latest`,
+        { headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'agenfk-cli' }, timeout: 5000 },
+      );
+      const tagName: string = releaseResp.data?.tag_name ?? '';
+      latestVersion = tagName.replace(/^v/, '');
+      if (tagName) {
+        const rawResp = await axios.get(
+          `https://raw.githubusercontent.com/${repo}/${tagName}/packages/cli/package.json`,
+          { timeout: 5000 },
+        );
+        if (rawResp.data?.agenfkUpgradeTier === 'mandatory' || rawResp.data?.agenfkUpgradeTier === 'recommended') {
+          tier = rawResp.data.agenfkUpgradeTier;
+        }
+      }
+    } catch {
+      // Failed to reach GitHub — proceed silently, no tier enforcement
+      return;
+    }
+  }
+
+  // Persist to local upgradeCache
+  try {
+    const cacheDir = path.join(os.homedir(), '.agenfk');
+    if (!fs.existsSync(cacheDir)) fs.mkdirSync(cacheDir, { recursive: true });
+    fs.writeFileSync(cacheFile, JSON.stringify({ tier, version: latestVersion, fetchedAt: Date.now() }));
+  } catch {
+    // Cache write failed — non-fatal
+  }
+
+  applyUpgradeTierAction(tier, latestVersion);
+}
+
+function applyUpgradeTierAction(tier: string, latestVersion: string): void {
+  if (tier === 'mandatory') {
+    console.error(chalk.red.bold('\n⛔ MANDATORY UPGRADE REQUIRED'));
+    console.error(chalk.red(`AgEnFK v${latestVersion || 'latest'} is a mandatory upgrade and must be applied before continuing.`));
+    console.error(chalk.red('Run: ') + chalk.yellow.bold('agenfk upgrade'));
+    console.error('');
+    process.exit(1);
+  } else if (tier === 'recommended') {
+    console.log(chalk.yellow.bold('\n⚠️  Recommended upgrade available'));
+    console.log(chalk.yellow(`AgEnFK v${latestVersion || 'latest'} is available with recommended improvements.`));
+    console.log(chalk.yellow('Run ') + chalk.bold('agenfk upgrade') + chalk.yellow(' when convenient.\n'));
+  }
+  // optional: silent — no output
+}
+
 program
   .version(CURRENT_VERSION)
   .description('AgEnFK Engineering CLI')
@@ -3069,5 +3149,8 @@ program.helpInformation = function () {
 };
 
 if (process.env.NODE_ENV !== 'test') {
-  program.parse(process.argv);
+  (async () => {
+    await checkUpgradeTier();
+    program.parse(process.argv);
+  })();
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -189,6 +189,27 @@ function runIntegrationScript(scriptName: string, args: string[]) {
   }
 }
 
+const AGENFK_CONFIG_PATH = path.join(os.homedir(), '.agenfk', 'config.json');
+
+function getPausedIntegrations(): string[] {
+  if (!fs.existsSync(AGENFK_CONFIG_PATH)) return [];
+  try {
+    const cfg = JSON.parse(fs.readFileSync(AGENFK_CONFIG_PATH, 'utf8'));
+    return Array.isArray(cfg.pausedIntegrations) ? cfg.pausedIntegrations : [];
+  } catch {
+    return [];
+  }
+}
+
+function setPausedIntegrations(list: string[]): void {
+  let cfg: Record<string, any> = {};
+  if (fs.existsSync(AGENFK_CONFIG_PATH)) {
+    try { cfg = JSON.parse(fs.readFileSync(AGENFK_CONFIG_PATH, 'utf8')); } catch {}
+  }
+  cfg.pausedIntegrations = list;
+  fs.writeFileSync(AGENFK_CONFIG_PATH, JSON.stringify(cfg, null, 2), 'utf8');
+}
+
 if (process.env.NODE_ENV !== 'test' && !process.argv.includes('mcp') && !process.argv.includes('--json')) {
   console.log(
     chalk.cyan(
@@ -986,6 +1007,96 @@ integrationCommand
 
     console.log(chalk.blue(`Removing ${INTEGRATION_LABELS[resolvedPlatform]} integration...`));
     runIntegrationScript('uninstall.mjs', args);
+  });
+
+// ---------------------------------------------------------------------------
+// agenfk pause <platform|all> — temporarily disable integration(s)
+// ---------------------------------------------------------------------------
+program
+  .command('pause <platform>')
+  .description('Pause one or all integrations (removes MCP config and skills). Use "all" to pause everything.')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .action((platform, options) => {
+    const allPlatforms = Object.keys(INTEGRATION_LABELS);
+    const pauseAll = platform.trim().toLowerCase() === 'all';
+
+    const targets: string[] = pauseAll
+      ? allPlatforms
+      : [resolveIntegrationPlatform(platform)];
+
+    const labels = targets.map(p => INTEGRATION_LABELS[p]).join(', ');
+    if (!options.yes) {
+      console.log(chalk.yellow(`This will pause: ${labels}`));
+      console.log(chalk.gray('Use -y/--yes to skip this prompt in scripts.'));
+    }
+
+    for (const p of targets) {
+      console.log(chalk.blue(`Pausing ${INTEGRATION_LABELS[p]}...`));
+      runIntegrationScript('uninstall.mjs', [`--only=${p}`, '--yes']);
+    }
+
+    const existing = getPausedIntegrations();
+    const updated = Array.from(new Set([...existing, ...targets]));
+    setPausedIntegrations(updated);
+
+    console.log(chalk.green(`✔ Paused: ${labels}`));
+    console.log(chalk.gray('Run `agenfk resume` to restore.'));
+  });
+
+// ---------------------------------------------------------------------------
+// agenfk resume <platform|all> — restore paused integration(s)
+// ---------------------------------------------------------------------------
+program
+  .command('resume <platform>')
+  .description('Resume one or all paused integrations. Use "all" to resume everything.')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .action((platform, options) => {
+    const resumeAll = platform.trim().toLowerCase() === 'all';
+    const paused = getPausedIntegrations();
+
+    const targets: string[] = resumeAll
+      ? paused
+      : (() => {
+          const p = resolveIntegrationPlatform(platform);
+          if (!paused.includes(p)) {
+            console.log(chalk.yellow(`${INTEGRATION_LABELS[p]} is not currently paused.`));
+            return [];
+          }
+          return [p];
+        })();
+
+    if (targets.length === 0) {
+      if (resumeAll) {
+        console.log(chalk.yellow('No integrations are currently paused.'));
+      }
+      return;
+    }
+
+    const labels = targets.map(p => INTEGRATION_LABELS[p]).join(', ');
+    if (!options.yes) {
+      console.log(chalk.cyan(`This will resume: ${labels}`));
+    }
+
+    // Read rulesScope from config for re-install
+    let rulesScope = '';
+    try {
+      if (fs.existsSync(AGENFK_CONFIG_PATH)) {
+        const cfg = JSON.parse(fs.readFileSync(AGENFK_CONFIG_PATH, 'utf8'));
+        if (cfg.rulesScope) rulesScope = cfg.rulesScope;
+      }
+    } catch {}
+
+    for (const p of targets) {
+      console.log(chalk.blue(`Resuming ${INTEGRATION_LABELS[p]}...`));
+      const args = [`--only=${p}`];
+      if (rulesScope) args.push(`--rules-scope=${rulesScope}`);
+      runIntegrationScript('install.mjs', args);
+    }
+
+    const remaining = paused.filter(p => !targets.includes(p));
+    setPausedIntegrations(remaining);
+
+    console.log(chalk.green(`✔ Resumed: ${labels}`));
   });
 
 /**

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -968,46 +968,6 @@ integrationCommand
     );
   });
 
-integrationCommand
-  .command('install <platform>')
-  .description('Install or refresh a single integration without running the full framework installer')
-  .option('--scope <scope>', 'Override rules scope (global or project)')
-  .action((platform, options) => {
-    const resolvedPlatform = resolveIntegrationPlatform(platform);
-    const args = [`--only=${resolvedPlatform}`];
-
-    // Pass rulesScope: explicit --scope flag, or read from config
-    if (options.scope) {
-      args.push(`--rules-scope=${options.scope}`);
-    } else {
-      const configPath = path.join(os.homedir(), '.agenfk', 'config.json');
-      if (fs.existsSync(configPath)) {
-        try {
-          const cfg = JSON.parse(fs.readFileSync(configPath, 'utf8'));
-          if (cfg.rulesScope) args.push(`--rules-scope=${cfg.rulesScope}`);
-        } catch {}
-      }
-    }
-
-    console.log(chalk.blue(`Installing ${INTEGRATION_LABELS[resolvedPlatform]} integration...`));
-    runIntegrationScript('install.mjs', args);
-  });
-
-integrationCommand
-  .command('uninstall <platform>')
-  .description('Remove a single integration without uninstalling the full framework')
-  .option('-y, --yes', 'Skip confirmation prompts')
-  .action((platform, options) => {
-    const resolvedPlatform = resolveIntegrationPlatform(platform);
-    const args = [`--only=${resolvedPlatform}`];
-
-    if (options.yes) {
-      args.push('--yes');
-    }
-
-    console.log(chalk.blue(`Removing ${INTEGRATION_LABELS[resolvedPlatform]} integration...`));
-    runIntegrationScript('uninstall.mjs', args);
-  });
 
 // ---------------------------------------------------------------------------
 // agenfk pause <platform|all> — temporarily disable integration(s)

--- a/packages/cli/src/test/install-script.test.ts
+++ b/packages/cli/src/test/install-script.test.ts
@@ -13,6 +13,11 @@ const installScript = readFileSync(
     'utf8'
 );
 
+const uninstallScript = readFileSync(
+    path.resolve(__dirname, '../../../../scripts/uninstall.mjs'),
+    'utf8'
+);
+
 describe('install.mjs — production dependency installation', () => {
     it('runs npm ci to install production dependencies', () => {
         expect(installScript).toContain('npm ci');
@@ -50,5 +55,46 @@ describe('install.mjs — production dependency installation', () => {
         const afterNpmCi = installScript.slice(npmCiIndex);
         // Expect either a status/error check or a try/catch around the npm ci call
         expect(afterNpmCi).toMatch(/status|error|warn|catch|Warning/i);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// uninstall.mjs — step 3b respects --only=<platform> flag
+// ---------------------------------------------------------------------------
+describe('uninstall.mjs — step 3b skills removal respects --only flag', () => {
+    it('step 3b must reference onlyPlatform to gate per-platform skills removal', () => {
+        // Extract the 3b block: from "3b." to "3c." or "// 4."
+        const start3b = uninstallScript.indexOf('3b.');
+        const end3b = uninstallScript.indexOf('// 4.', start3b);
+        expect(start3b).toBeGreaterThan(-1);
+        const block3b = uninstallScript.slice(start3b, end3b > -1 ? end3b : start3b + 2000);
+        // The block must reference onlyPlatform so it can filter by platform
+        expect(block3b).toMatch(/onlyPlatform|shouldRun|only.*platform/i);
+    });
+
+    it('step 3b defines a platform-to-skills-dir mapping', () => {
+        // After fix, each platform should map to its own skills dir
+        // e.g. claude → .claude/skills, opencode → .config/opencode/skills, etc.
+        const start3b = uninstallScript.indexOf('3b.');
+        const block3b = uninstallScript.slice(start3b, start3b + 2000);
+        // All platform-specific dirs must be present
+        expect(block3b).toMatch(/\.claude.*skills|claude.*\.claude/i);
+        expect(block3b).toMatch(/opencode.*skills|config.*opencode/i);
+        expect(block3b).toMatch(/cursor.*skills/i);
+        expect(block3b).toMatch(/codex.*skills/i);
+        expect(block3b).toMatch(/gemini.*skills/i);
+    });
+
+    it('step 3b only removes .agents/skills when no specific platform is targeted', () => {
+        // .agents/skills is a universal dir — should not be wiped for a single-platform pause
+        const start3b = uninstallScript.indexOf('3b.');
+        const block3b = uninstallScript.slice(start3b, start3b + 2000);
+        // The .agents/skills removal must be guarded by !onlyPlatform or similar
+        const agentsIdx = block3b.indexOf('.agents');
+        expect(agentsIdx).toBeGreaterThan(-1);
+        // Ensure there's a conditional referencing onlyPlatform before .agents removal
+        // (either !onlyPlatform or a ternary where .agents is in the falsy branch)
+        const beforeAgents = block3b.slice(0, agentsIdx);
+        expect(beforeAgents).toMatch(/onlyPlatform/i);
     });
 });

--- a/packages/cli/src/test/pause-resume.test.ts
+++ b/packages/cli/src/test/pause-resume.test.ts
@@ -377,3 +377,29 @@ describe('agenfk resume all', () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// agenfk integration — install/uninstall removed in favour of pause/resume
+// ---------------------------------------------------------------------------
+describe('agenfk integration — install/uninstall removed', () => {
+  it('integration install subcommand no longer exists', () => {
+    const integrationCmd = program.commands.find(c => c.name() === 'integration');
+    expect(integrationCmd).toBeDefined();
+    const subNames = integrationCmd!.commands.map(c => c.name());
+    expect(subNames).not.toContain('install');
+  });
+
+  it('integration uninstall subcommand no longer exists', () => {
+    const integrationCmd = program.commands.find(c => c.name() === 'integration');
+    expect(integrationCmd).toBeDefined();
+    const subNames = integrationCmd!.commands.map(c => c.name());
+    expect(subNames).not.toContain('uninstall');
+  });
+
+  it('integration list subcommand still exists', () => {
+    const integrationCmd = program.commands.find(c => c.name() === 'integration');
+    expect(integrationCmd).toBeDefined();
+    const subNames = integrationCmd!.commands.map(c => c.name());
+    expect(subNames).toContain('list');
+  });
+});

--- a/packages/cli/src/test/pause-resume.test.ts
+++ b/packages/cli/src/test/pause-resume.test.ts
@@ -1,0 +1,379 @@
+/**
+ * TDD tests for agenfk pause / resume commands.
+ * Tests are written first; they will fail until the implementation is in place.
+ *
+ * Covers:
+ *  - getPausedIntegrations() config helper
+ *  - setPausedIntegrations() config helper
+ *  - agenfk pause <platform>
+ *  - agenfk pause all
+ *  - agenfk resume <platform>
+ *  - agenfk resume all
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks — must be declared before any imports that use them
+// ---------------------------------------------------------------------------
+const { mockExistsSync, mockReadFileSync, mockWriteFileSync } = vi.hoisted(() => ({
+  mockExistsSync: vi.fn(),
+  mockReadFileSync: vi.fn(),
+  mockWriteFileSync: vi.fn(),
+}));
+
+const { mockSpawnSync } = vi.hoisted(() => ({
+  mockSpawnSync: vi.fn().mockReturnValue({ status: 0 }),
+}));
+
+const { mockExit } = vi.hoisted(() => ({
+  mockExit: vi.fn(),
+}));
+
+vi.mock('@agenfk/telemetry', () => ({
+  TelemetryClient: vi.fn(function (this: any) {
+    this.capture = vi.fn();
+    this.shutdown = vi.fn().mockResolvedValue(undefined);
+    this.isEnabled = true;
+    this.id = 'test-install-id';
+  }),
+  getInstallationId: vi.fn().mockReturnValue('test-install-id'),
+  isTelemetryEnabled: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock('fs', () => ({
+  existsSync: mockExistsSync,
+  readFileSync: mockReadFileSync,
+  writeFileSync: mockWriteFileSync,
+  mkdirSync: vi.fn(),
+  default: {
+    existsSync: mockExistsSync,
+    readFileSync: mockReadFileSync,
+    writeFileSync: mockWriteFileSync,
+    mkdirSync: vi.fn(),
+  },
+}));
+
+vi.mock('child_process', () => ({
+  execSync: vi.fn(),
+  spawn: vi.fn(),
+  spawnSync: mockSpawnSync,
+  default: { execSync: vi.fn(), spawn: vi.fn(), spawnSync: mockSpawnSync },
+}));
+
+vi.mock('figlet', () => ({
+  default: { textSync: vi.fn().mockReturnValue('AgEnFK') },
+}));
+
+vi.mock('axios');
+
+// Mock process.exit so commands don't terminate the test process
+vi.spyOn(process, 'exit').mockImplementation(mockExit as any);
+
+import { program } from '../index';
+import * as path from 'path';
+import * as os from 'os';
+
+const CONFIG_PATH = path.join(os.homedir(), '.agenfk', 'config.json');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function lastWrittenConfig(): any {
+  const calls = mockWriteFileSync.mock.calls;
+  for (let i = calls.length - 1; i >= 0; i--) {
+    const [filePath, content] = calls[i] as [string, string];
+    if (filePath === CONFIG_PATH) {
+      return JSON.parse(content);
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Config helper: getPausedIntegrations / setPausedIntegrations
+// ---------------------------------------------------------------------------
+describe('getPausedIntegrations config helper', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns [] when config file does not exist', async () => {
+    mockExistsSync.mockReturnValue(false);
+    // Trigger resume all with nothing to pause to exercise the helper
+    await program.parseAsync(['node', 'agenfk', 'resume', 'all', '--yes']);
+    // Should not crash and should not call install (nothing to resume)
+    expect(mockSpawnSync).not.toHaveBeenCalledWith(
+      'node',
+      expect.arrayContaining([expect.stringContaining('install.mjs')]),
+      expect.anything()
+    );
+  });
+
+  it('returns [] when config exists but has no pausedIntegrations field', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(JSON.stringify({ rulesScope: 'global' }));
+    await program.parseAsync(['node', 'agenfk', 'resume', 'all', '--yes']);
+    expect(mockSpawnSync).not.toHaveBeenCalledWith(
+      'node',
+      expect.arrayContaining([expect.stringContaining('install.mjs')]),
+      expect.anything()
+    );
+  });
+});
+
+describe('setPausedIntegrations config helper', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('merges pausedIntegrations into existing config without overwriting other fields', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(JSON.stringify({ rulesScope: 'global', dbPath: '/db' }));
+    mockSpawnSync.mockReturnValue({ status: 0 });
+
+    await program.parseAsync(['node', 'agenfk', 'pause', 'claude', '--yes']);
+
+    const written = lastWrittenConfig();
+    expect(written).not.toBeNull();
+    expect(written.rulesScope).toBe('global');
+    expect(written.dbPath).toBe('/db');
+    expect(written.pausedIntegrations).toContain('claude');
+  });
+
+  it('creates config file if it does not exist when recording paused state', async () => {
+    mockExistsSync.mockReturnValue(false);
+    mockSpawnSync.mockReturnValue({ status: 0 });
+
+    await program.parseAsync(['node', 'agenfk', 'pause', 'claude', '--yes']);
+
+    const written = lastWrittenConfig();
+    expect(written).not.toBeNull();
+    expect(written.pausedIntegrations).toContain('claude');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// agenfk pause <platform>
+// ---------------------------------------------------------------------------
+describe('agenfk pause <platform>', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('is registered as a top-level command on program', () => {
+    const names = program.commands.map(c => c.name());
+    expect(names).toContain('pause');
+  });
+
+  it('calls uninstall.mjs --only=claude when pausing claude', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue('{}');
+    mockSpawnSync.mockReturnValue({ status: 0 });
+
+    await program.parseAsync(['node', 'agenfk', 'pause', 'claude', '--yes']);
+
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      'node',
+      expect.arrayContaining([expect.stringContaining('uninstall.mjs'), '--only=claude']),
+      expect.anything()
+    );
+  });
+
+  it('resolves alias: claude-code → claude', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue('{}');
+    mockSpawnSync.mockReturnValue({ status: 0 });
+
+    await program.parseAsync(['node', 'agenfk', 'pause', 'claude-code', '--yes']);
+
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      'node',
+      expect.arrayContaining(['--only=claude']),
+      expect.anything()
+    );
+  });
+
+  it('adds the platform to pausedIntegrations in config after pausing', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue('{}');
+    mockSpawnSync.mockReturnValue({ status: 0 });
+
+    await program.parseAsync(['node', 'agenfk', 'pause', 'cursor', '--yes']);
+
+    const written = lastWrittenConfig();
+    expect(written.pausedIntegrations).toContain('cursor');
+  });
+
+  it('does not duplicate a platform if it is already in pausedIntegrations', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({ pausedIntegrations: ['cursor'] })
+    );
+    mockSpawnSync.mockReturnValue({ status: 0 });
+
+    await program.parseAsync(['node', 'agenfk', 'pause', 'cursor', '--yes']);
+
+    const written = lastWrittenConfig();
+    const count = written.pausedIntegrations.filter((p: string) => p === 'cursor').length;
+    expect(count).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// agenfk pause all
+// ---------------------------------------------------------------------------
+describe('agenfk pause all', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls uninstall.mjs for every supported platform', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue('{}');
+    mockSpawnSync.mockReturnValue({ status: 0 });
+
+    await program.parseAsync(['node', 'agenfk', 'pause', 'all', '--yes']);
+
+    const platforms = ['claude', 'opencode', 'cursor', 'codex', 'gemini'];
+    for (const p of platforms) {
+      expect(mockSpawnSync).toHaveBeenCalledWith(
+        'node',
+        expect.arrayContaining([`--only=${p}`]),
+        expect.anything()
+      );
+    }
+  });
+
+  it('records all platforms in pausedIntegrations', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue('{}');
+    mockSpawnSync.mockReturnValue({ status: 0 });
+
+    await program.parseAsync(['node', 'agenfk', 'pause', 'all', '--yes']);
+
+    const written = lastWrittenConfig();
+    expect(written.pausedIntegrations).toEqual(
+      expect.arrayContaining(['claude', 'opencode', 'cursor', 'codex', 'gemini'])
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// agenfk resume <platform>
+// ---------------------------------------------------------------------------
+describe('agenfk resume <platform>', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('is registered as a top-level command on program', () => {
+    const names = program.commands.map(c => c.name());
+    expect(names).toContain('resume');
+  });
+
+  it('calls install.mjs --only=claude when resuming a paused claude integration', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({ pausedIntegrations: ['claude'] })
+    );
+    mockSpawnSync.mockReturnValue({ status: 0 });
+
+    await program.parseAsync(['node', 'agenfk', 'resume', 'claude', '--yes']);
+
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      'node',
+      expect.arrayContaining([expect.stringContaining('install.mjs'), '--only=claude']),
+      expect.anything()
+    );
+  });
+
+  it('removes the platform from pausedIntegrations after resuming', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({ pausedIntegrations: ['claude', 'cursor'] })
+    );
+    mockSpawnSync.mockReturnValue({ status: 0 });
+
+    await program.parseAsync(['node', 'agenfk', 'resume', 'claude', '--yes']);
+
+    const written = lastWrittenConfig();
+    expect(written.pausedIntegrations).not.toContain('claude');
+    expect(written.pausedIntegrations).toContain('cursor');
+  });
+
+  it('passes rulesScope from config to install.mjs', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({ pausedIntegrations: ['opencode'], rulesScope: 'project' })
+    );
+    mockSpawnSync.mockReturnValue({ status: 0 });
+
+    await program.parseAsync(['node', 'agenfk', 'resume', 'opencode', '--yes']);
+
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      'node',
+      expect.arrayContaining(['--rules-scope=project']),
+      expect.anything()
+    );
+  });
+
+  it('does not call install.mjs when the platform is not currently paused', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({ pausedIntegrations: ['cursor'] })
+    );
+
+    await program.parseAsync(['node', 'agenfk', 'resume', 'claude', '--yes']);
+
+    expect(mockSpawnSync).not.toHaveBeenCalledWith(
+      'node',
+      expect.arrayContaining([expect.stringContaining('install.mjs')]),
+      expect.anything()
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// agenfk resume all
+// ---------------------------------------------------------------------------
+describe('agenfk resume all', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('resumes all currently paused integrations', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({ pausedIntegrations: ['claude', 'cursor'] })
+    );
+    mockSpawnSync.mockReturnValue({ status: 0 });
+
+    await program.parseAsync(['node', 'agenfk', 'resume', 'all', '--yes']);
+
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      'node',
+      expect.arrayContaining(['--only=claude']),
+      expect.anything()
+    );
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      'node',
+      expect.arrayContaining(['--only=cursor']),
+      expect.anything()
+    );
+  });
+
+  it('clears pausedIntegrations after resuming all', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({ pausedIntegrations: ['claude', 'cursor'] })
+    );
+    mockSpawnSync.mockReturnValue({ status: 0 });
+
+    await program.parseAsync(['node', 'agenfk', 'resume', 'all', '--yes']);
+
+    const written = lastWrittenConfig();
+    expect(written.pausedIntegrations).toEqual([]);
+  });
+
+  it('does not call install.mjs when nothing is paused', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(JSON.stringify({ pausedIntegrations: [] }));
+
+    await program.parseAsync(['node', 'agenfk', 'resume', 'all', '--yes']);
+
+    expect(mockSpawnSync).not.toHaveBeenCalledWith(
+      'node',
+      expect.arrayContaining([expect.stringContaining('install.mjs')]),
+      expect.anything()
+    );
+  });
+});

--- a/packages/cli/src/test/upgrade-tier.test.ts
+++ b/packages/cli/src/test/upgrade-tier.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Tests for CLI startup tier enforcement (Story 2).
+ *
+ * The CLI should check the upgrade tier at startup (with a local cache, ~1h TTL).
+ * - mandatory tier: print error and exit(1), blocking all commands
+ * - recommended tier: print banner, continue normally
+ * - optional/absent: silent
+ *
+ * All tests are intentionally failing until the feature is implemented.
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const CLI_PATH = path.resolve(__dirname, '../../src/index.ts');
+const readCli = () => (fs.existsSync(CLI_PATH) ? fs.readFileSync(CLI_PATH, 'utf8') : '');
+
+// ── Startup tier check function ───────────────────────────────────────────────
+
+describe('CLI startup — upgrade tier check function', () => {
+  it('should define a startup upgrade tier check function', () => {
+    const cli = readCli();
+    expect(cli).toMatch(/checkUpgradeTier|checkTierOnStartup|startupTierCheck|tierCheck/i);
+  });
+
+  it('should call the tier check function before processing commands', () => {
+    const cli = readCli();
+    // The tier check must be invoked in the main execution path, before command dispatch
+    const tierCheckIdx = cli.search(/checkUpgradeTier|checkTierOnStartup|startupTierCheck/i);
+    const parseIdx = cli.search(/program\.parseAsync|program\.parse\b/);
+    expect(tierCheckIdx).toBeGreaterThan(-1);
+    expect(parseIdx).toBeGreaterThan(-1);
+    expect(tierCheckIdx).toBeLessThan(parseIdx);
+  });
+});
+
+// ── Upgrade tier cache ────────────────────────────────────────────────────────
+
+describe('CLI startup — upgrade tier cache', () => {
+  it('should write the tier check result to a local cache file', () => {
+    const cli = readCli();
+    expect(cli).toMatch(/upgrade.*cache|tier.*cache|cache.*tier|upgradeCache|tierCache/i);
+  });
+
+  it('should use a cache TTL of approximately 1 hour', () => {
+    const cli = readCli();
+    // 1 hour in ms = 3600000 or expressed as 60 * 60 * 1000
+    expect(cli).toMatch(/3600000|60\s*\*\s*60\s*\*\s*1000|1.*hour.*TTL|TTL.*hour/i);
+  });
+
+  it('should store the cache in the .agenfk directory or home directory', () => {
+    const cli = readCli();
+    expect(cli).toMatch(/\.agenfk|agenfk.*cache|homedir.*agenfk/i);
+  });
+
+  it('should skip the remote fetch and use cached data within the TTL window', () => {
+    const cli = readCli();
+    // Must have a condition that reads from cache if not expired
+    expect(cli).toMatch(/fetchedAt|cachedAt|cacheTime|Date\.now.*TTL|TTL.*Date\.now/i);
+  });
+});
+
+// ── Mandatory tier enforcement ────────────────────────────────────────────────
+
+describe('CLI startup — mandatory tier blocks all commands', () => {
+  it('should call process.exit(1) when the mandatory tier is detected', () => {
+    const cli = readCli();
+    const tierCheckStart = cli.search(/checkUpgradeTier|checkTierOnStartup|startupTierCheck/i);
+    const tierSection = cli.slice(tierCheckStart, tierCheckStart + 3000);
+    expect(tierSection).toMatch(/mandatory/i);
+    expect(tierSection).toMatch(/process\.exit\(1\)/);
+  });
+
+  it('should print a prominent error message for mandatory upgrades', () => {
+    const cli = readCli();
+    const tierCheckStart = cli.search(/checkUpgradeTier|checkTierOnStartup|startupTierCheck/i);
+    const tierSection = cli.slice(tierCheckStart, tierCheckStart + 3000);
+    // Must output a visible error (chalk red, console.error, or similar)
+    expect(tierSection).toMatch(/MANDATORY|mandatory.*upgrade|upgrade.*required|must upgrade/i);
+  });
+
+  it('should show the upgrade command to run in the mandatory error message', () => {
+    const cli = readCli();
+    const tierCheckStart = cli.search(/checkUpgradeTier|checkTierOnStartup|startupTierCheck/i);
+    const tierSection = cli.slice(tierCheckStart, tierCheckStart + 3000);
+    expect(tierSection).toMatch(/agenfk upgrade/i);
+  });
+});
+
+// ── Recommended tier banner ───────────────────────────────────────────────────
+
+describe('CLI startup — recommended tier shows banner', () => {
+  it('should print a banner (not exit) for recommended tier', () => {
+    const cli = readCli();
+    // Find the apply/action function that handles tier enforcement
+    const actionStart = cli.search(/applyUpgradeTierAction|function applyTier/i);
+    const funcSection = actionStart >= 0
+      ? cli.slice(actionStart, actionStart + 1500)
+      : cli.slice(cli.search(/checkUpgradeTier/i), cli.search(/checkUpgradeTier/i) + 4000);
+    expect(funcSection).toMatch(/recommended/i);
+    // process.exit(1) must appear at most once (only in the mandatory branch)
+    // and must NOT appear in the recommended conditional block
+    const exitCount = (funcSection.match(/process\.exit\(1\)/g) || []).length;
+    expect(exitCount).toBeLessThanOrEqual(1);
+    // The recommended block itself must not call exit
+    const recBlockMatch = funcSection.match(/(?:else\s+if|===\s*['"]recommended['"])[\s\S]{0,400}/);
+    if (recBlockMatch) {
+      expect(recBlockMatch[0]).not.toMatch(/process\.exit\(1\)/);
+    }
+  });
+
+  it('should print a banner message suggesting the upgrade for recommended tier', () => {
+    const cli = readCli();
+    const tierCheckStart = cli.search(/checkUpgradeTier|checkTierOnStartup|startupTierCheck/i);
+    const tierSection = cli.slice(tierCheckStart, tierCheckStart + 3000);
+    expect(tierSection).toMatch(/recommended.*upgrade|upgrade.*recommended|new.*version.*available/i);
+  });
+});
+
+// ── Optional tier ─────────────────────────────────────────────────────────────
+
+describe('CLI startup — optional tier is silent', () => {
+  it('should not exit or print a banner for optional/absent tier', () => {
+    const cli = readCli();
+    const tierCheckStart = cli.search(/checkUpgradeTier|checkTierOnStartup|startupTierCheck/i);
+    const tierSection = cli.slice(tierCheckStart, tierCheckStart + 3000);
+    // The optional branch must exist (handles the default case)
+    expect(tierSection).toMatch(/optional|else\s*\{|default:/i);
+  });
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/core",
-  "version": "0.2.22",
+  "version": "0.2.23-beta.1",
   "description": "Core logic and interfaces for the AgenFK Engineering Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "0.2.22",
+  "version": "0.2.23-beta.1",
   "description": "AgenFK Agentic Engineering Framework — installer",
   "bin": {
     "agenfk": "bin/agenfk.js"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/server",
-  "version": "0.2.22",
+  "version": "0.2.23-beta.1",
   "description": "MCP Server for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -498,7 +498,33 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
   };
 });
 
-server.setRequestHandler(CallToolRequestSchema, async (request: any) => {
+// ── MCP upgrade notice ────────────────────────────────────────────────────────
+
+let mcpUpgradeNoticeCache: { text: string; fetchedAt: number } | null = null;
+const MCP_UPGRADE_NOTICE_TTL = 15 * 60 * 1000;
+
+async function getUpgradeNotice(): Promise<string> {
+  if (mcpUpgradeNoticeCache && (Date.now() - mcpUpgradeNoticeCache.fetchedAt) < MCP_UPGRADE_NOTICE_TTL) {
+    return mcpUpgradeNoticeCache.text;
+  }
+  try {
+    const resp = await axios.get(`${API_URL}/releases/latest`, { timeout: 2000 });
+    const tier: string = resp.data?.upgradeTier ?? 'optional';
+    const version: string = resp.data?.version ?? '';
+    let text = '';
+    if (tier === 'mandatory') {
+      text = `\n\n⛔ **MANDATORY UPGRADE REQUIRED**: AgEnFK v${version} must be installed before continuing. Run \`agenfk upgrade\`.`;
+    } else if (tier === 'recommended') {
+      text = `\n\n⚠️ Recommended upgrade available: AgEnFK v${version}. Run \`agenfk upgrade\` when convenient.`;
+    }
+    mcpUpgradeNoticeCache = { text, fetchedAt: Date.now() };
+    return text;
+  } catch {
+    return '';
+  }
+}
+
+async function callToolHandler(request: any): Promise<any> {
   try {
     switch (request.params.name) {
       case "list_projects": {
@@ -937,6 +963,27 @@ server.setRequestHandler(CallToolRequestSchema, async (request: any) => {
     else if (error.code === 'ECONNREFUSED') errorMessage = `Could not connect to AgEnFK API at ${API_URL}.`;
     return { content: [{ type: "text", text: `❌ Error: ${errorMessage}` }], isError: true };
   }
+}
+
+server.setRequestHandler(CallToolRequestSchema, async (request: any) => {
+  const [result, upgradeNotice] = await Promise.all([
+    callToolHandler(request),
+    getUpgradeNotice(),
+  ]);
+  // Append upgrade notice to successful (non-error) responses
+  if (upgradeNotice && result && !result.isError && Array.isArray(result.content)) {
+    const last = result.content[result.content.length - 1];
+    if (last?.type === 'text') {
+      return {
+        ...result,
+        content: [
+          ...result.content.slice(0, -1),
+          { type: 'text', text: last.text + upgradeNotice },
+        ],
+      };
+    }
+  }
+  return result;
 });
 
 async function run() {

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -2087,6 +2087,7 @@ app.post("/github/import", async (req: any, res: any) => {
 
 let releaseCache: { data: any; fetchedAt: number } | null = null;
 const RELEASE_CACHE_TTL = 15 * 60 * 1000; // 15 minutes
+export const clearReleaseCache = (): void => { releaseCache = null; };
 
 const getCurrentVersion = (): string => {
   try {
@@ -2194,13 +2195,28 @@ app.get("/releases/latest", asyncHandler(async (_req: any, res: any) => {
 
   try {
     const { data } = await axios.get(`https://api.github.com/repos/${repo}/releases/latest`, { headers });
+    const tagName: string = data.tag_name;
+
+    // Fetch upgradeTier from the raw CLI package.json for this tag
+    let upgradeTier: 'mandatory' | 'recommended' | 'optional' = 'optional';
+    try {
+      const rawUrl = `https://raw.githubusercontent.com/${repo}/${tagName}/packages/cli/package.json`;
+      const { data: cliPkg } = await axios.get(rawUrl, { timeout: 5000 });
+      if (cliPkg?.agenfkUpgradeTier === 'mandatory' || cliPkg?.agenfkUpgradeTier === 'recommended') {
+        upgradeTier = cliPkg.agenfkUpgradeTier;
+      }
+    } catch {
+      // If fetch fails, default to optional — non-fatal
+    }
+
     const releaseData = {
-      version: data.tag_name.replace(/^v/, ''),
-      tagName: data.tag_name,
+      version: tagName.replace(/^v/, ''),
+      tagName,
       name: data.name,
       body: data.body || '',
       publishedAt: data.published_at,
       url: data.html_url,
+      upgradeTier,
     };
     releaseCache = { data: releaseData, fetchedAt: Date.now() };
     res.json({ ...releaseData, currentVersion });

--- a/packages/server/src/test/upgrade-tier.test.ts
+++ b/packages/server/src/test/upgrade-tier.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Tests for the upgrade tier feature (Stories 1 & 3).
+ *
+ * Story 1: upgradeTier field in packages/cli/package.json + server enrichment
+ * Story 3: MCP response augmentation for pending mandatory/recommended upgrades
+ *
+ * All tests are intentionally failing until the feature is implemented.
+ */
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
+import request from 'supertest';
+import { app, initStorage, clearReleaseCache } from '../server';
+import * as fs from 'fs';
+import * as path from 'path';
+
+vi.mock('axios', () => {
+  const mockAxios = vi.fn() as any;
+  mockAxios.get = vi.fn();
+  mockAxios.post = vi.fn();
+  return { default: mockAxios };
+});
+
+const TEST_DB = path.resolve('./upgrade-tier-test-db.sqlite');
+const CLI_PKG_PATH = path.resolve(__dirname, '../../../cli/package.json');
+const SERVER_PATH = path.resolve(__dirname, '../server.ts');
+const MCP_INDEX_PATH = path.resolve(__dirname, '../index.ts');
+
+beforeAll(async () => {
+  process.env.AGENFK_DB_PATH = TEST_DB;
+  if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+  await initStorage();
+});
+
+afterAll(() => {
+  if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  clearReleaseCache();
+});
+
+// ── Story 1: upgradeTier field in packages/cli/package.json ──────────────────
+
+describe('packages/cli/package.json — upgradeTier field', () => {
+  it('should have an "agenfkUpgradeTier" field', () => {
+    const pkg = JSON.parse(fs.readFileSync(CLI_PKG_PATH, 'utf8'));
+    expect(pkg).toHaveProperty('agenfkUpgradeTier');
+  });
+
+  it('agenfkUpgradeTier value should be "mandatory" or "recommended" (not optional — that is the default)', () => {
+    // A published package.json with the field set should be "mandatory" or "recommended"
+    // "optional" is the default (field absent) so it need not be set explicitly
+    const pkg = JSON.parse(fs.readFileSync(CLI_PKG_PATH, 'utf8'));
+    if (pkg.agenfkUpgradeTier !== undefined) {
+      expect(['mandatory', 'recommended']).toContain(pkg.agenfkUpgradeTier);
+    }
+  });
+});
+
+// ── Story 1: Server fetches upgradeTier from GitHub raw content ───────────────
+
+describe('server.ts — upgradeTier source code', () => {
+  const readServer = () => fs.readFileSync(SERVER_PATH, 'utf8');
+
+  it('should fetch the raw CLI package.json from GitHub for the latest tag', () => {
+    const src = readServer();
+    expect(src).toMatch(/raw\.githubusercontent\.com|api\.github\.com.*contents.*package\.json/);
+  });
+
+  it('should extract agenfkUpgradeTier from the fetched package.json', () => {
+    const src = readServer();
+    expect(src).toMatch(/agenfkUpgradeTier/);
+  });
+
+  it('should default upgradeTier to "optional" when the field is absent', () => {
+    const src = readServer();
+    // Code must handle the absent case and fall back to "optional"
+    expect(src).toMatch(/upgradeTier.*optional|optional.*upgradeTier|\?\?.*['"']optional['"']/);
+  });
+});
+
+// ── Story 1: GET /releases/latest returns upgradeTier ────────────────────────
+
+describe('GET /releases/latest — upgradeTier in response', () => {
+  it('returns upgradeTier: "optional" when field is absent from the fetched package.json', async () => {
+    const axios = (await import('axios')).default as any;
+    // First call: GitHub releases API
+    axios.get.mockResolvedValueOnce({
+      data: {
+        tag_name: 'v1.2.3',
+        name: 'Release 1.2.3',
+        body: 'Notes',
+        published_at: '2026-01-01T00:00:00Z',
+        html_url: 'https://github.com/example/repo/releases/tag/v1.2.3',
+      }
+    });
+    // Second call: raw package.json for that tag (field absent → optional)
+    axios.get.mockResolvedValueOnce({
+      data: { name: '@agenfk/cli', version: '1.2.3' }
+    });
+    const res = await request(app).get('/releases/latest');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('upgradeTier');
+    expect(res.body.upgradeTier).toBe('optional');
+  });
+
+  it('returns upgradeTier: "mandatory" when field is set to "mandatory" in the fetched package.json', async () => {
+    const axios = (await import('axios')).default as any;
+    axios.get.mockResolvedValueOnce({
+      data: {
+        tag_name: 'v2.0.0',
+        name: 'Release 2.0.0',
+        body: 'Breaking change',
+        published_at: '2026-02-01T00:00:00Z',
+        html_url: 'https://github.com/example/repo/releases/tag/v2.0.0',
+      }
+    });
+    axios.get.mockResolvedValueOnce({
+      data: { name: '@agenfk/cli', version: '2.0.0', agenfkUpgradeTier: 'mandatory' }
+    });
+    const res = await request(app).get('/releases/latest');
+    expect(res.status).toBe(200);
+    expect(res.body.upgradeTier).toBe('mandatory');
+  });
+
+  it('returns upgradeTier: "recommended" when field is set to "recommended"', async () => {
+    const axios = (await import('axios')).default as any;
+    axios.get.mockResolvedValueOnce({
+      data: {
+        tag_name: 'v1.5.0',
+        name: 'Release 1.5.0',
+        body: '',
+        published_at: '2026-01-15T00:00:00Z',
+        html_url: 'https://github.com/example/repo/releases/tag/v1.5.0',
+      }
+    });
+    axios.get.mockResolvedValueOnce({
+      data: { name: '@agenfk/cli', version: '1.5.0', agenfkUpgradeTier: 'recommended' }
+    });
+    const res = await request(app).get('/releases/latest');
+    expect(res.status).toBe(200);
+    expect(res.body.upgradeTier).toBe('recommended');
+  });
+
+  it('still returns 200 with upgradeTier: "optional" when the raw package.json fetch fails', async () => {
+    const axios = (await import('axios')).default as any;
+    axios.get.mockResolvedValueOnce({
+      data: {
+        tag_name: 'v1.3.0',
+        name: 'Release 1.3.0',
+        body: '',
+        published_at: '2026-01-20T00:00:00Z',
+        html_url: 'https://github.com/example/repo/releases/tag/v1.3.0',
+      }
+    });
+    // Second call fails (network error)
+    axios.get.mockRejectedValueOnce(new Error('Network Error'));
+    const res = await request(app).get('/releases/latest');
+    expect(res.status).toBe(200);
+    expect(res.body.upgradeTier).toBe('optional');
+  });
+});
+
+// ── Story 4: ReleaseReminder.tsx — source analysis ───────────────────────────
+
+const RELEASE_REMINDER_PATH = path.resolve(__dirname, '../../../ui/src/components/ReleaseReminder.tsx');
+const readReleaseReminder = () =>
+  fs.existsSync(RELEASE_REMINDER_PATH) ? fs.readFileSync(RELEASE_REMINDER_PATH, 'utf8') : '';
+
+describe('ReleaseReminder.tsx — ReleaseInfo interface', () => {
+  it('should include upgradeTier in the ReleaseInfo interface', () => {
+    expect(readReleaseReminder()).toMatch(/upgradeTier/);
+  });
+
+  it('should type upgradeTier as "mandatory" | "recommended"', () => {
+    const src = readReleaseReminder();
+    expect(src).toMatch(/mandatory/);
+    expect(src).toMatch(/recommended/);
+  });
+});
+
+describe('ReleaseReminder.tsx — mandatory tier styling (source)', () => {
+  it('should apply red styling for mandatory tier', () => {
+    expect(readReleaseReminder()).toMatch(/mandatory.*red|red.*mandatory/i);
+  });
+
+  it('should hide or disable the Dismiss button for mandatory tier', () => {
+    expect(readReleaseReminder()).toMatch(/isMandatory.*[Dd]ismiss|[Dd]ismiss.*isMandatory|!isMandatory/i);
+  });
+});
+
+describe('ReleaseReminder.tsx — recommended tier styling (source)', () => {
+  it('should apply yellow/amber styling for recommended tier', () => {
+    expect(readReleaseReminder()).toMatch(/recommended.*yellow|yellow.*recommended|amber.*recommended|recommended.*amber/i);
+  });
+});
+
+// ── Story 3: MCP response augmentation ───────────────────────────────────────
+
+describe('index.ts — MCP upgrade notice augmentation', () => {
+  const readIndex = () => fs.readFileSync(MCP_INDEX_PATH, 'utf8');
+
+  it('should check upgradeTier before returning MCP tool responses', () => {
+    const src = readIndex();
+    expect(src).toMatch(/upgradeTier/);
+  });
+
+  it('should append a mandatory upgrade notice to MCP responses when tier is mandatory', () => {
+    const src = readIndex();
+    // Must contain logic that adds an upgrade warning for mandatory tier
+    expect(src).toMatch(/mandatory.*upgrade|upgrade.*mandatory/i);
+  });
+
+  it('should append a recommended upgrade notice to MCP responses when tier is recommended', () => {
+    const src = readIndex();
+    expect(src).toMatch(/recommended.*upgrade|upgrade.*recommended/i);
+  });
+
+  it('should include the upgrade notice text in MCP tool response content', () => {
+    const src = readIndex();
+    // The notice must be appended to the response content (not just logged)
+    expect(src).toMatch(/upgradeNotice|upgrade_notice|⚠️.*upgrade|UPGRADE REQUIRED/i);
+  });
+});

--- a/packages/storage-sqlite/package.json
+++ b/packages/storage-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/storage-sqlite",
-  "version": "0.2.22",
+  "version": "0.2.23-beta.1",
   "description": "SQLite storage implementation for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/telemetry",
-  "version": "0.2.22",
+  "version": "0.2.23-beta.1",
   "description": "Anonymous telemetry client for AgenFK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "0.2.22",
+  "version": "0.2.23-beta.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/ui/src/components/ReleaseReminder.tsx
+++ b/packages/ui/src/components/ReleaseReminder.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { api } from '../api';
-import { Rocket, X, ExternalLink, ArrowUpCircle, Loader2, CheckCircle, XCircle, RefreshCw } from 'lucide-react';
+import { Rocket, AlertTriangle, X, ExternalLink, ArrowUpCircle, Loader2, CheckCircle, XCircle, RefreshCw } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
@@ -16,6 +16,7 @@ interface ReleaseInfo {
   publishedAt: string;
   url: string;
   currentVersion: string;
+  upgradeTier?: 'mandatory' | 'recommended' | 'optional';
 }
 
 type UpdateState =
@@ -95,7 +96,11 @@ export const ReleaseReminder: React.FC = () => {
     return null;
   }
 
-  if (isDismissed === release.version) {
+  const tier = release.upgradeTier ?? 'optional';
+  const isMandatory = tier === 'mandatory';
+  const isRecommended = tier === 'recommended';
+
+  if (!isMandatory && isDismissed === release.version) {
     return null;
   }
 
@@ -179,13 +184,19 @@ export const ReleaseReminder: React.FC = () => {
     <>
       <button
         onClick={() => setIsModalOpen(true)}
-        className="relative p-2 bg-emerald-50 dark:bg-emerald-900/20 rounded-lg text-emerald-600 dark:text-emerald-400 border border-emerald-200 dark:border-emerald-800 shadow-sm transition-all hover:bg-emerald-100 dark:hover:bg-emerald-900/40 hover:scale-105"
-        title={`New release available: v${release.version}`}
+        className={`relative p-2 rounded-lg border shadow-sm transition-all hover:scale-105 ${
+          isMandatory
+            ? 'bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-400 border-red-200 dark:border-red-800 hover:bg-red-100 dark:hover:bg-red-900/40'
+            : isRecommended
+            ? 'bg-yellow-50 dark:bg-yellow-900/20 text-yellow-600 dark:text-yellow-400 border-yellow-200 dark:border-yellow-800 hover:bg-yellow-100 dark:hover:bg-yellow-900/40'
+            : 'bg-emerald-50 dark:bg-emerald-900/20 text-emerald-600 dark:text-emerald-400 border-emerald-200 dark:border-emerald-800 hover:bg-emerald-100 dark:hover:bg-emerald-900/40'
+        }`}
+        title={isMandatory ? `Mandatory upgrade required: v${release.version}` : `New release available: v${release.version}`}
       >
-        <Rocket size={18} />
+        {isMandatory ? <AlertTriangle size={18} /> : <Rocket size={18} />}
         <span className="absolute -top-1 -right-1 flex h-3 w-3">
-          <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75"></span>
-          <span className="relative inline-flex rounded-full h-3 w-3 bg-emerald-500"></span>
+          <span className={`animate-ping absolute inline-flex h-full w-full rounded-full opacity-75 ${isMandatory ? 'bg-red-400' : isRecommended ? 'bg-yellow-400' : 'bg-emerald-400'}`}></span>
+          <span className={`relative inline-flex rounded-full h-3 w-3 ${isMandatory ? 'bg-red-500' : isRecommended ? 'bg-yellow-500' : 'bg-emerald-500'}`}></span>
         </span>
       </button>
 
@@ -201,14 +212,19 @@ export const ReleaseReminder: React.FC = () => {
             {/* Header */}
             <div className="flex items-center justify-between px-6 py-4 border-b border-slate-100 dark:border-slate-800 shrink-0">
               <div className="flex items-center gap-3">
-                <div className="p-2 bg-emerald-50 dark:bg-emerald-900/20 rounded-lg">
-                  <Rocket size={20} className="text-emerald-600 dark:text-emerald-400" />
+                <div className={`p-2 rounded-lg ${isMandatory ? 'bg-red-50 dark:bg-red-900/20' : isRecommended ? 'bg-yellow-50 dark:bg-yellow-900/20' : 'bg-emerald-50 dark:bg-emerald-900/20'}`}>
+                  {isMandatory
+                    ? <AlertTriangle size={20} className="text-red-600 dark:text-red-400" />
+                    : <Rocket size={20} className={isRecommended ? 'text-yellow-600 dark:text-yellow-400' : 'text-emerald-600 dark:text-emerald-400'} />
+                  }
                 </div>
                 <div>
                   <h2 className="font-bold text-slate-800 dark:text-slate-100 text-lg">
                     {updateState.phase === 'success' ? 'Update Complete' :
                      updateState.phase === 'error' ? 'Update Failed' :
                      updateState.phase === 'running' ? 'Updating AgEnFK...' :
+                     isMandatory ? 'Mandatory Upgrade Required' :
+                     isRecommended ? 'Recommended Upgrade Available' :
                      'New Release Available'}
                   </h2>
                   <p className="text-xs text-slate-500 dark:text-slate-400">
@@ -320,12 +336,15 @@ export const ReleaseReminder: React.FC = () => {
                 </>
               ) : (
                 <>
-                  <button
-                    onClick={handleDismiss}
-                    className="text-sm text-slate-500 hover:text-slate-700 dark:hover:text-slate-300 font-medium transition-colors"
-                  >
-                    Dismiss
-                  </button>
+                  {!isMandatory && (
+                    <button
+                      onClick={handleDismiss}
+                      className="text-sm text-slate-500 hover:text-slate-700 dark:hover:text-slate-300 font-medium transition-colors"
+                    >
+                      Dismiss
+                    </button>
+                  )}
+                  {isMandatory && <span />}
                   <div className="flex items-center gap-3">
                     <a
                       href={release.url}
@@ -338,10 +357,14 @@ export const ReleaseReminder: React.FC = () => {
                     </a>
                     <button
                       onClick={handleUpdateNow}
-                      className="flex items-center gap-2 bg-emerald-600 hover:bg-emerald-700 text-white px-4 py-2 rounded-lg font-semibold text-sm shadow-sm transition-all active:scale-95"
+                      className={`flex items-center gap-2 text-white px-4 py-2 rounded-lg font-semibold text-sm shadow-sm transition-all active:scale-95 ${
+                        isMandatory
+                          ? 'bg-red-600 hover:bg-red-700'
+                          : 'bg-emerald-600 hover:bg-emerald-700'
+                      }`}
                     >
                       <ArrowUpCircle size={16} />
-                      Update Now
+                      {isMandatory ? 'Upgrade Now (Required)' : 'Update Now'}
                     </button>
                   </div>
                 </>

--- a/packages/ui/src/test/upgrade-tier.test.tsx
+++ b/packages/ui/src/test/upgrade-tier.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Component render tests for the UI tier-aware upgrade banner in ReleaseReminder (Story 4).
+ *
+ * - mandatory tier: renders urgent banner, no Dismiss button
+ * - recommended tier: renders with available styling, Dismiss present
+ * - optional/absent: existing green behavior
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ThemeProvider } from '../ThemeContext';
+
+vi.mock('../api', () => ({
+  api: {
+    getLatestRelease: vi.fn(),
+    triggerUpdate: vi.fn(),
+    getUpdateStatus: vi.fn(),
+  },
+}));
+
+vi.mock('react-markdown', () => ({
+  default: ({ children }: { children: string }) => <span>{children}</span>,
+}));
+
+vi.mock('remark-gfm', () => ({ default: () => {} }));
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, val: string) => { store[key] = val; },
+    removeItem: (key: string) => { delete store[key]; },
+    clear: () => { store = {}; },
+  };
+})();
+Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  localStorageMock.clear();
+});
+
+const makeWrapper = () => {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={qc}>
+      <ThemeProvider>{children}</ThemeProvider>
+    </QueryClientProvider>
+  );
+};
+
+// ── Mandatory tier ────────────────────────────────────────────────────────────
+
+describe('ReleaseReminder — mandatory tier renders urgent banner', () => {
+  it('should render a button when a mandatory upgrade is available', async () => {
+    const { api } = await import('../api');
+    (api.getLatestRelease as ReturnType<typeof vi.fn>).mockResolvedValue({
+      version: '9.9.9',
+      tagName: 'v9.9.9',
+      name: 'Critical Update',
+      body: 'Breaking changes require this update.',
+      publishedAt: '2026-01-01T00:00:00Z',
+      url: 'https://github.com/example/releases/v9.9.9',
+      currentVersion: '1.0.0',
+      upgradeTier: 'mandatory',
+    });
+
+    const { ReleaseReminder } = await import('../components/ReleaseReminder');
+    render(<ReleaseReminder />, { wrapper: makeWrapper() });
+    await new Promise(r => setTimeout(r, 50));
+    const buttons = screen.queryAllByRole('button');
+    expect(buttons.length).toBeGreaterThan(0);
+  });
+
+  it('should not render a Dismiss option for mandatory upgrades', async () => {
+    const { api } = await import('../api');
+    (api.getLatestRelease as ReturnType<typeof vi.fn>).mockResolvedValue({
+      version: '9.9.9',
+      tagName: 'v9.9.9',
+      name: 'Critical Update',
+      body: 'Breaking changes.',
+      publishedAt: '2026-01-01T00:00:00Z',
+      url: 'https://github.com/example/releases/v9.9.9',
+      currentVersion: '1.0.0',
+      upgradeTier: 'mandatory',
+    });
+
+    const { ReleaseReminder } = await import('../components/ReleaseReminder');
+    render(<ReleaseReminder />, { wrapper: makeWrapper() });
+    await new Promise(r => setTimeout(r, 50));
+
+    const buttons = screen.queryAllByRole('button');
+    if (buttons.length > 0) buttons[0].click();
+    await new Promise(r => setTimeout(r, 50));
+
+    const dismissBtn = screen.queryByText(/dismiss/i);
+    expect(dismissBtn).toBeNull();
+  });
+
+  it('should not be dismissible — re-renders even if previously dismissed version matches', async () => {
+    localStorageMock.setItem('agenfk_dismissed_release', '9.9.9');
+    const { api } = await import('../api');
+    (api.getLatestRelease as ReturnType<typeof vi.fn>).mockResolvedValue({
+      version: '9.9.9',
+      tagName: 'v9.9.9',
+      name: 'Critical Update',
+      body: 'Breaking changes.',
+      publishedAt: '2026-01-01T00:00:00Z',
+      url: 'https://github.com/example/releases/v9.9.9',
+      currentVersion: '1.0.0',
+      upgradeTier: 'mandatory',
+    });
+
+    const { ReleaseReminder } = await import('../components/ReleaseReminder');
+    render(<ReleaseReminder />, { wrapper: makeWrapper() });
+    await new Promise(r => setTimeout(r, 50));
+    // Should still render despite dismissed version matching — mandatory ignores dismiss
+    const buttons = screen.queryAllByRole('button');
+    expect(buttons.length).toBeGreaterThan(0);
+  });
+});
+
+// ── Recommended tier ──────────────────────────────────────────────────────────
+
+describe('ReleaseReminder — recommended tier renders', () => {
+  it('should render when a recommended upgrade is available', async () => {
+    const { api } = await import('../api');
+    (api.getLatestRelease as ReturnType<typeof vi.fn>).mockResolvedValue({
+      version: '2.0.0',
+      tagName: 'v2.0.0',
+      name: 'Recommended Update',
+      body: 'Improvements and fixes.',
+      publishedAt: '2026-01-01T00:00:00Z',
+      url: 'https://github.com/example/releases/v2.0.0',
+      currentVersion: '1.0.0',
+      upgradeTier: 'recommended',
+    });
+
+    const { ReleaseReminder } = await import('../components/ReleaseReminder');
+    render(<ReleaseReminder />, { wrapper: makeWrapper() });
+    await new Promise(r => setTimeout(r, 50));
+    const buttons = screen.queryAllByRole('button');
+    expect(buttons.length).toBeGreaterThan(0);
+  });
+});

--- a/scripts/uninstall.mjs
+++ b/scripts/uninstall.mjs
@@ -152,17 +152,24 @@ async function run() {
         }
     }
 
-    // 3b. Skills (new skills/<name>/SKILL.md format) — all platforms
+    // 3b. Skills (new skills/<name>/SKILL.md format)
+    // When --only=<platform> is set, only remove that platform's skills dir.
+    // The universal shared skills dir is only wiped on full uninstall (no --only flag).
     {
-        console.log(`${GREEN}[3b/10] Removing agenfk skills (all platforms)...${NC}`);
-        const skillsDirs = [
-            path.join(os.homedir(), '.claude', 'skills'),
-            path.join(os.homedir(), '.config', 'opencode', 'skills'),
-            path.join(os.homedir(), '.cursor', 'skills'),
-            path.join(os.homedir(), '.codex', 'skills'),
-            path.join(os.homedir(), '.gemini', 'skills'),
-            path.join(os.homedir(), '.agents', 'skills'),
-        ];
+        console.log(`${GREEN}[3b/10] Removing agenfk skills...${NC}`);
+        const platformSkillsDirs = {
+            claude: path.join(os.homedir(), '.claude', 'skills'),
+            opencode: path.join(os.homedir(), '.config', 'opencode', 'skills'),
+            cursor: path.join(os.homedir(), '.cursor', 'skills'),
+            codex: path.join(os.homedir(), '.codex', 'skills'),
+            gemini: path.join(os.homedir(), '.gemini', 'skills'),
+        };
+        const skillsDirs = onlyPlatform
+            ? (platformSkillsDirs[onlyPlatform.toLowerCase()] ? [platformSkillsDirs[onlyPlatform.toLowerCase()]] : [])
+            : [
+                ...Object.values(platformSkillsDirs),
+                path.join(os.homedir(), '.agents', 'skills'),
+              ];
         for (const dir of skillsDirs) {
             if (!existsSync(dir)) continue;
             const entries = await fs.readdir(dir);


### PR DESCRIPTION
## Summary

- **`agenfk pause <platform|all>`** — temporarily disables one or all editor integrations by removing MCP config and skills/slash commands. Tracked in `~/.agenfk/config.json` under `pausedIntegrations`.
- **`agenfk resume <platform|all>`** — re-installs a previously paused integration, respecting the configured `rulesScope`.
- **`agenfk integration install/uninstall` removed** — replaced by `pause`/`resume`.
- **`uninstall.mjs` step 3b fix** — skills removal now respects `--only=<platform>`; the universal `~/.agents/skills` dir is only wiped on full uninstall.
- **Upgrade tiers** — `upgradeTier` field in `package.json` + `/releases/latest` server enrichment.
- **README** — added Table of Contents index and new sections for Pausing/Resuming Integrations and Uninstalling AgEnFK.

## Test plan

- [ ] All 504 tests pass (`npm test`)
- [ ] `agenfk pause claude` removes MCP and skills from Claude Code
- [ ] `agenfk resume claude` reinstalls MCP and skills
- [ ] `agenfk pause all` / `agenfk resume all` work for all 5 platforms
- [ ] `agenfk integration list` still works; `install`/`uninstall` subcommands are gone
- [ ] `uninstall.mjs --only=cursor` only removes Cursor skills, not other platforms