### PR TITLE
fix: Windows/MinGW installation fixes for v0.2.24

### DIFF
--- a/bin/agenfk.js
+++ b/bin/agenfk.js
@@ -34,7 +34,24 @@ const isNpxCache = !fs.existsSync(path.join(REPO_ROOT, '.git'));
 const shouldRebuild = process.argv.includes('--rebuild');
 const isBeta = process.argv.includes('--beta');
 
-// On Windows, BSD tar treats "C:" as a remote hostname; the force-local flag disables that.
+// On MSYS2 / Git-for-Windows (MinGW), Node.js reports process.platform === 'win32' but
+// the bundled tar is an MSYS2 binary that understands POSIX paths (/c/Users/...).
+// Converting Win32 paths to POSIX form avoids the "C: treated as remote hostname" error
+// even when --force-local is not supported or not respected by the installed tar version.
+const isMinGW = !!(process.env.MSYSTEM || process.env.MINGW_PREFIX ||
+  (process.platform === 'win32' && process.env.SHELL?.includes('bash')));
+
+// Convert a Win32 drive path to an MSYS2 POSIX path (/c/Users/...) so that
+// MSYS2 tar never sees a bare "C:" that it might interpret as a remote hostname.
+function toPosixPath(p) {
+  if (isMinGW && /^[a-zA-Z]:/.test(p)) {
+    return '/' + p[0].toLowerCase() + p.slice(2).replace(/\\/g, '/');
+  }
+  return p;
+}
+
+// On Windows, BSD tar treats "C:" as a remote hostname; --force-local disables that.
+// On MinGW we also convert paths to POSIX form as a belt-and-suspenders measure.
 const tarFlags = process.platform === 'win32' ? '--force-local -xzf' : '-xzf';
 
 // Fetch latest release tag — curl (no auth) first, gh CLI as fallback.
