### PR TITLE
fix: persist full validate_progress output to disk with head+tail preview and rolling window

### DIFF
--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -52,6 +52,54 @@ let dbPath: string = "";
 // Anonymous usage telemetry — no-op when AGENFK_POSTHOG_KEY is unset or opted out.
 const telemetry = new TelemetryClient();
 
+// ── Validation log persistence ───────────────────────────────────────────────
+// Full command output from validate_progress is written to
+// <dbDir>/logs/<itemId>/<testId>.log. The HTTP response, comment, and tests[]
+// record carry only a head+tail truncated preview plus the log file path, so
+// MCP payloads stay small while full logs remain available on disk.
+const MAX_LOGS_PER_ITEM = 3;
+const PREVIEW_HEAD_BYTES = 1024;
+const PREVIEW_TAIL_BYTES = 1024;
+
+const getItemLogDir = (itemId: string): string =>
+  path.join(path.dirname(dbPath), 'logs', itemId);
+
+const writeValidationLog = (itemId: string, testId: string, output: string): string => {
+  const dir = getItemLogDir(itemId);
+  fs.mkdirSync(dir, { recursive: true });
+  const logPath = path.join(dir, `${testId}.log`);
+  fs.writeFileSync(logPath, output);
+  // Prune to newest MAX_LOGS_PER_ITEM by mtime.
+  const entries = fs.readdirSync(dir)
+    .map(name => ({ name, mtime: fs.statSync(path.join(dir, name)).mtimeMs }))
+    .sort((a, b) => b.mtime - a.mtime);
+  for (const old of entries.slice(MAX_LOGS_PER_ITEM)) {
+    try { fs.unlinkSync(path.join(dir, old.name)); } catch { /* ignore */ }
+  }
+  return logPath;
+};
+
+const buildOutputPreview = (output: string, logPath: string): string => {
+  const headTailBudget = PREVIEW_HEAD_BYTES + PREVIEW_TAIL_BYTES;
+  let body: string;
+  if (output.length <= headTailBudget) {
+    body = output;
+  } else {
+    const head = output.substring(0, PREVIEW_HEAD_BYTES);
+    const tail = output.substring(output.length - PREVIEW_TAIL_BYTES);
+    const omitted = output.length - headTailBudget;
+    body = `${head}\n... (${omitted} bytes truncated) ...\n${tail}`;
+  }
+  return `${body}\n[Full log: ${logPath}]`;
+};
+
+const purgeItemLogs = (itemId: string): void => {
+  const dir = getItemLogDir(itemId);
+  if (fs.existsSync(dir)) {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+};
+
 // ── Backup ───────────────────────────────────────────────────────────────────
 
 const BACKUP_DIR = path.join(os.homedir(), '.agenfk', 'backup');
@@ -125,8 +173,9 @@ const trashRecursively = async (id: string): Promise<boolean> => {
   if (!item || item.status === Status.TRASHED) return false;
 
   console.log(`[AUTO_TRASH] Trashing ${item.id} (${item.title}) and its children`);
-  
+
   await storage.updateItem(id, { status: Status.TRASHED });
+  purgeItemLogs(id);
 
   const children = await storage.listItems({ parentId: id });
   for (const child of children) {
@@ -1350,35 +1399,37 @@ async function handleValidateProgress(itemId: string, command: string | undefine
     child.on('error', (err) => resolve({ output: err.message, code: 1 }));
   });
 
-  const truncated = output.substring(0, 2000) + (output.length > 2000 ? '\n... (truncated)' : '');
+  const testId = uuidv4();
+  const logPath = writeValidationLog(itemId, testId, output);
+  const preview = buildOutputPreview(output, logPath);
   const passed = code === 0;
   const exitNote = exitCriteria ? `\n**Exit criteria**: ${exitCriteria}` : '';
 
   const comments = [...(item.comments || []), {
     id: uuidv4(),
     author: 'ValidateTool',
-    content: `### Validation ${passed ? 'PASSED' : 'FAILED'}\n\n**Step**: ${item.status} → ${passed ? nextStatus : failureStatus}${exitNote}\n**Command**: \`${resolvedCommand}\`\n\n**Output**:\n\`\`\`\n${truncated}\n\`\`\``,
+    content: `### Validation ${passed ? 'PASSED' : 'FAILED'}\n\n**Step**: ${item.status} → ${passed ? nextStatus : failureStatus}${exitNote}\n**Command**: \`${resolvedCommand}\`\n\n**Output**:\n\`\`\`\n${preview}\n\`\`\``,
     timestamp: new Date(),
   }];
 
   if (passed) {
     const updates: any = { status: nextStatus, comments };
     if (nextStatus === Status.DONE) {
-      updates.tests = [...(item.tests || []), { id: uuidv4(), command: resolvedCommand, output: truncated, status: 'PASSED', executedAt: new Date() }];
+      updates.tests = [...(item.tests || []), { id: testId, command: resolvedCommand, output: preview, status: 'PASSED', executedAt: new Date() }];
     }
     const updated = await storage.updateItem(itemId, updates);
     io.emit('items_updated');
     if (updated.parentId) await syncParentStatus(updated.parentId);
     if (nextStatus === Status.DONE && process.env.NODE_ENV !== 'test' && !process.env.VITEST) autoGitCommit(updated, projectRoot);
-    return res.json({ status: nextStatus, message: `✅ Validation Passed!\n\nCommand: \`${resolvedCommand}\`\nItem moved to ${nextStatus}.${mandatoryInstructions}${pushInstruction}`, output: truncated });
+    return res.json({ status: nextStatus, message: `✅ Validation Passed!\n\nCommand: \`${resolvedCommand}\`\nItem moved to ${nextStatus}.${mandatoryInstructions}${pushInstruction}`, output: preview });
   } else {
     const updates: any = { status: failureStatus, comments };
     if (nextStatus === Status.DONE) {
-      updates.tests = [...(item.tests || []), { id: uuidv4(), command: resolvedCommand, output: truncated, status: 'FAILED', executedAt: new Date() }];
+      updates.tests = [...(item.tests || []), { id: testId, command: resolvedCommand, output: preview, status: 'FAILED', executedAt: new Date() }];
     }
     await storage.updateItem(itemId, updates);
     io.emit('items_updated');
-    return res.status(422).json({ status: failureStatus, message: `❌ Validation Failed!\n\nCommand: \`${resolvedCommand}\`\nRoot: \`${projectRoot}\`\n\nOutput:\n${truncated}`, output: truncated });
+    return res.status(422).json({ status: failureStatus, message: `❌ Validation Failed!\n\nCommand: \`${resolvedCommand}\`\nRoot: \`${projectRoot}\`\n\nOutput:\n${preview}`, output: preview });
   }
 }
 

--- a/packages/server/src/test/server.supplemental.test.ts
+++ b/packages/server/src/test/server.supplemental.test.ts
@@ -1982,3 +1982,228 @@ describe('PUT /items/:id — comment with step field', () => {
     expect(fetched.comments[0].content).toBe('evidence text');
   });
 });
