### PR TITLE
feat(observability): Codex + Claude Code session-log parsers

### DIFF
--- a/packages/server/src/test/token-ingestion-parser-claude.test.ts
+++ b/packages/server/src/test/token-ingestion-parser-claude.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { parseClaudeCodeJsonl } from '../token-ingestion/parsers/claude-code';
+
+describe('parseClaudeCodeJsonl', () => {
+  it('emits one event per assistant message with usage; ignores other lines', () => {
+    const a1 = {
+      type: 'assistant',
+      timestamp: '2026-05-10T00:00:00.000Z',
+      sessionId: 'sess-1',
+      message: {
+        model: 'claude-opus-4-7',
+        usage: {
+          input_tokens: 100,
+          cache_creation_input_tokens: 50,
+          cache_read_input_tokens: 30,
+          output_tokens: 40,
+        },
+      },
+    };
+    const userMsg = { type: 'user', timestamp: '2026-05-10T00:00:01Z', sessionId: 'sess-1', message: { content: 'hi' } };
+    const a2 = {
+      type: 'assistant',
+      timestamp: '2026-05-10T00:00:02Z',
+      sessionId: 'sess-1',
+      message: {
+        model: 'claude-opus-4-7',
+        usage: { input_tokens: 5, cache_read_input_tokens: 80, output_tokens: 12 },
+      },
+    };
+    const text = [JSON.stringify(a1), JSON.stringify(userMsg), JSON.stringify(a2), ''].join('\n');
+    const events = parseClaudeCodeJsonl(text, '/p/sess.jsonl', 0);
+
+    expect(events).toHaveLength(2);
+    expect(events[0]).toMatchObject({
+      ts: '2026-05-10T00:00:00.000Z',
+      sessionId: 'sess-1',
+      model: 'claude-opus-4-7',
+      input: 100,
+      // cached_input combines cache-creation + cache-read because Claude bills both as "non-fresh" input
+      cachedInput: 80,
+      output: 40,
+      reasoning: 0,
+      total: 100 + 80 + 40,
+      sourcePath: '/p/sess.jsonl',
+    });
+    expect(events[0].sourceOffset).toBe(0);
+
+    // Second event's offset is past the first two lines.
+    const expectedOffset = Buffer.byteLength(JSON.stringify(a1) + '\n' + JSON.stringify(userMsg) + '\n', 'utf8');
+    expect(events[1].sourceOffset).toBe(expectedOffset);
+    expect(events[1].input).toBe(5);
+    expect(events[1].cachedInput).toBe(80);
+    expect(events[1].output).toBe(12);
+  });
+
+  it('handles a slice with a non-zero baseOffset', () => {
+    const a = {
+      type: 'assistant',
+      timestamp: '2026-05-10T00:00:00Z',
+      sessionId: 'sess-1',
+      message: { model: 'claude', usage: { input_tokens: 1, output_tokens: 2 } },
+    };
+    const text = JSON.stringify(a) + '\n';
+    const events = parseClaudeCodeJsonl(text, '/p/sess.jsonl', 1024);
+    expect(events).toHaveLength(1);
+    expect(events[0].sourceOffset).toBe(1024);
+  });
+
+  it('skips malformed JSON lines without throwing', () => {
+    const a = {
+      type: 'assistant',
+      timestamp: '2026-05-10T00:00:00Z',
+      sessionId: 'sess-1',
+      message: { model: 'claude', usage: { input_tokens: 1, output_tokens: 2 } },
+    };
+    const text = ['{not json}', JSON.stringify(a), ''].join('\n');
+    const events = parseClaudeCodeJsonl(text, '/p/sess.jsonl', 0);
+    expect(events).toHaveLength(1);
+  });
+});

