### PR TITLE
feat(observability): remove legacy log_token_usage / tokenUsage entirely

### DIFF
--- a/clauderules/CLAUDE.md
+++ b/clauderules/CLAUDE.md
@@ -40,7 +40,8 @@ Or via REST: `GET http://localhost:3000/projects/<projectId>/flow`
 After completing changes — using MCP tools:
 - `get_flow(projectId)` — call at session start to load the full flow with all steps and exit criteria. Your working contract for the session.
 - `validate_progress(itemId, evidence, command?)` — step-completion gate. `evidence` is **required**: describe how you satisfied the current step's exit criteria (logged as a tagged comment). **Use this for ALL forward step transitions** (including TODO → first working step). `command` is optional: if omitted, uses `project.verifyCommand` on the final step. If it returns `NO_VERIFY_COMMAND`, auto-detect the project stack from config files (e.g. `package.json`, `Cargo.toml`, `go.mod`, `*.csproj`), set the command via `update_project({ id, verifyCommand })`, and retry. Only ask the developer as a last resort.
-- `log_token_usage(itemId, input, output, model)`.
+
+Token usage is captured automatically by the server-side ingestion worker — agents do not need to (and cannot) self-report tokens.
 
 **ALWAYS use MCP tools for workflow state changes. NEVER use the `agenfk` CLI
 to create items, update status, or close tasks — the CLI bypasses enforcement.**
@@ -83,7 +84,6 @@ CLI equivalents via Bash. The enforcer auto-detects MCP unavailability and allow
 | `add_comment(id, text)` | `agenfk comment <id> "<text>"` |
 | `get_flow(projectId)` | `agenfk flow show --project <id> --json` |
 | `validate_progress(id, evidence, command?)` | `agenfk verify <id> --evidence "<evidence>" "<command>"` or `agenfk verify <id> --evidence "<evidence>"` |
-| `log_token_usage(id, in, out, model)` | `agenfk log-tokens <id> --input N --output N --model M` |
 | `log_test_result(id, cmd, out, status)` | `agenfk log-test <id> --command "..." --output "..." --status PASSED` |
 
 The workflow rules still apply: call `agenfk gatekeeper` before editing files.

--- a/codexrules/AGENTS.md
+++ b/codexrules/AGENTS.md
@@ -53,7 +53,8 @@ Or via CLI: `agenfk flow show --project <projectId>`
 After completing changes — using MCP tools:
 - `get_flow(projectId)` — call at session start to load the full flow with all steps and exit criteria.
 - `validate_progress(itemId, evidence, command?)` — step-completion gate. `evidence` is **required**: describe how you satisfied the current step's exit criteria (logged as a tagged comment). **Use this for ALL forward step transitions**. `command` is optional: if omitted, uses `project.verifyCommand` on the final step. If it returns `NO_VERIFY_COMMAND`, auto-detect the project stack from config files (e.g. `package.json`, `Cargo.toml`, `go.mod`, `*.csproj`), set the command via `update_project({ id, verifyCommand })`, and retry.
-- `log_token_usage(itemId, input, output, model)`.
+
+Token usage is captured automatically by the server-side ingestion worker — agents do not need to (and cannot) self-report tokens.
 
 **ALWAYS use MCP tools for workflow state changes. NEVER use the `agenfk` CLI
 to create items, update status, or close tasks — the CLI bypasses enforcement.**
@@ -92,7 +93,6 @@ CLI equivalents via Bash:
 | `add_comment(id, text)` | `agenfk comment <id> "<text>"` |
 | `get_flow(projectId)` | `agenfk flow show --project <id> --json` |
 | `validate_progress(id, evidence, command?)` | `agenfk verify <id> --evidence "<evidence>" "<command>"` or `agenfk verify <id> --evidence "<evidence>"` |
-| `log_token_usage(id, in, out, model)` | `agenfk log-tokens <id> --input N --output N --model M` |
 | `log_test_result(id, cmd, out, status)` | `agenfk log-test <id> --command "..." --output "..." --status PASSED` |
 
 The workflow rules still apply: call `agenfk gatekeeper` before editing files.

