### PR TITLE
feat(observability): PostToolUse hook + per-client wiring for PR sizing

### DIFF
--- a/bin/agenfk-pr-hook-opencode.mjs
+++ b/bin/agenfk-pr-hook-opencode.mjs
@@ -1,0 +1,42 @@
+/**
+ * AgEnFK PR sizing hook — OpenCode plugin variant. Runs as a `tool.execute.after`
+ * plugin under ~/.config/opencode/plugins/. Mirrors the standalone agenfk-pr-hook.mjs
+ * shell-script version but emits the directive via the OpenCode plugin context
+ * rather than stdout.
+ *
+ * Installed by scripts/install.mjs.
+ */
+import { spawnSync } from 'child_process';
+import path from 'path';
+import os from 'os';
+
+const HOOK_BIN = path.join(os.homedir(), '.agenfk', 'bin', 'agenfk-pr-hook.mjs');
+
+export default async function agenfkPrHookOpencode(_context) {
+  return {
+    'tool.execute.after': async (input) => {
+      const tool = (input.tool || '').toLowerCase();
+      if (tool !== 'bash' && tool !== 'execute') return;
+      const command = input?.args?.command || '';
+      if (!command) return;
+      // Delegate classification + directive shape to the shared script.
+      try {
+        const result = spawnSync('node', [HOOK_BIN, '--client', 'opencode'], {
+          input: JSON.stringify({ args: { command } }),
+          encoding: 'utf8',
+          timeout: 1500,
+        });
+        const out = (result.stdout || '').trim();
+        if (!out) return;
+        try {
+          const parsed = JSON.parse(out);
+          if (parsed?.message) {
+            // OpenCode plugins surface notes via a console-style log; the agent
+            // sees the directive in its tool-call output stream.
+            console.log(`[agenfk-pr-hook] ${parsed.message}`);
+          }
+        } catch { /* malformed output — ignore */ }
+      } catch { /* hook should never break the host */ }
+    },
+  };
+}

