### PR TITLE
docs(observability): per-client PR-sizing rule + AFK_ARCHITECTURE matrix update

### DIFF
--- a/AFK_ARCHITECTURE.md
+++ b/AFK_ARCHITECTURE.md
@@ -52,21 +52,24 @@ This automation ensures consistent engineering rigor while minimizing human micr
 
 ## Supported AI Clients
 
-AgenFK supports three AI coding assistants. Each integrates with the same MCP server but uses a different mechanism for workflow enforcement:
+AgenFK supports five AI coding assistants. Each integrates with the same MCP server but uses a different hook mechanism for workflow enforcement. **As of 2025–2026, all five clients now have hooks** — the prior "instructional-only" gap for Codex / Cursor / Gemini has closed.
 
-| Client | MCP Registration | Workflow Rules | Enforcement Model |
-|--------|-----------------|----------------|-------------------|
-| **Claude Code** | `claude mcp add` (user scope) | `~/.claude/CLAUDE.md` | **Mechanical** — two PreToolUse hooks: `agenfk-gatekeeper` (blocks edits without IN_PROGRESS task) and `agenfk-mcp-enforcer` (blocks db/REST/CLI bypass routes) |
-| **OpenCode** | `~/.config/opencode/opencode.json` | `~/.config/opencode/skills/agenfk/SKILL.md` | **Mechanical** — `tool.execute.before` plugin (`agenfk-mcp-enforcer-opencode.mjs`) intercepting tool calls before execution |
-| **Cursor** | `~/.cursor/mcp.json` (Linux/macOS) or `%APPDATA%\Cursor\mcp.json` (Windows) | `~/.cursor/rules/agenfk.mdc` (Linux/macOS) or `%APPDATA%\Cursor\rules\agenfk.mdc` (Windows) | **Instructional** — Cursor has no PreToolUse hook or plugin system. Enforcement relies on the `workflow_gatekeeper` MCP tool called per instruction in `agenfk.mdc`. The model is expected to follow rules; no mechanical trip-wire exists. |
+| Client | MCP Registration | Workflow Rules | Pre-edit hook | Post-tool hook (PR sizing) |
+|--------|-----------------|----------------|---------------|----------------------------|
+| **Claude Code** | `claude mcp add` (user scope) | `~/.claude/CLAUDE.md` | `PreToolUse` — `agenfk-gatekeeper` + `agenfk-mcp-enforcer` | `PostToolUse` matcher `Bash` — `agenfk-pr-hook --client claude-code` |
+| **OpenCode** | `~/.config/opencode/opencode.json` | `~/.config/opencode/skills/agenfk/SKILL.md` | `tool.execute.before` plugin (`agenfk-mcp-enforcer-opencode.mjs`) | `tool.execute.after` plugin (`agenfk-pr-hook-opencode.mjs`) |
+| **Codex CLI** | `codex mcp add` | `~/.codex/AGENTS.md` | (no equivalent — CLAUDE.md-style instructional) | `PostToolUse` matcher `shell` (hooks reliably fire only for shell) — `agenfk-pr-hook --client codex` |
+| **Gemini CLI** (v0.26+) | `gemini mcp add` | `~/.gemini/GEMINI.md` | (no equivalent — instructional) | `AfterTool` matcher `run_shell_command` — `agenfk-pr-hook --client gemini` |
+| **Cursor** (1.7+) | `~/.cursor/mcp.json` | `~/.cursor/rules/agenfk.mdc` | (no equivalent — instructional + `alwaysApply: true` rule) | `afterShellExecution` — `agenfk-pr-hook --client cursor` |
 
-### Enforcement Gap (Cursor)
+### Enforcement model
 
