### PR TITLE
feat(observability): token-ingestion attribution + poller infrastructure

### DIFF
--- a/packages/server/src/test/token-ingestion-attribution.test.ts
+++ b/packages/server/src/test/token-ingestion-attribution.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { findActiveItemAt } from '../token-ingestion/attribution';
+import type { AgEnFKItem } from '@agenfk/core';
+
+const FLOW = {
+  steps: [
+    { name: 'TODO', order: 0, isAnchor: true },
+    { name: 'IN_PROGRESS', order: 1 },
+    { name: 'REVIEW', order: 2 },
+    { name: 'DONE', order: 3, isAnchor: true },
+  ],
+};
+
+function makeItem(id: string, history: { from: string; to: string; ts: string }[]): AgEnFKItem {
+  return {
+    id,
+    projectId: 'p1',
+    type: 'TASK',
+    title: id,
+    description: '',
+    status: history[history.length - 1]?.to as any,
+    createdAt: new Date(history[0]?.ts ?? '2026-05-01'),
+    updatedAt: new Date(history[history.length - 1]?.ts ?? '2026-05-01'),
+    history: history.map((h, i) => ({
+      id: `h-${id}-${i}`,
+      fromStatus: h.from as any,
+      toStatus: h.to as any,
+      timestamp: new Date(h.ts),
+    })),
+  } as AgEnFKItem;
+}
+
+describe('findActiveItemAt', () => {
+  it('returns null when no items have transitioned to a working step', () => {
+    const items: AgEnFKItem[] = [
+      makeItem('a', [{ from: 'TODO', to: 'TODO', ts: '2026-05-01T00:00:00Z' }]),
+    ];
+    expect(findActiveItemAt(items, FLOW, '2026-05-10T00:00:00Z')).toBeNull();
+  });
+
+  it('returns the item whose most-recent transition INTO an active step is at or before T', () => {
+    const a = makeItem('a', [
+      { from: 'TODO', to: 'IN_PROGRESS', ts: '2026-05-10T00:00:00Z' },
+    ]);
+    const b = makeItem('b', [
+      { from: 'TODO', to: 'IN_PROGRESS', ts: '2026-05-10T01:00:00Z' },
+    ]);
+    expect(findActiveItemAt([a, b], FLOW, '2026-05-10T02:00:00Z')).toBe('b');
+    expect(findActiveItemAt([a, b], FLOW, '2026-05-10T00:30:00Z')).toBe('a');
+  });
+
+  it('skips items that transitioned out of an active step before T', () => {
+    const a = makeItem('a', [
+      { from: 'TODO', to: 'IN_PROGRESS', ts: '2026-05-10T00:00:00Z' },
+      { from: 'IN_PROGRESS', to: 'DONE', ts: '2026-05-10T01:00:00Z' },
+    ]);
+    const b = makeItem('b', [
+      { from: 'TODO', to: 'IN_PROGRESS', ts: '2026-05-10T00:30:00Z' },
+    ]);
+    // At T = 02:00, a is DONE (anchor), b is IN_PROGRESS → b wins
+    expect(findActiveItemAt([a, b], FLOW, '2026-05-10T02:00:00Z')).toBe('b');
+  });
+
+  it('treats PAUSED/BLOCKED/ARCHIVED/TRASHED/IDEAS as inactive', () => {
+    const a = makeItem('a', [
+      { from: 'TODO', to: 'IN_PROGRESS', ts: '2026-05-10T00:00:00Z' },
+      { from: 'IN_PROGRESS', to: 'PAUSED', ts: '2026-05-10T01:00:00Z' },
+    ]);
+    const b = makeItem('b', [
+      { from: 'TODO', to: 'REVIEW', ts: '2026-05-10T00:30:00Z' },
+    ]);
+    expect(findActiveItemAt([a, b], FLOW, '2026-05-10T02:00:00Z')).toBe('b');
+  });
+
+  it('handles a single item that re-entered an active step', () => {
+    const a = makeItem('a', [
+      { from: 'TODO', to: 'IN_PROGRESS', ts: '2026-05-10T00:00:00Z' },
+      { from: 'IN_PROGRESS', to: 'REVIEW', ts: '2026-05-10T01:00:00Z' },
+      { from: 'REVIEW', to: 'IN_PROGRESS', ts: '2026-05-10T02:00:00Z' },
+    ]);
+    expect(findActiveItemAt([a], FLOW, '2026-05-10T03:00:00Z')).toBe('a');
+  });
+
+  it('ignores items whose only transition is after T', () => {
+    const a = makeItem('a', [
+      { from: 'TODO', to: 'IN_PROGRESS', ts: '2026-05-10T05:00:00Z' },
+    ]);
+    expect(findActiveItemAt([a], FLOW, '2026-05-10T03:00:00Z')).toBeNull();
+  });
+});