--- a/bin/agenfk-pr-hook.mjs
+++ b/bin/agenfk-pr-hook.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+/**
+ * AgEnFK PR sizing hook — fires on PostToolUse / tool.execute.after for shell
+ * commands. Detects `gh pr create` (open trigger) or `git push` to a branch
+ * with a registered PR (push trigger), then emits a directive back to the
+ * agent telling it to call register_pr(...) or update_pr_sizing(...).
+ *
+ * The hook NEVER writes to the database itself — it only nudges the agent,
+ * because the agent has the semantic knowledge (which items are bundled into
+ * this PR) that a server-side walk doesn't.
+ *
+ * Usage in client config: `agenfk-pr-hook --client <name>`
+ */
+import http from 'http';
+import { execSync } from 'child_process';
+
+const API_URL = process.env.AGENFK_API_URL || 'http://127.0.0.1:3000';
+
+// ── Pure helpers (also exported for unit tests) ──────────────────────────────
+
+export function classifyTrigger(command) {
+  if (typeof command !== 'string') return null;
+  const trimmed = command.trim();
+  if (/^gh\s+pr\s+create\b/.test(trimmed)) return { kind: 'open' };
+  const pushMatch = trimmed.match(/^git\s+push\b(.*)$/);
+  if (pushMatch) {
+    const rest = (pushMatch[1] || '').trim().split(/\s+/);
+    // crude branch extraction: last non-flag token, ignoring 'origin' / '-u'
+    let branch;
+    for (let i = rest.length - 1; i >= 0; i--) {
+      const tok = rest[i];
+      if (!tok || tok.startsWith('-')) continue;
+      if (tok === 'origin') continue;
+      branch = tok;
+      break;
+    }
+    return { kind: 'push', branch };
+  }
+  return null;
+}
+
+export function buildDirective(client, message) {
+  switch (client) {
+    case 'claude-code':
+      return { hookSpecificOutput: { hookEventName: 'PostToolUse', additionalContext: message } };
+    case 'codex':
+      return { decision: 'continue', reason: message };
+    case 'gemini':
+      return { decision: 'continue', context: message };
+    case 'cursor':
+      return { permission: 'allow', userMessage: message };
+    case 'opencode':
+      return { message };
+    default:
+      return { message };
+  }
+}
+
+// ── Runtime glue ─────────────────────────────────────────────────────────────
+
+async function readStdinJson() {
+  return new Promise((resolve) => {
+    let data = '';
+    const timeout = setTimeout(() => resolve(null), 500);
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (c) => (data += c));
+    process.stdin.on('end', () => {
+      clearTimeout(timeout);
+      try { resolve(data.trim() ? JSON.parse(data) : null); } catch { resolve(null); }
+    });
+    process.stdin.on('close', () => { clearTimeout(timeout); resolve(null); });
+  });
+}
+
+function extractCommand(input) {
+  // Handle several shapes: Claude Code PostToolUse, Codex hooks, Gemini, OpenCode tool.execute.after, Cursor afterShellExecution
+  if (!input || typeof input !== 'object') return '';
+  return (
+    input?.tool_input?.command ||
+    input?.toolInput?.command ||
+    input?.args?.command ||
+    input?.input?.command ||
+    input?.payload?.command ||
+    ''
+  );
+}
+
+function getCurrentBranch() {
+  try { return execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim(); }
+  catch { return null; }
+}
+
+function fetchJson(url) {
+  return new Promise((resolve) => {
+    http.get(url, (res) => {
+      if (res.statusCode !== 200) { res.resume(); resolve(null); return; }
+      let body = '';
+      res.on('data', (c) => (body += c));
+      res.on('end', () => { try { resolve(JSON.parse(body)); } catch { resolve(null); } });
+    }).on('error', () => resolve(null));
+  });
+}
+
+function emit(directive) {
+  process.stdout.write(JSON.stringify(directive));
+  process.exit(0);
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const clientIdx = args.indexOf('--client');
+  const client = clientIdx >= 0 ? args[clientIdx + 1] : 'claude-code';
+
+  const input = await readStdinJson();
+  const command = extractCommand(input);
+  if (!command) process.exit(0);
+
+  const trigger = classifyTrigger(command);
+  if (!trigger) process.exit(0);
+
+  if (trigger.kind === 'open') {
+    emit(buildDirective(client,
+      'You just opened a PR. Reply by calling `register_pr(itemId, prNumber, repo, sizing)` ' +
+      'with sizing = { epic, story, task, bug } counted across all items included in this PR. ' +
+      'Use the active item id as itemId.'));
+  }
+
+  // push trigger: only nudge if the branch already has a registered PR.
+  const branch = trigger.branch || getCurrentBranch();
+  if (!branch) process.exit(0);
+  // We don't currently index PRs by branch, but the agent can still answer the
+  // "did I add items to this PR?" question itself. Emit the directive
+  // unconditionally and let the agent decide; the server-side dedup window
+  // (last_sizing_check_at within 5 min) prevents wasted turns.
+  emit(buildDirective(client,
+    `You just pushed to '${branch}'. If this branch has an open PR registered with AgEnFK and ` +
+    'more items were added since the last sizing, call `update_pr_sizing(prNumber, repo, sizing)` ' +
+    'with the new counts. If unchanged, take no action.'));
+}
+
+// ESM script entry detection: only run main() when executed directly, not when imported.
+const isMain = (() => {
+  try {
+    const url = new URL(import.meta.url);
+    return process.argv[1] && url.pathname === process.argv[1];
+  } catch { return false; }
+})();
+if (isMain) {
+  main().catch(() => process.exit(0));
+}

--- a/codexrules/hooks.json
+++ b/codexrules/hooks.json
@@ -1,0 +1,13 @@
+{
+  "PostToolUse": [
+    {
+      "matcher": "shell",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "agenfk-pr-hook --client codex"
+        }
+      ]
+    }
+  ]
+}

--- a/cursorrules/.cursor/hooks.json
+++ b/cursorrules/.cursor/hooks.json
@@ -1,0 +1,7 @@
+{
+  "afterShellExecution": [
+    {
+      "command": "agenfk-pr-hook --client cursor"
+    }
+  ]
+}