--- a/cursorrules/agenfk.mdc
+++ b/cursorrules/agenfk.mdc
@@ -61,7 +61,8 @@ After completing changes — using MCP tools:
 - `update_item(id, {status: "<next-flow-step>"})` — move to the next step in the active flow when coding is done (typically REVIEW in the default flow).
 - `review_changes(itemId, command)` — build gate, advances to the next flow step on success.
 - `test_changes(itemId)` — runs project verifyCommand, advances to the terminal flow step (DONE).
-- `log_token_usage(itemId, input, output, model)`.
+
+Token usage is captured automatically by the server-side ingestion worker — agents do not need to (and cannot) self-report tokens.
 
 **ALWAYS use MCP tools for workflow state changes. NEVER use the `agenfk` CLI
 to create items, update status, or close tasks — the CLI bypasses enforcement.**
@@ -100,7 +101,6 @@ CLI equivalents via Bash:
 | `add_comment(id, text)` | `agenfk comment <id> "<text>"` |
 | `review_changes(id, command)` | `agenfk verify <id> "<command>"` (from REVIEW: moves to TEST) |
 | `test_changes(id)` | `agenfk verify <id>` (from TEST: moves to DONE, uses project verifyCommand) |
-| `log_token_usage(id, in, out, model)` | `agenfk log-tokens <id> --input N --output N --model M` |
 | `log_test_result(id, cmd, out, status)` | `agenfk log-test <id> --command "..." --output "..." --status PASSED` |
 
 The workflow rules still apply: call `agenfk gatekeeper` before editing files.

--- a/geminirules/GEMINI.md
+++ b/geminirules/GEMINI.md
@@ -53,7 +53,8 @@ Or via CLI: `agenfk flow show --project <projectId>`
 After completing changes — using MCP tools:
 - `get_flow(projectId)` — call at session start to load the full flow with all steps and exit criteria.
 - `validate_progress(itemId, evidence, command?)` — step-completion gate. `evidence` is **required**: describe how you satisfied the current step's exit criteria (logged as a tagged comment). **Use this for ALL forward step transitions**. `command` is optional: if omitted, uses `project.verifyCommand` on the final step. If it returns `NO_VERIFY_COMMAND`, auto-detect the project stack from config files (e.g. `package.json`, `Cargo.toml`, `go.mod`, `*.csproj`), set the command via `update_project({ id, verifyCommand })`, and retry.
-- `log_token_usage(itemId, input, output, model)`.
+
+Token usage is captured automatically by the server-side ingestion worker — agents do not need to (and cannot) self-report tokens.
 
 **ALWAYS use MCP tools for workflow state changes. NEVER use the `agenfk` CLI
 to create items, update status, or close tasks — the CLI bypasses enforcement.**
@@ -92,7 +93,6 @@ CLI equivalents via Bash:
 | `add_comment(id, text)` | `agenfk comment <id> "<text>"` |
 | `get_flow(projectId)` | `agenfk flow show --project <id> --json` |
 | `validate_progress(id, evidence, command?)` | `agenfk verify <id> --evidence "<evidence>" "<command>"` or `agenfk verify <id> --evidence "<evidence>"` |