--- a/packages/server/src/test/token-ingestion-processFile.test.ts
+++ b/packages/server/src/test/token-ingestion-processFile.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { processFile } from '../token-ingestion/watcher';
+import type { TokenEvent, IngestionState } from '@agenfk/core';
+
+/**
+ * processFile is the pure-logic core of the file watcher: given the prior
+ * ingestion state for a path, the file's current contents, and a parser, it
+ * returns the new events to insert plus the next ingestion state. No I/O.
+ */
+describe('processFile', () => {
+  const fakeParser = (text: string, basePath: string, baseOffset: number): TokenEvent[] => {
+    // Each line is "<input>,<output>" → one event per non-empty line.
+    const out: TokenEvent[] = [];
+    let off = baseOffset;
+    for (const line of text.split('\n')) {
+      if (line.trim()) {
+        const [i, o] = line.split(',').map(Number);
+        out.push({
+          id: `${basePath}:${off}`,
+          ts: '2026-05-10T00:00:00Z',
+          client: 'codex',
+          sessionId: 'sess',
+          model: 'm',
+          input: i,
+          cachedInput: 0,
+          output: o,
+          reasoning: 0,
+          total: i + o,
+          sourcePath: basePath,
+          sourceOffset: off,
+        });
+      }
+      off += Buffer.byteLength(line, 'utf8') + 1;
+    }
+    return out;
+  };
+
+  it('returns events for the full file on first run (no prior state)', () => {
+    const r = processFile('/p/a.jsonl', '10,20\n30,40\n', null, fakeParser);
+    expect(r.events.map((e) => e.input)).toEqual([10, 30]);
+    expect(r.nextState.lastOffset).toBe(Buffer.byteLength('10,20\n30,40\n', 'utf8'));
+    expect(r.nextState.sourcePath).toBe('/p/a.jsonl');
+  });
+
+  it('returns only newly-appended events on subsequent runs', () => {
+    const initial: IngestionState = {
+      sourcePath: '/p/a.jsonl',
+      lastOffset: Buffer.byteLength('10,20\n', 'utf8'),
+      lastRunAt: '2026-05-10T00:00:00Z',
+    };
+    const r = processFile('/p/a.jsonl', '10,20\n30,40\n', initial, fakeParser);
+    expect(r.events.map((e) => e.input)).toEqual([30]);
+    expect(r.nextState.lastOffset).toBe(Buffer.byteLength('10,20\n30,40\n', 'utf8'));
+  });
+
+  it('returns no events when nothing has been appended', () => {
+    const initial: IngestionState = {
+      sourcePath: '/p/a.jsonl',
+      lastOffset: Buffer.byteLength('10,20\n30,40\n', 'utf8'),
+      lastRunAt: '2026-05-10T00:00:00Z',
+    };
+    const r = processFile('/p/a.jsonl', '10,20\n30,40\n', initial, fakeParser);
+    expect(r.events).toEqual([]);
+    expect(r.nextState.lastOffset).toBe(initial.lastOffset);
+  });
+
+  it('handles file truncation by resetting offset to 0 and re-emitting', () => {
+    // File got truncated/rotated; current contents are smaller than lastOffset.
+    const initial: IngestionState = {
+      sourcePath: '/p/a.jsonl',
+      lastOffset: 999,
+      lastRunAt: '2026-05-10T00:00:00Z',
+    };
+    const r = processFile('/p/a.jsonl', '5,5\n', initial, fakeParser);
+    expect(r.events.map((e) => e.input)).toEqual([5]);
+    expect(r.nextState.lastOffset).toBe(Buffer.byteLength('5,5\n', 'utf8'));
+  });
+});