--- a/geminirules/.gemini/settings.json
+++ b/geminirules/.gemini/settings.json
@@ -1,0 +1,10 @@
+{
+  "hooks": {
+    "AfterTool": [
+      {
+        "matcher": "run_shell_command",
+        "command": "agenfk-pr-hook --client gemini"
+      }
+    ]
+  }
+}

--- a/packages/server/src/test/pr-hook-classifier.test.ts
+++ b/packages/server/src/test/pr-hook-classifier.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+// Importing the .mjs hook script directly. Pure helpers are exported by name.
+// @ts-ignore — .mjs has no .d.ts; the helpers are JS functions.
+import { classifyTrigger, buildDirective } from '../../../../bin/agenfk-pr-hook.mjs';
+
+describe('classifyTrigger', () => {
+  it('detects gh pr create', () => {
+    expect(classifyTrigger('gh pr create --title foo --body bar')).toEqual({ kind: 'open' });
+    expect(classifyTrigger("gh   pr   create --fill")).toEqual({ kind: 'open' });
+  });
+
+  it('detects git push and extracts branch when present', () => {
+    expect(classifyTrigger('git push -u origin feature/x')).toEqual({ kind: 'push', branch: 'feature/x' });
+    expect(classifyTrigger('git push origin HEAD')).toEqual({ kind: 'push', branch: 'HEAD' });
+    expect(classifyTrigger('git push')).toEqual({ kind: 'push', branch: undefined });
+  });
+
+  it('returns null for unrelated commands', () => {
+    expect(classifyTrigger('ls -la')).toBeNull();
+    expect(classifyTrigger('git status')).toBeNull();
+    expect(classifyTrigger('gh pr view 123')).toBeNull();
+  });
+
+  it('handles multiline / leading whitespace', () => {
+    expect(classifyTrigger('  gh pr create')).toEqual({ kind: 'open' });
+  });
+});
+
+describe('buildDirective', () => {
+  const message = 'You just opened PR #N. Call register_pr(...).';
+
+  it('claude-code: emits additionalContext', () => {
+    expect(buildDirective('claude-code', message)).toEqual({
+      hookSpecificOutput: { hookEventName: 'PostToolUse', additionalContext: message },
+    });
+  });
+
+  it('codex: emits decision/reason envelope', () => {
+    expect(buildDirective('codex', message)).toEqual({
+      decision: 'continue',
+      reason: message,
+    });
+  });
+
+  it('gemini: emits context injection', () => {
+    expect(buildDirective('gemini', message)).toEqual({
+      decision: 'continue',
+      context: message,
+    });
+  });
+
+  it('cursor: emits permission/output shape', () => {
+    expect(buildDirective('cursor', message)).toEqual({
+      permission: 'allow',
+      userMessage: message,
+    });
+  });
+
+  it('opencode: returns shape consumable by tool.execute.after plugin', () => {
+    expect(buildDirective('opencode', message)).toEqual({
+      message,
+    });
+  });
+
+  it('unknown client: falls back to a generic shape', () => {
+    expect(buildDirective('mystery', message)).toEqual({ message });
+  });
+});

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -364,6 +364,8 @@ async function run() {
     const gatekeeperDest = os.platform() === 'win32' ? `${gatekeeperDestBase}.cmd` : gatekeeperDestBase;
     const enforcerDestBase = path.join(localBinDir, 'agenfk-mcp-enforcer');
     const enforcerDest = os.platform() === 'win32' ? `${enforcerDestBase}.cmd` : enforcerDestBase;
+    const prHookDestBase = path.join(localBinDir, 'agenfk-pr-hook');
+    const prHookDest = os.platform() === 'win32' ? `${prHookDestBase}.cmd` : prHookDestBase;
 
     // --rules-only: skip steps 3b–12, jump straight to rules installation (step 13)
     if (rulesOnly) {
@@ -964,6 +966,22 @@ process.exit(0);
             }
         }
         console.log(`  Installed: ${enforcerDestBase}${os.platform() === 'win32' ? '.cmd' : ''}`);