-| `log_token_usage(id, in, out, model)` | `agenfk log-tokens <id> --input N --output N --model M` |
 | `log_test_result(id, cmd, out, status)` | `agenfk log-test <id> --command "..." --output "..." --status PASSED` |
 
 The workflow rules still apply: call `agenfk gatekeeper` before editing files.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -939,7 +939,7 @@ function configureClaudeCodeIde(rootDir: string): boolean {
         'mcp__agenfk__get_item', 'mcp__agenfk__create_item',
         'mcp__agenfk__update_item', 'mcp__agenfk__add_comment',
         'mcp__agenfk__workflow_gatekeeper', 'mcp__agenfk__review_changes',
-        'mcp__agenfk__test_changes', 'mcp__agenfk__log_token_usage',
+        'mcp__agenfk__test_changes',
         'mcp__agenfk__analyze_request', 'mcp__agenfk__get_server_info',
         'mcp__agenfk__add_context', 'mcp__agenfk__delete_item',
         'mcp__agenfk__log_test_result', 'mcp__agenfk__update_project',
@@ -2430,7 +2430,6 @@ program
         if (item.parentId) console.log(`  Parent:      ${item.parentId}`);
         if (item.description) console.log(`  Description: ${item.description}`);
         if (item.comments?.length) console.log(`  Comments:    ${item.comments.length}`);
-        if (item.tokenUsage?.length) console.log(`  Token logs:  ${item.tokenUsage.length}`);
       }
     } catch (error: any) {
       console.error(chalk.red('Error fetching item:'), error.response?.data?.error || error.message);
@@ -2451,35 +2450,6 @@ program
       console.log(chalk.green('Comment added.'));
     } catch (error: any) {
       console.error(chalk.red('Error adding comment:'), error.response?.data?.error || error.message);
-      process.exit(1);
-    }
-  });
-
-program
-  .command('log-tokens <id>')
-  .description('Log token usage for an item (MCP fallback: log_token_usage)')
-  .requiredOption('--input <n>', 'Input tokens', parseInt)
-  .requiredOption('--output <n>', 'Output tokens', parseInt)
-  .requiredOption('--model <model>', 'Model name')
-  .option('--cost <c>', 'Cost in USD', parseFloat)
-  .option('--session <id>', 'Session ID for deduplication')
-  .action(async (id, options) => {
-    try {
-      const { data: item } = await axios.get(`${API_URL}/items/${id}`);
-      const tokenUsage = item.tokenUsage || [];
-      const entry: any = {
-        input: options.input,
-        output: options.output,
-        model: options.model,
-        timestamp: new Date().toISOString(),
-      };
-      if (options.cost !== undefined) entry.cost = options.cost;
-      if (options.session) entry.sessionId = options.session;
-      tokenUsage.push(entry);
-      await axios.put(`${API_URL}/items/${id}`, { tokenUsage });
-      console.log(chalk.green('Token usage logged.'));
-    } catch (error: any) {
-      console.error(chalk.red('Error logging tokens:'), error.response?.data?.error || error.message);
       process.exit(1);
     }
   });
