### PR TITLE
feat(observability): query_token_events MCP tool + GET /token-events + agenfk tokens CLI

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2455,6 +2455,32 @@ program
   });
 
 program
+  .command('tokens')
+  .description('Query the server-side token-events store (MCP fallback: query_token_events)')
+  .option('--item <id>', 'Filter to events attributed to this item')
+  .option('--project <id>', 'Filter to a project')
+  .option('--client <name>', 'Filter to a client (claude-code | codex | gemini | cursor | opencode)')
+  .option('--since <ts>', 'ISO timestamp inclusive lower bound')
+  .option('--until <ts>', 'ISO timestamp exclusive upper bound')
+  .option('--limit <n>', 'Cap number of rows', (v) => parseInt(v, 10))
+  .action(async (options) => {
+    try {
+      const params: Record<string, string | number> = {};
+      if (options.item) params.itemId = options.item;
+      if (options.project) params.projectId = options.project;
+      if (options.client) params.client = options.client;
+      if (options.since) params.since = options.since;
+      if (options.until) params.until = options.until;
+      if (options.limit) params.limit = options.limit;
+      const { data } = await axios.get(`${API_URL}/token-events`, { params });
+      console.log(JSON.stringify(data, null, 2));
+    } catch (error: any) {
+      console.error(chalk.red('Error querying token events:'), error.response?.data?.error || error.message);
+      process.exit(1);
+    }
+  });
+
+program
   .command('log-test <id>')
   .description('Log a test result for an item (MCP fallback: log_test_result)')
   .requiredOption('--command <cmd>', 'Test command that was run')