-Claude Code and OpenCode provide *mechanical* enforcement: a hook fires before every tool call and can hard-block it regardless of model intent. Cursor provides no equivalent interception point. AgenFK's Cursor integration compensates with:
+- **Pre-edit gatekeeping** (does the agent have an active IN_PROGRESS task?) is mechanical only on Claude Code + OpenCode, where their hook systems support pre-tool blocking. On Codex / Gemini / Cursor, this remains **instructional** via the per-client rule docs — backed by the server-side `workflow_gatekeeper` audit trail.
+- **PR sizing prompt** (after `gh pr create` / `git push`) is mechanical on **all five** clients via their respective post-tool hook events. Even when the post-tool directive isn't followed, the per-client instruction docs include a belt-and-suspenders rule asking the agent to call `register_pr` / `update_pr_sizing`.
 
-1. **`alwaysApply: true` in `agenfk.mdc`** — the rule is auto-attached to every conversation, maximising the chance the model sees it.
-2. **Explicit breach-handling instructions** — `agenfk.mdc` instructs the model to stop and resolve a gatekeeper rejection before proceeding, not to silently skip it.
-3. **`workflow_gatekeeper` MCP tool** — the server-side check still verifies that a valid IN_PROGRESS task exists and logs the authorization intent, providing an audit trail even without a mechanical block.
+### Note on Codex hook coverage
+
+Codex's hook system reliably fires for the shell tool but not for `apply_patch` or most MCP tool calls (open issues `openai/codex#14882`, `#16732`, May 2026). The PR sizing hook is unaffected because `gh pr create` and `git push` always run via the shell tool. If pre-edit gatekeeping is added to Codex later, this caveat will need to be revisited.
 
 ## Tech Stack
 - **Language**: TypeScript (Strong typing across the stack)

--- a/clauderules/CLAUDE.md
+++ b/clauderules/CLAUDE.md
@@ -43,6 +43,10 @@ After completing changes — using MCP tools:
 
 Token usage is captured automatically by the server-side ingestion worker — agents do not need to (and cannot) self-report tokens.
 
+### PR sizing — MANDATORY
+
+After running `gh pr create`, you MUST call `register_pr(itemId, prNumber, repo, sizing)` via MCP, where `sizing = { epic, story, task, bug }` counts the items included in this PR. After `git push` to a branch that already has a registered PR and you've added more items, call `update_pr_sizing(prNumber, repo, sizing)` with the new counts. The server records a shadow sizing computed from the item tree as a sanity check — only your declared count is authoritative. A PostToolUse hook prompts you to do this on each `gh pr create` / `git push`.
+
 **ALWAYS use MCP tools for workflow state changes. NEVER use the `agenfk` CLI
 to create items, update status, or close tasks — the CLI bypasses enforcement.**
 

--- a/codexrules/AGENTS.md
+++ b/codexrules/AGENTS.md
@@ -56,6 +56,10 @@ After completing changes — using MCP tools:
 
 Token usage is captured automatically by the server-side ingestion worker — agents do not need to (and cannot) self-report tokens.
 
+### PR sizing — MANDATORY
+
+After running `gh pr create`, you MUST call `register_pr(itemId, prNumber, repo, sizing)` via MCP, where `sizing = { epic, story, task, bug }` counts the items included in this PR. After `git push` to a branch that already has a registered PR and you've added more items, call `update_pr_sizing(prNumber, repo, sizing)` with the new counts. A PostToolUse hook will also prompt you to do this on each `gh pr create` / `git push`.
+
 **ALWAYS use MCP tools for workflow state changes. NEVER use the `agenfk` CLI
 to create items, update status, or close tasks — the CLI bypasses enforcement.**
 

--- a/cursorrules/agenfk.mdc
+++ b/cursorrules/agenfk.mdc
@@ -64,6 +64,10 @@ After completing changes — using MCP tools:
 
 Token usage is captured automatically by the server-side ingestion worker — agents do not need to (and cannot) self-report tokens.
 
+### PR sizing — MANDATORY
+
+After running `gh pr create`, you MUST call `register_pr(itemId, prNumber, repo, sizing)` via MCP, where `sizing = { epic, story, task, bug }` counts the items included in this PR. After `git push` to a branch that already has a registered PR and you've added more items, call `update_pr_sizing(prNumber, repo, sizing)` with the new counts. An afterShellExecution hook (Cursor 1.7+) will also prompt you to do this on each `gh pr create` / `git push`.
+
 **ALWAYS use MCP tools for workflow state changes. NEVER use the `agenfk` CLI
 to create items, update status, or close tasks — the CLI bypasses enforcement.**
 

