### PR TITLE
feat(observability): schema for token_events, ingestion_state, prs

### DIFF
--- a/packages/core/src/interfaces.ts
+++ b/packages/core/src/interfaces.ts
@@ -1,4 +1,16 @@
-import { AgEnFKItem, ItemType, Status, Project, PauseSnapshot, Flow } from './types';
+import {
+  AgEnFKItem,
+  ItemType,
+  Status,
+  Project,
+  PauseSnapshot,
+  Flow,
+  TokenEvent,
+  TokenEventQuery,
+  IngestionState,
+  Pr,
+  PrSizing,
+} from './types';
 
 export interface PluginConfig {
   [key: string]: any;
@@ -48,6 +60,18 @@ export interface StorageProvider extends AgEnFKPlugin {
   deleteFlow(id: string): Promise<boolean>;
   getFlow(id: string): Promise<Flow | null>;
   listFlows(): Promise<Flow[]>;
+
+  // Observability — token events (server-side ingestion of per-client session logs)
+  insertTokenEvent(event: TokenEvent): Promise<void>;
+  queryTokenEvents(query: TokenEventQuery): Promise<TokenEvent[]>;
+  getIngestionState(sourcePath: string): Promise<IngestionState | null>;
+  setIngestionState(state: IngestionState): Promise<void>;
+
+  // Observability — PR sizing (agent-declared)
+  insertPr(pr: Pr): Promise<Pr>;
+  updatePrSizing(repo: string, prNumber: number, sizing: PrSizing, shadow?: PrSizing): Promise<Pr>;
+  getPrByRepoNumber(repo: string, prNumber: number): Promise<Pr | null>;
+  getPrsByItemId(itemId: string): Promise<Pr[]>;
 }
 
 export interface TokenTracker extends AgEnFKPlugin {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -28,6 +28,71 @@ export interface TokenUsage {
   timestamp?: string;   // ISO date when logged
 }
 
+// ── Observability: per-turn token telemetry from session-log ingestion ───────
+// Populated by packages/server/src/token-ingestion. Authoritative replacement
+// for agent-self-reported TokenUsage (deprecated; see types removal task).
+
+export type TokenClient =
+  | 'claude-code'
+  | 'codex'
+  | 'gemini'
+  | 'cursor'
+  | 'opencode';
+
+export interface TokenEvent {
+  id: string;
+  ts: string;                 // ISO timestamp of the model turn
+  client: TokenClient;
+  sessionId: string;
+  turnId?: string;
+  model: string;
+  input: number;
+  cachedInput: number;
+  output: number;
+  reasoning: number;
+  total: number;
+  itemId?: string;            // attribution (most-recent active item at ts)
+  projectId?: string;
+  sourcePath: string;         // absolute path of the session log file
+  sourceOffset: number;       // byte/line offset within the file (dedup key)
+}
+
+export interface TokenEventQuery {
+  itemId?: string;
+  projectId?: string;
+  since?: string;
+  until?: string;
+  client?: TokenClient;
+  limit?: number;
+}
+
+export interface IngestionState {
+  sourcePath: string;
+  lastOffset: number;
+  lastRunAt: string;
+}
+
+// ── Observability: PR sizing (agent-declared, server-shadowed) ──────────────
+
+export interface PrSizing {
+  epic: number;
+  story: number;
+  task: number;
+  bug: number;
+}
+
+export interface Pr {
+  id: string;
+  prNumber: number;
+  repo: string;              // e.g. "owner/repo"
+  itemId: string;
+  openedAt: string;
+  sizing: PrSizing;          // agent-declared
+  sizingDeclaredAt: string;
+  sizingShadow?: PrSizing;   // server-computed from item tree, sanity check only
+  lastSizingCheckAt?: string;
+}
+
 export interface ContextItem {
   id: string;
   path: string;

--- a/packages/storage-sqlite/src/index.ts
+++ b/packages/storage-sqlite/src/index.ts
@@ -9,7 +9,12 @@ import {
   Status,
   Project,
   PauseSnapshot,
-  Flow
+  Flow,
+  TokenEvent,
+  TokenEventQuery,
+  IngestionState,
+  Pr,
+  PrSizing,
 } from '@agenfk/core';
 
 // node:sqlite is a built-in module available from Node.js v22+.
@@ -88,6 +93,46 @@ export class SQLiteStorageProvider implements StorageProvider {
         created_at TEXT NOT NULL DEFAULT (datetime('now'))
       );
       CREATE INDEX IF NOT EXISTS idx_hub_outbox_occurred ON hub_outbox(occurred_at);
+      CREATE TABLE IF NOT EXISTS token_events (
+        id TEXT PRIMARY KEY,
+        ts TEXT NOT NULL,
+        client TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        turn_id TEXT,
+        model TEXT NOT NULL,
+        input INTEGER NOT NULL DEFAULT 0,
+        cached_input INTEGER NOT NULL DEFAULT 0,
+        output INTEGER NOT NULL DEFAULT 0,
+        reasoning INTEGER NOT NULL DEFAULT 0,
+        total INTEGER NOT NULL DEFAULT 0,
+        item_id TEXT,
+        project_id TEXT,
+        source_path TEXT NOT NULL,
+        source_offset INTEGER NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_token_events_ts ON token_events(ts);
+      CREATE INDEX IF NOT EXISTS idx_token_events_item ON token_events(item_id);
+      CREATE INDEX IF NOT EXISTS idx_token_events_session ON token_events(session_id);
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_token_events_dedup
+        ON token_events(client, source_path, source_offset);
+      CREATE TABLE IF NOT EXISTS ingestion_state (
+        source_path TEXT PRIMARY KEY,
+        last_offset INTEGER NOT NULL,
+        last_run_at TEXT NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS prs (
+        id TEXT PRIMARY KEY,
+        pr_number INTEGER NOT NULL,
+        repo TEXT NOT NULL,
+        item_id TEXT NOT NULL,
+        opened_at TEXT NOT NULL,
+        sizing_json TEXT NOT NULL,
+        sizing_declared_at TEXT NOT NULL,
+        sizing_shadow_json TEXT,
+        last_sizing_check_at TEXT
+      );
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_prs_repo_number ON prs(repo, pr_number);
+      CREATE INDEX IF NOT EXISTS idx_prs_item ON prs(item_id);
     `);
     this.migrateFlowsTable();
   }
@@ -365,5 +410,46 @@ export class SQLiteStorageProvider implements StorageProvider {
   async listFlows(): Promise<Flow[]> {
     const rows = this.database.prepare('SELECT data FROM flows').all() as { data: string }[];
     return rows.map(r => this.parseFlow(r.data));
+  }
+
+  // ── Observability stubs ────────────────────────────────────────────────────
+  // Real implementations land in the next task in the observability initiative.
+  // The schema (token_events, ingestion_state, prs) is created above.
+
+  async insertTokenEvent(_event: TokenEvent): Promise<void> {
+    throw new Error('insertTokenEvent: not yet implemented');
+  }
+
+  async queryTokenEvents(_query: TokenEventQuery): Promise<TokenEvent[]> {
+    throw new Error('queryTokenEvents: not yet implemented');
+  }
+
+  async getIngestionState(_sourcePath: string): Promise<IngestionState | null> {
+    throw new Error('getIngestionState: not yet implemented');
+  }
+
+  async setIngestionState(_state: IngestionState): Promise<void> {
+    throw new Error('setIngestionState: not yet implemented');
+  }
+
+  async insertPr(_pr: Pr): Promise<Pr> {
+    throw new Error('insertPr: not yet implemented');
+  }
+
+  async updatePrSizing(
+    _repo: string,
+    _prNumber: number,
+    _sizing: PrSizing,
+    _shadow?: PrSizing,
+  ): Promise<Pr> {
+    throw new Error('updatePrSizing: not yet implemented');
+  }
+
+  async getPrByRepoNumber(_repo: string, _prNumber: number): Promise<Pr | null> {
+    throw new Error('getPrByRepoNumber: not yet implemented');
+  }
+
+  async getPrsByItemId(_itemId: string): Promise<Pr[]> {
+    throw new Error('getPrsByItemId: not yet implemented');
   }
 }

--- a/packages/storage-sqlite/src/test/schema-observability.test.ts
+++ b/packages/storage-sqlite/src/test/schema-observability.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { SQLiteStorageProvider } from '../index';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const { DatabaseSync } = require('node:sqlite');
+
+const TEST_DB = path.join(os.tmpdir(), `agenfk-sqlite-observability-${process.pid}.sqlite`);
+
+function cleanup() {
+  for (const suffix of ['', '-wal', '-shm']) {
+    const f = TEST_DB + suffix;
+    if (fs.existsSync(f)) fs.unlinkSync(f);
+  }
+}
+
+function tableColumns(db: any, table: string): string[] {
+  return (db.prepare(`PRAGMA table_info(${table})`).all() as { name: string }[]).map((c) => c.name);
+}
+
+function indexNames(db: any, table: string): string[] {
+  return (db.prepare(`PRAGMA index_list(${table})`).all() as { name: string }[]).map((i) => i.name);
+}
+
+describe('SQLiteStorageProvider observability schema', () => {
+  afterEach(cleanup);
+
+  it('creates token_events table with the expected columns and indexes', async () => {
+    const storage = new SQLiteStorageProvider();
+    await storage.init({ path: TEST_DB });
+    await storage.shutdown();
+
+    const db = new DatabaseSync(TEST_DB);
+    const cols = tableColumns(db, 'token_events');
+    expect(cols).toEqual(
+      expect.arrayContaining([
+        'id', 'ts', 'client', 'session_id', 'turn_id', 'model',
+        'input', 'cached_input', 'output', 'reasoning', 'total',
+        'item_id', 'project_id', 'source_path', 'source_offset',
+      ])
+    );
+
+    const idx = indexNames(db, 'token_events');
+    expect(idx).toEqual(expect.arrayContaining([
+      'idx_token_events_ts',
+      'idx_token_events_item',
+      'idx_token_events_session',
+      'idx_token_events_dedup',
+    ]));
+    db.close();
+  });
+
+  it('token_events dedup index is UNIQUE on (client, source_path, source_offset)', async () => {
+    const storage = new SQLiteStorageProvider();
+    await storage.init({ path: TEST_DB });
+    await storage.shutdown();
+
+    const db = new DatabaseSync(TEST_DB);
+    db.prepare(
+      `INSERT INTO token_events
+       (id, ts, client, session_id, model, input, cached_input, output, reasoning, total, source_path, source_offset)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run('e1', '2026-05-10T00:00:00Z', 'codex', 's1', 'gpt-x', 1, 0, 2, 0, 3, '/p/a.jsonl', 0);
+
+    expect(() => {
+      db.prepare(
+        `INSERT INTO token_events
+         (id, ts, client, session_id, model, input, cached_input, output, reasoning, total, source_path, source_offset)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ).run('e2', '2026-05-10T00:00:00Z', 'codex', 's1', 'gpt-x', 1, 0, 2, 0, 3, '/p/a.jsonl', 0);
+    }).toThrow(/UNIQUE/i);
+
+    db.close();
+  });
+
+  it('creates ingestion_state table with source_path PRIMARY KEY', async () => {
+    const storage = new SQLiteStorageProvider();
+    await storage.init({ path: TEST_DB });
+    await storage.shutdown();
+
+    const db = new DatabaseSync(TEST_DB);
+    const cols = tableColumns(db, 'ingestion_state');
+    expect(cols).toEqual(expect.arrayContaining(['source_path', 'last_offset', 'last_run_at']));
+
+    db.prepare('INSERT INTO ingestion_state (source_path, last_offset, last_run_at) VALUES (?, ?, ?)')
+      .run('/p/a.jsonl', 100, '2026-05-10T00:00:00Z');
+    expect(() =>
+      db.prepare('INSERT INTO ingestion_state (source_path, last_offset, last_run_at) VALUES (?, ?, ?)')
+        .run('/p/a.jsonl', 200, '2026-05-10T00:00:01Z')
+    ).toThrow(/UNIQUE|PRIMARY/i);
+    db.close();
+  });
+
+  it('creates prs table with the expected columns and indexes', async () => {
+    const storage = new SQLiteStorageProvider();
+    await storage.init({ path: TEST_DB });
+    await storage.shutdown();
+
+    const db = new DatabaseSync(TEST_DB);
+    const cols = tableColumns(db, 'prs');
+    expect(cols).toEqual(
+      expect.arrayContaining([
+        'id', 'pr_number', 'repo', 'item_id', 'opened_at',
+        'sizing_json', 'sizing_declared_at', 'sizing_shadow_json',
+        'last_sizing_check_at',
+      ])
+    );
+
+    const idx = indexNames(db, 'prs');
+    expect(idx).toEqual(expect.arrayContaining(['idx_prs_repo_number', 'idx_prs_item']));
+    db.close();
+  });
+
+  it('prs unique constraint covers (repo, pr_number)', async () => {
+    const storage = new SQLiteStorageProvider();
+    await storage.init({ path: TEST_DB });
+    await storage.shutdown();
+
+    const db = new DatabaseSync(TEST_DB);
+    db.prepare(
+      `INSERT INTO prs (id, pr_number, repo, item_id, opened_at, sizing_json, sizing_declared_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`
+    ).run('p1', 42, 'foo/bar', 'item-1', '2026-05-10T00:00:00Z', '{"epic":0,"story":1,"task":2,"bug":0}', '2026-05-10T00:00:00Z');
+
+    expect(() =>
+      db.prepare(
+        `INSERT INTO prs (id, pr_number, repo, item_id, opened_at, sizing_json, sizing_declared_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`
+      ).run('p2', 42, 'foo/bar', 'item-2', '2026-05-10T01:00:00Z', '{"epic":0,"story":0,"task":1,"bug":0}', '2026-05-10T01:00:00Z')
+    ).toThrow(/UNIQUE/i);
+
+    // Same number, different repo — allowed.
+    expect(() =>
+      db.prepare(
+        `INSERT INTO prs (id, pr_number, repo, item_id, opened_at, sizing_json, sizing_declared_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`
+      ).run('p3', 42, 'baz/qux', 'item-3', '2026-05-10T02:00:00Z', '{"epic":0,"story":0,"task":1,"bug":0}', '2026-05-10T02:00:00Z')
+    ).not.toThrow();
+
+    db.close();
+  });
+
+  it('init() is idempotent across re-runs (CREATE TABLE IF NOT EXISTS)', async () => {
+    const storage1 = new SQLiteStorageProvider();
+    await storage1.init({ path: TEST_DB });
+    await storage1.shutdown();
+
+    const storage2 = new SQLiteStorageProvider();
+    await expect(storage2.init({ path: TEST_DB })).resolves.not.toThrow();
+    await storage2.shutdown();
+
+    // After re-init, tables should still be queryable.
+    const db = new DatabaseSync(TEST_DB);
+    expect(() => db.prepare('SELECT 1 FROM token_events LIMIT 1').all()).not.toThrow();
+    expect(() => db.prepare('SELECT 1 FROM ingestion_state LIMIT 1').all()).not.toThrow();
+    expect(() => db.prepare('SELECT 1 FROM prs LIMIT 1').all()).not.toThrow();
+    db.close();
+  });
+});


### PR DESCRIPTION
## Summary

First step of the observability initiative (plan: `/Users/daniel/.claude/plans/hashed-rolling-marshmallow.md`, EPIC `ce6291f4-b9fa-4741-abb8-f48a3cbb5c3a`).

- Adds three new tables in `packages/storage-sqlite/src/index.ts` `createTables()`:
  - `token_events` — per-turn token telemetry from per-client session-log ingestion (unique dedup on `client + source_path + source_offset`)
  - `ingestion_state` — per-file offset bookkeeping for resumable parsing
  - `prs` — agent-declared PR sizing with server-shadow sanity check (unique on `repo, pr_number`)
- Adds `TokenEvent`, `TokenEventQuery`, `IngestionState`, `Pr`, `PrSizing`, `TokenClient` types to `packages/core/src/types.ts`.
- Extends `StorageProvider` interface with 8 new methods. SQLiteStorageProvider gets throwing stubs; real implementations follow in Task #3.

No behaviour change for existing functionality — schema is idempotent (`CREATE TABLE IF NOT EXISTS`) and additive.

## Test plan

- [x] New unit tests in `packages/storage-sqlite/src/test/schema-observability.test.ts` cover column sets, indexes, unique constraints, and `init()` idempotency
- [x] `npm run build` clean
- [x] `npm test` full suite green (1189 tests, 108 files)