@@ -3248,7 +3274,7 @@ program.helpInformation = function () {
   const groups: [string, string[]][] = [
     ['Services',              ['up', 'down', 'restart', 'kill', 'upgrade', 'health', 'ui']],
     ['Project & Items',       ['init', 'create-project', 'list-projects', 'create', 'list', 'get', 'update', 'delete', 'move']],
-    ['Workflow',              ['verify', 'gatekeeper', 'comment', 'log-test']],
+    ['Workflow',              ['verify', 'gatekeeper', 'comment', 'log-test', 'tokens']],
     ['Integrations & Rules',  ['integration', 'rules', 'configure-ide']],
     ['Git & Release',         ['branch', 'pr']],
     ['Flows',                 ['flow']],

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -116,6 +116,15 @@ const GetItemSchema = z.object({
   id: z.string(),
 });
 
+const QueryTokenEventsSchema = z.object({
+  itemId: z.string().optional(),
+  projectId: z.string().optional(),
+  client: z.enum(['claude-code', 'codex', 'gemini', 'cursor', 'opencode']).optional(),
+  since: z.string().optional(),
+  until: z.string().optional(),
+  limit: z.number().int().positive().optional(),
+});
+
 const AddContextSchema = z.object({
   itemId: z.string(),
   path: z.string(),
@@ -226,6 +235,22 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           type: "object",
           properties: { id: { type: "string" } },
           required: ["id"],
+        },
+      },
+      {
+        name: "query_token_events",
+        description:
+          "Query the server-side token-event store. Events are written by the token-ingestion worker that parses per-client session log files (Codex, Claude Code, etc.) — agents do not self-report.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            itemId: { type: "string", description: "Filter to events attributed to this item." },
+            projectId: { type: "string" },
+            client: { type: "string", enum: ['claude-code', 'codex', 'gemini', 'cursor', 'opencode'] },
+            since: { type: "string", description: "ISO timestamp inclusive lower bound." },
+            until: { type: "string", description: "ISO timestamp exclusive upper bound." },
+            limit: { type: "number" },
+          },
         },
       },
       {
@@ -780,6 +805,18 @@ async function callToolHandler(request: any): Promise<any> {
         const { id } = z.object({ id: z.string() }).parse(request.params.arguments);
         await api.delete(`/items/${id}`);
         return { content: [{ type: "text", text: `Item ${id} and its children moved to trash.` }] };
+      }
+      case "query_token_events": {
+        const args = QueryTokenEventsSchema.parse(request.params.arguments ?? {});
+        const params: Record<string, string | number> = {};
+        if (args.itemId) params.itemId = args.itemId;
+        if (args.projectId) params.projectId = args.projectId;
+        if (args.client) params.client = args.client;
+        if (args.since) params.since = args.since;
+        if (args.until) params.until = args.until;
+        if (args.limit) params.limit = args.limit;
+        const { data } = await api.get('/token-events', { params });
+        return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
       }
       case "add_comment": {
         const args = AddCommentSchema.parse(request.params.arguments);

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -792,6 +792,27 @@ app.get("/flows", asyncHandler(async (_req: any, res: any) => {
   res.json(flows);
 }));
 
+// ── Observability: token events read API ────────────────────────────────────
+// Writes happen via the server-side ingestion worker (packages/server/src/token-ingestion).
+// This GET route exposes filtered reads to MCP / CLI / UI consumers.
+
+app.get("/token-events", asyncHandler(async (req: any, res: any) => {
+  const { itemId, projectId, client, since, until, limit } = req.query as Record<string, string | undefined>;
+  const ALLOWED_CLIENTS = new Set(['claude-code', 'codex', 'gemini', 'cursor', 'opencode']);
+  if (client && !ALLOWED_CLIENTS.has(client)) {
+    return res.status(400).json({ error: `Invalid client '${client}'. Must be one of: ${[...ALLOWED_CLIENTS].join(', ')}` });
+  }
+  const limitNum = limit !== undefined ? Number(limit) : undefined;
+  if (limit !== undefined && (!Number.isFinite(limitNum) || (limitNum as number) <= 0)) {
+    return res.status(400).json({ error: 'limit must be a positive integer' });
+  }
+  const events = await storage.queryTokenEvents({
+    itemId, projectId, client: client as any, since, until,
+    limit: limitNum,
+  });
+  res.json(events);
+}));
+
 const HUB_MANAGED_FLOW_MSG = "Flow is managed by your organization's Hub and cannot be modified locally";
 
 app.post("/flows", asyncHandler(async (req: any, res: any) => {

--- a/packages/server/src/test/token-events-api.test.ts
+++ b/packages/server/src/test/token-events-api.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import request from 'supertest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { app, initStorage } from '../server';
+
+vi.mock('axios', () => {
+  const mockAxios = vi.fn() as any;
+  mockAxios.get = vi.fn();
+  mockAxios.post = vi.fn();
+  mockAxios.create = vi.fn(() => mockAxios);
+  return { default: mockAxios };
+});
+
+const ROOT = path.resolve(__dirname, '../../../..');
+const TEST_DB = path.resolve('./token-events-api-test-db.sqlite');
+
+describe('query_token_events MCP tool registration', () => {
+  let src: string;
+  beforeAll(() => {
+    src = fs.readFileSync(path.join(ROOT, 'packages/server/src/index.ts'), 'utf8');
+  });
+  it('declares "query_token_events" in the tools list', () => {
+    expect(src).toMatch(/name:\s*["']query_token_events["']/);
+  });
+  it('handles "query_token_events" in the call-tool switch', () => {
+    expect(src).toMatch(/case\s+["']query_token_events["']/);
+  });
+});
+
+describe('agenfk tokens CLI command', () => {
+  it('declares a `tokens` command in packages/cli/src/index.ts', () => {
+    const src = fs.readFileSync(path.join(ROOT, 'packages/cli/src/index.ts'), 'utf8');
+    expect(src).toMatch(/\.command\s*\(\s*['"]tokens/);
+  });
+});
+
+describe('GET /token-events REST', () => {
+  beforeAll(async () => {
+    process.env.AGENFK_DB_PATH = TEST_DB;
+    if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+    await initStorage();
+  });
+  afterAll(() => {
+    if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+  });
+  beforeEach(async () => { await initStorage(); });
+
+  it('returns an empty array when no events exist', async () => {
+    const res = await request(app).get('/token-events');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body).toEqual([]);
+  });
+
+  it('filters by itemId, projectId, since, until, client, limit', async () => {
+    // Use the storage directly via a small test endpoint helper isn't available;
+    // instead poke the storage by importing and inserting. Both tests below
+    // are independent, so we accept that this test exercises only the route's
+    // parameter forwarding.
+    const { storage } = await import('../server');
+    await storage.insertTokenEvent({
+      id: 'a', ts: '2026-05-10T00:00:00Z', client: 'codex', sessionId: 's',
+      model: 'm', input: 1, cachedInput: 0, output: 1, reasoning: 0, total: 2,
+      itemId: 'item-X', projectId: 'proj-1', sourcePath: '/p/a', sourceOffset: 0,
+    });
+    await storage.insertTokenEvent({
+      id: 'b', ts: '2026-05-11T00:00:00Z', client: 'claude-code', sessionId: 's',
+      model: 'm', input: 2, cachedInput: 0, output: 2, reasoning: 0, total: 4,
+      itemId: 'item-X', projectId: 'proj-1', sourcePath: '/p/b', sourceOffset: 0,
+    });
+
+    const byItem = await request(app).get('/token-events').query({ itemId: 'item-X' });
+    expect(byItem.status).toBe(200);
+    expect(byItem.body.map((e: any) => e.id).sort()).toEqual(['a', 'b']);
+
+    const byClient = await request(app).get('/token-events').query({ client: 'codex' });
+    expect(byClient.body.map((e: any) => e.id)).toEqual(['a']);
+
+    const limited = await request(app).get('/token-events').query({ limit: 1 });
+    expect(limited.body).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Stacks on #74 → #75 → #76 → #77 → #78. Adds the read surface that completes Track 2.

- New `query_token_events` MCP tool + `QueryTokenEventsSchema` Zod schema. Filters: `itemId`, `projectId`, `client`, `since`, `until`, `limit`. Delegates to REST.
- New `GET /token-events` REST route. Validates the `client` enum and `limit` shape at the boundary.
- New `agenfk tokens` CLI subcommand with `--item`, `--project`, `--client`, `--since`, `--until`, `--limit` options. Help-info group updated.

## Test plan

- [x] `token-events-api.test.ts` — 5 tests: MCP registration (name + case), CLI command declared, `GET /token-events` returns array empty/filtered/limited
- [x] `npm run build` clean
- [x] `npm test` full suite green (1232 tests, 115 files; one flaky ECONNRESET on Hub reconciler unrelated to this change cleared on re-run)