+
+// ── validate_progress: full-output log persistence + rolling window ──────────
+
+describe('POST /items/:id/validate — full-output log persistence', () => {
+  const LOGS_DIR = path.join(path.dirname(TEST_DB), 'logs');
+  const rmLogs = () => { if (fs.existsSync(LOGS_DIR)) fs.rmSync(LOGS_DIR, { recursive: true, force: true }); };
+
+  beforeEach(async () => { await initStorage(); rmLogs(); });
+  afterEach(() => { rmLogs(); });
+
+  const setupItemInCoding = async (name: string) => {
+    const p = (await request(app).post('/projects').send({ name })).body;
+    const item = (await request(app).post('/items').send({ type: 'TASK', title: name, projectId: p.id })).body;
+    await request(app).put(`/items/${item.id}`).send({ status: 'IN_PROGRESS' });
+    return { p, item };
+  };
+
+  // Node one-liner emitting a deterministic payload > 2KB with distinctive
+  // head+tail markers placed within the head/tail truncation windows.
+  const longOutputCommand = (tag: string) =>
+    `node -e "const head='HEAD_${tag}_START'+'A'.repeat(1500); const tail='Z'.repeat(900)+'TAIL_${tag}_END'; console.log(head); console.log(tail);"`;
+
+  it('writes the full command output to .agenfk/logs/<itemId>/<testId>.log', async () => {
+    if (!VERIFY_TOKEN) return;
+    const { item } = await setupItemInCoding('LogPersist1');
+
+    const res = await request(app)
+      .post(`/items/${item.id}/validate`)
+      .set('x-agenfk-internal', VERIFY_TOKEN)
+      .send({ command: longOutputCommand('r1') });
+
+    expect(res.status).toBe(200);
+
+    const itemLogDir = path.join(LOGS_DIR, item.id);
+    expect(fs.existsSync(itemLogDir)).toBe(true);
+    const files = fs.readdirSync(itemLogDir);
+    expect(files).toHaveLength(1);
+
+    const full = fs.readFileSync(path.join(itemLogDir, files[0]), 'utf8');
+    expect(full).toContain('HEAD_r1_START');
+    expect(full).toContain('TAIL_r1_END');
+    expect(full).toContain('A'.repeat(1500));
+    expect(full).toContain('Z'.repeat(900));
+    expect(full.length).toBeGreaterThan(2400);
+    expect(full).not.toContain('(truncated)');
+  });
+
+  it('returns head+tail truncated preview in response when output exceeds threshold', async () => {
+    if (!VERIFY_TOKEN) return;
+    const { item } = await setupItemInCoding('LogPersist2');
+
+    const res = await request(app)
+      .post(`/items/${item.id}/validate`)
+      .set('x-agenfk-internal', VERIFY_TOKEN)
+      .send({ command: longOutputCommand('r2') });
+
+    expect(res.status).toBe(200);
+    const preview: string = res.body.output;
+    expect(preview).toBeDefined();
+    // Preview must contain the head of output
+    expect(preview).toContain('HEAD_r2_START');
+    // Preview must contain the tail of output
+    expect(preview).toContain('TAIL_r2_END');
+    // Preview must be substantially smaller than full output (full is ~2.4KB payload + newlines)
+    // Head+tail+marker should be ~2-3KB; assert it's bounded
+    expect(preview.length).toBeLessThan(3500);
+    // Truncation marker present
+    expect(preview).toMatch(/truncated/);
+    // Log file path referenced so the agent can read full output
+    expect(preview).toContain('Full log:');
+    expect(preview).toContain(path.join('logs', item.id));
+  });
+
+  it('does not truncate when output is short (below threshold)', async () => {
+    if (!VERIFY_TOKEN) return;
+    const { item } = await setupItemInCoding('LogPersist3');
+
+    const res = await request(app)
+      .post(`/items/${item.id}/validate`)
+      .set('x-agenfk-internal', VERIFY_TOKEN)
+      .send({ command: "echo short-output-xyz" });
+
+    expect(res.status).toBe(200);
+    const preview: string = res.body.output;
+    expect(preview).toContain('short-output-xyz');
+    // No truncation marker for short output
+    expect(preview).not.toMatch(/\(truncated\)/);
+    expect(preview).not.toMatch(/bytes truncated/);
+  });
+
+  it('stores head+tail preview (not full output) in the comment and includes log path', async () => {
+    if (!VERIFY_TOKEN) return;
+    const { item } = await setupItemInCoding('LogPersist4');
+
+    await request(app)
+      .post(`/items/${item.id}/validate`)
+      .set('x-agenfk-internal', VERIFY_TOKEN)
+      .send({ command: longOutputCommand('r4') });
+
+    const fetched = (await request(app).get(`/items/${item.id}`)).body;
+    const validationComment = fetched.comments.find((c: any) =>
+      c.author === 'ValidateTool' && typeof c.content === 'string' && c.content.includes('Validation')
+    );
+    expect(validationComment).toBeDefined();
+    // Comment should contain the head and tail markers from the output
+    expect(validationComment.content).toContain('HEAD_r4_START');
+    expect(validationComment.content).toContain('TAIL_r4_END');
+    // Full 1500-A block must not appear — output exceeds head+tail budget so it's truncated
+    expect(validationComment.content).not.toContain('A'.repeat(1500));
+    // Log path referenced in comment
+    expect(validationComment.content).toContain('Full log:');
+  });
+
+  it('stores head+tail preview (not full output) in the tests[] record on final step', async () => {
+    if (!VERIFY_TOKEN) return;
+    const p = (await request(app).post('/projects').send({ name: 'LogPersist5', verifyCommand: longOutputCommand('r5') })).body;
+    const item = (await request(app).post('/items').send({ type: 'TASK', title: 'LogPersist5', projectId: p.id })).body;
+    await request(app)
+      .post('/items/bulk')
+      .set('x-agenfk-internal', VERIFY_TOKEN)
+      .send({ items: [{ id: item.id, updates: { status: 'TEST' } }] });
+
+    const current = (await request(app).get(`/items/${item.id}`)).body;
+    if (current.status !== 'TEST') return;
+
+    const res = await request(app)
+      .post(`/items/${item.id}/validate`)
+      .set('x-agenfk-internal', VERIFY_TOKEN)
+      .send({});
+    if (res.status !== 200) return;
+
+    const fetched = (await request(app).get(`/items/${item.id}`)).body;
+    expect(fetched.tests).toBeDefined();
+    expect(fetched.tests.length).toBeGreaterThan(0);
+    const lastTest = fetched.tests[fetched.tests.length - 1];
+    expect(lastTest.output).toContain('HEAD_r5_START');
+    expect(lastTest.output).toContain('TAIL_r5_END');
+    // Full output not stored inline
+    expect(lastTest.output).not.toContain('A'.repeat(1500));
+    // Log file exists on disk with full content
+    const itemLogDir = path.join(LOGS_DIR, item.id);
+    expect(fs.existsSync(itemLogDir)).toBe(true);
+    const files = fs.readdirSync(itemLogDir);
+    expect(files.length).toBeGreaterThan(0);
+    const fullLogContent = fs.readFileSync(path.join(itemLogDir, files[files.length - 1]), 'utf8');
+    expect(fullLogContent).toContain('A'.repeat(1500));
+  });
+
+  it('prunes per-item log directory to the newest 3 files (rolling window)', async () => {
+    if (!VERIFY_TOKEN) return;
+    const { item } = await setupItemInCoding('LogPersist6');
+
+    const runOnce = async (tag: string) => {
+      await request(app)
+        .post(`/items/${item.id}/validate`)
+        .set('x-agenfk-internal', VERIFY_TOKEN)
+        .send({ command: `echo OUTPUT_${tag}` });
+      // bounce back to coding step so we can validate again
+      await request(app)
+        .post('/items/bulk')
+        .set('x-agenfk-internal', VERIFY_TOKEN)
+        .send({ items: [{ id: item.id, updates: { status: 'IN_PROGRESS' } }] });
+      // small delay so mtimes differ
+      await new Promise(r => setTimeout(r, 20));
+    };
+
+    await runOnce('one');
+    await runOnce('two');
+    await runOnce('three');
+    await runOnce('four');
+
+    const itemLogDir = path.join(LOGS_DIR, item.id);
+    expect(fs.existsSync(itemLogDir)).toBe(true);
+    const files = fs.readdirSync(itemLogDir);
+    expect(files).toHaveLength(3);
+
+    const contents = files.map(f => fs.readFileSync(path.join(itemLogDir, f), 'utf8'));
+    // Oldest run (one) should have been pruned; runs two, three, four retained.
+    expect(contents.some(c => c.includes('OUTPUT_one'))).toBe(false);
+    expect(contents.some(c => c.includes('OUTPUT_two'))).toBe(true);
+    expect(contents.some(c => c.includes('OUTPUT_three'))).toBe(true);
+    expect(contents.some(c => c.includes('OUTPUT_four'))).toBe(true);
+  });
+
+  it('purges the item log directory when the item is trashed via DELETE', async () => {
+    if (!VERIFY_TOKEN) return;
+    const { item } = await setupItemInCoding('LogPersist7');
+
+    // Create a log file by running validate
+    await request(app)
+      .post(`/items/${item.id}/validate`)
+      .set('x-agenfk-internal', VERIFY_TOKEN)
+      .send({ command: "echo will-be-trashed" });
+
+    const itemLogDir = path.join(LOGS_DIR, item.id);
+    expect(fs.existsSync(itemLogDir)).toBe(true);
+
+    // Delete (soft-trash)
+    const delRes = await request(app).delete(`/items/${item.id}`);
+    expect(delRes.status).toBe(204);
+
+    expect(fs.existsSync(itemLogDir)).toBe(false);
+  });
+
+  it('purges log directories of descendant items when a parent is trashed', async () => {
+    if (!VERIFY_TOKEN) return;
+    const p = (await request(app).post('/projects').send({ name: 'LogPersist8' })).body;
+    const parent = (await request(app).post('/items').send({ type: 'STORY', title: 'parent', projectId: p.id })).body;
+    const child = (await request(app).post('/items').send({ type: 'TASK', title: 'child', projectId: p.id, parentId: parent.id })).body;
+    await request(app).put(`/items/${child.id}`).send({ status: 'IN_PROGRESS' });
+
+    await request(app)
+      .post(`/items/${child.id}/validate`)
+      .set('x-agenfk-internal', VERIFY_TOKEN)
+      .send({ command: "echo child-output" });
+
+    const childLogDir = path.join(LOGS_DIR, child.id);
+    expect(fs.existsSync(childLogDir)).toBe(true);
+
+    const delRes = await request(app).delete(`/items/${parent.id}`);
+    expect(delRes.status).toBe(204);
+
+    expect(fs.existsSync(childLogDir)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Replaces the hard 2000-char head-only truncation of `validate_progress` command output with a disk-backed approach that keeps full logs available while keeping MCP payloads small.
- Full stdout+stderr written to `.agenfk/logs/<itemId>/<testId>.log` alongside `db.sqlite`.
- HTTP response, comment, and `tests[]` record carry a **head 1KB + tail 1KB** preview with an elision marker and the log file path — agent can `Read` the log when it needs more context.
- Per-item rolling window: newest 3 log files kept per item; older files pruned on each run.
- Log directory purged when an item (or any of its descendants) is trashed via `DELETE /items/:id`.

## Test plan

- [x] Full output written to `.agenfk/logs/<itemId>/<testId>.log` with correct content
- [x] Head+tail truncated preview in HTTP response includes `Full log:` path reference
- [x] Short outputs (< 2KB) returned without truncation marker
- [x] ValidateTool comment contains head+tail preview and log path, not full output
- [x] `tests[]` record on final-step transition carries preview, not full output; log file has full content
- [x] Per-item rolling window prunes to 3 files (oldest-by-mtime removed)
- [x] `DELETE /items/:id` purges item log directory
- [x] Recursive parent trash purges descendant log directories
- [x] Full server test suite (278 tests) passes
- [x] Full monorepo build (`npm run build && npm test`) passes