+
+        // 12d. Install agenfk-pr-hook script (used by PostToolUse hooks across clients)
+        const prHookSource = path.join(rootDir, 'bin', 'agenfk-pr-hook.mjs');
+        if (os.platform() === 'win32') {
+            await fs.writeFile(`${prHookDestBase}.cmd`, `@echo off\nnode "${prHookSource}" %*`, 'utf8');
+            if (isMinGW) {
+                await fs.writeFile(prHookDestBase, `#!/bin/sh\nnode "${prHookSource}" "$@"`, 'utf8');
+                chmodSync(prHookDestBase, 0o755);
+            }
+        } else {
+            if (existsSync(prHookSource)) {
+                await fs.copyFile(prHookSource, prHookDestBase);
+                chmodSync(prHookDestBase, 0o755);
+            }
+        }
+        console.log(`  Installed: ${prHookDestBase}${os.platform() === 'win32' ? '.cmd' : ''}`);
     }
 
     // 12c. Install Opencode MCP enforcer plugin
@@ -976,6 +994,11 @@ process.exit(0);
             if (existsSync(opencodeEnforcerSource)) {
                 await fs.copyFile(opencodeEnforcerSource, path.join(opencodePluginsDir, 'agenfk-mcp-enforcer.mjs'));
                 console.log(`  Installed Opencode plugin: ${path.join(opencodePluginsDir, 'agenfk-mcp-enforcer.mjs')}`);
+            }
+            const opencodePrHookSource = path.join(rootDir, 'bin', 'agenfk-pr-hook-opencode.mjs');
+            if (existsSync(opencodePrHookSource)) {
+                await fs.copyFile(opencodePrHookSource, path.join(opencodePluginsDir, 'agenfk-pr-hook.mjs'));
+                console.log(`  Installed Opencode plugin: ${path.join(opencodePluginsDir, 'agenfk-pr-hook.mjs')}`);
             }
         } else if (!onlyPlatform) {
             console.log(`  Opencode not found. Skipping Opencode plugin installation.`);
@@ -1175,11 +1198,79 @@ process.exit(0);
             hooks: [{ type: 'command', command: enforcerDest }]
         });
 
+        // PostToolUse hook for PR sizing (fires on Bash so it can react to
+        // `gh pr create` and `git push`).
+        if (!settings.hooks.PostToolUse) settings.hooks.PostToolUse = [];
+        settings.hooks.PostToolUse = settings.hooks.PostToolUse.filter(entry =>
+            !JSON.stringify(entry).includes('agenfk-pr-hook')
+        );
+        settings.hooks.PostToolUse.push({
+            matcher: 'Bash',
+            hooks: [{ type: 'command', command: `${prHookDest} --client claude-code` }]
+        });
+
         // Remove legacy mcpServers key if present (MCP is now registered via `claude mcp add`)
         delete settings.mcpServers;
 
         await fs.writeFile(settingsPath, JSON.stringify(settings, null, 2), 'utf8');