@@ -101,7 +118,7 @@ if (isNpxCache) {
     try {
       const latestTag = fetchLatestTag(REPO, isBeta);
       downloadAsset(REPO, latestTag, 'agenfk-dist.tar.gz', path.join(INSTALL_DIR, 'agenfk-dist.tar.gz'));
-      execSync(`tar ${tarFlags} "${path.join(INSTALL_DIR, 'agenfk-dist.tar.gz')}" -C "${INSTALL_DIR}"`, { stdio: 'inherit' });
+      execSync(`tar ${tarFlags} "${toPosixPath(path.join(INSTALL_DIR, 'agenfk-dist.tar.gz'))}" -C "${toPosixPath(INSTALL_DIR)}"`, { stdio: 'inherit' });
       fs.unlinkSync(path.join(INSTALL_DIR, 'agenfk-dist.tar.gz'));
     } catch (e) {
       console.error(`Failed to download pre-built binary: ${e.message}`);
@@ -122,7 +139,7 @@ if (isNpxCache) {
     try {
       const latestTag = fetchLatestTag(REPO, isBeta);
       downloadAsset(REPO, latestTag, 'agenfk-dist.tar.gz', path.join(REPO_ROOT, 'agenfk-dist.tar.gz'));
-      execSync(`tar ${tarFlags} "${path.join(REPO_ROOT, 'agenfk-dist.tar.gz')}" -C "${REPO_ROOT}"`, { stdio: 'inherit' });
+      execSync(`tar ${tarFlags} "${toPosixPath(path.join(REPO_ROOT, 'agenfk-dist.tar.gz'))}" -C "${toPosixPath(REPO_ROOT)}"`, { stdio: 'inherit' });
       fs.unlinkSync(path.join(REPO_ROOT, 'agenfk-dist.tar.gz'));
     } catch (e) {
       console.error(`Failed to download pre-built binary: ${e.message}`);

--- a/bin/agenfk.js
+++ b/bin/agenfk.js
@@ -32,18 +32,33 @@ console.log(`${BLUE}=== AgEnFK Installer ===${RESET}\n`);
 // A real clone has a .git directory; the npx cache does not.
 const isNpxCache = !fs.existsSync(path.join(REPO_ROOT, '.git'));
 const shouldRebuild = process.argv.includes('--rebuild');
+const isBeta = process.argv.includes('--beta');
 
-// Fetch latest release tag — curl (no auth) first, gh CLI as fallback
-function fetchLatestTag(repo) {
+// On Windows, BSD tar treats "C:" as a remote hostname; the force-local flag disables that.
+const tarFlags = process.platform === 'win32' ? '--force-local -xzf' : '-xzf';
+
+// Fetch latest release tag — curl (no auth) first, gh CLI as fallback.
+// When beta=true, fetches all recent releases and picks the most recently published
+// (including pre-releases), mirroring the behaviour of `agenfk upgrade --beta`.
+function fetchLatestTag(repo, beta = false) {
   try {
+    const url = beta
+      ? `https://api.github.com/repos/${repo}/releases?per_page=20`
+      : `https://api.github.com/repos/${repo}/releases/latest`;
     const json = execSync(
-      `curl -fsSL "https://api.github.com/repos/${repo}/releases/latest" -H "Accept: application/vnd.github+json" -H "User-Agent: agenfk-installer"`,
+      `curl -fsSL "${url}" -H "Accept: application/vnd.github+json" -H "User-Agent: agenfk-installer"`,
       { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }
     );
-    const tag = JSON.parse(json).tag_name;
+    const data = JSON.parse(json);
+    const tag = beta
+      ? (Array.isArray(data) ? data.sort((a, b) => new Date(b.published_at) - new Date(a.published_at))[0]?.tag_name : null)
+      : data.tag_name;
     if (tag) return tag;
   } catch {}
   // Fallback: gh CLI
+  if (beta) {
+    return execSync(`gh release list --repo ${repo} --limit 1 --json tagName --template '{{range .}}{{.tagName}}{{end}}'`, { encoding: 'utf8' }).trim();
+  }
   return execSync(`gh release view --repo ${repo} --json tagName --template '{{.tagName}}'`, { encoding: 'utf8' }).trim();
 }
 
@@ -84,9 +99,9 @@ if (isNpxCache) {
     const REPO = 'cglab-public/agenfk';
     console.log(`${GREEN}Downloading pre-built binary from GitHub...${RESET}`);
     try {
-      const latestTag = fetchLatestTag(REPO);
+      const latestTag = fetchLatestTag(REPO, isBeta);
       downloadAsset(REPO, latestTag, 'agenfk-dist.tar.gz', path.join(INSTALL_DIR, 'agenfk-dist.tar.gz'));
-      execSync(`tar -xzf "${path.join(INSTALL_DIR, 'agenfk-dist.tar.gz')}" -C "${INSTALL_DIR}"`, { stdio: 'inherit' });
+      execSync(`tar ${tarFlags} "${path.join(INSTALL_DIR, 'agenfk-dist.tar.gz')}" -C "${INSTALL_DIR}"`, { stdio: 'inherit' });
       fs.unlinkSync(path.join(INSTALL_DIR, 'agenfk-dist.tar.gz'));
     } catch (e) {
       console.error(`Failed to download pre-built binary: ${e.message}`);
@@ -95,7 +110,7 @@ if (isNpxCache) {
   }
 
   console.log(`\n${GREEN}Running setup from ${INSTALL_DIR}...${RESET}\n`);
-  execSync(`node scripts/install.mjs${shouldRebuild ? ' --rebuild' : ''}`, { cwd: INSTALL_DIR, stdio: 'inherit' });
+  execSync(`node scripts/install.mjs${shouldRebuild ? ' --rebuild' : ''}${isBeta ? ' --beta' : ''}`, { cwd: INSTALL_DIR, stdio: 'inherit' });
 } else {
   // Running from a real git clone — install in place
   console.log(`${GREEN}Running install from ${REPO_ROOT}...${RESET}\n`);
@@ -105,9 +120,9 @@ if (isNpxCache) {
     const REPO = 'cglab-public/agenfk';
     console.log(`${GREEN}Downloading pre-built binary from GitHub...${RESET}`);
     try {
-      const latestTag = fetchLatestTag(REPO);
+      const latestTag = fetchLatestTag(REPO, isBeta);
       downloadAsset(REPO, latestTag, 'agenfk-dist.tar.gz', path.join(REPO_ROOT, 'agenfk-dist.tar.gz'));
-      execSync(`tar -xzf "${path.join(REPO_ROOT, 'agenfk-dist.tar.gz')}" -C "${REPO_ROOT}"`, { stdio: 'inherit' });
+      execSync(`tar ${tarFlags} "${path.join(REPO_ROOT, 'agenfk-dist.tar.gz')}" -C "${REPO_ROOT}"`, { stdio: 'inherit' });
       fs.unlinkSync(path.join(REPO_ROOT, 'agenfk-dist.tar.gz'));
     } catch (e) {
       console.error(`Failed to download pre-built binary: ${e.message}`);
@@ -115,7 +130,7 @@ if (isNpxCache) {
     }
   }
 
-  execSync(`node scripts/install.mjs${shouldRebuild ? ' --rebuild' : ''}`, { cwd: REPO_ROOT, stdio: 'inherit' });
+  execSync(`node scripts/install.mjs${shouldRebuild ? ' --rebuild' : ''}${isBeta ? ' --beta' : ''}`, { cwd: REPO_ROOT, stdio: 'inherit' });
 }
 
 // Final reminder — always shown so it's visible at the end of install output

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk-framework",
-  "version": "0.2.24-beta.1",
+  "version": "0.2.24-beta.2",
   "description": "AgenFK Engineering Framework",
   "private": true,
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk-framework",
-  "version": "0.2.24-beta.3",
+  "version": "0.2.24",
   "description": "AgenFK Engineering Framework",
   "private": true,
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk-framework",
-  "version": "0.2.23",
+  "version": "0.2.23-beta.3",
   "description": "AgenFK Engineering Framework",
   "private": true,
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk-framework",
-  "version": "0.2.23-beta.3",
+  "version": "0.2.24-beta.1",
   "description": "AgenFK Engineering Framework",
   "private": true,
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk-framework",
-  "version": "0.2.24-beta.2",
+  "version": "0.2.24-beta.3",
   "description": "AgenFK Engineering Framework",
   "private": true,
   "workspaces": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/cli",
-  "version": "0.2.24-beta.2",
+  "version": "0.2.24-beta.3",
   "description": "CLI for AgenFK Engineering Framework",
   "main": "dist/index.js",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/cli",
-  "version": "0.2.23",
+  "version": "0.2.23-beta.3",
   "description": "CLI for AgenFK Engineering Framework",
   "main": "dist/index.js",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/cli",
-  "version": "0.2.24-beta.3",
+  "version": "0.2.24",
   "description": "CLI for AgenFK Engineering Framework",
   "main": "dist/index.js",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/cli",
-  "version": "0.2.23-beta.3",
+  "version": "0.2.24-beta.1",
   "description": "CLI for AgenFK Engineering Framework",
   "main": "dist/index.js",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/cli",
-  "version": "0.2.24-beta.1",
+  "version": "0.2.24-beta.2",
   "description": "CLI for AgenFK Engineering Framework",
   "main": "dist/index.js",
   "bin": {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2517,7 +2517,7 @@ program
     try {
       const body: any = { evidence: options.evidence };
       if (command) body.command = command;
-      const { data } = await axios.post(`${API_URL}/items/${targetId}/validate`, body, { headers: { 'x-agenfk-internal': verifyToken } });
+      const { data } = await axios.post(`${API_URL}/items/${targetId}/validate`, body, { headers: { 'x-agenfk-internal': verifyToken }, timeout: 300000 });
       if (data.output) console.log(data.output);
       console.log(chalk.green(data.message || `\n✅ Validation passed.`));
     } catch (error: any) {

--- a/packages/cli/src/test/install-script.test.ts
+++ b/packages/cli/src/test/install-script.test.ts
@@ -157,3 +157,50 @@ describe('install.mjs — Windows tar --force-local', () => {
         expect(before).toMatch(/win32/);
     });
 });
+
+// ---------------------------------------------------------------------------
+// MCP server + CLI — validate_progress 5-minute timeout (task 9c5d2fbe)
+// ---------------------------------------------------------------------------
+const mcpServerScript = readFileSync(
+    path.resolve(__dirname, '../../../server/src/index.ts'),
+    'utf8'
+);
+
+const cliScript = readFileSync(
+    path.resolve(__dirname, '../../src/index.ts'),
+    'utf8'
+);
+
+describe('MCP server — validate_progress uses 5-minute timeout', () => {
+    it('validate_progress post call has a 300000ms timeout', () => {
+        // 30s is too short for npm run build && npm test; must be 5 minutes.
+        const validateIdx = mcpServerScript.indexOf('case "validate_progress"');
+        expect(validateIdx).toBeGreaterThan(-1);
+        const block = mcpServerScript.slice(validateIdx, validateIdx + 500);
+        expect(block).toMatch(/300000/);
+    });
+
+    it('review_changes post call has a 300000ms timeout', () => {
+        const idx = mcpServerScript.indexOf('case "review_changes"');
+        expect(idx).toBeGreaterThan(-1);
+        const block = mcpServerScript.slice(idx, idx + 400);
+        expect(block).toMatch(/300000/);
+    });
+
+    it('test_changes post call has a 300000ms timeout', () => {
+        const idx = mcpServerScript.indexOf('case "test_changes"');
+        expect(idx).toBeGreaterThan(-1);
+        const block = mcpServerScript.slice(idx, idx + 400);
+        expect(block).toMatch(/300000/);
+    });
+});
+
+describe('CLI — agenfk verify uses 5-minute timeout', () => {
+    it('verify command axios.post has a 300000ms timeout', () => {
+        // The verify command calls /items/:id/validate — must not time out on long builds.
+        const verifyIdx = cliScript.indexOf(".command('verify");
+        expect(verifyIdx).toBeGreaterThan(-1);
+        const block = cliScript.slice(verifyIdx, verifyIdx + 2000);
+        expect(block).toMatch(/300000/);
+    });
+});

--- a/packages/cli/src/test/install-script.test.ts
+++ b/packages/cli/src/test/install-script.test.ts
@@ -210,6 +210,47 @@ describe('CLI — agenfk verify uses 5-minute timeout', () => {
 // On MinGW, spawnSync('npm') without shell:true fails to find npm.cmd,
 // silently skipping npm ci and leaving node_modules empty.
 // ---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
+// install.mjs template + start-services.mjs — npm spawn shell:true (bug 47c80eec)
+// spawn(npmCmd, ['run', 'preview']) without shell:true fails with ENOENT on MinGW
+// because npm is a .cmd script that requires cmd.exe to execute.
+// ---------------------------------------------------------------------------
+const startServicesScript = readFileSync(
+    path.resolve(__dirname, '../../../../scripts/start-services.mjs'),
+    'utf8'
+);
+
+describe('start-services.mjs — npm spawn uses shell:true on Windows', () => {
+    it('passes shell option to the npm run preview spawn call', () => {
+        const spawnIdx = startServicesScript.indexOf("spawn(npmCmd, ['run', 'preview']");
+        expect(spawnIdx).toBeGreaterThan(-1);
+        const spawnBlock = startServicesScript.slice(spawnIdx, spawnIdx + 400);
+        expect(spawnBlock).toMatch(/shell/);
+    });
+
+    it('gates shell:true to win32 only in start-services', () => {
+        const spawnIdx = startServicesScript.indexOf("spawn(npmCmd, ['run', 'preview']");
+        const spawnBlock = startServicesScript.slice(spawnIdx, spawnIdx + 400);
+        expect(spawnBlock).toMatch(/win32/);
+    });
+});
+
+describe('install.mjs template — npm spawn uses shell:true on Windows', () => {
+    it('template passes shell option to the npm run preview spawn call', () => {
+        // The template written to start-services.mjs must include shell on the spawn
+        const templateStart = installScript.indexOf("spawn(npmCmd, ['run', 'preview']");
+        expect(templateStart).toBeGreaterThan(-1);
+        const templateBlock = installScript.slice(templateStart, templateStart + 400);
+        expect(templateBlock).toMatch(/shell/);
+    });
+
+    it('template gates shell:true to win32 only', () => {
+        const templateStart = installScript.indexOf("spawn(npmCmd, ['run', 'preview']");
+        const templateBlock = installScript.slice(templateStart, templateStart + 400);
+        expect(templateBlock).toMatch(/win32/);
+    });
+});
+
 describe('install.mjs — npm spawnSync uses shell:true on Windows', () => {
     it('passes shell option to the npm ci spawnSync call', () => {
         // The spawnSync for npm ci must include a shell option so .cmd scripts

--- a/packages/cli/src/test/install-script.test.ts
+++ b/packages/cli/src/test/install-script.test.ts
@@ -204,3 +204,29 @@ describe('CLI — agenfk verify uses 5-minute timeout', () => {
         expect(block).toMatch(/300000/);
     });
 });
+
+// ---------------------------------------------------------------------------
+// install.mjs — npm spawnSync must use shell:true on Windows (bug acb7232c)
+// On MinGW, spawnSync('npm') without shell:true fails to find npm.cmd,
+// silently skipping npm ci and leaving node_modules empty.
+// ---------------------------------------------------------------------------
+describe('install.mjs — npm spawnSync uses shell:true on Windows', () => {
+    it('passes shell option to the npm ci spawnSync call', () => {
+        // The spawnSync for npm ci must include a shell option so .cmd scripts
+        // are resolved on Windows (both MinGW and native cmd.exe).
+        // Match the assignment: const npmCiResult = spawnSync(...)
+        const assignIdx = installScript.indexOf('npmCiResult = spawnSync');
+        expect(assignIdx).toBeGreaterThan(-1);
+        // Grab from the assignment to closing brace of the options object
+        const spawnBlock = installScript.slice(assignIdx, assignIdx + 300);
+        expect(spawnBlock).toMatch(/shell/);
+    });
+
+    it('gates shell:true to win32 only — not forced on Linux/macOS', () => {
+        // shell:true on Linux spawns an extra process for no reason.
+        // Must be conditional on win32.
+        const assignIdx = installScript.indexOf('npmCiResult = spawnSync');
+        const spawnBlock = installScript.slice(assignIdx, assignIdx + 300);
+        expect(spawnBlock).toMatch(/win32/);
+    });
+});

--- a/packages/cli/src/test/install-script.test.ts
+++ b/packages/cli/src/test/install-script.test.ts
@@ -18,6 +18,11 @@ const uninstallScript = readFileSync(
     'utf8'
 );
 
+const bootstrapScript = readFileSync(
+    path.resolve(__dirname, '../../../../bin/agenfk.js'),
+    'utf8'
+);
+
 describe('install.mjs — production dependency installation', () => {
     it('runs npm ci to install production dependencies', () => {
         expect(installScript).toContain('npm ci');
@@ -96,5 +101,59 @@ describe('uninstall.mjs — step 3b skills removal respects --only flag', () => 
         // (either !onlyPlatform or a ternary where .agents is in the falsy branch)
         const beforeAgents = block3b.slice(0, agentsIdx);
         expect(beforeAgents).toMatch(/onlyPlatform/i);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// bin/agenfk.js — --beta flag (task ece8514b)
+// ---------------------------------------------------------------------------
+describe('bin/agenfk.js — --beta flag for npx beta installs', () => {
+    it('detects --beta flag from process.argv', () => {
+        // The bootstrap must check process.argv for --beta
+        expect(bootstrapScript).toMatch(/argv.*beta|beta.*argv/i);
+    });
+
+    it('uses /releases?per_page= endpoint when beta flag is set', () => {
+        // Beta installs fetch all releases and pick the latest by date,
+        // not /releases/latest which excludes pre-releases.
+        expect(bootstrapScript).toMatch(/releases\?per_page=/);
+    });
+
+    it('forwards --beta flag to scripts/install.mjs', () => {
+        // install.mjs is invoked via execSync — the --beta flag must be forwarded
+        // so downstream steps know this is a beta install.
+        expect(bootstrapScript).toMatch(/install\.mjs.*beta|beta.*install\.mjs/);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// bin/agenfk.js + install.mjs — Windows tar --force-local (bug 7c938419)
+// ---------------------------------------------------------------------------
+describe('bin/agenfk.js — Windows tar --force-local', () => {
+    it('uses --force-local when extracting tar on Windows', () => {
+        // BSD tar (Windows built-in) treats "C:" in paths as a remote hostname.
+        // --force-local disables that behaviour.
+        expect(bootstrapScript).toContain('--force-local');
+    });
+
+    it('--force-local is gated to win32 platform', () => {
+        // Should not add the flag on Linux/macOS where GNU tar handles it fine.
+        const forceLocalIdx = bootstrapScript.indexOf('--force-local');
+        expect(forceLocalIdx).toBeGreaterThan(-1);
+        const before = bootstrapScript.slice(0, forceLocalIdx);
+        expect(before).toMatch(/win32/);
+    });
+});
+
+describe('install.mjs — Windows tar --force-local', () => {
+    it('uses --force-local when extracting tar on Windows', () => {
+        expect(installScript).toContain('--force-local');
+    });
+
+    it('--force-local is gated to win32 platform', () => {
+        const forceLocalIdx = installScript.indexOf('--force-local');
+        expect(forceLocalIdx).toBeGreaterThan(-1);
+        const before = installScript.slice(0, forceLocalIdx);
+        expect(before).toMatch(/win32/);
     });
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/core",
-  "version": "0.2.23-beta.3",
+  "version": "0.2.24-beta.1",
   "description": "Core logic and interfaces for the AgenFK Engineering Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/core",
-  "version": "0.2.24-beta.3",
+  "version": "0.2.24",
   "description": "Core logic and interfaces for the AgenFK Engineering Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/core",
-  "version": "0.2.23",
+  "version": "0.2.23-beta.3",
   "description": "Core logic and interfaces for the AgenFK Engineering Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/core",
-  "version": "0.2.24-beta.2",
+  "version": "0.2.24-beta.3",
   "description": "Core logic and interfaces for the AgenFK Engineering Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/core",
-  "version": "0.2.24-beta.1",
+  "version": "0.2.24-beta.2",
   "description": "Core logic and interfaces for the AgenFK Engineering Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/src/test/installer-path-utils.test.ts
+++ b/packages/core/src/test/installer-path-utils.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+
+// ─── toPosixPath ────────────────────────────────────────────────────────────
+// Pure-function spec for the helper that will be inlined in bin/agenfk.js and
+// scripts/install.mjs.  The function must convert Windows drive paths to MSYS2
+// POSIX form so that Git-for-Windows / MSYS2 tar never sees a bare "C:" that it
+// might interpret as a remote hostname.
+
+function toPosixPath(p: string, isMinGW: boolean): string {
+  if (isMinGW && /^[a-zA-Z]:/.test(p)) {
+    return '/' + p[0].toLowerCase() + p.slice(2).replace(/\\/g, '/');
+  }
+  return p;
+}
+
+describe('toPosixPath', () => {
+  describe('when isMinGW = true', () => {
+    it('converts a C:\\ path to /c/ form', () => {
+      expect(toPosixPath('C:\\Users\\Dan\\agenfk', true)).toBe('/c/Users/Dan/agenfk');
+    });
+
+    it('lowercases the drive letter', () => {
+      expect(toPosixPath('D:\\Projects\\foo', true)).toBe('/d/Projects/foo');
+    });
+
+    it('converts all backslashes to forward slashes', () => {
+      expect(toPosixPath('C:\\Users\\Dan\\agenfk\\agenfk-dist.tar.gz', true))
+        .toBe('/c/Users/Dan/agenfk/agenfk-dist.tar.gz');
+    });
+
+    it('handles a path that already uses forward slashes (rare, but safe)', () => {
+      // Node path.join on Windows produces backslashes, but guard anyway.
+      expect(toPosixPath('C:/Users/Dan/agenfk', true)).toBe('/c/Users/Dan/agenfk');
+    });
+
+    it('passes through a path that starts with / unchanged', () => {
+      expect(toPosixPath('/tmp/agenfk-heal-123.tar.gz', true))
+        .toBe('/tmp/agenfk-heal-123.tar.gz');
+    });
+  });
+
+  describe('when isMinGW = false (Linux / macOS / plain Windows cmd)', () => {
+    it('leaves Windows paths unchanged', () => {
+      expect(toPosixPath('C:\\Users\\Dan\\agenfk', false)).toBe('C:\\Users\\Dan\\agenfk');
+    });
+
+    it('leaves POSIX paths unchanged', () => {
+      expect(toPosixPath('/home/dan/agenfk', false)).toBe('/home/dan/agenfk');
+    });
+  });
+});
+
+// ─── autoHealRedownload tar exit-status check ────────────────────────────────
+// Spec for the behaviour fix: if spawnSync('tar', ...) returns a non-zero status
+// the function must return false instead of silently logging "Re-download complete."
+
+describe('autoHealRedownload tar exit-status handling', () => {
+  it('returns false when tar exits with non-zero status', () => {
+    // Simulate the fixed logic: check tarResult.status before returning true.
+    const tarResult = { status: 128 };
+    const healed = tarResult.status === 0;
+    expect(healed).toBe(false);
+  });
+
+  it('returns true when tar exits with status 0', () => {
+    const tarResult = { status: 0 };
+    const healed = tarResult.status === 0;
+    expect(healed).toBe(true);
+  });
+
+  it('treats a null status (signal-killed) as failure', () => {
+    // spawnSync sets status=null when the process is killed by a signal.
+    const tarResult = { status: null as number | null };
+    const healed = tarResult.status === 0;
+    expect(healed).toBe(false);
+  });
+});

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "0.2.23",
+  "version": "0.2.23-beta.3",
   "description": "AgenFK Agentic Engineering Framework — installer",
   "bin": {
     "agenfk": "bin/agenfk.js"

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "0.2.24-beta.1",
+  "version": "0.2.24-beta.2",
   "description": "AgenFK Agentic Engineering Framework — installer",
   "bin": {
     "agenfk": "bin/agenfk.js"

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "0.2.23-beta.3",
+  "version": "0.2.24-beta.1",
   "description": "AgenFK Agentic Engineering Framework — installer",
   "bin": {
     "agenfk": "bin/agenfk.js"

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "0.2.24-beta.3",
+  "version": "0.2.24",
   "description": "AgenFK Agentic Engineering Framework — installer",
   "bin": {
     "agenfk": "bin/agenfk.js"

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "0.2.24-beta.2",
+  "version": "0.2.24-beta.3",
   "description": "AgenFK Agentic Engineering Framework — installer",
   "bin": {
     "agenfk": "bin/agenfk.js"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/server",
-  "version": "0.2.24-beta.1",
+  "version": "0.2.24-beta.2",
   "description": "MCP Server for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/server",
-  "version": "0.2.23",
+  "version": "0.2.23-beta.3",
   "description": "MCP Server for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/server",
-  "version": "0.2.23-beta.3",
+  "version": "0.2.24-beta.1",
   "description": "MCP Server for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/server",
-  "version": "0.2.24-beta.2",
+  "version": "0.2.24-beta.3",
   "description": "MCP Server for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/server",
-  "version": "0.2.24-beta.3",
+  "version": "0.2.24",
   "description": "MCP Server for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -567,7 +567,7 @@ async function callToolHandler(request: any): Promise<any> {
       case "validate_progress": {
         const { itemId, evidence, command } = z.object({ itemId: z.string(), evidence: z.string(), command: z.string().optional() }).parse(request.params.arguments);
         try {
-          const { data } = await api.post(`/items/${itemId}/validate`, { evidence, command, cwd: process.cwd() }, { headers: { 'x-agenfk-internal': VERIFY_TOKEN } });
+          const { data } = await api.post(`/items/${itemId}/validate`, { evidence, command, cwd: process.cwd() }, { headers: { 'x-agenfk-internal': VERIFY_TOKEN }, timeout: 300000 });
           return { content: [{ type: "text", text: data.message }] };
         } catch (error: any) {
           const msg = error.response?.data?.message || error.response?.data?.error || error.message;
@@ -577,7 +577,7 @@ async function callToolHandler(request: any): Promise<any> {
       case "review_changes": {
         const { itemId, command } = z.object({ itemId: z.string(), command: z.string() }).parse(request.params.arguments);
         try {
-          const { data } = await api.post(`/items/${itemId}/validate`, { command }, { headers: { 'x-agenfk-internal': VERIFY_TOKEN } });
+          const { data } = await api.post(`/items/${itemId}/validate`, { command }, { headers: { 'x-agenfk-internal': VERIFY_TOKEN }, timeout: 300000 });
           return { content: [{ type: "text", text: `[DEPRECATED: use validate_progress] ${data.message}` }] };
         } catch (error: any) {
           const msg = error.response?.data?.message || error.response?.data?.error || error.message;
@@ -587,7 +587,7 @@ async function callToolHandler(request: any): Promise<any> {
       case "test_changes": {
         const { itemId } = z.object({ itemId: z.string() }).parse(request.params.arguments);
         try {
-          const { data } = await api.post(`/items/${itemId}/validate`, {}, { headers: { 'x-agenfk-internal': VERIFY_TOKEN } });
+          const { data } = await api.post(`/items/${itemId}/validate`, {}, { headers: { 'x-agenfk-internal': VERIFY_TOKEN }, timeout: 300000 });
           return { content: [{ type: "text", text: `[DEPRECATED: use validate_progress] ${data.message}` }] };
         } catch (error: any) {
           const msg = error.response?.data?.message || error.response?.data?.error || error.message;

--- a/packages/storage-sqlite/package.json
+++ b/packages/storage-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/storage-sqlite",
-  "version": "0.2.24-beta.1",
+  "version": "0.2.24-beta.2",
   "description": "SQLite storage implementation for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/storage-sqlite/package.json
+++ b/packages/storage-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/storage-sqlite",
-  "version": "0.2.23-beta.3",
+  "version": "0.2.24-beta.1",
   "description": "SQLite storage implementation for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/storage-sqlite/package.json
+++ b/packages/storage-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/storage-sqlite",
-  "version": "0.2.24-beta.2",
+  "version": "0.2.24-beta.3",
   "description": "SQLite storage implementation for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/storage-sqlite/package.json
+++ b/packages/storage-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/storage-sqlite",
-  "version": "0.2.23",
+  "version": "0.2.23-beta.3",
   "description": "SQLite storage implementation for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/storage-sqlite/package.json
+++ b/packages/storage-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/storage-sqlite",
-  "version": "0.2.24-beta.3",
+  "version": "0.2.24",
   "description": "SQLite storage implementation for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/telemetry",
-  "version": "0.2.23",
+  "version": "0.2.23-beta.3",
   "description": "Anonymous telemetry client for AgenFK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/telemetry",
-  "version": "0.2.24-beta.3",
+  "version": "0.2.24",
   "description": "Anonymous telemetry client for AgenFK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/telemetry",
-  "version": "0.2.24-beta.2",
+  "version": "0.2.24-beta.3",
   "description": "Anonymous telemetry client for AgenFK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/telemetry",
-  "version": "0.2.23-beta.3",
+  "version": "0.2.24-beta.1",
   "description": "Anonymous telemetry client for AgenFK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/telemetry",
-  "version": "0.2.24-beta.1",
+  "version": "0.2.24-beta.2",
   "description": "Anonymous telemetry client for AgenFK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "0.2.24-beta.2",
+  "version": "0.2.24-beta.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "0.2.24-beta.1",
+  "version": "0.2.24-beta.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "0.2.24-beta.3",
+  "version": "0.2.24",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "0.2.23",
+  "version": "0.2.23-beta.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "0.2.23-beta.3",
+  "version": "0.2.24-beta.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -169,7 +169,11 @@ async function run() {
                 if (existsSync(ghFile)) renameSync(ghFile, tmpFile);
                 else return false;
             }
-            spawnSync('tar', ['-xzf', tmpFile, '-C', rootDir], { stdio: 'inherit' });
+            // On Windows, BSD tar treats "C:" as a remote hostname — --force-local disables that.
+            const tarArgs = os.platform() === 'win32'
+                ? ['--force-local', '-xzf', tmpFile, '-C', rootDir]
+                : ['-xzf', tmpFile, '-C', rootDir];
+            spawnSync('tar', tarArgs, { stdio: 'inherit' });
             console.log(`${GREEN}  Re-download complete.${NC}`);
             return true;
         } catch { return false; } finally {

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -43,6 +43,15 @@ function toWindowsPath(p) {
     return p;
 }
 
+// Converts a Win32 drive path (C:\Users\...) to an MSYS2 POSIX path (/c/Users/...)
+// so that MSYS2 tar never sees a bare "C:" that it might interpret as a remote hostname.
+function toPosixPath(p) {
+    if (isMinGW && /^[a-zA-Z]:/.test(p)) {
+        return '/' + p[0].toLowerCase() + p.slice(2).replace(/\\/g, '/');
+    }
+    return p;
+}
+
 // Returns the platform-appropriate directory for Cursor's global rules (.mdc files).
 function getCursorRulesDir() {
     if (os.platform() === 'win32') {
@@ -170,10 +179,13 @@ async function run() {
                 else return false;
             }
             // On Windows, BSD tar treats "C:" as a remote hostname — --force-local disables that.
+            // On MinGW (Git for Windows) we also convert paths to POSIX form (/c/Users/...)
+            // so MSYS2 tar never sees a bare "C:" regardless of --force-local support.
             const tarArgs = os.platform() === 'win32'
-                ? ['--force-local', '-xzf', tmpFile, '-C', rootDir]
+                ? ['--force-local', '-xzf', toPosixPath(tmpFile), '-C', toPosixPath(rootDir)]
                 : ['-xzf', tmpFile, '-C', rootDir];
-            spawnSync('tar', tarArgs, { stdio: 'inherit' });
+            const tarResult = spawnSync('tar', tarArgs, { stdio: 'inherit' });
+            if (tarResult.status !== 0) return false;
             console.log(`${GREEN}  Re-download complete.${NC}`);
             return true;
         } catch { return false; } finally {

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -251,6 +251,7 @@ async function run() {
         const npmCiResult = spawnSync(npmCiCmd, ['ci', '--omit=dev', '--ignore-scripts'], {
             cwd: rootDir,
             stdio: 'inherit',
+            shell: os.platform() === 'win32', // .cmd scripts need shell on Windows (MinGW + native)
         });
         if (npmCiResult.status !== 0) {
             console.log(`${YELLOW}  Warning: npm ci failed (exit ${npmCiResult.status}). Run 'npm ci --omit=dev' manually in ${rootDir} if agenfk commands fail to resolve modules.${NC}`);

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -459,7 +459,8 @@ const uiProcess = spawn(npmCmd, ['run', 'preview'], {
     cwd: path.join(rootDir, 'packages/ui'),
     env: { ...process.env, VITE_PORT: UI_PORT, VITE_API_URL: \`http://localhost:\${API_PORT}\` },
     detached: true,
-    stdio: ['ignore', uiLog, uiLog]
+    stdio: ['ignore', uiLog, uiLog],
+    shell: os.platform() === 'win32', // .cmd scripts need shell on Windows (MinGW + native)
 });
 uiProcess.unref();
 

--- a/scripts/start-services.mjs
+++ b/scripts/start-services.mjs
@@ -48,7 +48,8 @@ const uiProcess = spawn(npmCmd, ['run', 'preview'], {
     cwd: path.join(rootDir, 'packages/ui'),
     env: { ...process.env, VITE_PORT: UI_PORT, VITE_API_URL: `http://localhost:${API_PORT}` },
     detached: true,
-    stdio: ['ignore', uiLog, uiLog]
+    stdio: ['ignore', uiLog, uiLog],
+    shell: os.platform() === 'win32', // .cmd scripts need shell on Windows (MinGW + native)
 });
 uiProcess.unref();
 


### PR DESCRIPTION
## Summary

- Fix Windows/MinGW tar failure during install — `toPosixPath()` converts `C:\...` paths to `/c/...` so MSYS2 tar never sees `C:` as a remote hostname
- Fix `autoHealRedownload()` false-positive — `spawnSync` exit status is now checked; tar failure no longer silently reports success
- Fix `Cannot find module 'commander'` — `npm ci` spawnSync now passes `shell: true` on Windows so `.cmd` scripts resolve correctly
- Fix `spawn npm ENOENT` on `agenfk up` — UI process spawn in `start-services.mjs` now passes `shell: true` on Windows
- Add `--beta` flag support to `bin/agenfk.js` for installing latest pre-release via `node bin/agenfk install --beta`
- Increase `validate_progress` axios timeout to 5 minutes for long-running builds

## Test plan

- [x] All 531 tests pass (`npm test`)
- [x] Tested end-to-end on Windows MinGW (Git Bash): install completes, `agenfk up` starts API on :3000 and UI on :5173
- [x] Verified via `v0.2.24-beta.1` through `v0.2.24-beta.3` pre-releases