--- a/geminirules/GEMINI.md
+++ b/geminirules/GEMINI.md
@@ -56,6 +56,10 @@ After completing changes — using MCP tools:
 
 Token usage is captured automatically by the server-side ingestion worker — agents do not need to (and cannot) self-report tokens.
 
+### PR sizing — MANDATORY
+
+After running `gh pr create`, you MUST call `register_pr(itemId, prNumber, repo, sizing)` via MCP, where `sizing = { epic, story, task, bug }` counts the items included in this PR. After `git push` to a branch that already has a registered PR and you've added more items, call `update_pr_sizing(prNumber, repo, sizing)` with the new counts. An AfterTool hook will also prompt you to do this on each `gh pr create` / `git push`.
+
 **ALWAYS use MCP tools for workflow state changes. NEVER use the `agenfk` CLI
 to create items, update status, or close tasks — the CLI bypasses enforcement.**
 

--- a/packages/server/src/test/pr-registration-rule-docs.test.ts
+++ b/packages/server/src/test/pr-registration-rule-docs.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(__dirname, '../../../..');
+
+const DOCS = [
+  'clauderules/CLAUDE.md',
+  'codexrules/AGENTS.md',
+  'geminirules/GEMINI.md',
+  'cursorrules/agenfk.mdc',
+];
+
+describe('PR-registration belt-and-suspenders rule', () => {
+  for (const rel of DOCS) {
+    it(`${rel} mentions register_pr after gh pr create`, () => {
+      const src = fs.readFileSync(path.join(ROOT, rel), 'utf8');
+      expect(src).toMatch(/register_pr/);
+      expect(src).toMatch(/update_pr_sizing/);
+    });
+  }
+});
+
+describe('AFK_ARCHITECTURE.md client matrix', () => {
+  it('no longer claims Codex / Cursor / Gemini are instructional-only on hooks', () => {
+    const src = fs.readFileSync(path.join(ROOT, 'AFK_ARCHITECTURE.md'), 'utf8');
+    // Acceptable: any mention that these clients HAVE hooks now.
+    expect(src).toMatch(/hooks/i);
+    // The phrase "instructional-only" used to apply to Cursor / Codex / Gemini —
+    // ensure that, if present, it is now scoped or disclaimed.
+    if (/instructional[-\s]only/i.test(src)) {
+      expect(src).toMatch(/now\s+(have|support|expose)\s+hooks|hook\s+system\s+(added|added in|since)/i);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Stacks on #74 → #75 → #76 → #77 → #78 → #79 → #80 → #81. Final doc PR for the observability initiative.

- Per-client instruction docs (`clauderules/CLAUDE.md`, `codexrules/AGENTS.md`, `geminirules/GEMINI.md`, `cursorrules/agenfk.mdc`) each get a new "PR sizing — MANDATORY" section explaining `register_pr` / `update_pr_sizing` and noting the per-client hook event (PostToolUse / `tool.execute.after` / AfterTool / afterShellExecution).
- `AFK_ARCHITECTURE.md` client matrix rewritten: all five clients (Claude Code, OpenCode, Codex, Gemini, Cursor) now listed with both pre-edit and post-tool hook columns. Calls out that as of 2025–2026 all five have hooks (previously the doc claimed three were instructional-only, which is now stale). Notes the Codex hook-coverage caveat (shell-only; issues #14882, #16732).

## Test plan

- [x] `pr-registration-rule-docs.test.ts` — 5 tests: each per-client doc references `register_pr` + `update_pr_sizing`; `AFK_ARCHITECTURE.md` no longer has the stale claim
- [x] `npm run build` clean
- [x] `npm test` full suite green (1259 tests, 118 files)