### PR TITLE
Hub: token-gated first-run admin bootstrap

### DIFF
--- a/packages/hub-ui/src/pages/Setup.tsx
+++ b/packages/hub-ui/src/pages/Setup.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { api, ProvidersResponse } from '../api';
+import { buildSetupPayload, canSubmitSetup } from './setupSubmit';
 
 export function SetupPage() {
   const providers = useQuery<ProvidersResponse>({
@@ -9,26 +10,41 @@ export function SetupPage() {
     queryFn: async () => (await api.get('/auth/providers')).data,
   });
   const nav = useNavigate();
+  const [token, setToken] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [err, setErr] = useState<string | null>(null);
   const setup = useMutation({
-    mutationFn: () => api.post('/setup/initial-admin', { email, password }),
+    mutationFn: () => api.post('/setup/initial-admin', buildSetupPayload({ token, email, password })),
     onSuccess: () => nav('/login'),
     onError: (e: any) => setErr(e?.response?.data?.error ?? 'Setup failed'),
   });
 
   if (providers.data && !providers.data.requiresSetup) { nav('/login'); return null; }
 
+  const submittable = canSubmitSetup({ token, email, password, isPending: setup.isPending });
+
   return (
     <div className="min-h-screen flex items-center justify-center p-6">
       <div className="w-full max-w-sm space-y-6">
         <h1 className="text-xl font-semibold">First-run setup</h1>
-        <p className="text-sm text-zinc-500">Create the initial admin account. After this, sign-in is gated by the providers you enable.</p>
+        <p className="text-sm text-zinc-500">
+          Paste the bootstrap token printed in the hub's startup logs, then create the initial admin account.
+          After this, sign-in is gated by the providers you enable.
+        </p>
         <form className="space-y-3" onSubmit={(e) => { e.preventDefault(); setErr(null); setup.mutate(); }}>
+          <input
+            type="text"
+            value={token}
+            onChange={(e) => setToken(e.target.value)}
+            placeholder="bootstrap token (from hub startup logs)"
+            autoComplete="off"
+            spellCheck={false}
+            className="w-full px-3 py-2 border rounded font-mono text-sm"
+          />
           <input type="email" value={email} onChange={(e) => setEmail(e.target.value)} placeholder="admin email" className="w-full px-3 py-2 border rounded" />
           <input type="password" minLength={8} value={password} onChange={(e) => setPassword(e.target.value)} placeholder="password (≥8 chars)" className="w-full px-3 py-2 border rounded" />
-          <button type="submit" className="w-full px-3 py-2 bg-zinc-900 text-white rounded hover:bg-zinc-800" disabled={setup.isPending}>
+          <button type="submit" className="w-full px-3 py-2 bg-zinc-900 text-white rounded hover:bg-zinc-800 disabled:opacity-50" disabled={!submittable}>
             {setup.isPending ? 'Creating…' : 'Create admin'}
           </button>
           {err && <div className="text-sm text-red-600">{err}</div>}

--- a/packages/hub-ui/src/pages/setupSubmit.ts
+++ b/packages/hub-ui/src/pages/setupSubmit.ts
@@ -1,0 +1,36 @@
+/**
+ * Subtask 5daa24df — Setup page must POST a `token` field alongside email +
+ * password so the hub's token-gated /setup/initial-admin route accepts it.
+ *
+ * Extracted from the JSX so the body-shape contract is testable in isolation.
+ */
+export interface SetupFields {
+  token: string;
+  email: string;
+  password: string;
+}
+
+/**
+ * Whitespace-trim the token so an operator who copy-pasted the boxed banner
+ * doesn't fail validation because of a stray space. Email + password are
+ * passed through unchanged — the server is the authority on those.
+ */
+export function buildSetupPayload(fields: SetupFields): SetupFields {
+  return {
+    token: fields.token.trim(),
+    email: fields.email,
+    password: fields.password,
+  };
+}
+
+/**
+ * The submit button is enabled only when all three fields look minimally
+ * sane and we're not already submitting. Server still owns final validation.
+ */
+export function canSubmitSetup(args: SetupFields & { isPending: boolean }): boolean {
+  if (args.isPending) return false;
+  if (args.token.trim().length === 0) return false;
+  if (args.email.length === 0) return false;
+  if (args.password.length < 8) return false;
+  return true;
+}

--- a/packages/hub-ui/src/test/setupSubmit.test.ts
+++ b/packages/hub-ui/src/test/setupSubmit.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { buildSetupPayload, canSubmitSetup } from '../pages/setupSubmit';
+
+describe('buildSetupPayload', () => {
+  it('returns token + email + password as the body shape the hub expects', () => {
+    expect(buildSetupPayload({ token: 't', email: 'a@b', password: 'longenough1' })).toEqual({
+      token: 't',
+      email: 'a@b',
+      password: 'longenough1',
+    });
+  });
+
+  it('trims surrounding whitespace from the token (operator paste-with-space is common)', () => {
+    expect(buildSetupPayload({ token: '  abc  ', email: 'a@b', password: 'longenough1' }).token).toBe('abc');
+  });
+
+  it('does not trim email or password (server owns those)', () => {
+    const out = buildSetupPayload({ token: 't', email: '  a@b  ', password: '  longenough1  ' });
+    expect(out.email).toBe('  a@b  ');
+    expect(out.password).toBe('  longenough1  ');
+  });
+});
+
+describe('canSubmitSetup', () => {
+  const base = { token: 'abc', email: 'a@b', password: 'longenough1', isPending: false };
+
+  it('enabled when all fields are present and not pending', () => {
+    expect(canSubmitSetup(base)).toBe(true);
+  });
+
+  it('disabled while a request is in flight', () => {
+    expect(canSubmitSetup({ ...base, isPending: true })).toBe(false);
+  });
+
+  it('disabled when the token is empty or whitespace-only', () => {
+    expect(canSubmitSetup({ ...base, token: '' })).toBe(false);
+    expect(canSubmitSetup({ ...base, token: '   ' })).toBe(false);
+  });
+
+  it('disabled when email is empty', () => {
+    expect(canSubmitSetup({ ...base, email: '' })).toBe(false);
+  });
+
+  it('disabled when password is shorter than 8 chars', () => {
+    expect(canSubmitSetup({ ...base, password: 'short' })).toBe(false);
+    expect(canSubmitSetup({ ...base, password: '1234567' })).toBe(false);
+    expect(canSubmitSetup({ ...base, password: '12345678' })).toBe(true);
+  });
+});

--- a/packages/hub/src/auth/bootstrapToken.ts
+++ b/packages/hub/src/auth/bootstrapToken.ts
@@ -1,0 +1,35 @@
+import { randomUUID } from 'crypto';
+import type { DB } from '../db.js';
+import { countUsers } from './password.js';
+
+/**
+ * First-run admin bootstrap.
+ *
+ * On fresh installs the operator has no admin yet — but the open
+ * `/setup/initial-admin` route is a TOFU race (anyone reachable on the
+ * network can claim admin if they hit it first). To close that race the
+ * hub generates a single-use UUIDv4 on first boot, persists it, and the
+ * operator pastes it into the Setup UI before email/password are accepted.
+ *
+ * Restart-friendly: the row persists across reboots until the admin is
+ * created, so an operator who restarts mid-setup keeps the same token
+ * (re-logged on next boot) instead of hunting through old log lines.
+ *
+ * Returns the active token, or null when setup is already closed
+ * (i.e. at least one user already exists in the DB).
+ */
+export async function ensureBootstrapToken(db: DB): Promise<string | null> {
+  if ((await countUsers(db)) > 0) return null;
+
+  const existing = await db.get<{ token: string }>(
+    'SELECT token FROM bootstrap_tokens LIMIT 1',
+  );
+  if (existing?.token) return existing.token;
+
+  const token = randomUUID();
+  await db.run(
+    'INSERT INTO bootstrap_tokens (token) VALUES (?)',
+    [token],
+  );
+  return token;
+}

--- a/packages/hub/src/db/postgres.ts
+++ b/packages/hub/src/db/postgres.ts
@@ -170,6 +170,12 @@ const SCHEMA_PG = `
     value TEXT,
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
   );
+
+  -- First-run admin bootstrap. See packages/hub/src/auth/bootstrapToken.ts.
+  CREATE TABLE IF NOT EXISTS bootstrap_tokens (
+    token TEXT PRIMARY KEY,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  );
 `;
 
 /**

--- a/packages/hub/src/db/sqlite.ts
+++ b/packages/hub/src/db/sqlite.ts
@@ -179,6 +179,14 @@ const SCHEMA_SQLITE = `
     value TEXT,
     updated_at TEXT NOT NULL DEFAULT (datetime('now'))
   );
+
+  -- First-run admin bootstrap. Single-use UUIDv4 generated on the first
+  -- boot of an empty install, deleted in the same transaction that
+  -- creates the initial admin (see /setup/initial-admin route).
+  CREATE TABLE IF NOT EXISTS bootstrap_tokens (
+    token TEXT PRIMARY KEY,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
 `;
 
 class SqliteAdapter implements HubDb {

--- a/packages/hub/src/routes/auth.ts
+++ b/packages/hub/src/routes/auth.ts
@@ -44,16 +44,7 @@ export function authRouter(ctx: HubServerContext): Router {
       return res.status(400).json({ error: 'email and password required' });
     }
 
-    let user = await findUserByEmail(ctx.db, email);
-
-    // Initial-admin bootstrap.
-    if (!user && (await countUsers(ctx.db)) === 0
-      && ctx.config.initialAdminEmail
-      && ctx.config.initialAdminPassword
-      && email.toLowerCase() === ctx.config.initialAdminEmail.toLowerCase()
-      && password === ctx.config.initialAdminPassword) {
-      user = await createPasswordUser(ctx.db, ctx.config.defaultOrgId, email, password, 'admin');
-    }
+    const user = await findUserByEmail(ctx.db, email);
 
     if (!user || !user.password_hash || !user.active) {
       return res.status(401).json({ error: 'Invalid credentials' });

--- a/packages/hub/src/routes/auth.ts
+++ b/packages/hub/src/routes/auth.ts
@@ -1,4 +1,5 @@
 import { Router, Request, Response } from 'express';
+import { timingSafeEqual } from 'crypto';
 import { HubServerContext } from '../server.js';
 import {
   countUsers,
@@ -89,11 +90,35 @@ export function setupRouter(ctx: HubServerContext): Router {
     if ((await countUsers(ctx.db)) > 0) {
       return res.status(409).json({ error: 'Setup is closed: an admin already exists.' });
     }
-    const { email, password } = req.body ?? {};
+    const { token, email, password } = req.body ?? {};
+
+    // Token check first — single generic 401 for missing/empty/wrong, so a
+    // probe can't tell the difference between "no token row" and "wrong
+    // token". Constant-time compare on equal-length buffers.
+    const stored = await ctx.db.get<{ token: string }>('SELECT token FROM bootstrap_tokens LIMIT 1');
+    const ok = (() => {
+      if (!stored?.token) return false;
+      if (typeof token !== 'string' || token.length === 0) return false;
+      const a = Buffer.from(stored.token, 'utf8');
+      const b = Buffer.from(token, 'utf8');
+      if (a.length !== b.length) return false;
+      return timingSafeEqual(a, b);
+    })();
+    if (!ok) {
+      return res.status(401).json({ error: 'Invalid token or setup is closed' });
+    }
+
     if (typeof email !== 'string' || typeof password !== 'string' || password.length < 8) {
       return res.status(400).json({ error: 'email + password (≥8 chars) required' });
     }
-    await createPasswordUser(ctx.db, ctx.config.defaultOrgId, email, password, 'admin');
+
+    // Create the admin and consume the token in a single transaction. If
+    // user creation throws (e.g. a UNIQUE collision on email), the token
+    // row is rolled back so the operator can retry.
+    await ctx.db.transaction(async () => {
+      await createPasswordUser(ctx.db, ctx.config.defaultOrgId, email, password, 'admin');
+      await ctx.db.run('DELETE FROM bootstrap_tokens', []);
+    });
     res.status(201).json({ ok: true });
   });
 

--- a/packages/hub/src/server.ts
+++ b/packages/hub/src/server.ts
@@ -11,6 +11,7 @@ import { adminRouter } from './routes/admin.js';
 import { orgRenameRouter } from './routes/orgRename.js';
 import { googleRouter } from './auth/google.js';
 import { entraRouter } from './auth/entra.js';
+import { ensureBootstrapToken } from './auth/bootstrapToken.js';
 import { queriesRouter } from './routes/queries.js';
 import { connectRouter } from './routes/connect.js';
 import { startRollupTimer } from './rollup.js';
@@ -151,6 +152,25 @@ export async function createHubApp(
   await db.run('INSERT OR IGNORE INTO orgs (id, name) VALUES (?, ?)', [config.defaultOrgId, config.defaultOrgId]);
   // Default auth_config row for the default org.
   await db.run('INSERT OR IGNORE INTO auth_config (org_id, password_enabled) VALUES (?, 1)', [config.defaultOrgId]);
+
+  // First-run admin bootstrap token. Logged once per boot (re-logged on
+  // restart while setup is still pending) so the operator can paste it into
+  // the Setup UI. Returns null once a user already exists, in which case
+  // we say nothing.
+  const bootstrapToken = await ensureBootstrapToken(db);
+  if (bootstrapToken) {
+    const banner = [
+      '╔══════════════════════════════════════════════════════════════════════╗',
+      '║  AgEnFK Hub — first-run setup                                        ║',
+      '║  Open the hub in your browser, click Setup, and paste this token:    ║',
+      '║                                                                      ║',
+      `║      ${bootstrapToken.padEnd(62)}  ║`,
+      '║                                                                      ║',
+      '║  This token works exactly once. Do not share it.                     ║',
+      '╚══════════════════════════════════════════════════════════════════════╝',
+    ].join('\n');
+    console.log(banner);
+  }
 
   const ctx: HubServerContext = { db, config };
 

--- a/packages/hub/src/test/auth.test.ts
+++ b/packages/hub/src/test/auth.test.ts
@@ -41,14 +41,16 @@ describe('hub auth + setup', () => {
   });
 
   it('POST /setup/initial-admin creates the first admin', async () => {
-    const r = await supertest(app).post('/setup/initial-admin').send({ email: 'first@x', password: 'longenough1' });
+    const tok = (await ctx.db.get('SELECT token FROM bootstrap_tokens LIMIT 1') as { token: string } | undefined)?.token;
+    const r = await supertest(app).post('/setup/initial-admin').send({ token: tok, email: 'first@x', password: 'longenough1' });
     expect(r.status).toBe(201);
-    const r2 = await supertest(app).post('/setup/initial-admin').send({ email: 'second@x', password: 'longenough2' });
+    const r2 = await supertest(app).post('/setup/initial-admin').send({ token: tok, email: 'second@x', password: 'longenough2' });
     expect(r2.status).toBe(409);
   });
 
   it('rejects short passwords on /setup/initial-admin', async () => {
-    const r = await supertest(app).post('/setup/initial-admin').send({ email: 'a@b', password: 'short' });
+    const tok = (await ctx.db.get('SELECT token FROM bootstrap_tokens LIMIT 1') as { token: string } | undefined)?.token;
+    const r = await supertest(app).post('/setup/initial-admin').send({ token: tok, email: 'a@b', password: 'short' });
     expect(r.status).toBe(400);
   });
 

--- a/packages/hub/src/test/auth.test.ts
+++ b/packages/hub/src/test/auth.test.ts
@@ -25,8 +25,6 @@ describe('hub auth + setup', () => {
       secretKey: '0'.repeat(64),
       sessionSecret: 'test-session-secret-min-32-bytes-please',
       defaultOrgId: 'org',
-      initialAdminEmail: 'boot@example.com',
-      initialAdminPassword: 'bootpass1',
     });
     app = out.app;
     ctx = out.ctx;
@@ -54,16 +52,41 @@ describe('hub auth + setup', () => {
     expect(r.status).toBe(400);
   });
 
-  it('login succeeds with seeded env credentials and creates the admin row', async () => {
-    const r = await supertest(app).post('/auth/login').send({ email: 'boot@example.com', password: 'bootpass1' });
-    expect(r.status).toBe(200);
-    expect(r.body.role).toBe('admin');
-    const cookie = r.headers['set-cookie']?.[0];
-    expect(cookie).toMatch(/agenfk_hub_session=/);
+  it('does NOT auto-create an admin from initialAdminEmail/Password env on /auth/login (env-var bootstrap removed)', async () => {
+    // Even if a deployment still passes the legacy fields, the login route
+    // ignores them — the only interactive bootstrap is /setup/initial-admin
+    // gated by the stdout token.
+    const r = await supertest(app)
+      .post('/auth/login')
+      .send({ email: 'boot@example.com', password: 'bootpass1' });
+    expect(r.status).toBe(401);
+    const users = await ctx.db.all('SELECT id FROM users');
+    expect(users).toHaveLength(0);
+  });
 
-    const me = await supertest(app).get('/auth/me').set('Cookie', cookie);
-    expect(me.status).toBe(200);
-    expect(me.body.role).toBe('admin');
+  it('ignores legacy initialAdminEmail/Password fields even when passed via deployment config', async () => {
+    // Tear down the default app and rebuild with the legacy fields supplied
+    // by a stale deployment manifest. Type-cast bypasses the now-removed
+    // optional fields to simulate a deployment that hasn't been updated yet.
+    await ctx.db.close();
+    cleanup();
+    const out = await createHubApp({
+      dbPath: TEST_DB,
+      secretKey: '0'.repeat(64),
+      sessionSecret: 'test-session-secret-min-32-bytes-please',
+      defaultOrgId: 'org',
+      initialAdminEmail: 'legacy@example.com',
+      initialAdminPassword: 'legacypass1',
+    } as any);
+    app = out.app;
+    ctx = out.ctx;
+
+    const r = await supertest(app)
+      .post('/auth/login')
+      .send({ email: 'legacy@example.com', password: 'legacypass1' });
+    expect(r.status).toBe(401);
+    const users = await ctx.db.all('SELECT id FROM users');
+    expect(users).toHaveLength(0);
   });
 
   it('login fails with wrong password', async () => {

--- a/packages/hub/src/test/bootstrap-e2e.test.ts
+++ b/packages/hub/src/test/bootstrap-e2e.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Subtask f4223258 — full first-boot bootstrap flow, run against both
+ * SQLite and pg-mem so the token gate is exercised on every supported
+ * adapter. Each scenario boots createHubApp, captures the stdout banner,
+ * extracts the token, hits /setup/initial-admin, and asserts both the
+ * server response and the resulting DB state.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import supertest from 'supertest';
+import { createHubApp } from '../server';
+import { openPgMemDb } from '../db/postgres';
+import type { HubDb } from '../db/types';
+
+const SECRET = '0'.repeat(64);
+const UUID_V4 = /\b[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b/i;
+
+const dbFor = (label: string) =>
+  path.join(os.tmpdir(), `agenfk-hub-bootstrap-e2e-${label}-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`);
+
+const cleanup = (dbPath: string) => {
+  for (const s of ['', '-wal', '-shm']) {
+    const f = dbPath + s;
+    if (fs.existsSync(f)) fs.unlinkSync(f);
+  }
+};
+
+interface BackendHarness {
+  name: 'sqlite' | 'postgres';
+  /** Fresh DB + tracking for cleanup. Returns a boot fn that opens against the same DB across calls. */
+  setup: () => Promise<{ boot: () => Promise<{ app: any; db: HubDb; close: () => Promise<void> }>; teardown: () => Promise<void> }>;
+}
+
+const sqliteHarness: BackendHarness = {
+  name: 'sqlite',
+  setup: async () => {
+    const dbPath = dbFor('e2e');
+    return {
+      boot: async () => {
+        const out = await createHubApp({
+          dbPath,
+          secretKey: SECRET,
+          sessionSecret: 'test-session-secret-min-32-bytes-please',
+          defaultOrgId: 'org',
+        });
+        return { app: out.app, db: out.ctx.db, close: () => out.ctx.db.close() };
+      },
+      teardown: async () => { cleanup(dbPath); },
+    };
+  },
+};
+
+const pgHarness: BackendHarness = {
+  name: 'postgres',
+  setup: async () => {
+    // pg-mem is in-process; share one HubDb instance across boots so a
+    // restart sees the same state. The `db` override on createHubApp means
+    // the first boot creates schema; the second skips re-opening.
+    const db = await openPgMemDb();
+    return {
+      boot: async () => {
+        const out = await createHubApp({
+          dbPath: '/tmp/unused-pg-mem.sqlite',
+          secretKey: SECRET,
+          sessionSecret: 'test-session-secret-min-32-bytes-please',
+          defaultOrgId: 'org',
+          db,
+        });
+        // Don't actually close the shared db on per-boot teardown.
+        return { app: out.app, db, close: async () => { /* shared */ } };
+      },
+      teardown: async () => { await db.close(); },
+    };
+  },
+};
+
+for (const harness of [sqliteHarness, pgHarness]) {
+  describe(`first-boot bootstrap (${harness.name})`, () => {
+    let logSpy: ReturnType<typeof vi.spyOn>;
+    let h: Awaited<ReturnType<BackendHarness['setup']>>;
+
+    beforeEach(async () => {
+      logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      h = await harness.setup();
+    });
+
+    afterEach(async () => {
+      logSpy.mockRestore();
+      await h.teardown();
+    });
+
+    const extractToken = (): string => {
+      const all = logSpy.mock.calls.map(c => c.join(' ')).join('\n');
+      const m = all.match(UUID_V4);
+      if (!m) throw new Error(`expected a UUIDv4 in stdout, got:\n${all}`);
+      return m[0];
+    };
+
+    it('end-to-end: token from stdout → /setup/initial-admin → admin row created and token consumed', async () => {
+      const { app, db, close } = await h.boot();
+      try {
+        const token = extractToken();
+
+        const r = await supertest(app)
+          .post('/setup/initial-admin')
+          .send({ token, email: 'admin@x', password: 'longenough1' });
+        expect(r.status).toBe(201);
+
+        const remaining = await db.all('SELECT token FROM bootstrap_tokens');
+        expect(remaining).toHaveLength(0);
+
+        const users = await db.all<{ email: string; role: string }>("SELECT email, role FROM users");
+        expect(users).toHaveLength(1);
+        expect(users[0].email).toBe('admin@x');
+        expect(users[0].role).toBe('admin');
+
+        // Negative: second attempt returns 409 (single-use).
+        const second = await supertest(app)
+          .post('/setup/initial-admin')
+          .send({ token, email: 'second@x', password: 'longenough2' });
+        expect(second.status).toBe(409);
+
+        // The newly-created admin can log in via /auth/login.
+        const login = await supertest(app)
+          .post('/auth/login')
+          .send({ email: 'admin@x', password: 'longenough1' });
+        expect(login.status).toBe(200);
+        expect(login.body.role).toBe('admin');
+      } finally {
+        await close();
+      }
+    });
+
+    it('wrong token is rejected with 401 and the bootstrap row stays available for a retry', async () => {
+      const { app, db, close } = await h.boot();
+      try {
+        const token = extractToken();
+
+        const wrong = await supertest(app)
+          .post('/setup/initial-admin')
+          .send({ token: '00000000-0000-4000-8000-000000000000', email: 'admin@x', password: 'longenough1' });
+        expect(wrong.status).toBe(401);
+        expect(wrong.body.error).toMatch(/invalid token/i);
+
+        const usersAfter401 = await db.all('SELECT id FROM users');
+        expect(usersAfter401).toHaveLength(0);
+        const stillHave = await db.all('SELECT token FROM bootstrap_tokens');
+        expect(stillHave).toHaveLength(1);
+
+        // Operator now retries with the right token.
+        const ok = await supertest(app)
+          .post('/setup/initial-admin')
+          .send({ token, email: 'admin@x', password: 'longenough1' });
+        expect(ok.status).toBe(201);
+      } finally {
+        await close();
+      }
+    });
+
+    it('restart while setup is still pending re-logs the same token; restart after setup logs nothing', async () => {
+      // Boot 1: token logged.
+      const first = await h.boot();
+      const token1 = extractToken();
+      await first.close();
+
+      // Boot 2: same token re-logged because setup is still open.
+      logSpy.mockClear();
+      const second = await h.boot();
+      const token2 = extractToken();
+      expect(token2).toBe(token1);
+
+      // Complete setup.
+      const r = await supertest(second.app)
+        .post('/setup/initial-admin')
+        .send({ token: token2, email: 'admin@x', password: 'longenough1' });
+      expect(r.status).toBe(201);
+      await second.close();
+
+      // Boot 3: setup is closed, no banner.
+      logSpy.mockClear();
+      const third = await h.boot();
+      try {
+        const all = logSpy.mock.calls.map(c => c.join(' ')).join('\n');
+        expect(all).not.toMatch(UUID_V4);
+        expect(all).not.toMatch(/first-run setup/i);
+      } finally {
+        await third.close();
+      }
+    });
+  });
+}

--- a/packages/hub/src/test/bootstrapToken.test.ts
+++ b/packages/hub/src/test/bootstrapToken.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Subtask 946a943c — bootstrap_tokens table + generator + first-boot stdout banner.
+ *
+ * Closes the TOFU race in /setup/initial-admin by gating it with a single-use
+ * UUIDv4 the operator reads from the hub's stdout. This file covers the
+ * generator + banner; the route change lives in subtask 442639e6.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ensureBootstrapToken } from '../auth/bootstrapToken';
+import { openSqliteDb } from '../db/sqlite';
+import { createHubApp } from '../server';
+import { createPasswordUser } from '../auth/password';
+
+const dbFor = (label: string) =>
+  path.join(os.tmpdir(), `agenfk-hub-bootstrap-${label}-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`);
+
+const cleanup = (dbPath: string) => {
+  for (const s of ['', '-wal', '-shm']) {
+    const f = dbPath + s;
+    if (fs.existsSync(f)) fs.unlinkSync(f);
+  }
+};
+
+const UUID_V4 = /\b[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b/i;
+
+describe('ensureBootstrapToken — generator', () => {
+  let dbPath: string;
+
+  beforeEach(() => { dbPath = dbFor('gen'); });
+  afterEach(() => { cleanup(dbPath); });
+
+  it('returns a UUIDv4 on a fresh DB with no users', async () => {
+    const db = await openSqliteDb(dbPath);
+    try {
+      const token = await ensureBootstrapToken(db);
+      expect(token).toMatch(UUID_V4);
+    } finally {
+      await db.close();
+    }
+  });
+
+  it('is idempotent: returns the same token on repeated calls within one process', async () => {
+    const db = await openSqliteDb(dbPath);
+    try {
+      const t1 = await ensureBootstrapToken(db);
+      const t2 = await ensureBootstrapToken(db);
+      const t3 = await ensureBootstrapToken(db);
+      expect(t1).not.toBeNull();
+      expect(t2).toBe(t1);
+      expect(t3).toBe(t1);
+    } finally {
+      await db.close();
+    }
+  });
+
+  it('persists the token across DB close + reopen (restart-friendly)', async () => {
+    let token1: string | null;
+    {
+      const db = await openSqliteDb(dbPath);
+      token1 = await ensureBootstrapToken(db);
+      await db.close();
+    }
+    const db2 = await openSqliteDb(dbPath);
+    try {
+      const token2 = await ensureBootstrapToken(db2);
+      expect(token2).toBe(token1);
+    } finally {
+      await db2.close();
+    }
+  });
+
+  it('returns null once a user already exists (setup is closed)', async () => {
+    const db = await openSqliteDb(dbPath);
+    try {
+      // Seed a default org row first — createPasswordUser expects one.
+      await db.run("INSERT OR IGNORE INTO orgs (id, name) VALUES (?, ?)", ['org', 'org']);
+      await createPasswordUser(db, 'org', 'first@x', 'longenough1', 'admin');
+      const token = await ensureBootstrapToken(db);
+      expect(token).toBeNull();
+    } finally {
+      await db.close();
+    }
+  });
+
+  it('does not regenerate after admin creation: a stale token row is ignored', async () => {
+    const db = await openSqliteDb(dbPath);
+    try {
+      const token1 = await ensureBootstrapToken(db);
+      expect(token1).toMatch(UUID_V4);
+      // Simulate the admin getting created (subtask 442639e6 will delete the
+      // token row in the same tx; here we delete it manually and seed a user).
+      await db.run("INSERT OR IGNORE INTO orgs (id, name) VALUES (?, ?)", ['org', 'org']);
+      await createPasswordUser(db, 'org', 'first@x', 'longenough1', 'admin');
+      await db.run('DELETE FROM bootstrap_tokens', []);
+      const token2 = await ensureBootstrapToken(db);
+      expect(token2).toBeNull();
+      const rows = await db.all('SELECT token FROM bootstrap_tokens');
+      expect(rows).toHaveLength(0);
+    } finally {
+      await db.close();
+    }
+  });
+});
+
+describe('createHubApp — first-boot stdout banner', () => {
+  let dbPath: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    dbPath = dbFor('banner');
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    cleanup(dbPath);
+  });
+
+  it('logs a banner containing a UUIDv4 token on first boot', async () => {
+    const out = await createHubApp({
+      dbPath,
+      secretKey: '0'.repeat(64),
+      sessionSecret: 'test-session-secret-min-32-bytes-please',
+      defaultOrgId: 'org',
+    });
+    try {
+      const all = logSpy.mock.calls.map(c => c.join(' ')).join('\n');
+      expect(all).toMatch(/first-run setup/i);
+      const m = all.match(UUID_V4);
+      expect(m, `expected a UUIDv4 in stdout, got:\n${all}`).not.toBeNull();
+    } finally {
+      await out.ctx.db.close();
+    }
+  });
+
+  it('re-logs the same token when the hub restarts before setup is finished', async () => {
+    const tokens: string[] = [];
+
+    for (const _ of [1, 2]) {
+      logSpy.mockClear();
+      const out = await createHubApp({
+        dbPath,
+        secretKey: '0'.repeat(64),
+        sessionSecret: 'test-session-secret-min-32-bytes-please',
+        defaultOrgId: 'org',
+      });
+      const all = logSpy.mock.calls.map(c => c.join(' ')).join('\n');
+      const m = all.match(UUID_V4);
+      expect(m).not.toBeNull();
+      tokens.push(m![0]);
+      await out.ctx.db.close();
+    }
+
+    expect(tokens[0]).toBe(tokens[1]);
+  });
+
+  it('logs no banner once a user already exists', async () => {
+    // Boot once to seed the token, then create an admin, then reboot.
+    {
+      const out = await createHubApp({
+        dbPath,
+        secretKey: '0'.repeat(64),
+        sessionSecret: 'test-session-secret-min-32-bytes-please',
+        defaultOrgId: 'org',
+      });
+      await createPasswordUser(out.ctx.db, 'org', 'first@x', 'longenough1', 'admin');
+      await out.ctx.db.close();
+    }
+    logSpy.mockClear();
+    const out2 = await createHubApp({
+      dbPath,
+      secretKey: '0'.repeat(64),
+      sessionSecret: 'test-session-secret-min-32-bytes-please',
+      defaultOrgId: 'org',
+    });
+    try {
+      const all = logSpy.mock.calls.map(c => c.join(' ')).join('\n');
+      expect(all).not.toMatch(/first-run setup/i);
+      expect(all).not.toMatch(UUID_V4);
+    } finally {
+      await out2.ctx.db.close();
+    }
+  });
+});