@@ -3278,7 +3248,7 @@ program.helpInformation = function () {
   const groups: [string, string[]][] = [
     ['Services',              ['up', 'down', 'restart', 'kill', 'upgrade', 'health', 'ui']],
     ['Project & Items',       ['init', 'create-project', 'list-projects', 'create', 'list', 'get', 'update', 'delete', 'move']],
-    ['Workflow',              ['verify', 'gatekeeper', 'comment', 'log-tokens', 'log-test']],
+    ['Workflow',              ['verify', 'gatekeeper', 'comment', 'log-test']],
     ['Integrations & Rules',  ['integration', 'rules', 'configure-ide']],
     ['Git & Release',         ['branch', 'pr']],
     ['Flows',                 ['flow']],

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -18,19 +18,9 @@ export enum ItemType {
   BUG = "BUG"
 }
 
-export interface TokenUsage {
-  input: number;
-  output: number;
-  model: string;
-  cost?: number;
-  sessionId?: string;   // Deduplication key
-  source?: string;      // "claude-code" | "opencode" | "manual"
-  timestamp?: string;   // ISO date when logged
-}
-
 // ── Observability: per-turn token telemetry from session-log ingestion ───────
-// Populated by packages/server/src/token-ingestion. Authoritative replacement
-// for agent-self-reported TokenUsage (deprecated; see types removal task).
+// Populated by packages/server/src/token-ingestion. Replaces agent-self-reported
+// per-item token logging entirely.
 
 export type TokenClient =
   | 'claude-code'
@@ -151,7 +141,6 @@ export interface BaseItem {
   description: string;
   status: Status;
   assignee?: string;
-  tokenUsage?: TokenUsage[]; // Array to track usage over time/sessions
   context?: ContextItem[];
   reviews?: ReviewRecord[];
   tests?: TestRecord[];

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -116,17 +116,6 @@ const GetItemSchema = z.object({
   id: z.string(),
 });
 
-const LogTokenUsageSchema = z.object({
-  itemId: z.string(),
-  input: z.number(),
-  output: z.number(),
-  model: z.string(),
-  cost: z.number().optional(),
-  sessionId: z.string().optional(),
-  source: z.string().optional(),
-  timestamp: z.string().optional(),
-});
-
 const AddContextSchema = z.object({
   itemId: z.string(),
   path: z.string(),
@@ -237,24 +226,6 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           type: "object",
           properties: { id: { type: "string" } },
           required: ["id"],
-        },
-      },
-      {
-        name: "log_token_usage",
-        description: "Log token usage for an item. Use this for manual/proactive reporting. Note: Automated hooks will also capture session totals using 'sessionId' for deduplication.",
-        inputSchema: {
-          type: "object",
-          properties: {
-            itemId: { type: "string" },
-            input: { type: "number" },
-            output: { type: "number" },
-            model: { type: "string" },
-            cost: { type: "number" },
-            sessionId: { type: "string", description: "Optional: session ID for deduplication with automated hooks." },
-            source: { type: "string", description: "Optional: source of report (e.g. 'agent', 'manual')." },
-            timestamp: { type: "string", description: "Optional: ISO timestamp." },
-          },
-          required: ["itemId", "input", "output", "model"],
         },
       },
       {
@@ -809,15 +780,6 @@ async function callToolHandler(request: any): Promise<any> {
         const { id } = z.object({ id: z.string() }).parse(request.params.arguments);
         await api.delete(`/items/${id}`);
         return { content: [{ type: "text", text: `Item ${id} and its children moved to trash.` }] };
-      }
-      case "log_token_usage": {
-        const args = LogTokenUsageSchema.parse(request.params.arguments);
-        const { itemId, ...usage } = args;
-        const { data: item } = await api.get(`/items/${itemId}`);
-        const tokenUsage = item.tokenUsage || [];
-        tokenUsage.push(usage);
-        await api.put(`/items/${itemId}`, { tokenUsage });
-        return { content: [{ type: "text", text: "Token usage logged." }] };
       }
       case "add_comment": {
         const args = AddCommentSchema.parse(request.params.arguments);

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -28,7 +28,7 @@ export const VERIFY_TOKEN = (() => {
     return ephemeral;
   }
 })();
-import { exec, execSync, execFileSync, spawn } from "child_process";
+import { exec, execSync, spawn } from "child_process";
 import { createServer } from "http";
 import { Server } from "socket.io";
 
@@ -1284,7 +1284,7 @@ app.post("/items/bulk", asyncHandler(async (req: any, res: any) => {
     const currentItem = await storage.getItem(id);
     if (!currentItem) continue;
 
-    const { title, description, status, parentId, tokenUsage, context, implementationPlan, reviews, comments, sortOrder } = bodyUpdates;
+    const { title, description, status, parentId, context, implementationPlan, reviews, comments, sortOrder } = bodyUpdates;
 
     if (!isInternalVerify && status === Status.DONE) continue;
 
@@ -1305,7 +1305,6 @@ app.post("/items/bulk", asyncHandler(async (req: any, res: any) => {
     if (description !== undefined) updates.description = description;
     if (status !== undefined) updates.status = status;
     if (parentId !== undefined) updates.parentId = parentId;
-    if (tokenUsage !== undefined) updates.tokenUsage = tokenUsage;
     if (context !== undefined) updates.context = context;
     if (implementationPlan !== undefined) updates.implementationPlan = implementationPlan;
     if (reviews !== undefined) updates.reviews = reviews;
@@ -1321,14 +1320,6 @@ app.post("/items/bulk", asyncHandler(async (req: any, res: any) => {
         parentIdsToSync.add(updated.parentId);
       }
 
-      if (tokenUsage !== undefined) {
-        recordHubEvent({
-          type: 'tokens.logged',
-          projectId: updated.projectId,
-          itemId: updated.id,
-          payload: { tokenUsage },
-        });
-      }
       if (updated.status === Status.DONE && currentItem.status !== Status.DONE) {
         if (process.env.NODE_ENV !== 'test' && !process.env.VITEST) {
           const proj = await storage.getProject(updated.projectId);
@@ -1355,7 +1346,7 @@ app.post("/items/bulk", asyncHandler(async (req: any, res: any) => {
 
 app.put("/items/:id", asyncHandler(async (req: any, res: any) => {
   console.log(`[API_DEBUG] PUT /items/${req.params.id} body keys: ${Object.keys(req.body).join(', ')}`);
-  const { title, description, status, type, parentId, tokenUsage, context, implementationPlan, reviews, tests, comments, sortOrder, branchName, prUrl, prNumber, prStatus } = req.body;
+  const { title, description, status, type, parentId, context, implementationPlan, reviews, tests, comments, sortOrder, branchName, prUrl, prNumber, prStatus } = req.body;
 
   const currentItem = await storage.getItem(req.params.id);
   if (!currentItem) {
@@ -1419,7 +1410,6 @@ app.put("/items/:id", asyncHandler(async (req: any, res: any) => {
   if (status !== undefined) updates.status = status;
   if (type !== undefined) updates.type = type;
   if (parentId !== undefined) updates.parentId = parentId;
-  if (tokenUsage !== undefined) updates.tokenUsage = tokenUsage;
   if (context !== undefined) updates.context = context;
   if (implementationPlan !== undefined) updates.implementationPlan = implementationPlan;
   if (reviews !== undefined) updates.reviews = reviews;
@@ -1461,14 +1451,6 @@ app.put("/items/:id", asyncHandler(async (req: any, res: any) => {
         projectId: updated.projectId,
         itemId: updated.id,
         payload: { changedFields: Object.keys(updates) },
-      });
-    }
-    if (tokenUsage !== undefined) {
-      recordHubEvent({
-        type: 'tokens.logged',
-        projectId: updated.projectId,
-        itemId: updated.id,
-        payload: { tokenUsage },
       });
     }
     if (Array.isArray(comments) && comments.length > (currentItem.comments?.length ?? 0)) {
@@ -2692,168 +2674,6 @@ io.on('connection', (socket) => {
 });
 /* v8 ignore stop */
 
-// ── Opencode Token Scraper ────────────────────────────────────────────────────
-/* v8 ignore start */
-
-const OPENCODE_DB = path.join(os.homedir(), '.local/share/opencode/opencode.db');
-const OPENCODE_SCRAPE_INTERVAL = 5 * 60 * 1000; // 5 minutes
-
-const PRICING: Record<string, { input: number; output: number; cacheRead: number }> = {
-  'claude-opus-4-6':            { input: 15.0,  output: 75.0,  cacheRead: 1.5  },
-  'claude-sonnet-4-6':          { input: 3.0,   output: 15.0,  cacheRead: 0.3  },
-  'claude-sonnet-4-5-20250929': { input: 3.0,   output: 15.0,  cacheRead: 0.3  },
-  'claude-haiku-4-5-20251001':  { input: 0.8,   output: 4.0,   cacheRead: 0.08 },
-  'gemini-3-flash-preview':     { input: 0.15,  output: 0.60,  cacheRead: 0.02 },
-  'gemini-3-pro-preview':       { input: 1.25,  output: 5.0,   cacheRead: 0.31 },
-  'gemini-3.1-pro-preview':     { input: 1.25,  output: 5.0,   cacheRead: 0.31 },
-};
-const DEFAULT_RATES = PRICING['claude-sonnet-4-6'];
-
-const calcTokenCost = (model: string, input: number, output: number, cacheRead: number): number => {
-  const rates = PRICING[model] || DEFAULT_RATES;
-  return Math.round((input / 1e6 * rates.input + cacheRead / 1e6 * rates.cacheRead + output / 1e6 * rates.output) * 1e6) / 1e6;
-};
-
-const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi;
-
-const sqlite3Query = (db: string, query: string): any[] => {
-  try {
-    const result = execFileSync('sqlite3', ['-json', db, query], { encoding: 'utf8', timeout: 5000 });
-    return JSON.parse(result || '[]');
-  } catch { return []; }
-};
-
-const isAgEnFKDir = (dir: string): boolean => {
-  if (!dir) return false;
-  let d = path.isAbsolute(dir) ? dir : path.resolve(dir);
-  const root = path.parse(d).root;
-  while (d !== root) {
-    if (fs.existsSync(path.join(d, '.agenfk', 'project.json'))) return true;
-    d = path.dirname(d);
-  }
-  return false;
-};
-
-const scrapeOpencodeSessions = async () => {
-  if (!fs.existsSync(OPENCODE_DB)) return;
-
-  const cutoff = Date.now() - 24 * 60 * 60 * 1000;
-  const sessions = sqlite3Query(OPENCODE_DB, `SELECT id, directory FROM session WHERE time_created > ${cutoff}`);
-
-  for (const session of sessions) {
-    if (!isAgEnFKDir(session.directory)) continue;
-
-    // Build task switch timeline from tool call parts, ordered by time
-    const allParts = sqlite3Query(OPENCODE_DB, `
-      SELECT json_extract(data, '$.tool') as tool,
-             json_extract(data, '$.state.input') as input_data,
-             json_extract(data, '$.state.output') as output_data,
-             time_created
-      FROM part WHERE session_id = '${session.id}'
-        AND json_extract(data, '$.tool') IN ('agenfk_update_item', 'agenfk_workflow_gatekeeper')
-      ORDER BY time_created ASC
-    `);
-
-    const taskSwitches: { time: number; taskId: string }[] = [];
-    for (const part of allParts) {
-      let taskId: string | null = null;
-      if (part.tool === 'agenfk_update_item') {
-        try {
-          const inp = JSON.parse(part.input_data || '{}');
-          if (inp.id && inp.status === 'IN_PROGRESS') taskId = inp.id;
-        } catch { /* skip */ }
-      }
-      if (part.tool === 'agenfk_workflow_gatekeeper') {
-        try {
-          const inp = JSON.parse(part.input_data || '{}');
-          if (inp.itemId) taskId = inp.itemId;
-        } catch { /* skip */ }
-        if (!taskId) {
-          const matches = (part.output_data || '').match(UUID_RE);
-          if (matches && matches.length > 0) taskId = matches[0];
-        }
-      }
-      if (taskId) taskSwitches.push({ time: part.time_created, taskId });
-    }
-
-    if (taskSwitches.length === 0) continue;
-
-    // Get all assistant messages ordered by time
-    const messages = sqlite3Query(OPENCODE_DB, `
-      SELECT json_extract(data, '$.modelID') as model,
-             json_extract(data, '$.tokens.input') as inp,
-             json_extract(data, '$.tokens.output') as outp,
-             json_extract(data, '$.tokens.cache.read') as cr,
-             json_extract(data, '$.cost') as cost,
-             time_created
-      FROM message WHERE session_id = '${session.id}'
-        AND json_extract(data, '$.role') = 'assistant'
-      ORDER BY time_created ASC
-    `);
-
-    // Attribute each message to the most recent task switch before it
-    const perTask: Record<string, Record<string, { input: number; output: number; cacheRead: number; cost: number }>> = {};
-    for (const m of messages) {
-      let activeTask: string | null = null;
-      for (const sw of taskSwitches) {
-        if (sw.time <= m.time_created) activeTask = sw.taskId;
-        else break;
-      }
-      if (!activeTask) activeTask = taskSwitches[0].taskId;
-
-      const model = m.model || 'unknown';
-      if (!perTask[activeTask]) perTask[activeTask] = {};
-      if (!perTask[activeTask][model]) perTask[activeTask][model] = { input: 0, output: 0, cacheRead: 0, cost: 0 };
-      perTask[activeTask][model].input += m.inp || 0;
-      perTask[activeTask][model].output += m.outp || 0;
-      perTask[activeTask][model].cacheRead += m.cr || 0;
-      perTask[activeTask][model].cost += m.cost || 0;
-    }
-
-    if (Object.keys(perTask).length === 0) continue;
-
-    const now = new Date().toISOString();
-
-    for (const [taskId, tokensByModel] of Object.entries(perTask)) {
-      try {
-        const item = await storage.getItem(taskId);
-        if (!item) continue;
-
-        const existing = item.tokenUsage || [];
-        let added = 0;
-
-        for (const [model, tokens] of Object.entries(tokensByModel)) {
-          const isDup = existing.some((u: any) => u.sessionId === session.id && u.source === 'opencode' && u.model === model);
-          if (isDup) continue;
-
-          const cost = tokens.cost > 0
-            ? Math.round(tokens.cost * 1e6) / 1e6
-            : calcTokenCost(model, tokens.input, tokens.output, tokens.cacheRead);
-
-          existing.push({
-            input: tokens.input + tokens.cacheRead,
-            output: tokens.output,
-            model,
-            cost,
-            sessionId: session.id,
-            source: 'opencode',
-            timestamp: now,
-          });
-          added++;
-        }
-
-        if (added > 0) {
-          await storage.updateItem(taskId, { tokenUsage: existing });
-          console.log(`[OPENCODE_SCRAPER] Logged ${added} record(s) for task ${taskId} from session ${session.id}`);
-          io.emit('items_updated');
-        }
-      } catch { /* skip unreachable items */ }
-    }
-  }
-};
-
-/* v8 ignore stop */
-
 // ── Init and Listen ──────────────────────────────────────────────────────────
 /* v8 ignore start */
 
@@ -2863,12 +2683,6 @@ if (process.env.NODE_ENV !== 'test' && !process.env.VITEST) {
     setInterval(() => {
       performBackup().catch(e => console.error('[BACKUP] Periodic backup failed:', e.message));
     }, 30 * 60 * 1000);
-
-    // Periodic Opencode token scraping every 5 minutes
-    scrapeOpencodeSessions().catch(e => console.error('[OPENCODE_SCRAPER] Initial scrape failed:', e.message));
-    setInterval(() => {
-      scrapeOpencodeSessions().catch(e => console.error('[OPENCODE_SCRAPER] Periodic scrape failed:', e.message));
-    }, OPENCODE_SCRAPE_INTERVAL);
 
     // Backup on clean shutdown
     const shutdown = async () => {

--- a/packages/server/src/test/log-token-usage-removal.test.ts
+++ b/packages/server/src/test/log-token-usage-removal.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Asserts the legacy `log_token_usage` MCP tool, its `TokenUsage` type, and
+ * all related CLI/REST surface are removed from the codebase. The replacement
+ * is server-side ingestion of per-client session-log files, landing as
+ * `token_events` in storage.
+ *
+ * These tests fail before the removal and guide it.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(__dirname, '../../../..');
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(ROOT, rel), 'utf8');
+}
+
+describe('legacy token-tracking removal', () => {
+  describe('packages/server/src/index.ts', () => {
+    let src: string;
+    beforeAll(() => {
+      src = read('packages/server/src/index.ts');
+    });
+
+    it('does not register the log_token_usage MCP tool', () => {
+      expect(src).not.toMatch(/name:\s*["']log_token_usage["']/);
+    });
+
+    it('does not handle case "log_token_usage"', () => {
+      expect(src).not.toMatch(/case\s+["']log_token_usage["']/);
+    });
+
+    it('does not declare LogTokenUsageSchema', () => {
+      expect(src).not.toMatch(/LogTokenUsageSchema/);
+    });
+  });
+
+  describe('packages/server/src/server.ts', () => {
+    let src: string;
+    beforeAll(() => {
+      src = read('packages/server/src/server.ts');
+    });
+
+    it('PUT /items/:id no longer destructures or assigns tokenUsage', () => {
+      // Allow the field to exist transiently in unrelated history; just ensure
+      // we are not pulling it from the request body anymore.
+      expect(src).not.toMatch(/\btokenUsage\b\s*[,}]/);
+    });
+  });
+
+  describe('packages/cli/src/index.ts', () => {
+    let src: string;
+    beforeAll(() => {
+      src = read('packages/cli/src/index.ts');
+    });
+
+    it('does not declare a log-tokens command', () => {
+      expect(src).not.toMatch(/\.command\s*\(\s*['"]log-tokens/);
+    });
+
+    it('does not reference mcp__agenfk__log_token_usage', () => {
+      expect(src).not.toMatch(/log_token_usage/);
+    });
+  });
+
+  describe('packages/core/src/types.ts', () => {
+    let src: string;
+    beforeAll(() => {
+      src = read('packages/core/src/types.ts');
+    });
+
+    it('does not define a TokenUsage interface', () => {
+      expect(src).not.toMatch(/export\s+interface\s+TokenUsage\b/);
+    });
+
+    it('BaseItem does not declare a tokenUsage field', () => {
+      // Match within the BaseItem interface block.
+      const baseItemBlock = src.match(/export\s+interface\s+BaseItem\s*\{[\s\S]*?^\}/m)?.[0] ?? '';
+      expect(baseItemBlock).not.toMatch(/\btokenUsage\b/);
+    });
+  });
+
+  describe('per-client instruction docs', () => {
+    const docs = [
+      'clauderules/CLAUDE.md',
+      'codexrules/AGENTS.md',
+      'geminirules/GEMINI.md',
+      'cursorrules/agenfk.mdc',
+    ];
+
+    for (const rel of docs) {
+      it(`${rel} no longer references log_token_usage / log-tokens`, () => {
+        const src = read(rel);
+        expect(src).not.toMatch(/log_token_usage|agenfk\s+log-tokens/);
+      });
+    }
+  });
+});

--- a/packages/server/src/test/server.supplemental.test.ts
+++ b/packages/server/src/test/server.supplemental.test.ts
@@ -1210,14 +1210,13 @@ describe('syncParentStatus advanced scenarios', () => {
 describe('PUT /items/:id with optional fields', () => {
   beforeEach(async () => { await initStorage(); });
 
-  it('updates context, tokenUsage, implementationPlan, comments, sortOrder', async () => {
+  it('updates context, implementationPlan, comments, sortOrder', async () => {
     const p = (await request(app).post('/projects').send({ name: 'P' })).body;
     const item = (await request(app).post('/items').send({ type: 'TASK', title: 'T', projectId: p.id })).body;
     const res = await request(app).put(`/items/${item.id}`).send({
       title: 'Updated',
       description: 'desc',
       context: [{ path: '/foo.ts', content: 'code', description: 'desc' }],
-      tokenUsage: [{ input: 100, output: 50, model: 'claude-sonnet-4-6' }],
       implementationPlan: 'step 1',
       comments: [{ id: 'c1', author: 'Agent', content: 'done', timestamp: new Date() }],
       sortOrder: 5,
@@ -1255,7 +1254,7 @@ describe('POST /items/trash-archived', () => {
 describe('POST /items/bulk - branch coverage', () => {
   beforeEach(async () => { await initStorage(); });
 
-  it('updates item with all optional fields (title, description, parentId, tokenUsage, context, implementationPlan, reviews, comments)', async () => {
+  it('updates item with all optional fields (title, description, parentId, context, implementationPlan, reviews, comments)', async () => {
     const p = (await request(app).post('/projects').send({ name: 'P' })).body;
     const parent = (await request(app).post('/items').send({ type: 'STORY', title: 'Parent', projectId: p.id })).body;
     const item = (await request(app).post('/items').send({ type: 'TASK', title: 'T', projectId: p.id })).body;
@@ -1267,7 +1266,6 @@ describe('POST /items/bulk - branch coverage', () => {
           title: 'New Title',
           description: 'New desc',
           parentId: parent.id,
-          tokenUsage: [{ input: 100, output: 50, model: 'test' }],
           context: [{ path: '/x.ts', content: 'code' }],
           implementationPlan: 'step 1',
           reviews: [{ id: 'r1', content: 'lgtm' }],


### PR DESCRIPTION
## Summary

Stacks on #74 (schema migration). Removes the old agent-self-reported token-tracking surface that's being replaced by server-side session-log ingestion.

**Removed:**
- `TokenUsage` interface and `BaseItem.tokenUsage` field
- `LogTokenUsageSchema` + `log_token_usage` MCP tool (definition + handler)
- `tokenUsage` field acceptance in `PUT /items/:id` and `POST /items/bulk`
- The entire OpenCode token scraper (~160 lines: pricing table, scrape loop, periodic scheduler, unused `execFileSync` import)
- `log-tokens` CLI subcommand + the \"Token logs\" line in `agenfk get`
- `mcp__agenfk__log_token_usage` permission entry
- Per-client doc references (`clauderules/CLAUDE.md`, `codexrules/AGENTS.md`, `geminirules/GEMINI.md`, `cursorrules/agenfk.mdc`) — both the MCP usage line and the CLI fallback table row

**Kept:**
- `tokens.logged` HubEventType — used by Hub rollup queries; the upcoming ingestion worker will repopulate it.

Followup tasks (Track 2 from the observability initiative) will add the new server-side ingestion that replaces all of this with per-turn precision via session JSONL/SQLite parsing.

## Test plan

- [x] New `packages/server/src/test/log-token-usage-removal.test.ts` asserts the removal across 12 specific code/doc points
- [x] Existing `server.supplemental.test.ts` fixtures updated to drop `tokenUsage`
- [x] `npm run build` clean
- [x] `npm test` full suite green (1201 tests, 109 files)