--- a/packages/server/src/token-ingestion/attribution.ts
+++ b/packages/server/src/token-ingestion/attribution.ts
@@ -1,0 +1,72 @@
+import type { AgEnFKItem } from '@agenfk/core';
+
+interface MinimalFlow {
+  steps: Array<{ name: string; isAnchor?: boolean }>;
+}
+
+const INACTIVE_STATUSES = new Set(['BLOCKED', 'PAUSED', 'TRASHED', 'ARCHIVED', 'IDEAS']);
+
+function activeStatusSet(flow: MinimalFlow | null): (status: string) => boolean {
+  const anchors = new Set(
+    flow ? flow.steps.filter((s) => s.isAnchor).map((s) => s.name.toUpperCase()) : ['TODO', 'DONE'],
+  );
+  return (status: string) => {
+    const u = status.toUpperCase();
+    return !anchors.has(u) && !INACTIVE_STATUSES.has(u);
+  };
+}
+
+/**
+ * Given the items in a project and a timestamp T, return the id of the item
+ * whose most-recent transition INTO an active step occurred at or before T,
+ * provided the item has not transitioned OUT of the active step before T.
+ *
+ * "Active" = not an anchor (TODO/DONE) and not in the inactive set
+ * (BLOCKED/PAUSED/TRASHED/ARCHIVED/IDEAS).
+ *
+ * Returns null when no item was active at T.
+ */
+export function findActiveItemAt(
+  items: AgEnFKItem[],
+  flow: MinimalFlow | null,
+  ts: string,
+): string | null {
+  const isActive = activeStatusSet(flow);
+  const tMs = new Date(ts).getTime();
+
+  let bestId: string | null = null;
+  let bestActivationMs = -Infinity;
+
+  for (const item of items) {
+    const history = (item.history ?? [])
+      .map((h) => ({ to: String(h.toStatus), tMs: new Date(h.timestamp as any).getTime() }))
+      .filter((h) => h.tMs <= tMs)
+      .sort((a, b) => a.tMs - b.tMs);
+
+    if (history.length === 0) continue;
+
+    // Walk forward; track the latest activation point that is still in effect at T.
+    let activeSince = -Infinity;
+    for (const h of history) {
+      if (isActive(h.to)) {
+        // Only update activation point if we weren't already in an active step,
+        // so the "activation" reflects entry into the active region (handles re-entry).
+        if (activeSince === -Infinity || !isActive(h.to)) {
+          activeSince = h.tMs;
+        } else {
+          activeSince = h.tMs;
+        }
+      } else {
+        activeSince = -Infinity;
+      }
+    }
+
+    if (activeSince === -Infinity) continue;
+    if (activeSince > bestActivationMs) {
+      bestActivationMs = activeSince;
+      bestId = item.id;
+    }
+  }
+
+  return bestId;
+}

--- a/packages/server/src/token-ingestion/index.ts
+++ b/packages/server/src/token-ingestion/index.ts
@@ -1,0 +1,13 @@
+export { findActiveItemAt } from './attribution';
+export {
+  processFile,
+  ingestOnce,
+  startIngestionPoller,
+  listSourceFiles,
+} from './watcher';
+export type {
+  SessionLogParser,
+  IngestionSource,
+  IngestionPollerOptions,
+  ProcessFileResult,
+} from './watcher';