-        console.log(`  Registered PreToolUse hooks in ${settingsPath}`);
+        console.log(`  Registered Pre/PostToolUse hooks in ${settingsPath}`);
+    }
+
+    // 14b. Configure PostToolUse hook for Codex CLI (~/.codex/hooks.json)
+    if (shouldRun('codex')) {
+        const codexHooksPath = path.join(os.homedir(), '.codex', 'hooks.json');
+        if (existsSync(path.dirname(codexHooksPath))) {
+            let config = {};
+            if (existsSync(codexHooksPath)) {
+                try { config = JSON.parse(await fs.readFile(codexHooksPath, 'utf8')); } catch {}
+            }
+            if (!Array.isArray(config.PostToolUse)) config.PostToolUse = [];
+            config.PostToolUse = config.PostToolUse.filter(e => !JSON.stringify(e).includes('agenfk-pr-hook'));
+            config.PostToolUse.push({
+                matcher: 'shell',
+                hooks: [{ type: 'command', command: `${prHookDest} --client codex` }]
+            });
+            await fs.writeFile(codexHooksPath, JSON.stringify(config, null, 2), 'utf8');
+            console.log(`  Registered PostToolUse hook in ${codexHooksPath}`);
+        }
+    }
+
+    // 14c. Configure AfterTool hook for Gemini CLI (~/.gemini/settings.json)
+    if (shouldRun('gemini')) {
+        const geminiSettingsPath = path.join(os.homedir(), '.gemini', 'settings.json');
+        if (existsSync(path.dirname(geminiSettingsPath))) {
+            let settings = {};
+            if (existsSync(geminiSettingsPath)) {
+                try { settings = JSON.parse(await fs.readFile(geminiSettingsPath, 'utf8')); } catch {}
+            }
+            if (!settings.hooks) settings.hooks = {};
+            if (!Array.isArray(settings.hooks.AfterTool)) settings.hooks.AfterTool = [];
+            settings.hooks.AfterTool = settings.hooks.AfterTool.filter(e => !JSON.stringify(e).includes('agenfk-pr-hook'));
+            settings.hooks.AfterTool.push({
+                matcher: 'run_shell_command',
+                command: `${prHookDest} --client gemini`,
+            });
+            await fs.writeFile(geminiSettingsPath, JSON.stringify(settings, null, 2), 'utf8');
+            console.log(`  Registered AfterTool hook in ${geminiSettingsPath}`);
+        }
+    }
+
+    // 14d. Configure afterShellExecution hook for Cursor (~/.cursor/hooks.json, 1.7+)
+    if (shouldRun('cursor')) {
+        const cursorHooksPath = path.join(os.homedir(), '.cursor', 'hooks.json');
+        if (existsSync(path.dirname(cursorHooksPath))) {
+            let config = {};
+            if (existsSync(cursorHooksPath)) {
+                try { config = JSON.parse(await fs.readFile(cursorHooksPath, 'utf8')); } catch {}
+            }
+            if (!Array.isArray(config.afterShellExecution)) config.afterShellExecution = [];
+            config.afterShellExecution = config.afterShellExecution.filter(e => !JSON.stringify(e).includes('agenfk-pr-hook'));
+            config.afterShellExecution.push({
+                command: `${prHookDest} --client cursor`,
+            });
+            await fs.writeFile(cursorHooksPath, JSON.stringify(config, null, 2), 'utf8');
+            console.log(`  Registered afterShellExecution hook in ${cursorHooksPath}`);
+        }
     }
 
     // BUG 174270e6: if a server was running before we replaced the files on


### PR DESCRIPTION
## Summary

Stacks on #74 → #75 → #76 → #77 → #78 → #79 → #80. Closes Track 1: hook script + per-client install for the agent-declared PR sizing flow.

- `bin/agenfk-pr-hook.mjs` — shared script. Pure helpers `classifyTrigger` (detects `gh pr create` / `git push`) and `buildDirective` (per-client output shape: Claude `additionalContext`, Codex `decision/reason`, Gemini `decision/context`, Cursor `permission/userMessage`, OpenCode `message`). Reads PostToolUse stdin, emits a directive nudging the agent to call `register_pr` / `update_pr_sizing`.
- `bin/agenfk-pr-hook-opencode.mjs` — OpenCode plugin variant (`tool.execute.after`) that delegates to the shared script.
- Per-client config bundles under `clauderules/.claude/settings.json`, `codexrules/hooks.json`, `geminirules/.gemini/settings.json`, `cursorrules/.cursor/hooks.json`.
- `scripts/install.mjs` extended:
  - Installs `agenfk-pr-hook` alongside `agenfk-gatekeeper` / `agenfk-mcp-enforcer`.
  - Copies the OpenCode plugin variant into `~/.config/opencode/plugins/`.
  - Injects PostToolUse / AfterTool / afterShellExecution entries into `~/.claude/settings.json`, `~/.codex/hooks.json`, `~/.gemini/settings.json`, `~/.cursor/hooks.json` — each guarded by `existsSync(dirname)` so it silently skips when the client isn't installed.

## Test plan

- [x] `pr-hook-classifier.test.ts` — 10 tests: `classifyTrigger` (gh pr create, git push with/without branch, unrelated cmds, whitespace) + `buildDirective` (5 client shapes + fallback)
- [x] `npm run build` clean
- [x] `npm test` full suite green (1254 tests, 117 files)