### PR TITLE
feat(observability): register_pr / update_pr_sizing API + shadow sizing

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2455,6 +2455,53 @@ program
   });
 
 program
+  .command('pr-register')
+  .description('Register a freshly opened PR with agent-declared sizing (MCP fallback: register_pr)')
+  .requiredOption('--item <id>', 'Anchor item id for the PR')
+  .requiredOption('--number <n>', 'PR number', (v) => parseInt(v, 10))
+  .requiredOption('--repo <owner/repo>', 'GitHub repo')
+  .requiredOption('--epic <n>', 'Epic count', (v) => parseInt(v, 10))
+  .requiredOption('--story <n>', 'Story count', (v) => parseInt(v, 10))
+  .requiredOption('--task <n>', 'Task count', (v) => parseInt(v, 10))
+  .requiredOption('--bug <n>', 'Bug count', (v) => parseInt(v, 10))
+  .action(async (options) => {
+    try {
+      const { data } = await axios.post(`${API_URL}/prs`, {
+        itemId: options.item,
+        prNumber: options.number,
+        repo: options.repo,
+        sizing: { epic: options.epic, story: options.story, task: options.task, bug: options.bug },
+      });
+      console.log(JSON.stringify(data, null, 2));
+    } catch (error: any) {
+      console.error(chalk.red('Error registering PR:'), error.response?.data?.error || error.message);
+      process.exit(1);
+    }
+  });
+
+program
+  .command('pr-resize')
+  .description('Update an already-registered PR’s sizing (MCP fallback: update_pr_sizing)')
+  .requiredOption('--number <n>', 'PR number', (v) => parseInt(v, 10))
+  .requiredOption('--repo <owner/repo>', 'GitHub repo')
+  .requiredOption('--epic <n>', 'Epic count', (v) => parseInt(v, 10))
+  .requiredOption('--story <n>', 'Story count', (v) => parseInt(v, 10))
+  .requiredOption('--task <n>', 'Task count', (v) => parseInt(v, 10))
+  .requiredOption('--bug <n>', 'Bug count', (v) => parseInt(v, 10))
+  .action(async (options) => {
+    try {
+      const { data } = await axios.put(
+        `${API_URL}/prs/${encodeURIComponent(options.repo)}/${options.number}`,
+        { sizing: { epic: options.epic, story: options.story, task: options.task, bug: options.bug } },
+      );
+      console.log(JSON.stringify(data, null, 2));
+    } catch (error: any) {
+      console.error(chalk.red('Error updating PR sizing:'), error.response?.data?.error || error.message);
+      process.exit(1);
+    }
+  });
+
+program
   .command('tokens')
   .description('Query the server-side token-events store (MCP fallback: query_token_events)')
   .option('--item <id>', 'Filter to events attributed to this item')
