### PR TITLE
feat(observability): implement storage methods for token_events and prs

### DIFF
--- a/packages/storage-sqlite/src/index.ts
+++ b/packages/storage-sqlite/src/index.ts
@@ -412,44 +412,184 @@ export class SQLiteStorageProvider implements StorageProvider {
     return rows.map(r => this.parseFlow(r.data));
   }
 
-  // ── Observability stubs ────────────────────────────────────────────────────
-  // Real implementations land in the next task in the observability initiative.
-  // The schema (token_events, ingestion_state, prs) is created above.
+  // ── Observability: token events ─────────────────────────────────────────────
 
-  async insertTokenEvent(_event: TokenEvent): Promise<void> {
-    throw new Error('insertTokenEvent: not yet implemented');
+  async insertTokenEvent(event: TokenEvent): Promise<void> {
+    this.database.prepare(
+      `INSERT INTO token_events
+        (id, ts, client, session_id, turn_id, model,
+         input, cached_input, output, reasoning, total,
+         item_id, project_id, source_path, source_offset)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      event.id,
+      event.ts,
+      event.client,
+      event.sessionId,
+      event.turnId ?? null,
+      event.model,
+      event.input,
+      event.cachedInput,
+      event.output,
+      event.reasoning,
+      event.total,
+      event.itemId ?? null,
+      event.projectId ?? null,
+      event.sourcePath,
+      event.sourceOffset,
+    );
   }
 
-  async queryTokenEvents(_query: TokenEventQuery): Promise<TokenEvent[]> {
-    throw new Error('queryTokenEvents: not yet implemented');
+  async queryTokenEvents(query: TokenEventQuery): Promise<TokenEvent[]> {
+    const where: string[] = [];
+    const params: any[] = [];
+    if (query.itemId !== undefined) { where.push('item_id = ?'); params.push(query.itemId); }
+    if (query.projectId !== undefined) { where.push('project_id = ?'); params.push(query.projectId); }
+    if (query.client !== undefined) { where.push('client = ?'); params.push(query.client); }
+    if (query.since !== undefined) { where.push('ts >= ?'); params.push(query.since); }
+    if (query.until !== undefined) { where.push('ts < ?'); params.push(query.until); }
+    let sql =
+      `SELECT id, ts, client, session_id, turn_id, model,
+              input, cached_input, output, reasoning, total,
+              item_id, project_id, source_path, source_offset
+         FROM token_events`;
+    if (where.length) sql += ' WHERE ' + where.join(' AND ');
+    sql += ' ORDER BY ts ASC';
+    if (query.limit !== undefined) { sql += ' LIMIT ?'; params.push(query.limit); }
+    const rows = this.database.prepare(sql).all(...params) as any[];
+    return rows.map((r) => ({
+      id: r.id,
+      ts: r.ts,
+      client: r.client,
+      sessionId: r.session_id,
+      turnId: r.turn_id ?? undefined,
+      model: r.model,
+      input: r.input,
+      cachedInput: r.cached_input,
+      output: r.output,
+      reasoning: r.reasoning,
+      total: r.total,
+      itemId: r.item_id ?? undefined,
+      projectId: r.project_id ?? undefined,
+      sourcePath: r.source_path,
+      sourceOffset: r.source_offset,
+    }));
   }
 
-  async getIngestionState(_sourcePath: string): Promise<IngestionState | null> {
-    throw new Error('getIngestionState: not yet implemented');
+  // ── Observability: ingestion state (resumable file-watcher offsets) ────────
+
+  async getIngestionState(sourcePath: string): Promise<IngestionState | null> {
+    const row = this.database.prepare(
+      'SELECT source_path, last_offset, last_run_at FROM ingestion_state WHERE source_path = ?'
+    ).get(sourcePath) as { source_path: string; last_offset: number; last_run_at: string } | undefined;
+    if (!row) return null;
+    return {
+      sourcePath: row.source_path,
+      lastOffset: row.last_offset,
+      lastRunAt: row.last_run_at,
+    };
   }
 
-  async setIngestionState(_state: IngestionState): Promise<void> {
-    throw new Error('setIngestionState: not yet implemented');
+  async setIngestionState(state: IngestionState): Promise<void> {
+    this.database.prepare(
+      `INSERT INTO ingestion_state (source_path, last_offset, last_run_at)
+       VALUES (?, ?, ?)
+       ON CONFLICT(source_path) DO UPDATE SET
+         last_offset = excluded.last_offset,
+         last_run_at = excluded.last_run_at`
+    ).run(state.sourcePath, state.lastOffset, state.lastRunAt);
   }
 
-  async insertPr(_pr: Pr): Promise<Pr> {
-    throw new Error('insertPr: not yet implemented');
+  // ── Observability: PR registration ─────────────────────────────────────────
+
+  private rowToPr(row: any): Pr {
+    return {
+      id: row.id,
+      prNumber: row.pr_number,
+      repo: row.repo,
+      itemId: row.item_id,
+      openedAt: row.opened_at,
+      sizing: JSON.parse(row.sizing_json) as PrSizing,
+      sizingDeclaredAt: row.sizing_declared_at,
+      sizingShadow: row.sizing_shadow_json ? (JSON.parse(row.sizing_shadow_json) as PrSizing) : undefined,
+      lastSizingCheckAt: row.last_sizing_check_at ?? undefined,
+    };
+  }
+
+  async insertPr(pr: Pr): Promise<Pr> {
+    // Idempotent on (repo, pr_number): if row exists, refresh sizing fields
+    // (and itemId/openedAt) instead of throwing on the unique index.
+    this.database.prepare(
+      `INSERT INTO prs
+         (id, pr_number, repo, item_id, opened_at,
+          sizing_json, sizing_declared_at, sizing_shadow_json, last_sizing_check_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(repo, pr_number) DO UPDATE SET
+         item_id = excluded.item_id,
+         opened_at = excluded.opened_at,
+         sizing_json = excluded.sizing_json,
+         sizing_declared_at = excluded.sizing_declared_at,
+         sizing_shadow_json = excluded.sizing_shadow_json,
+         last_sizing_check_at = excluded.last_sizing_check_at`
+    ).run(
+      pr.id,
+      pr.prNumber,
+      pr.repo,
+      pr.itemId,
+      pr.openedAt,
+      JSON.stringify(pr.sizing),
+      pr.sizingDeclaredAt,
+      pr.sizingShadow ? JSON.stringify(pr.sizingShadow) : null,
+      pr.lastSizingCheckAt ?? null,
+    );
+    const row = this.database.prepare(
+      'SELECT * FROM prs WHERE repo = ? AND pr_number = ?'
+    ).get(pr.repo, pr.prNumber) as any;
+    return this.rowToPr(row);
   }
 
   async updatePrSizing(
-    _repo: string,
-    _prNumber: number,
-    _sizing: PrSizing,
-    _shadow?: PrSizing,
+    repo: string,
+    prNumber: number,
+    sizing: PrSizing,
+    shadow?: PrSizing,
   ): Promise<Pr> {
-    throw new Error('updatePrSizing: not yet implemented');
+    const now = new Date().toISOString();
+    const result = this.database.prepare(
+      `UPDATE prs SET
+         sizing_json = ?,
+         sizing_declared_at = ?,
+         sizing_shadow_json = ?,
+         last_sizing_check_at = ?
+       WHERE repo = ? AND pr_number = ?`
+    ).run(
+      JSON.stringify(sizing),
+      now,
+      shadow ? JSON.stringify(shadow) : null,
+      now,
+      repo,
+      prNumber,
+    );
+    if (Number(result.changes ?? 0) === 0) {
+      throw new Error(`updatePrSizing: PR ${repo}#${prNumber} not found`);
+    }
+    const row = this.database.prepare(
+      'SELECT * FROM prs WHERE repo = ? AND pr_number = ?'
+    ).get(repo, prNumber) as any;
+    return this.rowToPr(row);
   }
 
-  async getPrByRepoNumber(_repo: string, _prNumber: number): Promise<Pr | null> {
-    throw new Error('getPrByRepoNumber: not yet implemented');
+  async getPrByRepoNumber(repo: string, prNumber: number): Promise<Pr | null> {
+    const row = this.database.prepare(
+      'SELECT * FROM prs WHERE repo = ? AND pr_number = ?'
+    ).get(repo, prNumber) as any;
+    return row ? this.rowToPr(row) : null;
   }
 
-  async getPrsByItemId(_itemId: string): Promise<Pr[]> {
-    throw new Error('getPrsByItemId: not yet implemented');
+  async getPrsByItemId(itemId: string): Promise<Pr[]> {
+    const rows = this.database.prepare(
+      'SELECT * FROM prs WHERE item_id = ? ORDER BY opened_at ASC'
+    ).all(itemId) as any[];
+    return rows.map((r) => this.rowToPr(r));
   }
 }

--- a/packages/storage-sqlite/src/test/observability-storage.test.ts
+++ b/packages/storage-sqlite/src/test/observability-storage.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import { SQLiteStorageProvider } from '../index';
+import type { TokenEvent, IngestionState, Pr } from '@agenfk/core';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const TEST_DB = path.join(os.tmpdir(), `agenfk-sqlite-obs-storage-${process.pid}.sqlite`);
+
+function cleanup() {
+  for (const suffix of ['', '-wal', '-shm']) {
+    const f = TEST_DB + suffix;
+    if (fs.existsSync(f)) fs.unlinkSync(f);
+  }
+}
+
+function makeEvent(over: Partial<TokenEvent> = {}): TokenEvent {
+  return {
+    id: 'e-' + Math.random().toString(36).slice(2),
+    ts: '2026-05-10T00:00:00.000Z',
+    client: 'codex',
+    sessionId: 'sess-1',
+    turnId: 't-1',
+    model: 'gpt-x',
+    input: 100,
+    cachedInput: 20,
+    output: 50,
+    reasoning: 10,
+    total: 180,
+    itemId: 'item-A',
+    projectId: 'proj-1',
+    sourcePath: '/p/sess.jsonl',
+    sourceOffset: 0,
+    ...over,
+  };
+}
+
+describe('SQLiteStorageProvider observability methods', () => {
+  let storage: SQLiteStorageProvider;
+  beforeEach(async () => {
+    cleanup();
+    storage = new SQLiteStorageProvider();
+    await storage.init({ path: TEST_DB });
+  });
+  afterEach(async () => {
+    await storage.shutdown();
+    cleanup();
+  });
+
+  describe('token events', () => {
+    it('inserts and reads a single token event', async () => {
+      const ev = makeEvent();
+      await storage.insertTokenEvent(ev);
+      const rows = await storage.queryTokenEvents({ itemId: 'item-A' });
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        id: ev.id,
+        client: 'codex',
+        input: 100,
+        cachedInput: 20,
+        output: 50,
+        reasoning: 10,
+        total: 180,
+        sessionId: 'sess-1',
+        sourcePath: '/p/sess.jsonl',
+        sourceOffset: 0,
+      });
+    });
+
+    it('queryTokenEvents filters by projectId, since, until, and client', async () => {
+      await storage.insertTokenEvent(makeEvent({ id: 'a', ts: '2026-05-09T00:00:00.000Z', sourceOffset: 1 }));
+      await storage.insertTokenEvent(makeEvent({ id: 'b', ts: '2026-05-10T00:00:00.000Z', sourceOffset: 2 }));
+      await storage.insertTokenEvent(makeEvent({ id: 'c', ts: '2026-05-11T00:00:00.000Z', client: 'claude-code', sourceOffset: 3 }));
+      await storage.insertTokenEvent(makeEvent({ id: 'd', projectId: 'proj-2', sourceOffset: 4 }));
+
+      const inWindow = await storage.queryTokenEvents({ since: '2026-05-09T12:00:00.000Z', until: '2026-05-10T12:00:00.000Z' });
+      expect(inWindow.map((e) => e.id).sort()).toEqual(['b', 'd']);
+
+      const claude = await storage.queryTokenEvents({ client: 'claude-code' });
+      expect(claude.map((e) => e.id)).toEqual(['c']);
+
+      const proj1 = await storage.queryTokenEvents({ projectId: 'proj-1' });
+      expect(proj1.map((e) => e.id).sort()).toEqual(['a', 'b', 'c']);
+
+      const limited = await storage.queryTokenEvents({ projectId: 'proj-1', limit: 2 });
+      expect(limited).toHaveLength(2);
+    });
+
+    it('insertTokenEvent rejects duplicates on (client, sourcePath, sourceOffset)', async () => {
+      await storage.insertTokenEvent(makeEvent({ id: 'first', sourceOffset: 100 }));
+      await expect(storage.insertTokenEvent(makeEvent({ id: 'second', sourceOffset: 100 }))).rejects.toThrow();
+    });
+  });
+
+  describe('ingestion state', () => {
+    it('returns null for unseen source paths', async () => {
+      expect(await storage.getIngestionState('/never/seen')).toBeNull();
+    });
+
+    it('upserts and reads back', async () => {
+      const s1: IngestionState = { sourcePath: '/p/a.jsonl', lastOffset: 100, lastRunAt: '2026-05-10T00:00:00Z' };
+      await storage.setIngestionState(s1);
+      expect(await storage.getIngestionState('/p/a.jsonl')).toEqual(s1);
+
+      const s2: IngestionState = { sourcePath: '/p/a.jsonl', lastOffset: 250, lastRunAt: '2026-05-10T00:05:00Z' };
+      await storage.setIngestionState(s2);
+      expect(await storage.getIngestionState('/p/a.jsonl')).toEqual(s2);
+    });
+  });
+
+  describe('PR registration', () => {
+    function makePr(over: Partial<Pr> = {}): Pr {
+      return {
+        id: 'pr-' + Math.random().toString(36).slice(2),
+        prNumber: 42,
+        repo: 'foo/bar',
+        itemId: 'item-A',
+        openedAt: '2026-05-10T00:00:00Z',
+        sizing: { epic: 0, story: 1, task: 2, bug: 0 },
+        sizingDeclaredAt: '2026-05-10T00:00:00Z',
+        ...over,
+      };
+    }
+
+    it('inserts and looks up by repo+number and by itemId', async () => {
+      const pr = makePr();
+      const inserted = await storage.insertPr(pr);
+      expect(inserted).toMatchObject({ prNumber: 42, repo: 'foo/bar' });
+
+      const byNumber = await storage.getPrByRepoNumber('foo/bar', 42);
+      expect(byNumber).toMatchObject({ id: pr.id, sizing: { epic: 0, story: 1, task: 2, bug: 0 } });
+
+      const byItem = await storage.getPrsByItemId('item-A');
+      expect(byItem).toHaveLength(1);
+      expect(byItem[0].id).toBe(pr.id);
+    });
+
+    it('insertPr is idempotent on (repo, prNumber) — duplicate updates sizing instead of throwing', async () => {
+      await storage.insertPr(makePr({ id: 'pr-1' }));
+      // Re-call with same repo+number, different sizing → should refresh row, not error.
+      const updated = await storage.insertPr(
+        makePr({ id: 'pr-2', sizing: { epic: 1, story: 1, task: 5, bug: 0 } }),
+      );
+      const byNumber = await storage.getPrByRepoNumber('foo/bar', 42);
+      expect(byNumber?.sizing).toEqual({ epic: 1, story: 1, task: 5, bug: 0 });
+      expect(updated.sizing).toEqual({ epic: 1, story: 1, task: 5, bug: 0 });
+    });
+
+    it('updatePrSizing rewrites sizing + shadow + last_sizing_check_at', async () => {
+      await storage.insertPr(makePr());
+      const updated = await storage.updatePrSizing(
+        'foo/bar',
+        42,
+        { epic: 0, story: 0, task: 9, bug: 1 },
+        { epic: 0, story: 0, task: 7, bug: 0 },
+      );
+      expect(updated.sizing).toEqual({ epic: 0, story: 0, task: 9, bug: 1 });
+      expect(updated.sizingShadow).toEqual({ epic: 0, story: 0, task: 7, bug: 0 });
+      expect(updated.lastSizingCheckAt).toBeDefined();
+    });
+
+    it('returns null for unknown PRs', async () => {
+      expect(await storage.getPrByRepoNumber('foo/bar', 999)).toBeNull();
+      expect(await storage.getPrsByItemId('nonexistent')).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Stacks on #74 → #75. Replaces the 8 throwing observability stubs in `SQLiteStorageProvider` with real implementations.

- `insertTokenEvent` / `queryTokenEvents` — prepared INSERT + WHERE-clause builder supporting `itemId`, `projectId`, `client`, `since`, `until`, `limit`, ordered by `ts ASC`.
- `getIngestionState` / `setIngestionState` — `INSERT...ON CONFLICT(source_path) DO UPDATE` upsert.
- `insertPr` — idempotent on `(repo, pr_number)` via `ON CONFLICT...DO UPDATE`. Re-call refreshes sizing rather than throwing — matches the agent-redeclares-on-push flow.
- `updatePrSizing` — rewrites `sizing_json`, `sizing_shadow_json`, `sizing_declared_at`, `last_sizing_check_at`. Throws if PR not found.
- `getPrByRepoNumber` / `getPrsByItemId` — straight lookups via the indexes added in #74.

JSON columns round-tripped via a private `rowToPr` helper.

## Test plan

- [x] New `packages/storage-sqlite/src/test/observability-storage.test.ts` — 9 tests covering insert + filtered query + dedup error, ingestion state upsert, PR insert + lookups + idempotency, updatePrSizing
- [x] `npm run build` clean
- [x] `npm test` full suite green (1210 tests, 110 files)