--- a/packages/server/src/test/token-ingestion-parser-codex.test.ts
+++ b/packages/server/src/test/token-ingestion-parser-codex.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { parseCodexJsonl } from '../token-ingestion/parsers/codex';
+
+/**
+ * Codex writes session JSONL where each `event_msg` with payload.type ==='token_count'
+ * carries cumulative totals. Per-turn deltas are derived by subtracting the
+ * previous cumulative.
+ */
+
+function ev(ts: string, cum: Partial<{ input: number; cached_input: number; output: number; reasoning: number; total: number }>) {
+  return JSON.stringify({
+    type: 'event_msg',
+    timestamp: ts,
+    payload: {
+      type: 'token_count',
+      session_id: 'sess-codex',
+      model: 'gpt-5',
+      ...cum,
+    },
+  });
+}
+
+describe('parseCodexJsonl', () => {
+  it('emits per-turn deltas from cumulative totals', () => {
+    const text = [
+      ev('2026-05-10T00:00:00Z', { input: 10, output: 5, total: 15 }),
+      ev('2026-05-10T00:01:00Z', { input: 30, output: 12, total: 42 }),
+      '',
+    ].join('\n');
+    const events = parseCodexJsonl(text, '/p/codex.jsonl', 0);
+    expect(events).toHaveLength(2);
+    expect(events[0]).toMatchObject({
+      ts: '2026-05-10T00:00:00Z',
+      sessionId: 'sess-codex',
+      model: 'gpt-5',
+      input: 10,
+      output: 5,
+      total: 15,
+    });
+    // Second event delta = current - prev within this slice.
+    expect(events[1]).toMatchObject({
+      ts: '2026-05-10T00:01:00Z',
+      input: 20,
+      output: 7,
+      total: 27,
+    });
+  });
+
+  it('captures cached_input and reasoning when present', () => {
+    const text = [
+      ev('2026-05-10T00:00:00Z', {
+        input: 100,
+        cached_input: 30,
+        output: 50,
+        reasoning: 10,
+        total: 190,
+      }),
+      '',
+    ].join('\n');
+    const events = parseCodexJsonl(text, '/p/codex.jsonl', 0);
+    expect(events[0]).toMatchObject({
+      input: 100,
+      cachedInput: 30,
+      output: 50,
+      reasoning: 10,
+      total: 190,
+    });
+  });
+
+  it('ignores non-token_count event_msg lines', () => {
+    const noise = JSON.stringify({ type: 'event_msg', timestamp: '2026-05-10T00:00:00Z', payload: { type: 'agent_message' } });
+    const real = ev('2026-05-10T00:00:00Z', { input: 1, output: 1, total: 2 });
+    const text = [noise, real, ''].join('\n');
+    expect(parseCodexJsonl(text, '/p/c.jsonl', 0)).toHaveLength(1);
+  });
+
+  it('skips negative deltas (treats as session reset / new file)', () => {
+    // After truncation/rotation, cumulative may go down. Don't emit negative usage.
+    const text = [
+      ev('2026-05-10T00:00:00Z', { input: 100, output: 50, total: 150 }),
+      ev('2026-05-10T00:01:00Z', { input: 30, output: 12, total: 42 }), // smaller — likely session reset
+      '',
+    ].join('\n');
+    const events = parseCodexJsonl(text, '/p/codex.jsonl', 0);
+    expect(events.length).toBe(2);
+    // Second event treated as a fresh baseline (its cumulative IS the delta).
+    expect(events[1]).toMatchObject({ input: 30, output: 12, total: 42 });
+  });
+});

--- a/packages/server/src/token-ingestion/index.ts
+++ b/packages/server/src/token-ingestion/index.ts
@@ -11,3 +11,5 @@ export type {
   IngestionPollerOptions,
   ProcessFileResult,
 } from './watcher';
+export { parseClaudeCodeJsonl } from './parsers/claude-code';
+export { parseCodexJsonl } from './parsers/codex';

--- a/packages/server/src/token-ingestion/parsers/claude-code.ts
+++ b/packages/server/src/token-ingestion/parsers/claude-code.ts
@@ -1,0 +1,61 @@
+import { randomUUID } from 'crypto';
+import type { TokenEvent } from '@agenfk/core';
+import type { SessionLogParser } from '../watcher';
+
+/**
+ * Parses a slice of a Claude Code session JSONL file. Each line is a JSON
+ * object; lines with `type === 'assistant'` and a `message.usage` block
+ * yield one TokenEvent per line.
+ *
+ * Cached input combines `cache_creation_input_tokens` + `cache_read_input_tokens`
+ * because both represent input that was non-fresh at the model's turn.
+ *
+ * `client` is left as 'claude-code' but the runtime watcher will overwrite it
+ * with the configured source name.
+ */
+export const parseClaudeCodeJsonl: SessionLogParser = (text, sourcePath, baseOffset) => {
+  const events: TokenEvent[] = [];
+  let off = baseOffset;
+
+  for (const line of text.split('\n')) {
+    const lineBytes = Buffer.byteLength(line, 'utf8');
+    const lineOffset = off;
+    off += lineBytes + 1; // +1 for the \n delimiter we split on
+
+    if (!line.trim()) continue;
+    let obj: any;
+    try { obj = JSON.parse(line); } catch { continue; }
+
+    if (obj?.type !== 'assistant') continue;
+    const usage = obj?.message?.usage;
+    if (!usage || typeof usage !== 'object') continue;
+
+    const input = numberOr(usage.input_tokens, 0);
+    const cachedInput =
+      numberOr(usage.cache_creation_input_tokens, 0) + numberOr(usage.cache_read_input_tokens, 0);
+    const output = numberOr(usage.output_tokens, 0);
+    const reasoning = 0; // not separated in Claude's wire format
+    const total = input + cachedInput + output;
+
+    events.push({
+      id: randomUUID(),
+      ts: String(obj.timestamp ?? new Date().toISOString()),
+      client: 'claude-code',
+      sessionId: String(obj.sessionId ?? ''),
+      turnId: typeof obj.uuid === 'string' ? obj.uuid : undefined,
+      model: String(obj.message?.model ?? 'unknown'),
+      input,
+      cachedInput,
+      output,
+      reasoning,
+      total,
+      sourcePath,
+      sourceOffset: lineOffset,
+    });
+  }
+  return events;
+};
+
+function numberOr(v: any, fallback: number): number {
+  return typeof v === 'number' && Number.isFinite(v) ? v : fallback;
+}