--- a/packages/server/src/token-ingestion/watcher.ts
+++ b/packages/server/src/token-ingestion/watcher.ts
@@ -1,0 +1,162 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import type { TokenEvent, IngestionState, StorageProvider } from '@agenfk/core';
+
+/**
+ * Parser signature: given the new (un-ingested) text content from a file,
+ * the file path, and the byte offset where this slice starts, return the
+ * TokenEvents to insert. Each parser is responsible for its own per-client
+ * format (Codex, Claude Code, etc.) and for setting `sourceOffset` on each
+ * event to the byte offset of the record within the file (so the dedup
+ * unique index in storage rejects double-inserts on retry).
+ */
+export type SessionLogParser = (
+  text: string,
+  sourcePath: string,
+  baseOffset: number,
+) => TokenEvent[];
+
+export interface ProcessFileResult {
+  events: TokenEvent[];
+  nextState: IngestionState;
+}
+
+/**
+ * Pure-logic core of the watcher. Compares prior ingestion state against the
+ * file's current contents and returns the new events plus the next state.
+ *
+ * - First run (no prior state): parse the entire file from offset 0.
+ * - Normal append: parse only the bytes after lastOffset.
+ * - File truncation/rotation (currentSize < lastOffset): treat as a fresh
+ *   file, parse from 0.
+ *
+ * No I/O is performed here — caller passes the current contents in. Tests
+ * exercise this directly without touching the filesystem.
+ */
+export function processFile(
+  sourcePath: string,
+  currentContents: string,
+  priorState: IngestionState | null,
+  parser: SessionLogParser,
+): ProcessFileResult {
+  const totalBytes = Buffer.byteLength(currentContents, 'utf8');
+  const lastOffset = priorState?.lastOffset ?? 0;
+  const startOffset = lastOffset > totalBytes ? 0 : lastOffset; // truncation
+  const slice = startOffset === 0 ? currentContents : currentContents.slice(byteOffsetToCharOffset(currentContents, startOffset));
+  const events = slice.length ? parser(slice, sourcePath, startOffset) : [];
+  return {
+    events,
+    nextState: {
+      sourcePath,
+      lastOffset: totalBytes,
+      lastRunAt: new Date().toISOString(),
+    },
+  };
+}
+
+/**
+ * Convert a byte offset (within the UTF-8 encoding of `s`) to the equivalent
+ * character offset for `String.prototype.slice`. Optimized for the common ASCII
+ * case where byte offset == char offset.
+ */
+function byteOffsetToCharOffset(s: string, byteOffset: number): number {
+  if (byteOffset === 0) return 0;
+  // Fast path: if the prefix is all ASCII, byte offset == char offset.
+  let bytes = 0;
+  for (let i = 0; i < s.length; i++) {
+    const b = Buffer.byteLength(s[i], 'utf8');
+    bytes += b;
+    if (bytes === byteOffset) return i + 1;
+    if (bytes > byteOffset) return i; // mid-codepoint; align to char boundary
+  }
+  return s.length;
+}
+
+// ── Runtime poller (wraps processFile + storage) ─────────────────────────────
+// Discovers session log files under one or more root directories and ingests
+// them into the storage's token_events table. Picks up where it left off via
+// the ingestion_state table.
+
+export interface IngestionSource {
+  /** Stable name used as the `client` field on emitted events (e.g. 'codex'). */
+  client: string;
+  /** Root dir to scan (e.g. ~/.codex/sessions/). */
+  rootDir: string;
+  /** Glob-like predicate for which files to ingest. */
+  matches: (relativePath: string) => boolean;
+  /** Per-client parser. */
+  parser: SessionLogParser;
+}
+
+export interface IngestionPollerOptions {
+  storage: StorageProvider;
+  sources: IngestionSource[];
+  /** ms between polls. Default 30s. */
+  intervalMs?: number;
+}
+
+/**
+ * Walks a directory recursively and yields absolute paths matching `predicate`.
+ * Used at runtime by the poller; not invoked by the pure tests.
+ */
+export function listSourceFiles(rootDir: string, predicate: (rel: string) => boolean): string[] {
+  if (!fs.existsSync(rootDir)) return [];
+  const out: string[] = [];
+  const stack: string[] = [rootDir];
+  while (stack.length) {
+    const dir = stack.pop()!;
+    let entries: fs.Dirent[];
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { continue; }
+    for (const e of entries) {
+      const abs = path.join(dir, e.name);
+      const rel = path.relative(rootDir, abs);
+      if (e.isDirectory()) stack.push(abs);
+      else if (e.isFile() && predicate(rel)) out.push(abs);
+    }
+  }
+  return out;
+}
+
+/**
+ * Single ingestion pass: scan all sources, ingest any new bytes, return the
+ * total number of events written.
+ */
+export async function ingestOnce(opts: IngestionPollerOptions): Promise<number> {
+  let written = 0;
+  for (const source of opts.sources) {
+    const files = listSourceFiles(source.rootDir, source.matches);
+    for (const abs of files) {
+      let contents: string;
+      try { contents = fs.readFileSync(abs, 'utf8'); } catch { continue; }
+      const prior = await opts.storage.getIngestionState(abs);
+      const result = processFile(abs, contents, prior, source.parser);
+      // Tag every event with the source's client name (parsers may not know it).
+      for (const ev of result.events) {
+        ev.client = source.client as any;
+        try {
+          await opts.storage.insertTokenEvent(ev);
+          written++;
+        } catch {
+          // Most likely a duplicate via the unique (client, source_path, source_offset)
+          // index — safe to ignore on poll-overlap.
+        }
+      }
+      await opts.storage.setIngestionState(result.nextState);
+    }
+  }
+  return written;
+}
+
+export function startIngestionPoller(opts: IngestionPollerOptions): () => void {
+  const intervalMs = opts.intervalMs ?? 30_000;
+  let stopped = false;
+  const tick = async () => {
+    if (stopped) return;
+    try { await ingestOnce(opts); } catch (e) {
+      console.error('[TOKEN_INGESTION] tick failed:', (e as Error).message);
+    }
+    if (!stopped) timer = setTimeout(tick, intervalMs);
+  };
+  let timer: NodeJS.Timeout = setTimeout(tick, intervalMs);
+  return () => { stopped = true; clearTimeout(timer); };
+}