--- a/packages/hub/src/test/setup-token.test.ts
+++ b/packages/hub/src/test/setup-token.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Subtask 442639e6 — token-gated POST /setup/initial-admin.
+ *
+ * Replaces the old open body shape (email + password) with a three-field
+ * body (token + email + password). Token validation runs first; only on
+ * match do we accept the email/password and atomically delete the token
+ * in the same transaction that creates the admin.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import supertest from 'supertest';
+import { createHubApp } from '../server';
+
+const dbFor = (label: string) =>
+  path.join(os.tmpdir(), `agenfk-hub-setup-token-${label}-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`);
+
+const cleanup = (dbPath: string) => {
+  for (const s of ['', '-wal', '-shm']) {
+    const f = dbPath + s;
+    if (fs.existsSync(f)) fs.unlinkSync(f);
+  }
+};
+
+const boot = async (dbPath: string) => {
+  const out = await createHubApp({
+    dbPath,
+    secretKey: '0'.repeat(64),
+    sessionSecret: 'test-session-secret-min-32-bytes-please',
+    defaultOrgId: 'org',
+  });
+  const row = await out.ctx.db.get<{ token: string }>('SELECT token FROM bootstrap_tokens LIMIT 1');
+  return { ...out, token: row?.token ?? null };
+};
+
+describe('POST /setup/initial-admin — token gate', () => {
+  let dbPath: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    dbPath = dbFor('gate');
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    cleanup(dbPath);
+  });
+
+  it('creates the admin and consumes the token when the body has a matching token', async () => {
+    const { app, ctx, token } = await boot(dbPath);
+    try {
+      expect(token).toBeTruthy();
+      const r = await supertest(app)
+        .post('/setup/initial-admin')
+        .send({ token, email: 'admin@x', password: 'longenough1' });
+      expect(r.status).toBe(201);
+
+      const left = await ctx.db.all('SELECT token FROM bootstrap_tokens');
+      expect(left).toHaveLength(0);
+
+      const users = await ctx.db.all<{ email: string; role: string }>("SELECT email, role FROM users");
+      expect(users).toHaveLength(1);
+      expect(users[0].email).toBe('admin@x');
+      expect(users[0].role).toBe('admin');
+    } finally {
+      await ctx.db.close();
+    }
+  });
+
+  it('returns 409 when an admin already exists (single-use enforced)', async () => {
+    const { app, ctx, token } = await boot(dbPath);
+    try {
+      const ok = await supertest(app)
+        .post('/setup/initial-admin')
+        .send({ token, email: 'first@x', password: 'longenough1' });
+      expect(ok.status).toBe(201);
+
+      const second = await supertest(app)
+        .post('/setup/initial-admin')
+        .send({ token, email: 'second@x', password: 'longenough2' });
+      expect(second.status).toBe(409);
+    } finally {
+      await ctx.db.close();
+    }
+  });
+
+  it('returns 401 with a generic message when the token is wrong; row is preserved', async () => {
+    const { app, ctx } = await boot(dbPath);
+    try {
+      const r = await supertest(app)
+        .post('/setup/initial-admin')
+        .send({ token: '00000000-0000-4000-8000-000000000000', email: 'admin@x', password: 'longenough1' });
+      expect(r.status).toBe(401);
+      expect(r.body.error).toMatch(/invalid token/i);
+      // Token row preserved so a legit operator can still finish setup.
+      const left = await ctx.db.all('SELECT token FROM bootstrap_tokens');
+      expect(left).toHaveLength(1);
+      // No user was created.
+      const users = await ctx.db.all('SELECT id FROM users');
+      expect(users).toHaveLength(0);
+    } finally {
+      await ctx.db.close();
+    }
+  });
+
+  it('returns 401 when the token field is missing entirely', async () => {
+    const { app, ctx } = await boot(dbPath);
+    try {
+      const r = await supertest(app)
+        .post('/setup/initial-admin')
+        .send({ email: 'admin@x', password: 'longenough1' });
+      expect(r.status).toBe(401);
+      expect(r.body.error).toMatch(/invalid token/i);
+    } finally {
+      await ctx.db.close();
+    }
+  });
+
+  it('returns 401 when the token is the empty string', async () => {
+    const { app, ctx } = await boot(dbPath);
+    try {
+      const r = await supertest(app)
+        .post('/setup/initial-admin')
+        .send({ token: '', email: 'admin@x', password: 'longenough1' });
+      expect(r.status).toBe(401);
+    } finally {
+      await ctx.db.close();
+    }
+  });
+
+  it('returns 400 for a too-short password even with a valid token (validation still applies)', async () => {
+    const { app, ctx, token } = await boot(dbPath);
+    try {
+      const r = await supertest(app)
+        .post('/setup/initial-admin')
+        .send({ token, email: 'admin@x', password: 'short' });
+      expect(r.status).toBe(400);
+      // Token must NOT be consumed by a 400.
+      const left = await ctx.db.all('SELECT token FROM bootstrap_tokens');
+      expect(left).toHaveLength(1);
+    } finally {
+      await ctx.db.close();
+    }
+  });
+
+  it('a token captured before restart still works after a restart (persistence)', async () => {
+    const first = await boot(dbPath);
+    const tokenBeforeRestart = first.token!;
+    await first.ctx.db.close();
+
+    const second = await boot(dbPath);
+    try {
+      expect(second.token).toBe(tokenBeforeRestart);
+      const r = await supertest(second.app)
+        .post('/setup/initial-admin')
+        .send({ token: tokenBeforeRestart, email: 'admin@x', password: 'longenough1' });
+      expect(r.status).toBe(201);
+    } finally {
+      await second.ctx.db.close();
+    }
+  });
+
+  it('returns 401 with the same message regardless of whether the token is wrong or missing (no field-level disclosure)', async () => {
+    const { app, ctx } = await boot(dbPath);
+    try {
+      const wrong = await supertest(app)
+        .post('/setup/initial-admin')
+        .send({ token: '00000000-0000-4000-8000-000000000000', email: 'a@b', password: 'longenough1' });
+      const missing = await supertest(app)
+        .post('/setup/initial-admin')
+        .send({ email: 'a@b', password: 'longenough1' });
+      expect(wrong.status).toBe(401);
+      expect(missing.status).toBe(401);
+      expect(wrong.body.error).toBe(missing.body.error);
+    } finally {
+      await ctx.db.close();
+    }
+  });
+});

