### PR TITLE
Release 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk-framework",
-  "version": "0.3.0-beta.47",
+  "version": "1.0.0",
   "description": "AgenFK Engineering Framework",
   "private": true,
   "workspaces": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/cli",
-  "version": "0.3.0-beta.47",
+  "version": "1.0.0",
   "description": "CLI for AgenFK Engineering Framework",
   "main": "dist/index.js",
   "bin": {
@@ -12,8 +12,8 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "0.3.0-beta.47",
-    "@agenfk/telemetry": "0.3.0-beta.47",
+    "@agenfk/core": "1.0.0",
+    "@agenfk/telemetry": "1.0.0",
     "axios": "^1.13.5",
     "chalk": "^4.1.2",
     "commander": "^12.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/core",
-  "version": "0.3.0-beta.47",
+  "version": "1.0.0",
   "description": "Core logic and interfaces for the AgenFK Engineering Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "0.3.0-beta.47",
+  "version": "1.0.0",
   "description": "AgenFK Agentic Engineering Framework — installer",
   "bin": {
     "agenfk": "bin/agenfk.js"

--- a/packages/flow-editor/package.json
+++ b/packages/flow-editor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agenfk/flow-editor",
   "private": true,
-  "version": "0.3.0-beta.47",
+  "version": "1.0.0",
   "type": "module",
   "main": "./src/index.ts",
   "exports": {

--- a/packages/hub-ui/package.json
+++ b/packages/hub-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hub-ui",
   "private": true,
-  "version": "0.3.0-beta.47",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "0.3.0-beta.47",
+    "@agenfk/flow-editor": "1.0.0",
     "@tailwindcss/postcss": "^4.2.0",
     "mermaid": "^11.12.3",
     "@tanstack/react-query": "^5.90.21",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/hub",
-  "version": "0.3.0-beta.47",
+  "version": "1.0.0",
   "description": "Corporate Hub for AgEnFK — fleet-wide metrics + timeline server",
   "main": "dist/server.js",
   "types": "dist/server.d.ts",
@@ -20,7 +20,7 @@
     "start": "node dist/bin.js"
   },
   "dependencies": {
-    "@agenfk/core": "0.3.0-beta.47",
+    "@agenfk/core": "1.0.0",
     "axios": "^1.13.5",
     "bcryptjs": "^2.4.3",
     "cookie-parser": "^1.4.7",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/server",
-  "version": "0.3.0-beta.47",
+  "version": "1.0.0",
   "description": "MCP Server for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -12,9 +12,9 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "0.3.0-beta.47",
-    "@agenfk/storage-sqlite": "0.3.0-beta.47",
-    "@agenfk/telemetry": "0.3.0-beta.47",
+    "@agenfk/core": "1.0.0",
+    "@agenfk/storage-sqlite": "1.0.0",
+    "@agenfk/telemetry": "1.0.0",
     "@modelcontextprotocol/sdk": "0.6.0",
     "axios": "^1.13.5",
     "body-parser": "^2.2.2",

--- a/packages/storage-sqlite/package.json
+++ b/packages/storage-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/storage-sqlite",
-  "version": "0.3.0-beta.47",
+  "version": "1.0.0",
   "description": "SQLite storage implementation for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -11,7 +11,7 @@
     "uuid": "^9.0.1"
   },
   "devDependencies": {
-    "@agenfk/core": "0.3.0-beta.47",
+    "@agenfk/core": "1.0.0",
     "@types/node": "^22.0.0",
     "@types/uuid": "^9.0.8",
     "typescript": "^5.3.3"

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/telemetry",
-  "version": "0.3.0-beta.47",
+  "version": "1.0.0",
   "description": "Anonymous telemetry client for AgenFK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "0.3.0-beta.47",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -12,7 +12,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "0.3.0-beta.47",
+    "@agenfk/flow-editor": "1.0.0",
     "@tailwindcss/postcss": "^4.2.0",
     "@tailwindcss/typography": "^0.5.19",
     "@tanstack/react-query": "^5.90.21",


### PR DESCRIPTION
Bump all package versions from `0.3.0-beta.47` to `1.0.0`. No code changes — `npm test` and `npm run build` green at the same SHAs that shipped in beta.47 (PR #70).

After this PR is merged with a **merge commit** or **rebase-and-merge** (NOT squash, so the version-bump SHA is preserved on `main`), I'll tag `v1.0.0` on `main` and publish the GitHub release with the dist tarball.