### PR TITLE
fix: suppress upgrade tier warning when already on latest version

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -297,6 +297,8 @@ async function checkUpgradeTier(): Promise<void> {
 }
 
 function applyUpgradeTierAction(tier: string, latestVersion: string): void {
+  // If we already have the latest version, suppress all warnings regardless of tier.
+  if (latestVersion && latestVersion === CURRENT_VERSION) return;
   if (tier === 'mandatory') {
     console.error(chalk.red.bold('\n⛔ MANDATORY UPGRADE REQUIRED'));
     console.error(chalk.red(`AgEnFK v${latestVersion || 'latest'} is a mandatory upgrade and must be applied before continuing.`));

--- a/packages/cli/src/test/upgrade-tier.test.ts
+++ b/packages/cli/src/test/upgrade-tier.test.ts
@@ -128,3 +128,47 @@ describe('CLI startup — optional tier is silent', () => {
     expect(tierSection).toMatch(/optional|else\s*\{|default:/i);
   });
 });
+
+// ── Version-match suppression ─────────────────────────────────────────────────
+// When the local version already equals the remote version, no warning should
+// be displayed — not even for recommended tier.  The root cause was that
+// applyUpgradeTierAction showed the banner regardless of whether an upgrade
+// was actually available.
+
+describe('CLI startup — suppress tier warning when already on latest version', () => {
+  // Helper: find the function *definition* (not call sites)
+  function getApplyFuncSection(cli: string): string {
+    // Match "function applyUpgradeTierAction(" to find the definition
+    const defIdx = cli.search(/function applyUpgradeTierAction/i);
+    if (defIdx === -1) return '';
+    return cli.slice(defIdx, defIdx + 1200);
+  }
+
+  it('applyUpgradeTierAction checks latestVersion against CURRENT_VERSION before showing warning', () => {
+    const cli = readCli();
+    const funcSection = getApplyFuncSection(cli);
+    expect(funcSection.length).toBeGreaterThan(0);
+    // Must guard on version equality — look for CURRENT_VERSION or a semver compare
+    expect(funcSection).toMatch(/CURRENT_VERSION|currentVersion/i);
+  });
+
+  it('applyUpgradeTierAction returns early when latestVersion === CURRENT_VERSION', () => {
+    const cli = readCli();
+    const funcSection = getApplyFuncSection(cli);
+    expect(funcSection.length).toBeGreaterThan(0);
+    // Must have an early-return guard: if versions match → return without printing
+    expect(funcSection).toMatch(/===.*CURRENT_VERSION|CURRENT_VERSION.*===|latestVersion.*===|===.*latestVersion/i);
+  });
+
+  it('recommended banner is NOT shown when latestVersion equals current version', () => {
+    const cli = readCli();
+    const funcSection = getApplyFuncSection(cli);
+    expect(funcSection.length).toBeGreaterThan(0);
+    // The version equality check must appear BEFORE the recommended block
+    const versionCheckIdx = funcSection.search(/===.*CURRENT_VERSION|CURRENT_VERSION.*===|latestVersion.*CURRENT_VERSION/i);
+    const recommendedIdx = funcSection.search(/recommended/i);
+    expect(versionCheckIdx).toBeGreaterThan(-1);
+    expect(recommendedIdx).toBeGreaterThan(-1);
+    expect(versionCheckIdx).toBeLessThan(recommendedIdx);
+  });
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -511,8 +511,12 @@ async function getUpgradeNotice(): Promise<string> {
     const resp = await axios.get(`${API_URL}/releases/latest`, { timeout: 2000 });
     const tier: string = resp.data?.upgradeTier ?? 'optional';
     const version: string = resp.data?.version ?? '';
+    const currentVersion: string = resp.data?.currentVersion ?? '';
     let text = '';
-    if (tier === 'mandatory') {
+    // Suppress notice when already on the latest version.
+    if (!version || (currentVersion && version === currentVersion)) {
+      // nothing to show
+    } else if (tier === 'mandatory') {
       text = `\n\n⛔ **MANDATORY UPGRADE REQUIRED**: AgEnFK v${version} must be installed before continuing. Run \`agenfk upgrade\`.`;
     } else if (tier === 'recommended') {
       text = `\n\n⚠️ Recommended upgrade available: AgEnFK v${version}. Run \`agenfk upgrade\` when convenient.`;


### PR DESCRIPTION
## Summary

- `applyUpgradeTierAction` in CLI now returns early when `latestVersion === CURRENT_VERSION`, suppressing the banner even if the remote tag carries a `recommended` upgrade tier
- `getUpgradeNotice()` in the MCP server index applies the same guard using `currentVersion` already present in the `/releases/latest` response
- 3 new tests added to `upgrade-tier.test.ts` covering the version-match suppression

## Root cause

The `/releases/latest` API returns an `upgradeTier` flag (e.g. `recommended`) that is a property of the release itself, not a comparison against the installed version. Both the CLI banner and MCP notice were displaying that tier unconditionally — even when `Local version == Remote version`.

## Test plan

- [x] `npm run build && npm test` — 534/534 passing
- [x] New tests verify the early-return guard is present and fires before the recommended branch