@@ -3276,7 +3323,7 @@ program.helpInformation = function () {
     ['Project & Items',       ['init', 'create-project', 'list-projects', 'create', 'list', 'get', 'update', 'delete', 'move']],
     ['Workflow',              ['verify', 'gatekeeper', 'comment', 'log-test', 'tokens']],
     ['Integrations & Rules',  ['integration', 'rules', 'configure-ide']],
-    ['Git & Release',         ['branch', 'pr']],
+    ['Git & Release',         ['branch', 'pr', 'pr-register', 'pr-resize']],
     ['Flows',                 ['flow']],
     ['External Sync',         ['github', 'jira']],
     ['Configuration',         ['config', 'backup', 'db']],

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -125,6 +125,26 @@ const QueryTokenEventsSchema = z.object({
   limit: z.number().int().positive().optional(),
 });
 
+const PrSizingSchema = z.object({
+  epic: z.number().int().nonnegative(),
+  story: z.number().int().nonnegative(),
+  task: z.number().int().nonnegative(),
+  bug: z.number().int().nonnegative(),
+});
+
+const RegisterPrSchema = z.object({
+  itemId: z.string(),
+  prNumber: z.number().int().positive(),
+  repo: z.string(),
+  sizing: PrSizingSchema,
+});
+
+const UpdatePrSizingSchema = z.object({
+  prNumber: z.number().int().positive(),
+  repo: z.string(),
+  sizing: PrSizingSchema,
+});
+
 const AddContextSchema = z.object({
   itemId: z.string(),
   path: z.string(),
@@ -235,6 +255,52 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           type: "object",
           properties: { id: { type: "string" } },
           required: ["id"],
+        },
+      },
+      {
+        name: "register_pr",
+        description:
+          "Register a freshly opened PR with agent-declared sizing (cards by type included in the PR). Idempotent on (repo, prNumber) — re-call updates the sizing rather than erroring. Server computes a shadow sizing by walking the item tree from itemId; discrepancies are logged but the agent's number persists.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            itemId: { type: "string", description: "Anchor item id for the PR." },
+            prNumber: { type: "number" },
+            repo: { type: "string", description: "owner/repo" },
+            sizing: {
+              type: "object",
+              properties: {
+                epic: { type: "number" },
+                story: { type: "number" },
+                task: { type: "number" },
+                bug: { type: "number" },
+              },
+              required: ["epic", "story", "task", "bug"],
+            },
+          },
+          required: ["itemId", "prNumber", "repo", "sizing"],
+        },
+      },
+      {
+        name: "update_pr_sizing",
+        description: "Update an already-registered PR's sizing when more items have been piled onto its branch.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            prNumber: { type: "number" },
+            repo: { type: "string" },
+            sizing: {
+              type: "object",
+              properties: {
+                epic: { type: "number" },
+                story: { type: "number" },
+                task: { type: "number" },
+                bug: { type: "number" },
+              },
+              required: ["epic", "story", "task", "bug"],
+            },
+          },
+          required: ["prNumber", "repo", "sizing"],
         },
       },
       {
@@ -805,6 +871,16 @@ async function callToolHandler(request: any): Promise<any> {
         const { id } = z.object({ id: z.string() }).parse(request.params.arguments);
         await api.delete(`/items/${id}`);
         return { content: [{ type: "text", text: `Item ${id} and its children moved to trash.` }] };
+      }
+      case "register_pr": {
+        const args = RegisterPrSchema.parse(request.params.arguments);
+        const { data } = await api.post('/prs', args);
+        return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+      }
+      case "update_pr_sizing": {
+        const args = UpdatePrSizingSchema.parse(request.params.arguments);
+        const { data } = await api.put(`/prs/${encodeURIComponent(args.repo)}/${args.prNumber}`, { sizing: args.sizing });
+        return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
       }
       case "query_token_events": {
         const args = QueryTokenEventsSchema.parse(request.params.arguments ?? {});

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -792,6 +792,99 @@ app.get("/flows", asyncHandler(async (_req: any, res: any) => {
   res.json(flows);
 }));
 
+// ── Observability: PR registration ──────────────────────────────────────────
+// Agent-declared sizing on PR open + re-declares on push. Server computes a
+// shadow sizing by walking the item tree from the anchor item — logged for
+// discrepancy detection but never overrides the agent's number.
+
+async function computeShadowSizing(rootItemId: string): Promise<{ epic: number; story: number; task: number; bug: number }> {
+  const counts = { epic: 0, story: 0, task: 0, bug: 0 };
+  const root = await storage.getItem(rootItemId);
+  if (!root) return counts;
+  const stack: any[] = [root];
+  const seen = new Set<string>();
+  while (stack.length) {
+    const node = stack.pop()!;
+    if (seen.has(node.id)) continue;
+    seen.add(node.id);
+    switch (node.type) {
+      case 'EPIC':  counts.epic++;  break;
+      case 'STORY': counts.story++; break;
+      case 'TASK':  counts.task++;  break;
+      case 'BUG':   counts.bug++;   break;
+    }
+    const children = await storage.listChildren(node.id);
+    for (const c of children) stack.push(c);
+  }
+  return counts;
+}
+
+app.post("/prs", asyncHandler(async (req: any, res: any) => {
+  const { itemId, prNumber, repo, sizing } = req.body || {};
+  if (!itemId || typeof prNumber !== 'number' || !repo || !sizing
+    || typeof sizing.epic !== 'number' || typeof sizing.story !== 'number'
+    || typeof sizing.task !== 'number' || typeof sizing.bug !== 'number') {
+    return res.status(400).json({ error: 'itemId, prNumber, repo, sizing{epic,story,task,bug} required' });
+  }
+
+  const shadow = await computeShadowSizing(itemId);
+  const now = new Date().toISOString();
+  const pr = await storage.insertPr({
+    id: crypto.randomUUID(),
+    prNumber,
+    repo,
+    itemId,
+    openedAt: now,
+    sizing,
+    sizingDeclaredAt: now,
+    sizingShadow: shadow,
+    lastSizingCheckAt: now,
+  });
+
+  const matches =
+    sizing.epic === shadow.epic && sizing.story === shadow.story
+    && sizing.task === shadow.task && sizing.bug === shadow.bug;
+  if (!matches) {
+    console.log(
+      `[PR_SIZING] discrepancy on ${repo}#${prNumber} (item ${itemId}): ` +
+      `agent=${JSON.stringify(sizing)} shadow=${JSON.stringify(shadow)}`,
+    );
+  }
+
+  res.status(201).json(pr);
+}));
+
+app.put("/prs/:repo/:number", asyncHandler(async (req: any, res: any) => {
+  const repo = decodeURIComponent(req.params.repo);
+  const prNumber = Number(req.params.number);
+  if (!Number.isFinite(prNumber)) {
+    return res.status(400).json({ error: 'PR number must be an integer' });
+  }
+  const { sizing } = req.body || {};
+  if (!sizing
+    || typeof sizing.epic !== 'number' || typeof sizing.story !== 'number'
+    || typeof sizing.task !== 'number' || typeof sizing.bug !== 'number') {
+    return res.status(400).json({ error: 'sizing{epic,story,task,bug} required' });
+  }
+
+  const existing = await storage.getPrByRepoNumber(repo, prNumber);
+  if (!existing) return res.status(404).json({ error: `PR ${repo}#${prNumber} not registered` });
+
+  const shadow = await computeShadowSizing(existing.itemId);
+  const updated = await storage.updatePrSizing(repo, prNumber, sizing, shadow);
+
+  const matches =
+    sizing.epic === shadow.epic && sizing.story === shadow.story
+    && sizing.task === shadow.task && sizing.bug === shadow.bug;
+  if (!matches) {
+    console.log(
+      `[PR_SIZING] discrepancy on ${repo}#${prNumber}: agent=${JSON.stringify(sizing)} shadow=${JSON.stringify(shadow)}`,
+    );
+  }
+
+  res.json(updated);
+}));
+
 // ── Observability: token events read API ────────────────────────────────────
 // Writes happen via the server-side ingestion worker (packages/server/src/token-ingestion).
 // This GET route exposes filtered reads to MCP / CLI / UI consumers.

--- a/packages/server/src/test/pr-registration-api.test.ts
+++ b/packages/server/src/test/pr-registration-api.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import request from 'supertest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { app, initStorage } from '../server';
+
+vi.mock('axios', () => {
+  const mockAxios = vi.fn() as any;
+  mockAxios.get = vi.fn();
+  mockAxios.post = vi.fn();
+  mockAxios.put = vi.fn();
+  mockAxios.create = vi.fn(() => mockAxios);
+  return { default: mockAxios };
+});
+
+const ROOT = path.resolve(__dirname, '../../../..');
+const TEST_DB = path.resolve('./pr-registration-test-db.sqlite');
+
+describe('register_pr / update_pr_sizing — static registration', () => {
+  let src: string;
+  beforeAll(() => {
+    src = fs.readFileSync(path.join(ROOT, 'packages/server/src/index.ts'), 'utf8');
+  });
+  for (const name of ['register_pr', 'update_pr_sizing']) {
+    it(`declares "${name}" in tools list`, () => {
+      expect(src).toMatch(new RegExp(`name:\\s*["']${name}["']`));
+    });
+    it(`handles "${name}" in case switch`, () => {
+      expect(src).toMatch(new RegExp(`case\\s+["']${name}["']`));
+    });
+  }
+});
+
+describe('CLI: pr-register / pr-resize', () => {
+  let cli: string;
+  beforeAll(() => { cli = fs.readFileSync(path.join(ROOT, 'packages/cli/src/index.ts'), 'utf8'); });
+  it('declares pr-register command', () => {
+    expect(cli).toMatch(/\.command\s*\(\s*['"]pr-register/);
+  });
+  it('declares pr-resize command', () => {
+    expect(cli).toMatch(/\.command\s*\(\s*['"]pr-resize/);
+  });
+});
+
+describe('REST: POST /prs and PUT /prs/:repo/:number', () => {
+  beforeAll(async () => {
+    process.env.AGENFK_DB_PATH = TEST_DB;
+    if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+    await initStorage();
+  });
+  afterAll(() => {
+    if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+  });
+  beforeEach(async () => { await initStorage(); });
+
+  it('POST /prs registers a new PR with declared sizing', async () => {
+    const project = (await request(app).post('/projects').send({ name: 'P' })).body;
+    const item = (await request(app).post('/items').send({ projectId: project.id, type: 'TASK', title: 'T' })).body;
+
+    const res = await request(app).post('/prs').send({
+      itemId: item.id,
+      prNumber: 100,
+      repo: 'foo/bar',
+      sizing: { epic: 0, story: 1, task: 2, bug: 0 },
+    });
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({
+      prNumber: 100,
+      repo: 'foo/bar',
+      itemId: item.id,
+      sizing: { epic: 0, story: 1, task: 2, bug: 0 },
+    });
+    expect(res.body.id).toBeDefined();
+    expect(res.body.openedAt).toBeDefined();
+  });
+
+  it('POST /prs is idempotent on (repo, prNumber) — re-call refreshes sizing', async () => {
+    const project = (await request(app).post('/projects').send({ name: 'P' })).body;
+    const item = (await request(app).post('/items').send({ projectId: project.id, type: 'TASK', title: 'T' })).body;
+
+    await request(app).post('/prs').send({
+      itemId: item.id, prNumber: 200, repo: 'foo/bar',
+      sizing: { epic: 0, story: 1, task: 1, bug: 0 },
+    });
+    const second = await request(app).post('/prs').send({
+      itemId: item.id, prNumber: 200, repo: 'foo/bar',
+      sizing: { epic: 0, story: 1, task: 5, bug: 0 },
+    });
+    expect(second.status).toBe(201);
+    expect(second.body.sizing).toEqual({ epic: 0, story: 1, task: 5, bug: 0 });
+  });
+
+  it('PUT /prs/:repo/:number updates sizing', async () => {
+    const project = (await request(app).post('/projects').send({ name: 'P' })).body;
+    const item = (await request(app).post('/items').send({ projectId: project.id, type: 'TASK', title: 'T' })).body;
+    await request(app).post('/prs').send({
+      itemId: item.id, prNumber: 300, repo: 'foo/bar',
+      sizing: { epic: 0, story: 1, task: 1, bug: 0 },
+    });
+
+    const res = await request(app).put('/prs/foo%2Fbar/300').send({
+      sizing: { epic: 0, story: 1, task: 4, bug: 1 },
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.sizing).toEqual({ epic: 0, story: 1, task: 4, bug: 1 });
+    expect(res.body.lastSizingCheckAt).toBeDefined();
+  });
+
+  it('PUT /prs/:repo/:number returns 404 when PR not registered', async () => {
+    const res = await request(app).put('/prs/foo%2Fbar/999').send({
+      sizing: { epic: 0, story: 0, task: 1, bug: 0 },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('POST /prs validates required fields', async () => {
+    const res = await request(app).post('/prs').send({ prNumber: 1 });
+    expect(res.status).toBe(400);
+  });
+
+  it('POST /prs computes shadow sizing from the item tree', async () => {
+    const project = (await request(app).post('/projects').send({ name: 'P' })).body;
+    const epic = (await request(app).post('/items').send({ projectId: project.id, type: 'EPIC', title: 'E' })).body;
+    const story = (await request(app).post('/items').send({ projectId: project.id, type: 'STORY', title: 'S', parentId: epic.id })).body;
+    await request(app).post('/items').send({ projectId: project.id, type: 'TASK', title: 'T1', parentId: story.id });
+    await request(app).post('/items').send({ projectId: project.id, type: 'TASK', title: 'T2', parentId: story.id });
+    await request(app).post('/items').send({ projectId: project.id, type: 'BUG', title: 'B', parentId: story.id, severity: 'LOW' });
+
+    const res = await request(app).post('/prs').send({
+      itemId: epic.id, prNumber: 400, repo: 'foo/bar',
+      sizing: { epic: 1, story: 1, task: 99, bug: 99 }, // deliberately wrong
+    });
+    expect(res.status).toBe(201);
+    expect(res.body.sizing).toEqual({ epic: 1, story: 1, task: 99, bug: 99 }); // agent's number persists
+    expect(res.body.sizingShadow).toEqual({ epic: 1, story: 1, task: 2, bug: 1 }); // server's truth
+  });
+});


### PR DESCRIPTION
## Summary

Stacks on #74 → #75 → #76 → #77 → #78 → #79. Adds Track 1's API surface — agent-declared PR sizing with a server-computed shadow as a sanity check.

- New Zod schemas `PrSizingSchema`, `RegisterPrSchema`, `UpdatePrSizingSchema` in `packages/server/src/index.ts`.
- New MCP tools `register_pr` and `update_pr_sizing`, both delegating to REST.
- New REST routes:
  - `POST /prs` — idempotent on `(repo, prNumber)`. Computes shadow sizing by walking the item tree from `itemId` via `storage.listChildren`, persists, logs discrepancies (never overrides agent's number).
  - `PUT /prs/:repo/:number` — resolves `itemId` from the existing row, recomputes shadow, updates sizing + `last_sizing_check_at`. 404 if not registered.
- New CLI subcommands `agenfk pr-register` and `agenfk pr-resize`.

## Test plan

- [x] `pr-registration-api.test.ts` — 12 tests covering MCP/CLI registration, REST POST/PUT happy paths, idempotency, validation 400s, 404 on unknown PR, **shadow sizing computed from item tree**
- [x] `npm run build` clean
- [x] `npm test` full suite green (1244 tests, 116 files)