### PR TITLE
Release v0.2.27

### DIFF
--- a/commands/agenfk-release-beta.md
+++ b/commands/agenfk-release-beta.md
@@ -25,5 +25,6 @@ Run `git push` and show the output to the user.
 - Offer to auto-generate release notes from git log: run `git log $(git describe --tags --abbrev=0)..HEAD --oneline` and summarise the commits as bullet points.
 - Confirm the notes with the user, allow edits.
 - **Package Distributable**: Run `node scripts/package-dist.mjs` and verify `agenfk-dist.tar.gz` exists.
-- **Push & Create Beta**: Run `git push origin HEAD` to ensure the version bump is on the remote branch, then run `gh release create <tag> agenfk-dist.tar.gz --prerelease --title "<title>" --notes "<notes>"`.
+- **Tag & Push**: Run `git tag <tag>` to create the tag locally on the version-bump commit, then run `git push origin HEAD --tags` to push both the commit and the tag to the remote.
+- **Create Beta Release**: Run `gh release create <tag> agenfk-dist.tar.gz --prerelease --title "<title>" --notes "<notes>"`.
 - Show the release URL returned by `gh`.

--- a/commands/agenfk-release.md
+++ b/commands/agenfk-release.md
@@ -39,7 +39,8 @@ If YES:
   - **Cross-project guard**: If a commit message contains a task ID in brackets (e.g. `[1a18154d-...]`), verify it belongs to the current project by checking `.agenfk/project.json`. If the project ID does not match, omit the task reference from the release note and note it as a possible mislabelled commit.
 - Confirm the notes with the user, allow edits.
 - **Package Distributable**: Run `node scripts/package-dist.mjs` and verify `agenfk-dist.tar.gz` exists.
-- **Push & Create**: Run `git push origin HEAD` to ensure the version bump is on the remote branch, then run `gh release create <tag> agenfk-dist.tar.gz --title "<title>" --notes "<notes>"`.
+- **Tag & Push**: Run `git tag <tag>` to create the tag locally on the version-bump commit, then run `git push origin HEAD --tags` to push both the commit and the tag to the remote.
+- **Create Release**: Run `gh release create <tag> agenfk-dist.tar.gz --title "<title>" --notes "<notes">`.
 - Show the release URL returned by `gh`.
 
 If NO:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk-framework",
-  "version": "0.2.26",
+  "version": "0.2.27",
   "description": "AgenFK Engineering Framework",
   "private": true,
   "workspaces": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/cli",
-  "version": "0.2.26",
+  "version": "0.2.27",
   "description": "CLI for AgenFK Engineering Framework",
   "main": "dist/index.js",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/core",
-  "version": "0.2.26",
+  "version": "0.2.27",
   "description": "Core logic and interfaces for the AgenFK Engineering Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "0.2.26",
+  "version": "0.2.27",
   "description": "AgenFK Agentic Engineering Framework — installer",
   "bin": {
     "agenfk": "bin/agenfk.js"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/server",
-  "version": "0.2.26",
+  "version": "0.2.27",
   "description": "MCP Server for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/storage-sqlite/package.json
+++ b/packages/storage-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/storage-sqlite",
-  "version": "0.2.26",
+  "version": "0.2.27",
   "description": "SQLite storage implementation for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/telemetry",
-  "version": "0.2.26",
+  "version": "0.2.27",
   "description": "Anonymous telemetry client for AgenFK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "0.2.26",
+  "version": "0.2.27",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Fix: add explicit `git tag` step to release skills before pushing to remote
- Bump version to 0.2.27

## Release Notes
- **fix**: Add explicit `git tag` step to release skills before pushing to remote
- **fix(gatekeeper)**: STORY/EPIC items in active steps blocked when `itemId` provided explicitly