--- a/packages/hub/src/types.ts
+++ b/packages/hub/src/types.ts
@@ -3,8 +3,6 @@ export interface HubServerConfig {
   secretKey: string;          // AES-256-GCM key (hex or base64, 32 bytes)
   sessionSecret: string;      // HMAC key for session JWTs
   defaultOrgId: string;       // single-tenant v1: one org per hub deployment
-  initialAdminEmail?: string;
-  initialAdminPassword?: string;
   /**
    * Validates that a given agenfk version actually exists as a published
    * release. Used by the fleet-upgrade-directive admin POST so we never fan


### PR DESCRIPTION
## Summary

Closes the TOFU race in `/setup/initial-admin`. On first boot of a fresh hub the server generates a UUIDv4, persists it to a new `bootstrap_tokens` table, and logs the token + setup instructions to stdout once. The Setup UI now requires the operator to paste that token alongside email + password; the server validates with `crypto.timingSafeEqual` and consumes the token atomically (single transaction) when the admin row is created.

The previous open body shape (`{ email, password }`) and the env-var bootstrap path on `/auth/login` are both removed.

Builds on top of #70 (corp hub) — base is set to that branch so the diff stays focused on bootstrap-token work. Will retarget to `main` once #70 lands.

## What changed

- New: `bootstrap_tokens` table on both sqlite + postgres adapters; `ensureBootstrapToken()` generator; boxed stdout banner from `createHubApp`.
- `/setup/initial-admin` now accepts `{ token, email, password }`; constant-time compare, generic 401 for missing/wrong/empty tokens, 409 preserved for "setup is closed", 400 preserved for short password.
- `/auth/login` env-var fast-path deleted; `HubServerConfig.initialAdminEmail/Password` removed.
- hub-ui `Setup.tsx` adds a monospaced token field and uses an extracted `buildSetupPayload` / `canSubmitSetup` helper.

## Test plan
- [x] Unit: 8 tests for `ensureBootstrapToken` + boot banner (`bootstrapToken.test.ts`).
- [x] Route: 8 tests for token-gated `/setup/initial-admin` (`setup-token.test.ts`); covers single-use, wrong-token row preservation, indistinguishable error responses for missing vs wrong token.
- [x] Existing `auth.test.ts` updated to send token; pinned the env-var-removal contract with a "legacy fields ignored" case.
- [x] UI: 8 tests for the helper module (`setupSubmit.test.ts`).
- [x] Dual-backend e2e: 6 tests across sqlite + pg-mem covering happy path, wrong-token retry, and restart-mid-setup re-logs the same token (`bootstrap-e2e.test.ts`).
- [x] Full suite: 1143/1143 green; `npm run build -w packages/hub-ui` clean.