--- a/packages/server/src/token-ingestion/parsers/codex.ts
+++ b/packages/server/src/token-ingestion/parsers/codex.ts
@@ -1,0 +1,81 @@
+import { randomUUID } from 'crypto';
+import type { TokenEvent } from '@agenfk/core';
+import type { SessionLogParser } from '../watcher';
+
+/**
+ * Codex session JSONL: each line is an event_msg, and `payload.type === 'token_count'`
+ * lines carry CUMULATIVE totals for the session. Per-turn deltas are recovered
+ * by subtracting the previous cumulative within the same slice.
+ *
+ * If a delta is negative (lower than previous), treat that line's cumulative
+ * as a fresh baseline (likely session reset / file rotation) — emit it as-is
+ * rather than emitting a negative usage.
+ */
+export const parseCodexJsonl: SessionLogParser = (text, sourcePath, baseOffset) => {
+  const events: TokenEvent[] = [];
+  let off = baseOffset;
+
+  let prev = { input: 0, cachedInput: 0, output: 0, reasoning: 0, total: 0 };
+  let havePrev = false;
+
+  for (const line of text.split('\n')) {
+    const lineBytes = Buffer.byteLength(line, 'utf8');
+    const lineOffset = off;
+    off += lineBytes + 1;
+
+    if (!line.trim()) continue;
+    let obj: any;
+    try { obj = JSON.parse(line); } catch { continue; }
+
+    if (obj?.type !== 'event_msg') continue;
+    if (obj?.payload?.type !== 'token_count') continue;
+
+    const cum = {
+      input: numberOr(obj.payload.input, 0),
+      cachedInput: numberOr(obj.payload.cached_input, 0),
+      output: numberOr(obj.payload.output, 0),
+      reasoning: numberOr(obj.payload.reasoning, 0),
+      total: numberOr(obj.payload.total, 0),
+    };
+
+    let delta = havePrev
+      ? {
+          input: cum.input - prev.input,
+          cachedInput: cum.cachedInput - prev.cachedInput,
+          output: cum.output - prev.output,
+          reasoning: cum.reasoning - prev.reasoning,
+          total: cum.total - prev.total,
+        }
+      : { ...cum };
+
+    // Detect session reset: any negative component → treat current cumulative as fresh.
+    const negative =
+      delta.input < 0 || delta.cachedInput < 0 || delta.output < 0 ||
+      delta.reasoning < 0 || delta.total < 0;
+    if (negative) delta = { ...cum };
+
+    events.push({
+      id: randomUUID(),
+      ts: String(obj.timestamp ?? obj.payload.timestamp ?? new Date().toISOString()),
+      client: 'codex',
+      sessionId: String(obj.payload.session_id ?? obj.session_id ?? ''),
+      turnId: typeof obj.payload.turn_id === 'string' ? obj.payload.turn_id : undefined,
+      model: String(obj.payload.model ?? 'unknown'),
+      input: delta.input,
+      cachedInput: delta.cachedInput,
+      output: delta.output,
+      reasoning: delta.reasoning,
+      total: delta.total,
+      sourcePath,
+      sourceOffset: lineOffset,
+    });
+
+    prev = cum;
+    havePrev = true;
+  }
+  return events;
+};
+
+function numberOr(v: any, fallback: number): number {
+  return typeof v === 'number' && Number.isFinite(v) ? v : fallback;
+}


### PR DESCRIPTION
## Summary

Stacks on #74 → #75 → #76 → #77. Adds the two highest-value session-log parsers, plugged into the `SessionLogParser` shape introduced in #77.

- `parsers/claude-code.ts` — walks JSONL, emits one event per `type === 'assistant'` line with `message.usage`. Combines `cache_creation_input_tokens + cache_read_input_tokens` into `cachedInput`.
- `parsers/codex.ts` — walks JSONL, emits one event per `event_msg` line with `payload.type === 'token_count'`. Computes per-turn deltas from cumulative; treats any negative-component delta as a session reset (uses current cumulative as fresh baseline).

Both set `sourceOffset` to the byte offset of the line within the file → the unique dedup index in storage handles overlap on retry.

Gemini / Cursor / OpenCode parsers are deferred — the architecture supports them additively.

## Test plan

- [x] `token-ingestion-parser-claude.test.ts` — 3 cases: assistant-with-usage, base-offset honored, malformed-line skip
- [x] `token-ingestion-parser-codex.test.ts` — 4 cases: cumulative→delta, cached/reasoning passthrough, ignore non-token_count, session-reset detection
- [x] `npm run build` clean
- [x] `npm test` full suite green (1227 tests, 114 files)