### PR DESCRIPTION
## Summary

Stacks on #74 → #75 → #76. Adds the pure-logic core of the server-side token-ingestion pipeline. No parsers yet — they land in the next PR.

New module `packages/server/src/token-ingestion/`:
- `attribution.ts` — `findActiveItemAt(items, flow, ts)`: walks each item's `HistoryRecord`, tracks the latest activation into a non-anchor / non-inactive step still in effect at T. Most-recent-active wins; handles re-entry; returns null when nothing was active. **Pure function, no I/O.**
- `watcher.ts` — `processFile(path, contents, priorState, parser)`: pure diff of prior `IngestionState` vs current file contents; handles first-run, normal-append, and file truncation/rotation. Plus `ingestOnce` and `startIngestionPoller` runtime wrappers that combine `processFile` with storage I/O via the `StorageProvider` interface added in #74.
- `index.ts` — barrel.

Chokidar deliberately avoided: node-builtin polling keeps the dep surface minimal. Pure tests cover the diff/attribution logic without touching the filesystem.

## Test plan

- [x] `token-ingestion-attribution.test.ts` — 6 cases: null, most-recent-active wins, transitioned-out is skipped, inactive-set (PAUSED/BLOCKED/etc.), re-entry, future-only
- [x] `token-ingestion-processFile.test.ts` — 4 cases: first run, append delta, no-op when nothing new, truncation reset
- [x] `npm run build` clean
- [x] `npm test` full suite green (1220 tests, 112 files)