### PR TITLE
feat(observability): PR-opened metrics + server-side token telemetry

### DIFF
--- a/AFK_ARCHITECTURE.md
+++ b/AFK_ARCHITECTURE.md
@@ -52,21 +52,24 @@ This automation ensures consistent engineering rigor while minimizing human micr
 
 ## Supported AI Clients
 
-AgenFK supports three AI coding assistants. Each integrates with the same MCP server but uses a different mechanism for workflow enforcement:
+AgenFK supports five AI coding assistants. Each integrates with the same MCP server but uses a different hook mechanism for workflow enforcement. **As of 2025–2026, all five clients now have hooks** — the prior "instructional-only" gap for Codex / Cursor / Gemini has closed.
 
-| Client | MCP Registration | Workflow Rules | Enforcement Model |
-|--------|-----------------|----------------|-------------------|
-| **Claude Code** | `claude mcp add` (user scope) | `~/.claude/CLAUDE.md` | **Mechanical** — two PreToolUse hooks: `agenfk-gatekeeper` (blocks edits without IN_PROGRESS task) and `agenfk-mcp-enforcer` (blocks db/REST/CLI bypass routes) |
-| **OpenCode** | `~/.config/opencode/opencode.json` | `~/.config/opencode/skills/agenfk/SKILL.md` | **Mechanical** — `tool.execute.before` plugin (`agenfk-mcp-enforcer-opencode.mjs`) intercepting tool calls before execution |
-| **Cursor** | `~/.cursor/mcp.json` (Linux/macOS) or `%APPDATA%\Cursor\mcp.json` (Windows) | `~/.cursor/rules/agenfk.mdc` (Linux/macOS) or `%APPDATA%\Cursor\rules\agenfk.mdc` (Windows) | **Instructional** — Cursor has no PreToolUse hook or plugin system. Enforcement relies on the `workflow_gatekeeper` MCP tool called per instruction in `agenfk.mdc`. The model is expected to follow rules; no mechanical trip-wire exists. |
+| Client | MCP Registration | Workflow Rules | Pre-edit hook | Post-tool hook (PR sizing) |
+|--------|-----------------|----------------|---------------|----------------------------|
+| **Claude Code** | `claude mcp add` (user scope) | `~/.claude/CLAUDE.md` | `PreToolUse` — `agenfk-gatekeeper` + `agenfk-mcp-enforcer` | `PostToolUse` matcher `Bash` — `agenfk-pr-hook --client claude-code` |
+| **OpenCode** | `~/.config/opencode/opencode.json` | `~/.config/opencode/skills/agenfk/SKILL.md` | `tool.execute.before` plugin (`agenfk-mcp-enforcer-opencode.mjs`) | `tool.execute.after` plugin (`agenfk-pr-hook-opencode.mjs`) |
+| **Codex CLI** | `codex mcp add` | `~/.codex/AGENTS.md` | (no equivalent — CLAUDE.md-style instructional) | `PostToolUse` matcher `shell` (hooks reliably fire only for shell) — `agenfk-pr-hook --client codex` |
+| **Gemini CLI** (v0.26+) | `gemini mcp add` | `~/.gemini/GEMINI.md` | (no equivalent — instructional) | `AfterTool` matcher `run_shell_command` — `agenfk-pr-hook --client gemini` |
+| **Cursor** (1.7+) | `~/.cursor/mcp.json` | `~/.cursor/rules/agenfk.mdc` | (no equivalent — instructional + `alwaysApply: true` rule) | `afterShellExecution` — `agenfk-pr-hook --client cursor` |
 
-### Enforcement Gap (Cursor)
+### Enforcement model
 
-Claude Code and OpenCode provide *mechanical* enforcement: a hook fires before every tool call and can hard-block it regardless of model intent. Cursor provides no equivalent interception point. AgenFK's Cursor integration compensates with:
+- **Pre-edit gatekeeping** (does the agent have an active IN_PROGRESS task?) is mechanical only on Claude Code + OpenCode, where their hook systems support pre-tool blocking. On Codex / Gemini / Cursor, this remains **instructional** via the per-client rule docs — backed by the server-side `workflow_gatekeeper` audit trail.
+- **PR sizing prompt** (after `gh pr create` / `git push`) is mechanical on **all five** clients via their respective post-tool hook events. Even when the post-tool directive isn't followed, the per-client instruction docs include a belt-and-suspenders rule asking the agent to call `register_pr` / `update_pr_sizing`.
 
-1. **`alwaysApply: true` in `agenfk.mdc`** — the rule is auto-attached to every conversation, maximising the chance the model sees it.
-2. **Explicit breach-handling instructions** — `agenfk.mdc` instructs the model to stop and resolve a gatekeeper rejection before proceeding, not to silently skip it.
-3. **`workflow_gatekeeper` MCP tool** — the server-side check still verifies that a valid IN_PROGRESS task exists and logs the authorization intent, providing an audit trail even without a mechanical block.
+### Note on Codex hook coverage
+
+Codex's hook system reliably fires for the shell tool but not for `apply_patch` or most MCP tool calls (open issues `openai/codex#14882`, `#16732`, May 2026). The PR sizing hook is unaffected because `gh pr create` and `git push` always run via the shell tool. If pre-edit gatekeeping is added to Codex later, this caveat will need to be revisited.
 
 ## Tech Stack
 - **Language**: TypeScript (Strong typing across the stack)

--- a/bin/agenfk-pr-hook-opencode.mjs
+++ b/bin/agenfk-pr-hook-opencode.mjs
@@ -1,0 +1,42 @@
+/**
+ * AgEnFK PR sizing hook — OpenCode plugin variant. Runs as a `tool.execute.after`
+ * plugin under ~/.config/opencode/plugins/. Mirrors the standalone agenfk-pr-hook.mjs
+ * shell-script version but emits the directive via the OpenCode plugin context
+ * rather than stdout.
+ *
+ * Installed by scripts/install.mjs.
+ */
+import { spawnSync } from 'child_process';
+import path from 'path';
+import os from 'os';
+
+const HOOK_BIN = path.join(os.homedir(), '.agenfk', 'bin', 'agenfk-pr-hook.mjs');
+
+export default async function agenfkPrHookOpencode(_context) {
+  return {
+    'tool.execute.after': async (input) => {
+      const tool = (input.tool || '').toLowerCase();
+      if (tool !== 'bash' && tool !== 'execute') return;
+      const command = input?.args?.command || '';
+      if (!command) return;
+      // Delegate classification + directive shape to the shared script.
+      try {
+        const result = spawnSync('node', [HOOK_BIN, '--client', 'opencode'], {
+          input: JSON.stringify({ args: { command } }),
+          encoding: 'utf8',
+          timeout: 1500,
+        });
+        const out = (result.stdout || '').trim();
+        if (!out) return;
+        try {
+          const parsed = JSON.parse(out);
+          if (parsed?.message) {
+            // OpenCode plugins surface notes via a console-style log; the agent
+            // sees the directive in its tool-call output stream.
+            console.log(`[agenfk-pr-hook] ${parsed.message}`);
+          }
+        } catch { /* malformed output — ignore */ }
+      } catch { /* hook should never break the host */ }
+    },
+  };
+}

--- a/bin/agenfk-pr-hook.mjs
+++ b/bin/agenfk-pr-hook.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+/**
+ * AgEnFK PR sizing hook — fires on PostToolUse / tool.execute.after for shell
+ * commands. Detects `gh pr create` (open trigger) or `git push` to a branch
+ * with a registered PR (push trigger), then emits a directive back to the
+ * agent telling it to call register_pr(...) or update_pr_sizing(...).
+ *
+ * The hook NEVER writes to the database itself — it only nudges the agent,
+ * because the agent has the semantic knowledge (which items are bundled into
+ * this PR) that a server-side walk doesn't.
+ *
+ * Usage in client config: `agenfk-pr-hook --client <name>`
+ */
+import http from 'http';
+import { execSync } from 'child_process';
+
+const API_URL = process.env.AGENFK_API_URL || 'http://127.0.0.1:3000';
+
+// ── Pure helpers (also exported for unit tests) ──────────────────────────────
+
+export function classifyTrigger(command) {
+  if (typeof command !== 'string') return null;
+  const trimmed = command.trim();
+  if (/^gh\s+pr\s+create\b/.test(trimmed)) return { kind: 'open' };
+  const pushMatch = trimmed.match(/^git\s+push\b(.*)$/);
+  if (pushMatch) {
+    const rest = (pushMatch[1] || '').trim().split(/\s+/);
+    // crude branch extraction: last non-flag token, ignoring 'origin' / '-u'
+    let branch;
+    for (let i = rest.length - 1; i >= 0; i--) {
+      const tok = rest[i];
+      if (!tok || tok.startsWith('-')) continue;
+      if (tok === 'origin') continue;
+      branch = tok;
+      break;
+    }
+    return { kind: 'push', branch };
+  }
+  return null;
+}
+
+export function buildDirective(client, message) {
+  switch (client) {
+    case 'claude-code':
+      return { hookSpecificOutput: { hookEventName: 'PostToolUse', additionalContext: message } };
+    case 'codex':
+      return { decision: 'continue', reason: message };
+    case 'gemini':
+      return { decision: 'continue', context: message };
+    case 'cursor':
+      return { permission: 'allow', userMessage: message };
+    case 'opencode':
+      return { message };
+    default:
+      return { message };
+  }
+}
+
+// ── Runtime glue ─────────────────────────────────────────────────────────────
+
+async function readStdinJson() {
+  return new Promise((resolve) => {
+    let data = '';
+    const timeout = setTimeout(() => resolve(null), 500);
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (c) => (data += c));
+    process.stdin.on('end', () => {
+      clearTimeout(timeout);
+      try { resolve(data.trim() ? JSON.parse(data) : null); } catch { resolve(null); }
+    });
+    process.stdin.on('close', () => { clearTimeout(timeout); resolve(null); });
+  });
+}
+
+function extractCommand(input) {
+  // Handle several shapes: Claude Code PostToolUse, Codex hooks, Gemini, OpenCode tool.execute.after, Cursor afterShellExecution
+  if (!input || typeof input !== 'object') return '';
+  return (
+    input?.tool_input?.command ||
+    input?.toolInput?.command ||
+    input?.args?.command ||
+    input?.input?.command ||
+    input?.payload?.command ||
+    ''
+  );
+}
+
+function getCurrentBranch() {
+  try { return execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim(); }
+  catch { return null; }
+}
+
+function fetchJson(url) {
+  return new Promise((resolve) => {
+    http.get(url, (res) => {
+      if (res.statusCode !== 200) { res.resume(); resolve(null); return; }
+      let body = '';
+      res.on('data', (c) => (body += c));
+      res.on('end', () => { try { resolve(JSON.parse(body)); } catch { resolve(null); } });
+    }).on('error', () => resolve(null));
+  });
+}
+
+function emit(directive) {
+  process.stdout.write(JSON.stringify(directive));
+  process.exit(0);
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const clientIdx = args.indexOf('--client');
+  const client = clientIdx >= 0 ? args[clientIdx + 1] : 'claude-code';
+
+  const input = await readStdinJson();
+  const command = extractCommand(input);
+  if (!command) process.exit(0);
+
+  const trigger = classifyTrigger(command);
+  if (!trigger) process.exit(0);
+
+  if (trigger.kind === 'open') {
+    emit(buildDirective(client,
+      'You just opened a PR. Reply by calling `register_pr(itemId, prNumber, repo, sizing)` ' +
+      'with sizing = { epic, story, task, bug } counted across all items included in this PR. ' +
+      'Use the active item id as itemId.'));
+  }
+
+  // push trigger: only nudge if the branch already has a registered PR.
+  const branch = trigger.branch || getCurrentBranch();
+  if (!branch) process.exit(0);
+  // We don't currently index PRs by branch, but the agent can still answer the
+  // "did I add items to this PR?" question itself. Emit the directive
+  // unconditionally and let the agent decide; the server-side dedup window
+  // (last_sizing_check_at within 5 min) prevents wasted turns.
+  emit(buildDirective(client,
+    `You just pushed to '${branch}'. If this branch has an open PR registered with AgEnFK and ` +
+    'more items were added since the last sizing, call `update_pr_sizing(prNumber, repo, sizing)` ' +
+    'with the new counts. If unchanged, take no action.'));
+}
+
+// ESM script entry detection: only run main() when executed directly, not when imported.
+const isMain = (() => {
+  try {
+    const url = new URL(import.meta.url);
+    return process.argv[1] && url.pathname === process.argv[1];
+  } catch { return false; }
+})();
+if (isMain) {
+  main().catch(() => process.exit(0));
+}

--- a/clauderules/CLAUDE.md
+++ b/clauderules/CLAUDE.md
@@ -43,6 +43,10 @@ After completing changes — using MCP tools:
 
 Token usage is captured automatically by the server-side ingestion worker — agents do not need to (and cannot) self-report tokens.
 
+### PR sizing — MANDATORY
+
+After running `gh pr create`, you MUST call `register_pr(itemId, prNumber, repo, sizing)` via MCP, where `sizing = { epic, story, task, bug }` counts the items included in this PR. After `git push` to a branch that already has a registered PR and you've added more items, call `update_pr_sizing(prNumber, repo, sizing)` with the new counts. The server records a shadow sizing computed from the item tree as a sanity check — only your declared count is authoritative. A PostToolUse hook prompts you to do this on each `gh pr create` / `git push`.
+
 **ALWAYS use MCP tools for workflow state changes. NEVER use the `agenfk` CLI
 to create items, update status, or close tasks — the CLI bypasses enforcement.**
 

--- a/clauderules/CLAUDE.md
+++ b/clauderules/CLAUDE.md
@@ -40,7 +40,8 @@ Or via REST: `GET http://localhost:3000/projects/<projectId>/flow`
 After completing changes — using MCP tools:
 - `get_flow(projectId)` — call at session start to load the full flow with all steps and exit criteria. Your working contract for the session.
 - `validate_progress(itemId, evidence, command?)` — step-completion gate. `evidence` is **required**: describe how you satisfied the current step's exit criteria (logged as a tagged comment). **Use this for ALL forward step transitions** (including TODO → first working step). `command` is optional: if omitted, uses `project.verifyCommand` on the final step. If it returns `NO_VERIFY_COMMAND`, auto-detect the project stack from config files (e.g. `package.json`, `Cargo.toml`, `go.mod`, `*.csproj`), set the command via `update_project({ id, verifyCommand })`, and retry. Only ask the developer as a last resort.
-- `log_token_usage(itemId, input, output, model)`.
+
+Token usage is captured automatically by the server-side ingestion worker — agents do not need to (and cannot) self-report tokens.
 
 **ALWAYS use MCP tools for workflow state changes. NEVER use the `agenfk` CLI
 to create items, update status, or close tasks — the CLI bypasses enforcement.**
@@ -83,7 +84,6 @@ CLI equivalents via Bash. The enforcer auto-detects MCP unavailability and allow
 | `add_comment(id, text)` | `agenfk comment <id> "<text>"` |
 | `get_flow(projectId)` | `agenfk flow show --project <id> --json` |
 | `validate_progress(id, evidence, command?)` | `agenfk verify <id> --evidence "<evidence>" "<command>"` or `agenfk verify <id> --evidence "<evidence>"` |
-| `log_token_usage(id, in, out, model)` | `agenfk log-tokens <id> --input N --output N --model M` |
 | `log_test_result(id, cmd, out, status)` | `agenfk log-test <id> --command "..." --output "..." --status PASSED` |
 
 The workflow rules still apply: call `agenfk gatekeeper` before editing files.

--- a/codexrules/AGENTS.md
+++ b/codexrules/AGENTS.md
@@ -53,7 +53,8 @@ Or via CLI: `agenfk flow show --project <projectId>`
 After completing changes — using MCP tools:
 - `get_flow(projectId)` — call at session start to load the full flow with all steps and exit criteria.
 - `validate_progress(itemId, evidence, command?)` — step-completion gate. `evidence` is **required**: describe how you satisfied the current step's exit criteria (logged as a tagged comment). **Use this for ALL forward step transitions**. `command` is optional: if omitted, uses `project.verifyCommand` on the final step. If it returns `NO_VERIFY_COMMAND`, auto-detect the project stack from config files (e.g. `package.json`, `Cargo.toml`, `go.mod`, `*.csproj`), set the command via `update_project({ id, verifyCommand })`, and retry.
-- `log_token_usage(itemId, input, output, model)`.
+
+Token usage is captured automatically by the server-side ingestion worker — agents do not need to (and cannot) self-report tokens.
 
 **ALWAYS use MCP tools for workflow state changes. NEVER use the `agenfk` CLI
 to create items, update status, or close tasks — the CLI bypasses enforcement.**
@@ -92,7 +93,6 @@ CLI equivalents via Bash:
 | `add_comment(id, text)` | `agenfk comment <id> "<text>"` |
 | `get_flow(projectId)` | `agenfk flow show --project <id> --json` |
 | `validate_progress(id, evidence, command?)` | `agenfk verify <id> --evidence "<evidence>" "<command>"` or `agenfk verify <id> --evidence "<evidence>"` |
-| `log_token_usage(id, in, out, model)` | `agenfk log-tokens <id> --input N --output N --model M` |
 | `log_test_result(id, cmd, out, status)` | `agenfk log-test <id> --command "..." --output "..." --status PASSED` |
 
 The workflow rules still apply: call `agenfk gatekeeper` before editing files.

--- a/codexrules/AGENTS.md
+++ b/codexrules/AGENTS.md
@@ -56,6 +56,10 @@ After completing changes — using MCP tools:
 
 Token usage is captured automatically by the server-side ingestion worker — agents do not need to (and cannot) self-report tokens.
 
+### PR sizing — MANDATORY
+
+After running `gh pr create`, you MUST call `register_pr(itemId, prNumber, repo, sizing)` via MCP, where `sizing = { epic, story, task, bug }` counts the items included in this PR. After `git push` to a branch that already has a registered PR and you've added more items, call `update_pr_sizing(prNumber, repo, sizing)` with the new counts. A PostToolUse hook will also prompt you to do this on each `gh pr create` / `git push`.
+
 **ALWAYS use MCP tools for workflow state changes. NEVER use the `agenfk` CLI
 to create items, update status, or close tasks — the CLI bypasses enforcement.**
 

--- a/codexrules/hooks.json
+++ b/codexrules/hooks.json
@@ -1,0 +1,13 @@
+{
+  "PostToolUse": [
+    {
+      "matcher": "shell",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "agenfk-pr-hook --client codex"
+        }
+      ]
+    }
+  ]
+}

--- a/cursorrules/.cursor/hooks.json
+++ b/cursorrules/.cursor/hooks.json
@@ -1,0 +1,7 @@
+{
+  "afterShellExecution": [
+    {
+      "command": "agenfk-pr-hook --client cursor"
+    }
+  ]
+}

--- a/cursorrules/agenfk.mdc
+++ b/cursorrules/agenfk.mdc
@@ -61,7 +61,8 @@ After completing changes — using MCP tools:
 - `update_item(id, {status: "<next-flow-step>"})` — move to the next step in the active flow when coding is done (typically REVIEW in the default flow).
 - `review_changes(itemId, command)` — build gate, advances to the next flow step on success.
 - `test_changes(itemId)` — runs project verifyCommand, advances to the terminal flow step (DONE).
-- `log_token_usage(itemId, input, output, model)`.
+
+Token usage is captured automatically by the server-side ingestion worker — agents do not need to (and cannot) self-report tokens.
 
 **ALWAYS use MCP tools for workflow state changes. NEVER use the `agenfk` CLI
 to create items, update status, or close tasks — the CLI bypasses enforcement.**
@@ -100,7 +101,6 @@ CLI equivalents via Bash:
 | `add_comment(id, text)` | `agenfk comment <id> "<text>"` |
 | `review_changes(id, command)` | `agenfk verify <id> "<command>"` (from REVIEW: moves to TEST) |
 | `test_changes(id)` | `agenfk verify <id>` (from TEST: moves to DONE, uses project verifyCommand) |
-| `log_token_usage(id, in, out, model)` | `agenfk log-tokens <id> --input N --output N --model M` |
 | `log_test_result(id, cmd, out, status)` | `agenfk log-test <id> --command "..." --output "..." --status PASSED` |
 
 The workflow rules still apply: call `agenfk gatekeeper` before editing files.

--- a/cursorrules/agenfk.mdc
+++ b/cursorrules/agenfk.mdc
@@ -64,6 +64,10 @@ After completing changes — using MCP tools:
 
 Token usage is captured automatically by the server-side ingestion worker — agents do not need to (and cannot) self-report tokens.
 
+### PR sizing — MANDATORY
+
+After running `gh pr create`, you MUST call `register_pr(itemId, prNumber, repo, sizing)` via MCP, where `sizing = { epic, story, task, bug }` counts the items included in this PR. After `git push` to a branch that already has a registered PR and you've added more items, call `update_pr_sizing(prNumber, repo, sizing)` with the new counts. An afterShellExecution hook (Cursor 1.7+) will also prompt you to do this on each `gh pr create` / `git push`.
+
 **ALWAYS use MCP tools for workflow state changes. NEVER use the `agenfk` CLI
 to create items, update status, or close tasks — the CLI bypasses enforcement.**
 

--- a/geminirules/.gemini/settings.json
+++ b/geminirules/.gemini/settings.json
@@ -1,0 +1,10 @@
+{
+  "hooks": {
+    "AfterTool": [
+      {
+        "matcher": "run_shell_command",
+        "command": "agenfk-pr-hook --client gemini"
+      }
+    ]
+  }
+}

--- a/geminirules/GEMINI.md
+++ b/geminirules/GEMINI.md
@@ -53,7 +53,8 @@ Or via CLI: `agenfk flow show --project <projectId>`
 After completing changes — using MCP tools:
 - `get_flow(projectId)` — call at session start to load the full flow with all steps and exit criteria.
 - `validate_progress(itemId, evidence, command?)` — step-completion gate. `evidence` is **required**: describe how you satisfied the current step's exit criteria (logged as a tagged comment). **Use this for ALL forward step transitions**. `command` is optional: if omitted, uses `project.verifyCommand` on the final step. If it returns `NO_VERIFY_COMMAND`, auto-detect the project stack from config files (e.g. `package.json`, `Cargo.toml`, `go.mod`, `*.csproj`), set the command via `update_project({ id, verifyCommand })`, and retry.
-- `log_token_usage(itemId, input, output, model)`.
+
+Token usage is captured automatically by the server-side ingestion worker — agents do not need to (and cannot) self-report tokens.
 
 **ALWAYS use MCP tools for workflow state changes. NEVER use the `agenfk` CLI
 to create items, update status, or close tasks — the CLI bypasses enforcement.**
@@ -92,7 +93,6 @@ CLI equivalents via Bash:
 | `add_comment(id, text)` | `agenfk comment <id> "<text>"` |
 | `get_flow(projectId)` | `agenfk flow show --project <id> --json` |
 | `validate_progress(id, evidence, command?)` | `agenfk verify <id> --evidence "<evidence>" "<command>"` or `agenfk verify <id> --evidence "<evidence>"` |
-| `log_token_usage(id, in, out, model)` | `agenfk log-tokens <id> --input N --output N --model M` |
 | `log_test_result(id, cmd, out, status)` | `agenfk log-test <id> --command "..." --output "..." --status PASSED` |
 
 The workflow rules still apply: call `agenfk gatekeeper` before editing files.

--- a/geminirules/GEMINI.md
+++ b/geminirules/GEMINI.md
@@ -56,6 +56,10 @@ After completing changes — using MCP tools:
 
 Token usage is captured automatically by the server-side ingestion worker — agents do not need to (and cannot) self-report tokens.
 
+### PR sizing — MANDATORY
+
+After running `gh pr create`, you MUST call `register_pr(itemId, prNumber, repo, sizing)` via MCP, where `sizing = { epic, story, task, bug }` counts the items included in this PR. After `git push` to a branch that already has a registered PR and you've added more items, call `update_pr_sizing(prNumber, repo, sizing)` with the new counts. An AfterTool hook will also prompt you to do this on each `gh pr create` / `git push`.
+
 **ALWAYS use MCP tools for workflow state changes. NEVER use the `agenfk` CLI
 to create items, update status, or close tasks — the CLI bypasses enforcement.**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenfk-framework",
-  "version": "1.0.0",
+  "version": "1.0.1-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenfk-framework",
-      "version": "1.0.0",
+      "version": "1.0.1-beta.3",
       "license": "ISC",
       "workspaces": [
         "packages/core",
@@ -11171,11 +11171,11 @@
     },
     "packages/cli": {
       "name": "@agenfk/cli",
-      "version": "1.0.1-beta.1",
+      "version": "1.0.1-beta.3",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.0.1-beta.1",
-        "@agenfk/telemetry": "1.0.1-beta.1",
+        "@agenfk/core": "1.0.1-beta.3",
+        "@agenfk/telemetry": "1.0.1-beta.3",
         "axios": "^1.13.5",
         "chalk": "^4.1.2",
         "commander": "^12.0.0",
@@ -11195,7 +11195,7 @@
     },
     "packages/core": {
       "name": "@agenfk/core",
-      "version": "1.0.1-beta.1",
+      "version": "1.0.1-beta.3",
       "license": "ISC",
       "devDependencies": {
         "typescript": "^5.3.3"
@@ -11203,7 +11203,7 @@
     },
     "packages/create": {
       "name": "agenfk",
-      "version": "1.0.1-beta.1",
+      "version": "1.0.1-beta.3",
       "license": "ISC",
       "bin": {
         "agenfk": "bin/agenfk.js"
@@ -11214,7 +11214,7 @@
     },
     "packages/flow-editor": {
       "name": "@agenfk/flow-editor",
-      "version": "1.0.1-beta.1",
+      "version": "1.0.1-beta.3",
       "peerDependencies": {
         "@tanstack/react-query": "^5.90.21",
         "clsx": "^2.1.1",
@@ -11226,9 +11226,9 @@
     },
     "packages/hub": {
       "name": "@agenfk/hub",
-      "version": "1.0.1-beta.1",
+      "version": "1.0.1-beta.3",
       "dependencies": {
-        "@agenfk/core": "1.0.1-beta.1",
+        "@agenfk/core": "1.0.1-beta.3",
         "axios": "^1.13.5",
         "bcryptjs": "^2.4.3",
         "cookie-parser": "^1.4.7",
@@ -11252,9 +11252,9 @@
       }
     },
     "packages/hub-ui": {
-      "version": "1.0.1-beta.1",
+      "version": "1.0.1-beta.3",
       "dependencies": {
-        "@agenfk/flow-editor": "1.0.1-beta.1",
+        "@agenfk/flow-editor": "1.0.1-beta.3",
         "@tailwindcss/postcss": "^4.2.0",
         "@tanstack/react-query": "^5.90.21",
         "@vitejs/plugin-react": "^5.1.1",
@@ -11655,12 +11655,12 @@
     },
     "packages/server": {
       "name": "@agenfk/server",
-      "version": "1.0.1-beta.1",
+      "version": "1.0.1-beta.3",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.0.1-beta.1",
-        "@agenfk/storage-sqlite": "1.0.1-beta.1",
-        "@agenfk/telemetry": "1.0.1-beta.1",
+        "@agenfk/core": "1.0.1-beta.3",
+        "@agenfk/storage-sqlite": "1.0.1-beta.3",
+        "@agenfk/telemetry": "1.0.1-beta.3",
         "@modelcontextprotocol/sdk": "0.6.0",
         "axios": "^1.13.5",
         "body-parser": "^2.2.2",
@@ -11696,13 +11696,13 @@
     },
     "packages/storage-sqlite": {
       "name": "@agenfk/storage-sqlite",
-      "version": "1.0.1-beta.1",
+      "version": "1.0.1-beta.3",
       "license": "ISC",
       "dependencies": {
         "uuid": "^9.0.1"
       },
       "devDependencies": {
-        "@agenfk/core": "1.0.1-beta.1",
+        "@agenfk/core": "1.0.1-beta.3",
         "@types/node": "^22.0.0",
         "@types/uuid": "^9.0.8",
         "typescript": "^5.3.3"
@@ -11720,7 +11720,7 @@
     },
     "packages/telemetry": {
       "name": "@agenfk/telemetry",
-      "version": "1.0.1-beta.1",
+      "version": "1.0.1-beta.3",
       "license": "ISC",
       "dependencies": {
         "posthog-node": "^4.0.0"
@@ -11731,9 +11731,9 @@
       }
     },
     "packages/ui": {
-      "version": "1.0.1-beta.1",
+      "version": "1.0.1-beta.3",
       "dependencies": {
-        "@agenfk/flow-editor": "1.0.1-beta.1",
+        "@agenfk/flow-editor": "1.0.1-beta.3",
         "@tailwindcss/postcss": "^4.2.0",
         "@tailwindcss/typography": "^0.5.19",
         "@tanstack/react-query": "^5.90.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenfk-framework",
-  "version": "1.0.1-beta.5",
+  "version": "1.0.1-beta.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenfk-framework",
-      "version": "1.0.1-beta.5",
+      "version": "1.0.1-beta.6",
       "license": "ISC",
       "workspaces": [
         "packages/core",
@@ -11171,11 +11171,11 @@
     },
     "packages/cli": {
       "name": "@agenfk/cli",
-      "version": "1.0.1-beta.5",
+      "version": "1.0.1-beta.6",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.0.1-beta.5",
-        "@agenfk/telemetry": "1.0.1-beta.5",
+        "@agenfk/core": "1.0.1-beta.6",
+        "@agenfk/telemetry": "1.0.1-beta.6",
         "axios": "^1.13.5",
         "chalk": "^4.1.2",
         "commander": "^12.0.0",
@@ -11195,7 +11195,7 @@
     },
     "packages/core": {
       "name": "@agenfk/core",
-      "version": "1.0.1-beta.5",
+      "version": "1.0.1-beta.6",
       "license": "ISC",
       "devDependencies": {
         "typescript": "^5.3.3"
@@ -11203,7 +11203,7 @@
     },
     "packages/create": {
       "name": "agenfk",
-      "version": "1.0.1-beta.5",
+      "version": "1.0.1-beta.6",
       "license": "ISC",
       "bin": {
         "agenfk": "bin/agenfk.js"
@@ -11214,7 +11214,7 @@
     },
     "packages/flow-editor": {
       "name": "@agenfk/flow-editor",
-      "version": "1.0.1-beta.5",
+      "version": "1.0.1-beta.6",
       "peerDependencies": {
         "@tanstack/react-query": "^5.90.21",
         "clsx": "^2.1.1",
@@ -11226,9 +11226,9 @@
     },
     "packages/hub": {
       "name": "@agenfk/hub",
-      "version": "1.0.1-beta.5",
+      "version": "1.0.1-beta.6",
       "dependencies": {
-        "@agenfk/core": "1.0.1-beta.5",
+        "@agenfk/core": "1.0.1-beta.6",
         "axios": "^1.13.5",
         "bcryptjs": "^2.4.3",
         "cookie-parser": "^1.4.7",
@@ -11252,9 +11252,9 @@
       }
     },
     "packages/hub-ui": {
-      "version": "1.0.1-beta.5",
+      "version": "1.0.1-beta.6",
       "dependencies": {
-        "@agenfk/flow-editor": "1.0.1-beta.5",
+        "@agenfk/flow-editor": "1.0.1-beta.6",
         "@tailwindcss/postcss": "^4.2.0",
         "@tanstack/react-query": "^5.90.21",
         "@vitejs/plugin-react": "^5.1.1",
@@ -11655,12 +11655,12 @@
     },
     "packages/server": {
       "name": "@agenfk/server",
-      "version": "1.0.1-beta.5",
+      "version": "1.0.1-beta.6",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.0.1-beta.5",
-        "@agenfk/storage-sqlite": "1.0.1-beta.5",
-        "@agenfk/telemetry": "1.0.1-beta.5",
+        "@agenfk/core": "1.0.1-beta.6",
+        "@agenfk/storage-sqlite": "1.0.1-beta.6",
+        "@agenfk/telemetry": "1.0.1-beta.6",
         "@modelcontextprotocol/sdk": "0.6.0",
         "axios": "^1.13.5",
         "body-parser": "^2.2.2",
@@ -11696,13 +11696,13 @@
     },
     "packages/storage-sqlite": {
       "name": "@agenfk/storage-sqlite",
-      "version": "1.0.1-beta.5",
+      "version": "1.0.1-beta.6",
       "license": "ISC",
       "dependencies": {
         "uuid": "^9.0.1"
       },
       "devDependencies": {
-        "@agenfk/core": "1.0.1-beta.5",
+        "@agenfk/core": "1.0.1-beta.6",
         "@types/node": "^22.0.0",
         "@types/uuid": "^9.0.8",
         "typescript": "^5.3.3"
@@ -11720,7 +11720,7 @@
     },
     "packages/telemetry": {
       "name": "@agenfk/telemetry",
-      "version": "1.0.1-beta.5",
+      "version": "1.0.1-beta.6",
       "license": "ISC",
       "dependencies": {
         "posthog-node": "^4.0.0"
@@ -11731,9 +11731,9 @@
       }
     },
     "packages/ui": {
-      "version": "1.0.1-beta.5",
+      "version": "1.0.1-beta.6",
       "dependencies": {
-        "@agenfk/flow-editor": "1.0.1-beta.5",
+        "@agenfk/flow-editor": "1.0.1-beta.6",
         "@tailwindcss/postcss": "^4.2.0",
         "@tailwindcss/typography": "^0.5.19",
         "@tanstack/react-query": "^5.90.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenfk-framework",
-  "version": "1.0.1-beta.6",
+  "version": "1.0.1-beta.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenfk-framework",
-      "version": "1.0.1-beta.6",
+      "version": "1.0.1-beta.7",
       "license": "ISC",
       "workspaces": [
         "packages/core",
@@ -11171,11 +11171,11 @@
     },
     "packages/cli": {
       "name": "@agenfk/cli",
-      "version": "1.0.1-beta.6",
+      "version": "1.0.1-beta.7",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.0.1-beta.6",
-        "@agenfk/telemetry": "1.0.1-beta.6",
+        "@agenfk/core": "1.0.1-beta.7",
+        "@agenfk/telemetry": "1.0.1-beta.7",
         "axios": "^1.13.5",
         "chalk": "^4.1.2",
         "commander": "^12.0.0",
@@ -11195,7 +11195,7 @@
     },
     "packages/core": {
       "name": "@agenfk/core",
-      "version": "1.0.1-beta.6",
+      "version": "1.0.1-beta.7",
       "license": "ISC",
       "devDependencies": {
         "typescript": "^5.3.3"
@@ -11203,7 +11203,7 @@
     },
     "packages/create": {
       "name": "agenfk",
-      "version": "1.0.1-beta.6",
+      "version": "1.0.1-beta.7",
       "license": "ISC",
       "bin": {
         "agenfk": "bin/agenfk.js"
@@ -11214,7 +11214,7 @@
     },
     "packages/flow-editor": {
       "name": "@agenfk/flow-editor",
-      "version": "1.0.1-beta.6",
+      "version": "1.0.1-beta.7",
       "peerDependencies": {
         "@tanstack/react-query": "^5.90.21",
         "clsx": "^2.1.1",
@@ -11226,9 +11226,9 @@
     },
     "packages/hub": {
       "name": "@agenfk/hub",
-      "version": "1.0.1-beta.6",
+      "version": "1.0.1-beta.7",
       "dependencies": {
-        "@agenfk/core": "1.0.1-beta.6",
+        "@agenfk/core": "1.0.1-beta.7",
         "axios": "^1.13.5",
         "bcryptjs": "^2.4.3",
         "cookie-parser": "^1.4.7",
@@ -11252,9 +11252,9 @@
       }
     },
     "packages/hub-ui": {
-      "version": "1.0.1-beta.6",
+      "version": "1.0.1-beta.7",
       "dependencies": {
-        "@agenfk/flow-editor": "1.0.1-beta.6",
+        "@agenfk/flow-editor": "1.0.1-beta.7",
         "@tailwindcss/postcss": "^4.2.0",
         "@tanstack/react-query": "^5.90.21",
         "@vitejs/plugin-react": "^5.1.1",
@@ -11655,12 +11655,12 @@
     },
     "packages/server": {
       "name": "@agenfk/server",
-      "version": "1.0.1-beta.6",
+      "version": "1.0.1-beta.7",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.0.1-beta.6",
-        "@agenfk/storage-sqlite": "1.0.1-beta.6",
-        "@agenfk/telemetry": "1.0.1-beta.6",
+        "@agenfk/core": "1.0.1-beta.7",
+        "@agenfk/storage-sqlite": "1.0.1-beta.7",
+        "@agenfk/telemetry": "1.0.1-beta.7",
         "@modelcontextprotocol/sdk": "0.6.0",
         "axios": "^1.13.5",
         "body-parser": "^2.2.2",
@@ -11696,13 +11696,13 @@
     },
     "packages/storage-sqlite": {
       "name": "@agenfk/storage-sqlite",
-      "version": "1.0.1-beta.6",
+      "version": "1.0.1-beta.7",
       "license": "ISC",
       "dependencies": {
         "uuid": "^9.0.1"
       },
       "devDependencies": {
-        "@agenfk/core": "1.0.1-beta.6",
+        "@agenfk/core": "1.0.1-beta.7",
         "@types/node": "^22.0.0",
         "@types/uuid": "^9.0.8",
         "typescript": "^5.3.3"
@@ -11720,7 +11720,7 @@
     },
     "packages/telemetry": {
       "name": "@agenfk/telemetry",
-      "version": "1.0.1-beta.6",
+      "version": "1.0.1-beta.7",
       "license": "ISC",
       "dependencies": {
         "posthog-node": "^4.0.0"
@@ -11731,9 +11731,9 @@
       }
     },
     "packages/ui": {
-      "version": "1.0.1-beta.6",
+      "version": "1.0.1-beta.7",
       "dependencies": {
-        "@agenfk/flow-editor": "1.0.1-beta.6",
+        "@agenfk/flow-editor": "1.0.1-beta.7",
         "@tailwindcss/postcss": "^4.2.0",
         "@tailwindcss/typography": "^0.5.19",
         "@tanstack/react-query": "^5.90.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11171,11 +11171,11 @@
     },
     "packages/cli": {
       "name": "@agenfk/cli",
-      "version": "1.0.0",
+      "version": "1.0.1-beta.1",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.0.0",
-        "@agenfk/telemetry": "1.0.0",
+        "@agenfk/core": "1.0.1-beta.1",
+        "@agenfk/telemetry": "1.0.1-beta.1",
         "axios": "^1.13.5",
         "chalk": "^4.1.2",
         "commander": "^12.0.0",
@@ -11195,7 +11195,7 @@
     },
     "packages/core": {
       "name": "@agenfk/core",
-      "version": "1.0.0",
+      "version": "1.0.1-beta.1",
       "license": "ISC",
       "devDependencies": {
         "typescript": "^5.3.3"
@@ -11203,7 +11203,7 @@
     },
     "packages/create": {
       "name": "agenfk",
-      "version": "1.0.0",
+      "version": "1.0.1-beta.1",
       "license": "ISC",
       "bin": {
         "agenfk": "bin/agenfk.js"
@@ -11214,7 +11214,7 @@
     },
     "packages/flow-editor": {
       "name": "@agenfk/flow-editor",
-      "version": "1.0.0",
+      "version": "1.0.1-beta.1",
       "peerDependencies": {
         "@tanstack/react-query": "^5.90.21",
         "clsx": "^2.1.1",
@@ -11226,9 +11226,9 @@
     },
     "packages/hub": {
       "name": "@agenfk/hub",
-      "version": "1.0.0",
+      "version": "1.0.1-beta.1",
       "dependencies": {
-        "@agenfk/core": "1.0.0",
+        "@agenfk/core": "1.0.1-beta.1",
         "axios": "^1.13.5",
         "bcryptjs": "^2.4.3",
         "cookie-parser": "^1.4.7",
@@ -11252,9 +11252,9 @@
       }
     },
     "packages/hub-ui": {
-      "version": "1.0.0",
+      "version": "1.0.1-beta.1",
       "dependencies": {
-        "@agenfk/flow-editor": "1.0.0",
+        "@agenfk/flow-editor": "1.0.1-beta.1",
         "@tailwindcss/postcss": "^4.2.0",
         "@tanstack/react-query": "^5.90.21",
         "@vitejs/plugin-react": "^5.1.1",
@@ -11655,12 +11655,12 @@
     },
     "packages/server": {
       "name": "@agenfk/server",
-      "version": "1.0.0",
+      "version": "1.0.1-beta.1",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.0.0",
-        "@agenfk/storage-sqlite": "1.0.0",
-        "@agenfk/telemetry": "1.0.0",
+        "@agenfk/core": "1.0.1-beta.1",
+        "@agenfk/storage-sqlite": "1.0.1-beta.1",
+        "@agenfk/telemetry": "1.0.1-beta.1",
         "@modelcontextprotocol/sdk": "0.6.0",
         "axios": "^1.13.5",
         "body-parser": "^2.2.2",
@@ -11696,13 +11696,13 @@
     },
     "packages/storage-sqlite": {
       "name": "@agenfk/storage-sqlite",
-      "version": "1.0.0",
+      "version": "1.0.1-beta.1",
       "license": "ISC",
       "dependencies": {
         "uuid": "^9.0.1"
       },
       "devDependencies": {
-        "@agenfk/core": "1.0.0",
+        "@agenfk/core": "1.0.1-beta.1",
         "@types/node": "^22.0.0",
         "@types/uuid": "^9.0.8",
         "typescript": "^5.3.3"
@@ -11720,7 +11720,7 @@
     },
     "packages/telemetry": {
       "name": "@agenfk/telemetry",
-      "version": "1.0.0",
+      "version": "1.0.1-beta.1",
       "license": "ISC",
       "dependencies": {
         "posthog-node": "^4.0.0"
@@ -11731,9 +11731,9 @@
       }
     },
     "packages/ui": {
-      "version": "1.0.0",
+      "version": "1.0.1-beta.1",
       "dependencies": {
-        "@agenfk/flow-editor": "1.0.0",
+        "@agenfk/flow-editor": "1.0.1-beta.1",
         "@tailwindcss/postcss": "^4.2.0",
         "@tailwindcss/typography": "^0.5.19",
         "@tanstack/react-query": "^5.90.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenfk-framework",
-  "version": "1.0.1-beta.3",
+  "version": "1.0.1-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenfk-framework",
-      "version": "1.0.1-beta.3",
+      "version": "1.0.1-beta.4",
       "license": "ISC",
       "workspaces": [
         "packages/core",
@@ -11171,11 +11171,11 @@
     },
     "packages/cli": {
       "name": "@agenfk/cli",
-      "version": "1.0.1-beta.3",
+      "version": "1.0.1-beta.4",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.0.1-beta.3",
-        "@agenfk/telemetry": "1.0.1-beta.3",
+        "@agenfk/core": "1.0.1-beta.4",
+        "@agenfk/telemetry": "1.0.1-beta.4",
         "axios": "^1.13.5",
         "chalk": "^4.1.2",
         "commander": "^12.0.0",
@@ -11195,7 +11195,7 @@
     },
     "packages/core": {
       "name": "@agenfk/core",
-      "version": "1.0.1-beta.3",
+      "version": "1.0.1-beta.4",
       "license": "ISC",
       "devDependencies": {
         "typescript": "^5.3.3"
@@ -11203,7 +11203,7 @@
     },
     "packages/create": {
       "name": "agenfk",
-      "version": "1.0.1-beta.3",
+      "version": "1.0.1-beta.4",
       "license": "ISC",
       "bin": {
         "agenfk": "bin/agenfk.js"
@@ -11214,7 +11214,7 @@
     },
     "packages/flow-editor": {
       "name": "@agenfk/flow-editor",
-      "version": "1.0.1-beta.3",
+      "version": "1.0.1-beta.4",
       "peerDependencies": {
         "@tanstack/react-query": "^5.90.21",
         "clsx": "^2.1.1",
@@ -11226,9 +11226,9 @@
     },
     "packages/hub": {
       "name": "@agenfk/hub",
-      "version": "1.0.1-beta.3",
+      "version": "1.0.1-beta.4",
       "dependencies": {
-        "@agenfk/core": "1.0.1-beta.3",
+        "@agenfk/core": "1.0.1-beta.4",
         "axios": "^1.13.5",
         "bcryptjs": "^2.4.3",
         "cookie-parser": "^1.4.7",
@@ -11252,9 +11252,9 @@
       }
     },
     "packages/hub-ui": {
-      "version": "1.0.1-beta.3",
+      "version": "1.0.1-beta.4",
       "dependencies": {
-        "@agenfk/flow-editor": "1.0.1-beta.3",
+        "@agenfk/flow-editor": "1.0.1-beta.4",
         "@tailwindcss/postcss": "^4.2.0",
         "@tanstack/react-query": "^5.90.21",
         "@vitejs/plugin-react": "^5.1.1",
@@ -11655,12 +11655,12 @@
     },
     "packages/server": {
       "name": "@agenfk/server",
-      "version": "1.0.1-beta.3",
+      "version": "1.0.1-beta.4",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.0.1-beta.3",
-        "@agenfk/storage-sqlite": "1.0.1-beta.3",
-        "@agenfk/telemetry": "1.0.1-beta.3",
+        "@agenfk/core": "1.0.1-beta.4",
+        "@agenfk/storage-sqlite": "1.0.1-beta.4",
+        "@agenfk/telemetry": "1.0.1-beta.4",
         "@modelcontextprotocol/sdk": "0.6.0",
         "axios": "^1.13.5",
         "body-parser": "^2.2.2",
@@ -11696,13 +11696,13 @@
     },
     "packages/storage-sqlite": {
       "name": "@agenfk/storage-sqlite",
-      "version": "1.0.1-beta.3",
+      "version": "1.0.1-beta.4",
       "license": "ISC",
       "dependencies": {
         "uuid": "^9.0.1"
       },
       "devDependencies": {
-        "@agenfk/core": "1.0.1-beta.3",
+        "@agenfk/core": "1.0.1-beta.4",
         "@types/node": "^22.0.0",
         "@types/uuid": "^9.0.8",
         "typescript": "^5.3.3"
@@ -11720,7 +11720,7 @@
     },
     "packages/telemetry": {
       "name": "@agenfk/telemetry",
-      "version": "1.0.1-beta.3",
+      "version": "1.0.1-beta.4",
       "license": "ISC",
       "dependencies": {
         "posthog-node": "^4.0.0"
@@ -11731,9 +11731,9 @@
       }
     },
     "packages/ui": {
-      "version": "1.0.1-beta.3",
+      "version": "1.0.1-beta.4",
       "dependencies": {
-        "@agenfk/flow-editor": "1.0.1-beta.3",
+        "@agenfk/flow-editor": "1.0.1-beta.4",
         "@tailwindcss/postcss": "^4.2.0",
         "@tailwindcss/typography": "^0.5.19",
         "@tanstack/react-query": "^5.90.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenfk-framework",
-  "version": "1.0.1-beta.4",
+  "version": "1.0.1-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenfk-framework",
-      "version": "1.0.1-beta.4",
+      "version": "1.0.1-beta.5",
       "license": "ISC",
       "workspaces": [
         "packages/core",
@@ -11171,11 +11171,11 @@
     },
     "packages/cli": {
       "name": "@agenfk/cli",
-      "version": "1.0.1-beta.4",
+      "version": "1.0.1-beta.5",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.0.1-beta.4",
-        "@agenfk/telemetry": "1.0.1-beta.4",
+        "@agenfk/core": "1.0.1-beta.5",
+        "@agenfk/telemetry": "1.0.1-beta.5",
         "axios": "^1.13.5",
         "chalk": "^4.1.2",
         "commander": "^12.0.0",
@@ -11195,7 +11195,7 @@
     },
     "packages/core": {
       "name": "@agenfk/core",
-      "version": "1.0.1-beta.4",
+      "version": "1.0.1-beta.5",
       "license": "ISC",
       "devDependencies": {
         "typescript": "^5.3.3"
@@ -11203,7 +11203,7 @@
     },
     "packages/create": {
       "name": "agenfk",
-      "version": "1.0.1-beta.4",
+      "version": "1.0.1-beta.5",
       "license": "ISC",
       "bin": {
         "agenfk": "bin/agenfk.js"
@@ -11214,7 +11214,7 @@
     },
     "packages/flow-editor": {
       "name": "@agenfk/flow-editor",
-      "version": "1.0.1-beta.4",
+      "version": "1.0.1-beta.5",
       "peerDependencies": {
         "@tanstack/react-query": "^5.90.21",
         "clsx": "^2.1.1",
@@ -11226,9 +11226,9 @@
     },
     "packages/hub": {
       "name": "@agenfk/hub",
-      "version": "1.0.1-beta.4",
+      "version": "1.0.1-beta.5",
       "dependencies": {
-        "@agenfk/core": "1.0.1-beta.4",
+        "@agenfk/core": "1.0.1-beta.5",
         "axios": "^1.13.5",
         "bcryptjs": "^2.4.3",
         "cookie-parser": "^1.4.7",
@@ -11252,9 +11252,9 @@
       }
     },
     "packages/hub-ui": {
-      "version": "1.0.1-beta.4",
+      "version": "1.0.1-beta.5",
       "dependencies": {
-        "@agenfk/flow-editor": "1.0.1-beta.4",
+        "@agenfk/flow-editor": "1.0.1-beta.5",
         "@tailwindcss/postcss": "^4.2.0",
         "@tanstack/react-query": "^5.90.21",
         "@vitejs/plugin-react": "^5.1.1",
@@ -11655,12 +11655,12 @@
     },
     "packages/server": {
       "name": "@agenfk/server",
-      "version": "1.0.1-beta.4",
+      "version": "1.0.1-beta.5",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.0.1-beta.4",
-        "@agenfk/storage-sqlite": "1.0.1-beta.4",
-        "@agenfk/telemetry": "1.0.1-beta.4",
+        "@agenfk/core": "1.0.1-beta.5",
+        "@agenfk/storage-sqlite": "1.0.1-beta.5",
+        "@agenfk/telemetry": "1.0.1-beta.5",
         "@modelcontextprotocol/sdk": "0.6.0",
         "axios": "^1.13.5",
         "body-parser": "^2.2.2",
@@ -11696,13 +11696,13 @@
     },
     "packages/storage-sqlite": {
       "name": "@agenfk/storage-sqlite",
-      "version": "1.0.1-beta.4",
+      "version": "1.0.1-beta.5",
       "license": "ISC",
       "dependencies": {
         "uuid": "^9.0.1"
       },
       "devDependencies": {
-        "@agenfk/core": "1.0.1-beta.4",
+        "@agenfk/core": "1.0.1-beta.5",
         "@types/node": "^22.0.0",
         "@types/uuid": "^9.0.8",
         "typescript": "^5.3.3"
@@ -11720,7 +11720,7 @@
     },
     "packages/telemetry": {
       "name": "@agenfk/telemetry",
-      "version": "1.0.1-beta.4",
+      "version": "1.0.1-beta.5",
       "license": "ISC",
       "dependencies": {
         "posthog-node": "^4.0.0"
@@ -11731,9 +11731,9 @@
       }
     },
     "packages/ui": {
-      "version": "1.0.1-beta.4",
+      "version": "1.0.1-beta.5",
       "dependencies": {
-        "@agenfk/flow-editor": "1.0.1-beta.4",
+        "@agenfk/flow-editor": "1.0.1-beta.5",
         "@tailwindcss/postcss": "^4.2.0",
         "@tailwindcss/typography": "^0.5.19",
         "@tanstack/react-query": "^5.90.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk-framework",
-  "version": "1.0.1-beta.5",
+  "version": "1.0.1-beta.6",
   "description": "AgenFK Engineering Framework",
   "private": true,
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk-framework",
-  "version": "1.0.1-beta.4",
+  "version": "1.0.1-beta.5",
   "description": "AgenFK Engineering Framework",
   "private": true,
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk-framework",
-  "version": "1.0.1-beta.3",
+  "version": "1.0.1-beta.4",
   "description": "AgenFK Engineering Framework",
   "private": true,
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk-framework",
-  "version": "1.0.1-beta.6",
+  "version": "1.0.1-beta.7",
   "description": "AgenFK Engineering Framework",
   "private": true,
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk-framework",
-  "version": "1.0.0",
+  "version": "1.0.1-beta.3",
   "description": "AgenFK Engineering Framework",
   "private": true,
   "workspaces": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/cli",
-  "version": "1.0.1-beta.4",
+  "version": "1.0.1-beta.5",
   "description": "CLI for AgenFK Engineering Framework",
   "main": "dist/index.js",
   "bin": {
@@ -12,8 +12,8 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.0.1-beta.4",
-    "@agenfk/telemetry": "1.0.1-beta.4",
+    "@agenfk/core": "1.0.1-beta.5",
+    "@agenfk/telemetry": "1.0.1-beta.5",
     "axios": "^1.13.5",
     "chalk": "^4.1.2",
     "commander": "^12.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/cli",
-  "version": "1.0.0",
+  "version": "1.0.1-beta.1",
   "description": "CLI for AgenFK Engineering Framework",
   "main": "dist/index.js",
   "bin": {
@@ -12,8 +12,8 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.0.0",
-    "@agenfk/telemetry": "1.0.0",
+    "@agenfk/core": "1.0.1-beta.1",
+    "@agenfk/telemetry": "1.0.1-beta.1",
     "axios": "^1.13.5",
     "chalk": "^4.1.2",
     "commander": "^12.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/cli",
-  "version": "1.0.1-beta.5",
+  "version": "1.0.1-beta.6",
   "description": "CLI for AgenFK Engineering Framework",
   "main": "dist/index.js",
   "bin": {
@@ -12,8 +12,8 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.0.1-beta.5",
-    "@agenfk/telemetry": "1.0.1-beta.5",
+    "@agenfk/core": "1.0.1-beta.6",
+    "@agenfk/telemetry": "1.0.1-beta.6",
     "axios": "^1.13.5",
     "chalk": "^4.1.2",
     "commander": "^12.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/cli",
-  "version": "1.0.1-beta.1",
+  "version": "1.0.1-beta.3",
   "description": "CLI for AgenFK Engineering Framework",
   "main": "dist/index.js",
   "bin": {
@@ -12,8 +12,8 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.0.1-beta.1",
-    "@agenfk/telemetry": "1.0.1-beta.1",
+    "@agenfk/core": "1.0.1-beta.3",
+    "@agenfk/telemetry": "1.0.1-beta.3",
     "axios": "^1.13.5",
     "chalk": "^4.1.2",
     "commander": "^12.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/cli",
-  "version": "1.0.1-beta.3",
+  "version": "1.0.1-beta.4",
   "description": "CLI for AgenFK Engineering Framework",
   "main": "dist/index.js",
   "bin": {
@@ -12,8 +12,8 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.0.1-beta.3",
-    "@agenfk/telemetry": "1.0.1-beta.3",
+    "@agenfk/core": "1.0.1-beta.4",
+    "@agenfk/telemetry": "1.0.1-beta.4",
     "axios": "^1.13.5",
     "chalk": "^4.1.2",
     "commander": "^12.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/cli",
-  "version": "1.0.1-beta.6",
+  "version": "1.0.1-beta.7",
   "description": "CLI for AgenFK Engineering Framework",
   "main": "dist/index.js",
   "bin": {
@@ -12,8 +12,8 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.0.1-beta.6",
-    "@agenfk/telemetry": "1.0.1-beta.6",
+    "@agenfk/core": "1.0.1-beta.7",
+    "@agenfk/telemetry": "1.0.1-beta.7",
     "axios": "^1.13.5",
     "chalk": "^4.1.2",
     "commander": "^12.0.0",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -939,7 +939,7 @@ function configureClaudeCodeIde(rootDir: string): boolean {
         'mcp__agenfk__get_item', 'mcp__agenfk__create_item',
         'mcp__agenfk__update_item', 'mcp__agenfk__add_comment',
         'mcp__agenfk__workflow_gatekeeper', 'mcp__agenfk__review_changes',
-        'mcp__agenfk__test_changes', 'mcp__agenfk__log_token_usage',
+        'mcp__agenfk__test_changes',
         'mcp__agenfk__analyze_request', 'mcp__agenfk__get_server_info',
         'mcp__agenfk__add_context', 'mcp__agenfk__delete_item',
         'mcp__agenfk__log_test_result', 'mcp__agenfk__update_project',
@@ -2430,7 +2430,6 @@ program
         if (item.parentId) console.log(`  Parent:      ${item.parentId}`);
         if (item.description) console.log(`  Description: ${item.description}`);
         if (item.comments?.length) console.log(`  Comments:    ${item.comments.length}`);
-        if (item.tokenUsage?.length) console.log(`  Token logs:  ${item.tokenUsage.length}`);
       }
     } catch (error: any) {
       console.error(chalk.red('Error fetching item:'), error.response?.data?.error || error.message);
@@ -2451,35 +2450,6 @@ program
       console.log(chalk.green('Comment added.'));
     } catch (error: any) {
       console.error(chalk.red('Error adding comment:'), error.response?.data?.error || error.message);
-      process.exit(1);
-    }
-  });
-
-program
-  .command('log-tokens <id>')
-  .description('Log token usage for an item (MCP fallback: log_token_usage)')
-  .requiredOption('--input <n>', 'Input tokens', parseInt)
-  .requiredOption('--output <n>', 'Output tokens', parseInt)
-  .requiredOption('--model <model>', 'Model name')
-  .option('--cost <c>', 'Cost in USD', parseFloat)
-  .option('--session <id>', 'Session ID for deduplication')
-  .action(async (id, options) => {
-    try {
-      const { data: item } = await axios.get(`${API_URL}/items/${id}`);
-      const tokenUsage = item.tokenUsage || [];
-      const entry: any = {
-        input: options.input,
-        output: options.output,
-        model: options.model,
-        timestamp: new Date().toISOString(),
-      };
-      if (options.cost !== undefined) entry.cost = options.cost;
-      if (options.session) entry.sessionId = options.session;
-      tokenUsage.push(entry);
-      await axios.put(`${API_URL}/items/${id}`, { tokenUsage });
-      console.log(chalk.green('Token usage logged.'));
-    } catch (error: any) {
-      console.error(chalk.red('Error logging tokens:'), error.response?.data?.error || error.message);
       process.exit(1);
     }
   });
@@ -3278,7 +3248,7 @@ program.helpInformation = function () {
   const groups: [string, string[]][] = [
     ['Services',              ['up', 'down', 'restart', 'kill', 'upgrade', 'health', 'ui']],
     ['Project & Items',       ['init', 'create-project', 'list-projects', 'create', 'list', 'get', 'update', 'delete', 'move']],
-    ['Workflow',              ['verify', 'gatekeeper', 'comment', 'log-tokens', 'log-test']],
+    ['Workflow',              ['verify', 'gatekeeper', 'comment', 'log-test']],
     ['Integrations & Rules',  ['integration', 'rules', 'configure-ide']],
     ['Git & Release',         ['branch', 'pr']],
     ['Flows',                 ['flow']],

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2455,6 +2455,32 @@ program
   });
 
 program
+  .command('tokens')
+  .description('Query the server-side token-events store (MCP fallback: query_token_events)')
+  .option('--item <id>', 'Filter to events attributed to this item')
+  .option('--project <id>', 'Filter to a project')
+  .option('--client <name>', 'Filter to a client (claude-code | codex | gemini | cursor | opencode)')
+  .option('--since <ts>', 'ISO timestamp inclusive lower bound')
+  .option('--until <ts>', 'ISO timestamp exclusive upper bound')
+  .option('--limit <n>', 'Cap number of rows', (v) => parseInt(v, 10))
+  .action(async (options) => {
+    try {
+      const params: Record<string, string | number> = {};
+      if (options.item) params.itemId = options.item;
+      if (options.project) params.projectId = options.project;
+      if (options.client) params.client = options.client;
+      if (options.since) params.since = options.since;
+      if (options.until) params.until = options.until;
+      if (options.limit) params.limit = options.limit;
+      const { data } = await axios.get(`${API_URL}/token-events`, { params });
+      console.log(JSON.stringify(data, null, 2));
+    } catch (error: any) {
+      console.error(chalk.red('Error querying token events:'), error.response?.data?.error || error.message);
+      process.exit(1);
+    }
+  });
+
+program
   .command('log-test <id>')
   .description('Log a test result for an item (MCP fallback: log_test_result)')
   .requiredOption('--command <cmd>', 'Test command that was run')
@@ -3248,7 +3274,7 @@ program.helpInformation = function () {
   const groups: [string, string[]][] = [
     ['Services',              ['up', 'down', 'restart', 'kill', 'upgrade', 'health', 'ui']],
     ['Project & Items',       ['init', 'create-project', 'list-projects', 'create', 'list', 'get', 'update', 'delete', 'move']],
-    ['Workflow',              ['verify', 'gatekeeper', 'comment', 'log-test']],
+    ['Workflow',              ['verify', 'gatekeeper', 'comment', 'log-test', 'tokens']],
     ['Integrations & Rules',  ['integration', 'rules', 'configure-ide']],
     ['Git & Release',         ['branch', 'pr']],
     ['Flows',                 ['flow']],

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2455,6 +2455,53 @@ program
   });
 
 program
+  .command('pr-register')
+  .description('Register a freshly opened PR with agent-declared sizing (MCP fallback: register_pr)')
+  .requiredOption('--item <id>', 'Anchor item id for the PR')
+  .requiredOption('--number <n>', 'PR number', (v) => parseInt(v, 10))
+  .requiredOption('--repo <owner/repo>', 'GitHub repo')
+  .requiredOption('--epic <n>', 'Epic count', (v) => parseInt(v, 10))
+  .requiredOption('--story <n>', 'Story count', (v) => parseInt(v, 10))
+  .requiredOption('--task <n>', 'Task count', (v) => parseInt(v, 10))
+  .requiredOption('--bug <n>', 'Bug count', (v) => parseInt(v, 10))
+  .action(async (options) => {
+    try {
+      const { data } = await axios.post(`${API_URL}/prs`, {
+        itemId: options.item,
+        prNumber: options.number,
+        repo: options.repo,
+        sizing: { epic: options.epic, story: options.story, task: options.task, bug: options.bug },
+      });
+      console.log(JSON.stringify(data, null, 2));
+    } catch (error: any) {
+      console.error(chalk.red('Error registering PR:'), error.response?.data?.error || error.message);
+      process.exit(1);
+    }
+  });
+
+program
+  .command('pr-resize')
+  .description('Update an already-registered PR’s sizing (MCP fallback: update_pr_sizing)')
+  .requiredOption('--number <n>', 'PR number', (v) => parseInt(v, 10))
+  .requiredOption('--repo <owner/repo>', 'GitHub repo')
+  .requiredOption('--epic <n>', 'Epic count', (v) => parseInt(v, 10))
+  .requiredOption('--story <n>', 'Story count', (v) => parseInt(v, 10))
+  .requiredOption('--task <n>', 'Task count', (v) => parseInt(v, 10))
+  .requiredOption('--bug <n>', 'Bug count', (v) => parseInt(v, 10))
+  .action(async (options) => {
+    try {
+      const { data } = await axios.put(
+        `${API_URL}/prs/${encodeURIComponent(options.repo)}/${options.number}`,
+        { sizing: { epic: options.epic, story: options.story, task: options.task, bug: options.bug } },
+      );
+      console.log(JSON.stringify(data, null, 2));
+    } catch (error: any) {
+      console.error(chalk.red('Error updating PR sizing:'), error.response?.data?.error || error.message);
+      process.exit(1);
+    }
+  });
+
+program
   .command('tokens')
   .description('Query the server-side token-events store (MCP fallback: query_token_events)')
   .option('--item <id>', 'Filter to events attributed to this item')
@@ -3276,7 +3323,7 @@ program.helpInformation = function () {
     ['Project & Items',       ['init', 'create-project', 'list-projects', 'create', 'list', 'get', 'update', 'delete', 'move']],
     ['Workflow',              ['verify', 'gatekeeper', 'comment', 'log-test', 'tokens']],
     ['Integrations & Rules',  ['integration', 'rules', 'configure-ide']],
-    ['Git & Release',         ['branch', 'pr']],
+    ['Git & Release',         ['branch', 'pr', 'pr-register', 'pr-resize']],
     ['Flows',                 ['flow']],
     ['External Sync',         ['github', 'jira']],
     ['Configuration',         ['config', 'backup', 'db']],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/core",
-  "version": "1.0.1-beta.5",
+  "version": "1.0.1-beta.6",
   "description": "Core logic and interfaces for the AgenFK Engineering Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/core",
-  "version": "1.0.1-beta.3",
+  "version": "1.0.1-beta.4",
   "description": "Core logic and interfaces for the AgenFK Engineering Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/core",
-  "version": "1.0.1-beta.4",
+  "version": "1.0.1-beta.5",
   "description": "Core logic and interfaces for the AgenFK Engineering Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/core",
-  "version": "1.0.1-beta.1",
+  "version": "1.0.1-beta.3",
   "description": "Core logic and interfaces for the AgenFK Engineering Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/core",
-  "version": "1.0.0",
+  "version": "1.0.1-beta.1",
   "description": "Core logic and interfaces for the AgenFK Engineering Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/core",
-  "version": "1.0.1-beta.6",
+  "version": "1.0.1-beta.7",
   "description": "Core logic and interfaces for the AgenFK Engineering Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/src/interfaces.ts
+++ b/packages/core/src/interfaces.ts
@@ -1,4 +1,16 @@
-import { AgEnFKItem, ItemType, Status, Project, PauseSnapshot, Flow } from './types';
+import {
+  AgEnFKItem,
+  ItemType,
+  Status,
+  Project,
+  PauseSnapshot,
+  Flow,
+  TokenEvent,
+  TokenEventQuery,
+  IngestionState,
+  Pr,
+  PrSizing,
+} from './types';
 
 export interface PluginConfig {
   [key: string]: any;
@@ -48,6 +60,18 @@ export interface StorageProvider extends AgEnFKPlugin {
   deleteFlow(id: string): Promise<boolean>;
   getFlow(id: string): Promise<Flow | null>;
   listFlows(): Promise<Flow[]>;
+
+  // Observability — token events (server-side ingestion of per-client session logs)
+  insertTokenEvent(event: TokenEvent): Promise<void>;
+  queryTokenEvents(query: TokenEventQuery): Promise<TokenEvent[]>;
+  getIngestionState(sourcePath: string): Promise<IngestionState | null>;
+  setIngestionState(state: IngestionState): Promise<void>;
+
+  // Observability — PR sizing (agent-declared)
+  insertPr(pr: Pr): Promise<Pr>;
+  updatePrSizing(repo: string, prNumber: number, sizing: PrSizing, shadow?: PrSizing): Promise<Pr>;
+  getPrByRepoNumber(repo: string, prNumber: number): Promise<Pr | null>;
+  getPrsByItemId(itemId: string): Promise<Pr[]>;
 }
 
 export interface TokenTracker extends AgEnFKPlugin {

--- a/packages/core/src/interfaces.ts
+++ b/packages/core/src/interfaces.ts
@@ -107,7 +107,10 @@ export type HubEventType =
   // Fleet upgrade lifecycle (Story 2/3 of EPIC 541c12b3 — remote upgrade).
   | 'fleet:upgrade:started'
   | 'fleet:upgrade:succeeded'
-  | 'fleet:upgrade:failed';
+  | 'fleet:upgrade:failed'
+  // PR registration events emitted by the spoke on register/update.
+  | 'pr.opened'
+  | 'pr.updated';
 
 export interface HubActor {
   osUser: string;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -28,6 +28,71 @@ export interface TokenUsage {
   timestamp?: string;   // ISO date when logged
 }
 
+// ── Observability: per-turn token telemetry from session-log ingestion ───────
+// Populated by packages/server/src/token-ingestion. Authoritative replacement
+// for agent-self-reported TokenUsage (deprecated; see types removal task).
+
+export type TokenClient =
+  | 'claude-code'
+  | 'codex'
+  | 'gemini'
+  | 'cursor'
+  | 'opencode';
+
+export interface TokenEvent {
+  id: string;
+  ts: string;                 // ISO timestamp of the model turn
+  client: TokenClient;
+  sessionId: string;
+  turnId?: string;
+  model: string;
+  input: number;
+  cachedInput: number;
+  output: number;
+  reasoning: number;
+  total: number;
+  itemId?: string;            // attribution (most-recent active item at ts)
+  projectId?: string;
+  sourcePath: string;         // absolute path of the session log file
+  sourceOffset: number;       // byte/line offset within the file (dedup key)
+}
+
+export interface TokenEventQuery {
+  itemId?: string;
+  projectId?: string;
+  since?: string;
+  until?: string;
+  client?: TokenClient;
+  limit?: number;
+}
+
+export interface IngestionState {
+  sourcePath: string;
+  lastOffset: number;
+  lastRunAt: string;
+}
+
+// ── Observability: PR sizing (agent-declared, server-shadowed) ──────────────
+
+export interface PrSizing {
+  epic: number;
+  story: number;
+  task: number;
+  bug: number;
+}
+
+export interface Pr {
+  id: string;
+  prNumber: number;
+  repo: string;              // e.g. "owner/repo"
+  itemId: string;
+  openedAt: string;
+  sizing: PrSizing;          // agent-declared
+  sizingDeclaredAt: string;
+  sizingShadow?: PrSizing;   // server-computed from item tree, sanity check only
+  lastSizingCheckAt?: string;
+}
+
 export interface ContextItem {
   id: string;
   path: string;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -18,19 +18,9 @@ export enum ItemType {
   BUG = "BUG"
 }
 
-export interface TokenUsage {
-  input: number;
-  output: number;
-  model: string;
-  cost?: number;
-  sessionId?: string;   // Deduplication key
-  source?: string;      // "claude-code" | "opencode" | "manual"
-  timestamp?: string;   // ISO date when logged
-}
-
 // ── Observability: per-turn token telemetry from session-log ingestion ───────
-// Populated by packages/server/src/token-ingestion. Authoritative replacement
-// for agent-self-reported TokenUsage (deprecated; see types removal task).
+// Populated by packages/server/src/token-ingestion. Replaces agent-self-reported
+// per-item token logging entirely.
 
 export type TokenClient =
   | 'claude-code'
@@ -151,7 +141,6 @@ export interface BaseItem {
   description: string;
   status: Status;
   assignee?: string;
-  tokenUsage?: TokenUsage[]; // Array to track usage over time/sessions
   context?: ContextItem[];
   reviews?: ReviewRecord[];
   tests?: TestRecord[];

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -43,6 +43,7 @@ export interface TokenEvent {
   total: number;
   itemId?: string;            // attribution (most-recent active item at ts)
   projectId?: string;
+  cwd?: string;                // ingestion-only metadata used before attribution
   sourcePath: string;         // absolute path of the session log file
   sourceOffset: number;       // byte/line offset within the file (dedup key)
 }

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "1.0.1-beta.4",
+  "version": "1.0.1-beta.5",
   "description": "AgenFK Agentic Engineering Framework — installer",
   "bin": {
     "agenfk": "bin/agenfk.js"

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "1.0.1-beta.3",
+  "version": "1.0.1-beta.4",
   "description": "AgenFK Agentic Engineering Framework — installer",
   "bin": {
     "agenfk": "bin/agenfk.js"

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "1.0.0",
+  "version": "1.0.1-beta.1",
   "description": "AgenFK Agentic Engineering Framework — installer",
   "bin": {
     "agenfk": "bin/agenfk.js"

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "1.0.1-beta.6",
+  "version": "1.0.1-beta.7",
   "description": "AgenFK Agentic Engineering Framework — installer",
   "bin": {
     "agenfk": "bin/agenfk.js"

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "1.0.1-beta.5",
+  "version": "1.0.1-beta.6",
   "description": "AgenFK Agentic Engineering Framework — installer",
   "bin": {
     "agenfk": "bin/agenfk.js"

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "1.0.1-beta.1",
+  "version": "1.0.1-beta.3",
   "description": "AgenFK Agentic Engineering Framework — installer",
   "bin": {
     "agenfk": "bin/agenfk.js"

--- a/packages/flow-editor/package.json
+++ b/packages/flow-editor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agenfk/flow-editor",
   "private": true,
-  "version": "1.0.1-beta.1",
+  "version": "1.0.1-beta.3",
   "type": "module",
   "main": "./src/index.ts",
   "exports": {

--- a/packages/flow-editor/package.json
+++ b/packages/flow-editor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agenfk/flow-editor",
   "private": true,
-  "version": "1.0.1-beta.4",
+  "version": "1.0.1-beta.5",
   "type": "module",
   "main": "./src/index.ts",
   "exports": {

--- a/packages/flow-editor/package.json
+++ b/packages/flow-editor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agenfk/flow-editor",
   "private": true,
-  "version": "1.0.1-beta.6",
+  "version": "1.0.1-beta.7",
   "type": "module",
   "main": "./src/index.ts",
   "exports": {

--- a/packages/flow-editor/package.json
+++ b/packages/flow-editor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agenfk/flow-editor",
   "private": true,
-  "version": "1.0.1-beta.3",
+  "version": "1.0.1-beta.4",
   "type": "module",
   "main": "./src/index.ts",
   "exports": {

--- a/packages/flow-editor/package.json
+++ b/packages/flow-editor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agenfk/flow-editor",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1-beta.1",
   "type": "module",
   "main": "./src/index.ts",
   "exports": {

--- a/packages/flow-editor/package.json
+++ b/packages/flow-editor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agenfk/flow-editor",
   "private": true,
-  "version": "1.0.1-beta.5",
+  "version": "1.0.1-beta.6",
   "type": "module",
   "main": "./src/index.ts",
   "exports": {

--- a/packages/hub-ui/package.json
+++ b/packages/hub-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hub-ui",
   "private": true,
-  "version": "1.0.1-beta.3",
+  "version": "1.0.1-beta.4",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.0.1-beta.3",
+    "@agenfk/flow-editor": "1.0.1-beta.4",
     "@tailwindcss/postcss": "^4.2.0",
     "mermaid": "^11.12.3",
     "@tanstack/react-query": "^5.90.21",

--- a/packages/hub-ui/package.json
+++ b/packages/hub-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hub-ui",
   "private": true,
-  "version": "1.0.1-beta.6",
+  "version": "1.0.1-beta.7",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.0.1-beta.6",
+    "@agenfk/flow-editor": "1.0.1-beta.7",
     "@tailwindcss/postcss": "^4.2.0",
     "mermaid": "^11.12.3",
     "@tanstack/react-query": "^5.90.21",

--- a/packages/hub-ui/package.json
+++ b/packages/hub-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hub-ui",
   "private": true,
-  "version": "1.0.1-beta.5",
+  "version": "1.0.1-beta.6",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.0.1-beta.5",
+    "@agenfk/flow-editor": "1.0.1-beta.6",
     "@tailwindcss/postcss": "^4.2.0",
     "mermaid": "^11.12.3",
     "@tanstack/react-query": "^5.90.21",

--- a/packages/hub-ui/package.json
+++ b/packages/hub-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hub-ui",
   "private": true,
-  "version": "1.0.1-beta.1",
+  "version": "1.0.1-beta.3",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.0.1-beta.1",
+    "@agenfk/flow-editor": "1.0.1-beta.3",
     "@tailwindcss/postcss": "^4.2.0",
     "mermaid": "^11.12.3",
     "@tanstack/react-query": "^5.90.21",

--- a/packages/hub-ui/package.json
+++ b/packages/hub-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hub-ui",
   "private": true,
-  "version": "1.0.1-beta.4",
+  "version": "1.0.1-beta.5",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.0.1-beta.4",
+    "@agenfk/flow-editor": "1.0.1-beta.5",
     "@tailwindcss/postcss": "^4.2.0",
     "mermaid": "^11.12.3",
     "@tanstack/react-query": "^5.90.21",

--- a/packages/hub-ui/package.json
+++ b/packages/hub-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hub-ui",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1-beta.1",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.0.0",
+    "@agenfk/flow-editor": "1.0.1-beta.1",
     "@tailwindcss/postcss": "^4.2.0",
     "mermaid": "^11.12.3",
     "@tanstack/react-query": "^5.90.21",

--- a/packages/hub-ui/src/components/MetricsTilesRow.tsx
+++ b/packages/hub-ui/src/components/MetricsTilesRow.tsx
@@ -1,0 +1,37 @@
+import { Activity, CheckCircle2, XCircle, Inbox, ArrowDownToLine, ArrowUpFromLine, GitPullRequest } from 'lucide-react';
+
+export interface MetricsTotals {
+  events: number;
+  closed: number;
+  passes: number;
+  fails: number;
+  tokensIn: number;
+  tokensOut: number;
+  prsOpened: number;
+}
+
+function Tile({ label, value, icon, tone }: { label: string; value: number; icon: React.ReactNode; tone: string }) {
+  return (
+    <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl px-5 py-4 hover:border-indigo-300 dark:hover:border-indigo-700 hover:shadow-sm transition-all">
+      <div className="flex items-center justify-between">
+        <span className="text-[11px] font-medium uppercase tracking-[0.14em] text-slate-500 dark:text-slate-400">{label}</span>
+        <span className={`w-7 h-7 rounded-lg flex items-center justify-center ${tone}`}>{icon}</span>
+      </div>
+      <div className="mt-2 text-2xl font-bold tabular-nums text-slate-900 dark:text-slate-100">{value.toLocaleString()}</div>
+    </div>
+  );
+}
+
+export function MetricsTilesRow({ totals }: { totals: MetricsTotals }) {
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-7 gap-3">
+      <Tile label="Events"     value={totals.events}     icon={<Activity className="w-4 h-4 text-indigo-600 dark:text-indigo-400" />}        tone="bg-indigo-50 dark:bg-indigo-900/30" />
+      <Tile label="Closed"     value={totals.closed}     icon={<Inbox className="w-4 h-4 text-violet-600 dark:text-violet-400" />}           tone="bg-violet-50 dark:bg-violet-900/30" />
+      <Tile label="Validate ✓" value={totals.passes}     icon={<CheckCircle2 className="w-4 h-4 text-emerald-600 dark:text-emerald-400" />}  tone="bg-emerald-50 dark:bg-emerald-900/30" />
+      <Tile label="Validate ✗" value={totals.fails}      icon={<XCircle className="w-4 h-4 text-rose-600 dark:text-rose-400" />}             tone="bg-rose-50 dark:bg-rose-900/30" />
+      <Tile label="Tokens in"  value={totals.tokensIn}   icon={<ArrowDownToLine className="w-4 h-4 text-cyan-600 dark:text-cyan-400" />}     tone="bg-cyan-50 dark:bg-cyan-900/30" />
+      <Tile label="Tokens out" value={totals.tokensOut}  icon={<ArrowUpFromLine className="w-4 h-4 text-sky-600 dark:text-sky-400" />}       tone="bg-sky-50 dark:bg-sky-900/30" />
+      <Tile label="PRs"        value={totals.prsOpened}  icon={<GitPullRequest className="w-4 h-4 text-fuchsia-600 dark:text-fuchsia-400" />} tone="bg-fuchsia-50 dark:bg-fuchsia-900/30" />
+    </div>
+  );
+}

--- a/packages/hub-ui/src/components/TimelineBar.tsx
+++ b/packages/hub-ui/src/components/TimelineBar.tsx
@@ -20,6 +20,8 @@ interface Props {
   itemTypes?: string[];
   className?: string;
   title?: string;
+  range?: RangeKey;
+  onRangeChange?: (r: RangeKey) => void;
 }
 
 const RANGES: Array<{ key: RangeKey; label: string }> = [
@@ -48,8 +50,10 @@ function niceTicks(max: number): number[] {
   return out;
 }
 
-export function TimelineBar({ users, types, projects, itemTypes, className, title }: Props) {
-  const [range, setRange] = useState<RangeKey>('30d');
+export function TimelineBar({ users, types, projects, itemTypes, className, title, range: rangeProp, onRangeChange }: Props) {
+  const [rangeInternal, setRangeInternal] = useState<RangeKey>('30d');
+  const range = rangeProp ?? rangeInternal;
+  const setRange = (r: RangeKey) => { setRangeInternal(r); onRangeChange?.(r); };
   const [bucketSel, setBucketSel] = useState<Bucket>('day');
   const [hoverIdx, setHoverIdx] = useState<number | null>(null);
 

--- a/packages/hub-ui/src/components/TimelineBar.tsx
+++ b/packages/hub-ui/src/components/TimelineBar.tsx
@@ -13,6 +13,8 @@ import {
 interface HistogramBucket { time: string; total: number; by_type: Record<string, number> }
 interface HistogramResponse { bucket: 'day' | 'hour'; buckets: HistogramBucket[] }
 
+export interface TokenBucket { day: string; tokens_in: number; tokens_out: number }
+
 interface Props {
   users?: string[];
   types?: string[];
@@ -22,6 +24,7 @@ interface Props {
   title?: string;
   range?: RangeKey;
   onRangeChange?: (r: RangeKey) => void;
+  tokenSeries?: TokenBucket[];
 }
 
 const RANGES: Array<{ key: RangeKey; label: string }> = [
@@ -50,11 +53,12 @@ function niceTicks(max: number): number[] {
   return out;
 }
 
-export function TimelineBar({ users, types, projects, itemTypes, className, title, range: rangeProp, onRangeChange }: Props) {
+export function TimelineBar({ users, types, projects, itemTypes, className, title, range: rangeProp, onRangeChange, tokenSeries }: Props) {
   const [rangeInternal, setRangeInternal] = useState<RangeKey>('30d');
   const range = rangeProp ?? rangeInternal;
   const setRange = (r: RangeKey) => { setRangeInternal(r); onRangeChange?.(r); };
   const [bucketSel, setBucketSel] = useState<Bucket>('day');
+  const [mode, setMode] = useState<'events' | 'tokens'>('events');
   const [hoverIdx, setHoverIdx] = useState<number | null>(null);
 
   const bucket = effectiveBucket(range, bucketSel);
@@ -125,55 +129,181 @@ export function TimelineBar({ users, types, projects, itemTypes, className, titl
     ? 'today'
     : `last ${range === '7d' ? 7 : range === '30d' ? 30 : 90} days`;
 
+  // Token mode: use daily tokenSeries data mapped to day-axis keys.
+  const tokenByDay = useMemo(() => {
+    const m = new Map<string, TokenBucket>();
+    for (const b of tokenSeries ?? []) m.set(b.day, b);
+    return m;
+  }, [tokenSeries]);
+
+  const tokenDayAxis = useMemo(() => buildAxis(now, range, 'day'), [range, now.getHours()]);
+
+  const maxTokens = useMemo(() => {
+    let max = 0;
+    for (const d of tokenDayAxis) {
+      const b = tokenByDay.get(d);
+      if (b) max = Math.max(max, b.tokens_in + b.tokens_out);
+    }
+    return max;
+  }, [tokenDayAxis, tokenByDay]);
+
+  const tokenTicks = useMemo(() => niceTicks(maxTokens), [maxTokens]);
+  const tokenYTop = tokenTicks[tokenTicks.length - 1] || 1;
+
+  const tokenBarW = Math.max(1, (innerW - barGap * (tokenDayAxis.length - 1)) / Math.max(tokenDayAxis.length, 1));
+  const tokenXLabelStep = Math.max(1, Math.ceil(tokenDayAxis.length / 6));
+
+  const fmtTokens = (n: number) =>
+    n >= 1_000_000 ? `${(n / 1_000_000).toFixed(1)}M`
+    : n >= 1_000 ? `${(n / 1_000).toFixed(0)}k`
+    : String(n);
+
   return (
     <section className={`relative bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl shadow-sm ${className ?? ''}`}>
       <header className="flex items-center justify-between gap-4 px-5 pt-4 pb-3 border-b border-slate-100 dark:border-slate-800">
         <div className="min-w-0">
           <h3 className="text-sm font-semibold text-slate-800 dark:text-slate-100 truncate">{title ?? 'Activity'}</h3>
           <p className="mt-0.5 text-[11px] text-slate-500 dark:text-slate-400">
-            {totalEvents.toLocaleString()} event{totalEvents === 1 ? '' : 's'} · {rangeBlurb}{users?.length ? ` · ${users.length} user${users.length === 1 ? '' : 's'}` : ''}
-            {stackedTypes ? ` · ${stackedTypes.length} type${stackedTypes.length === 1 ? '' : 's'}` : ''}
+            {mode === 'events'
+              ? <>{totalEvents.toLocaleString()} event{totalEvents === 1 ? '' : 's'} · {rangeBlurb}{users?.length ? ` · ${users.length} user${users.length === 1 ? '' : 's'}` : ''}{stackedTypes ? ` · ${stackedTypes.length} type${stackedTypes.length === 1 ? '' : 's'}` : ''}</>
+              : <>{rangeBlurb}</>
+            }
           </p>
         </div>
         <div className="flex items-center gap-2">
-          <div className="inline-flex rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800 p-0.5 text-[11px] font-medium">
-            {RANGES.map(r => (
-              <button
-                key={r.key}
-                onClick={() => setRange(r.key)}
-                className={`px-2.5 py-1 rounded-md transition-colors ${range === r.key
-                  ? 'bg-white dark:bg-slate-900 text-indigo-600 dark:text-indigo-400 shadow-sm'
-                  : 'text-slate-500 hover:text-slate-700 dark:hover:text-slate-300'}`}
-              >
-                {r.label}
-              </button>
-            ))}
-          </div>
-          <div className="inline-flex rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800 p-0.5 text-[11px] font-medium">
-            {(['day', 'hour'] as const).map(b => {
-              const active = bucket === b;
-              const disabled = isToday && b === 'day';
-              return (
+          {tokenSeries && (
+            <div className="inline-flex rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800 p-0.5 text-[11px] font-medium">
+              {(['events', 'tokens'] as const).map(m => (
                 <button
-                  key={b}
-                  onClick={() => !disabled && setBucketSel(b)}
-                  disabled={disabled}
-                  title={disabled ? 'Today view is hourly' : undefined}
-                  className={`px-2.5 py-1 rounded-md transition-colors ${active
+                  key={m}
+                  onClick={() => setMode(m)}
+                  className={`px-2.5 py-1 rounded-md transition-colors ${mode === m
                     ? 'bg-white dark:bg-slate-900 text-indigo-600 dark:text-indigo-400 shadow-sm'
-                    : disabled
-                      ? 'text-slate-300 dark:text-slate-600 cursor-not-allowed'
-                      : 'text-slate-500 hover:text-slate-700 dark:hover:text-slate-300'}`}
+                    : 'text-slate-500 hover:text-slate-700 dark:hover:text-slate-300'}`}
                 >
-                  {b}
+                  {m}
                 </button>
-              );
-            })}
-          </div>
+              ))}
+            </div>
+          )}
+          {/* Range picker only shown when not controlled externally (standalone usage) */}
+          {rangeProp == null && (
+            <div className="inline-flex rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800 p-0.5 text-[11px] font-medium">
+              {RANGES.map(r => (
+                <button
+                  key={r.key}
+                  onClick={() => setRange(r.key)}
+                  className={`px-2.5 py-1 rounded-md transition-colors ${range === r.key
+                    ? 'bg-white dark:bg-slate-900 text-indigo-600 dark:text-indigo-400 shadow-sm'
+                    : 'text-slate-500 hover:text-slate-700 dark:hover:text-slate-300'}`}
+                >
+                  {r.label}
+                </button>
+              ))}
+            </div>
+          )}
+          {mode === 'events' && (
+            <div className="inline-flex rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800 p-0.5 text-[11px] font-medium">
+              {(['day', 'hour'] as const).map(b => {
+                const active = bucket === b;
+                const disabled = isToday && b === 'day';
+                return (
+                  <button
+                    key={b}
+                    onClick={() => !disabled && setBucketSel(b)}
+                    disabled={disabled}
+                    title={disabled ? 'Today view is hourly' : undefined}
+                    className={`px-2.5 py-1 rounded-md transition-colors ${active
+                      ? 'bg-white dark:bg-slate-900 text-indigo-600 dark:text-indigo-400 shadow-sm'
+                      : disabled
+                        ? 'text-slate-300 dark:text-slate-600 cursor-not-allowed'
+                        : 'text-slate-500 hover:text-slate-700 dark:hover:text-slate-300'}`}
+                  >
+                    {b}
+                  </button>
+                );
+              })}
+            </div>
+          )}
         </div>
       </header>
 
       <div className="px-3 pt-3 pb-3 relative">
+        {mode === 'tokens' && tokenSeries && (
+          <svg viewBox={`0 0 ${width} ${height}`} preserveAspectRatio="none" className="w-full h-[220px] block" role="img" aria-label="Token usage timeline">
+            {/* Y gridlines + labels */}
+            {tokenTicks.map((t) => {
+              const y = m.top + innerH - (t / tokenYTop) * innerH;
+              return (
+                <g key={t}>
+                  <line x1={m.left} x2={m.left + innerW} y1={y} y2={y}
+                        className="stroke-slate-200 dark:stroke-slate-800" strokeDasharray={t === 0 ? '0' : '2 3'} />
+                  <text x={m.left - 6} y={y} textAnchor="end" dominantBaseline="middle"
+                        className="fill-slate-400 dark:fill-slate-500" style={{ fontSize: 10 }}>
+                    {fmtTokens(t)}
+                  </text>
+                </g>
+              );
+            })}
+            {/* Stacked bars: tokens_in (bottom, cyan) + tokens_out (top, sky) */}
+            {tokenDayAxis.map((d, i) => {
+              const b = tokenByDay.get(d);
+              const tokIn = b?.tokens_in ?? 0;
+              const tokOut = b?.tokens_out ?? 0;
+              const total = tokIn + tokOut;
+              const x = m.left + i * (tokenBarW + barGap);
+              const inH = (tokIn / tokenYTop) * innerH;
+              const outH = (tokOut / tokenYTop) * innerH;
+              return (
+                <g key={d}>
+                  {tokIn > 0 && (
+                    <rect x={x} y={m.top + innerH - inH} width={tokenBarW} height={inH}
+                          rx={tokenBarW > 6 ? 1.5 : 0} fill="#22d3ee" opacity={0.85} />
+                  )}
+                  {tokOut > 0 && (
+                    <rect x={x} y={m.top + innerH - inH - outH} width={tokenBarW} height={outH}
+                          rx={tokenBarW > 6 ? 1.5 : 0} fill="#38bdf8" opacity={0.85} />
+                  )}
+                  {total === 0 && (
+                    <rect x={x} y={m.top + innerH - 1} width={tokenBarW} height={1}
+                          className="fill-slate-200 dark:fill-slate-800" />
+                  )}
+                </g>
+              );
+            })}
+            {/* X axis baseline */}
+            <line x1={m.left} x2={m.left + innerW} y1={m.top + innerH} y2={m.top + innerH}
+                  className="stroke-slate-300 dark:stroke-slate-700" />
+            {/* X tick labels */}
+            {tokenDayAxis.map((d, i) => {
+              if (i % tokenXLabelStep !== 0 && i !== tokenDayAxis.length - 1) return null;
+              const x = m.left + i * (tokenBarW + barGap) + tokenBarW / 2;
+              return (
+                <text key={d} x={x} y={m.top + innerH + 14} textAnchor="middle"
+                      className="fill-slate-500 dark:fill-slate-400 font-mono" style={{ fontSize: 10 }}>
+                  {shortLabel(d, 'day', range)}
+                </text>
+              );
+            })}
+            <text x={m.left} y={m.top - 2} className="fill-slate-400 dark:fill-slate-500"
+                  style={{ fontSize: 9, letterSpacing: '0.06em' }}>
+              TOKENS
+            </text>
+          </svg>
+        )}
+        {mode === 'tokens' && tokenSeries && (
+          <footer className="flex flex-wrap gap-x-4 gap-y-1.5 px-2 pb-1 pt-1 text-[11px] text-slate-500 dark:text-slate-400">
+            <span className="flex items-center gap-1.5">
+              <span className="inline-block w-2 h-2 rounded-sm" style={{ background: '#22d3ee' }} />
+              tokens in (incl. cache)
+            </span>
+            <span className="flex items-center gap-1.5">
+              <span className="inline-block w-2 h-2 rounded-sm" style={{ background: '#38bdf8' }} />
+              tokens out
+            </span>
+          </footer>
+        )}
+        {mode === 'events' && (<>
         <svg viewBox={`0 0 ${width} ${height}`} preserveAspectRatio="none" className="w-full h-[220px] block" role="img" aria-label="Event timeline histogram">
           {/* Y gridlines + labels */}
           {ticks.map((t) => {
@@ -304,6 +434,7 @@ export function TimelineBar({ users, types, projects, itemTypes, className, titl
             )}
           </div>
         )}
+        </>)}
       </div>
 
       {/* Legend (only when filtered by type) */}

--- a/packages/hub-ui/src/pages/Org.tsx
+++ b/packages/hub-ui/src/pages/Org.tsx
@@ -1,7 +1,7 @@
 import { Link } from 'react-router-dom';
 import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { Activity, CheckCircle2, XCircle, Inbox, ChevronRight, GitBranch } from 'lucide-react';
+import { Activity, CheckCircle2, XCircle, Inbox, ChevronRight, GitBranch, ArrowDownToLine, ArrowUpFromLine } from 'lucide-react';
 import { api } from '../api';
 import { TimelineBar } from '../components/TimelineBar';
 import { FacetMultiselect } from '../components/FacetMultiselect';
@@ -121,8 +121,10 @@ export function OrgPage() {
       closed: a.closed + r.items_closed,
       passes: a.passes + r.validate_passes,
       fails: a.fails + r.validate_fails,
+      tokensIn: a.tokensIn + r.tokens_in,
+      tokensOut: a.tokensOut + r.tokens_out,
     }),
-    { events: 0, closed: 0, passes: 0, fails: 0 },
+    { events: 0, closed: 0, passes: 0, fails: 0, tokensIn: 0, tokensOut: 0 },
   );
 
   const types = mergeEventTypes(eventTypes.data?.types);
@@ -141,11 +143,13 @@ export function OrgPage() {
         <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">Fleet-wide AgEnFK activity across every connected installation.</p>
       </header>
 
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3">
         <Tile label="Events"      value={totals.events}    icon={<Activity className="w-4 h-4 text-indigo-600 dark:text-indigo-400" />} tone="bg-indigo-50 dark:bg-indigo-900/30" />
         <Tile label="Closed"      value={totals.closed}    icon={<Inbox className="w-4 h-4 text-violet-600 dark:text-violet-400" />} tone="bg-violet-50 dark:bg-violet-900/30" />
         <Tile label="Validate ✓"  value={totals.passes}    icon={<CheckCircle2 className="w-4 h-4 text-emerald-600 dark:text-emerald-400" />} tone="bg-emerald-50 dark:bg-emerald-900/30" />
         <Tile label="Validate ✗"  value={totals.fails}     icon={<XCircle className="w-4 h-4 text-rose-600 dark:text-rose-400" />} tone="bg-rose-50 dark:bg-rose-900/30" />
+        <Tile label="Tokens in"   value={totals.tokensIn}  icon={<ArrowDownToLine className="w-4 h-4 text-cyan-600 dark:text-cyan-400" />} tone="bg-cyan-50 dark:bg-cyan-900/30" />
+        <Tile label="Tokens out"  value={totals.tokensOut} icon={<ArrowUpFromLine className="w-4 h-4 text-sky-600 dark:text-sky-400" />} tone="bg-sky-50 dark:bg-sky-900/30" />
       </div>
 
       <section className="space-y-4 p-5 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl">

--- a/packages/hub-ui/src/pages/Org.tsx
+++ b/packages/hub-ui/src/pages/Org.tsx
@@ -12,6 +12,13 @@ import { fmtRelative } from '../dates';
 import { useToggleSet } from '../hooks/useToggleSet';
 import { fromIsoForRange, type RangeKey } from '../components/timelineAxis';
 
+const RANGES: Array<{ key: RangeKey; label: string }> = [
+  { key: 'today', label: 'today' },
+  { key: '7d', label: '7d' },
+  { key: '30d', label: '30d' },
+  { key: '90d', label: '90d' },
+];
+
 interface MetricsResponse { bucket: string; series: Array<{ user_key: string; day: string; events_count: number; items_closed: number; tokens_in: number; tokens_out: number; validate_passes: number; validate_fails: number; prs_opened: number }> }
 interface UsersResponse { user_key: string; last_seen: string; events_count: number }
 interface EventTypesResponse { types: string[] }
@@ -165,6 +172,22 @@ export function OrgPage() {
           }}
         />
         <ChipRow label="Event type" options={types} selected={eventTypeSel.set} onToggle={eventTypeSel.toggle} onClear={eventTypeSel.clear} />
+        <div>
+          <h3 className="text-[11px] uppercase tracking-[0.14em] font-semibold text-slate-500 dark:text-slate-400 mb-1.5">Period</h3>
+          <div className="inline-flex rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800 p-0.5 text-[11px] font-medium">
+            {RANGES.map(r => (
+              <button
+                key={r.key}
+                onClick={() => setRange(r.key)}
+                className={`px-2.5 py-1 rounded-md transition-colors ${range === r.key
+                  ? 'bg-white dark:bg-slate-900 text-indigo-600 dark:text-indigo-400 shadow-sm'
+                  : 'text-slate-500 hover:text-slate-700 dark:hover:text-slate-300'}`}
+              >
+                {r.label}
+              </button>
+            ))}
+          </div>
+        </div>
       </section>
 
       <TimelineBar
@@ -174,6 +197,7 @@ export function OrgPage() {
         title="Activity timeline"
         range={range}
         onRangeChange={setRange}
+        tokenSeries={metrics.data?.series?.map(r => ({ day: r.day, tokens_in: r.tokens_in, tokens_out: r.tokens_out }))}
       />
 
       <section className="space-y-3">

--- a/packages/hub-ui/src/pages/Org.tsx
+++ b/packages/hub-ui/src/pages/Org.tsx
@@ -1,16 +1,17 @@
 import { Link } from 'react-router-dom';
 import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { Activity, CheckCircle2, XCircle, Inbox, ChevronRight, GitBranch, ArrowDownToLine, ArrowUpFromLine } from 'lucide-react';
+import { ChevronRight, GitBranch } from 'lucide-react';
 import { api } from '../api';
 import { TimelineBar } from '../components/TimelineBar';
 import { FacetMultiselect } from '../components/FacetMultiselect';
+import { MetricsTilesRow, MetricsTotals } from '../components/MetricsTilesRow';
 import { shortRemote } from '../components/facetSearch';
 import { mergeEventTypes } from '../eventTypes';
 import { fmtRelative } from '../dates';
 import { useToggleSet } from '../hooks/useToggleSet';
 
-interface MetricsResponse { bucket: string; series: Array<{ user_key: string; day: string; events_count: number; items_closed: number; tokens_in: number; tokens_out: number; validate_passes: number; validate_fails: number }> }
+interface MetricsResponse { bucket: string; series: Array<{ user_key: string; day: string; events_count: number; items_closed: number; tokens_in: number; tokens_out: number; validate_passes: number; validate_fails: number; prs_opened: number }> }
 interface UsersResponse { user_key: string; last_seen: string; events_count: number }
 interface EventTypesResponse { types: string[] }
 interface ProjectsResponse { projects: string[] }
@@ -54,19 +55,6 @@ function ChipRow({ label, options, selected, onToggle, onClear, optionLabel }: {
           );
         })}
       </div>
-    </div>
-  );
-}
-
-interface TileProps { label: string; value: number; icon: React.ReactNode; tone: string }
-function Tile({ label, value, icon, tone }: TileProps) {
-  return (
-    <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl px-5 py-4 hover:border-indigo-300 dark:hover:border-indigo-700 hover:shadow-sm transition-all">
-      <div className="flex items-center justify-between">
-        <span className="text-[11px] font-medium uppercase tracking-[0.14em] text-slate-500 dark:text-slate-400">{label}</span>
-        <span className={`w-7 h-7 rounded-lg flex items-center justify-center ${tone}`}>{icon}</span>
-      </div>
-      <div className="mt-2 text-2xl font-bold tabular-nums text-slate-900 dark:text-slate-100">{value.toLocaleString()}</div>
     </div>
   );
 }
@@ -115,7 +103,7 @@ export function OrgPage() {
     queryFn: async () => (await api.get(`/v1/item-types${itemTypesQs ? `?${itemTypesQs}` : ''}`)).data,
   });
 
-  const totals = (metrics.data?.series ?? []).reduce(
+  const totals: MetricsTotals = (metrics.data?.series ?? []).reduce(
     (a, r) => ({
       events: a.events + r.events_count,
       closed: a.closed + r.items_closed,
@@ -123,8 +111,9 @@ export function OrgPage() {
       fails: a.fails + r.validate_fails,
       tokensIn: a.tokensIn + r.tokens_in,
       tokensOut: a.tokensOut + r.tokens_out,
+      prsOpened: a.prsOpened + (r.prs_opened ?? 0),
     }),
-    { events: 0, closed: 0, passes: 0, fails: 0, tokensIn: 0, tokensOut: 0 },
+    { events: 0, closed: 0, passes: 0, fails: 0, tokensIn: 0, tokensOut: 0, prsOpened: 0 },
   );
 
   const types = mergeEventTypes(eventTypes.data?.types);
@@ -143,14 +132,7 @@ export function OrgPage() {
         <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">Fleet-wide AgEnFK activity across every connected installation.</p>
       </header>
 
-      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3">
-        <Tile label="Events"      value={totals.events}    icon={<Activity className="w-4 h-4 text-indigo-600 dark:text-indigo-400" />} tone="bg-indigo-50 dark:bg-indigo-900/30" />
-        <Tile label="Closed"      value={totals.closed}    icon={<Inbox className="w-4 h-4 text-violet-600 dark:text-violet-400" />} tone="bg-violet-50 dark:bg-violet-900/30" />
-        <Tile label="Validate ✓"  value={totals.passes}    icon={<CheckCircle2 className="w-4 h-4 text-emerald-600 dark:text-emerald-400" />} tone="bg-emerald-50 dark:bg-emerald-900/30" />
-        <Tile label="Validate ✗"  value={totals.fails}     icon={<XCircle className="w-4 h-4 text-rose-600 dark:text-rose-400" />} tone="bg-rose-50 dark:bg-rose-900/30" />
-        <Tile label="Tokens in"   value={totals.tokensIn}  icon={<ArrowDownToLine className="w-4 h-4 text-cyan-600 dark:text-cyan-400" />} tone="bg-cyan-50 dark:bg-cyan-900/30" />
-        <Tile label="Tokens out"  value={totals.tokensOut} icon={<ArrowUpFromLine className="w-4 h-4 text-sky-600 dark:text-sky-400" />} tone="bg-sky-50 dark:bg-sky-900/30" />
-      </div>
+      <MetricsTilesRow totals={totals} />
 
       <section className="space-y-4 p-5 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl">
         <div className="flex items-center gap-2">

--- a/packages/hub-ui/src/pages/Org.tsx
+++ b/packages/hub-ui/src/pages/Org.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { ChevronRight, GitBranch } from 'lucide-react';
 import { api } from '../api';
@@ -10,6 +10,7 @@ import { shortRemote } from '../components/facetSearch';
 import { mergeEventTypes } from '../eventTypes';
 import { fmtRelative } from '../dates';
 import { useToggleSet } from '../hooks/useToggleSet';
+import { fromIsoForRange, type RangeKey } from '../components/timelineAxis';
 
 interface MetricsResponse { bucket: string; series: Array<{ user_key: string; day: string; events_count: number; items_closed: number; tokens_in: number; tokens_out: number; validate_passes: number; validate_fails: number; prs_opened: number }> }
 interface UsersResponse { user_key: string; last_seen: string; events_count: number }
@@ -68,14 +69,16 @@ export function OrgPage() {
   const eventTypeSel = useToggleSet(['item.closed'], { storageKey: 'agenfk-hub:org:eventTypes' });
   const projectSel = useToggleSet([], { storageKey: 'agenfk-hub:org:projects' });
   const itemTypeSel = useToggleSet([], { storageKey: 'agenfk-hub:org:itemTypes' });
+  const [range, setRange] = useState<RangeKey>('30d');
 
   // Build the query string once for everything that needs the same filters.
   const qs = useMemo(() => {
     const p = new URLSearchParams();
     if (projectSel.set.size) p.set('projects', [...projectSel.set].join(','));
     if (itemTypeSel.set.size) p.set('itemTypes', [...itemTypeSel.set].join(','));
+    p.set('from', fromIsoForRange(new Date(), range));
     return p.toString();
-  }, [projectSel.set, itemTypeSel.set]);
+  }, [projectSel.set, itemTypeSel.set, range]);
 
   // For per-itemType counts we honour project + event-type selections but
   // intentionally drop the itemTypes filter — the chip count answers
@@ -169,6 +172,8 @@ export function OrgPage() {
         projects={[...projectSel.set]}
         itemTypes={[...itemTypeSel.set]}
         title="Activity timeline"
+        range={range}
+        onRangeChange={setRange}
       />
 
       <section className="space-y-3">

--- a/packages/hub-ui/src/pages/UserDetail.tsx
+++ b/packages/hub-ui/src/pages/UserDetail.tsx
@@ -1,5 +1,5 @@
 import { Link, useParams } from 'react-router-dom';
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { ArrowLeft, ChevronDown, GitBranch } from 'lucide-react';
 import { api } from '../api';
@@ -9,6 +9,7 @@ import { shortRemote } from '../components/facetSearch';
 import { mergeEventTypes } from '../eventTypes';
 import { fmtDateTime, browserTimezone } from '../dates';
 import { useToggleSet } from '../hooks/useToggleSet';
+import { scrollPageToTop } from '../scroll';
 
 interface TimelineRow {
   event_id: string; occurred_at: string; type: string; project_id: string | null; item_id: string | null; item_type: string | null; remote_url: string | null; item_title: string | null; external_id: string | null; user_key: string; reporting_version: string | null; payload: any;
@@ -87,6 +88,8 @@ function ChipRow({ label, options, selected, onToggle, onClear, optionLabel }: {
 export function UserDetailPage() {
   const { userKey = '' } = useParams();
   const decoded = decodeURIComponent(userKey);
+
+  useEffect(() => { scrollPageToTop(); }, [userKey]);
   // Default to "what did this user ship?" — closures only — until the dev
   // widens the chip selection. Persisted in localStorage so a refresh
   // restores the developer's last selection rather than snapping back.

--- a/packages/hub-ui/src/pages/UserDetail.tsx
+++ b/packages/hub-ui/src/pages/UserDetail.tsx
@@ -5,10 +5,13 @@ import { ArrowLeft, ChevronDown, GitBranch } from 'lucide-react';
 import { api } from '../api';
 import { TimelineBar } from '../components/TimelineBar';
 import { FacetMultiselect } from '../components/FacetMultiselect';
+import { MetricsTilesRow, MetricsTotals } from '../components/MetricsTilesRow';
 import { shortRemote } from '../components/facetSearch';
 import { mergeEventTypes } from '../eventTypes';
 import { fmtDateTime, browserTimezone } from '../dates';
 import { useToggleSet } from '../hooks/useToggleSet';
+
+interface MetricsResponse { bucket: string; series: Array<{ user_key: string; day: string; events_count: number; items_closed: number; tokens_in: number; tokens_out: number; validate_passes: number; validate_fails: number; prs_opened: number }> }
 
 interface TimelineRow {
   event_id: string; occurred_at: string; type: string; project_id: string | null; item_id: string | null; item_type: string | null; remote_url: string | null; item_title: string | null; external_id: string | null; user_key: string; reporting_version: string | null; payload: any;
@@ -122,6 +125,32 @@ export function UserDetailPage() {
   if (itemTypeSel.set.size) params.set('itemTypes', [...itemTypeSel.set].join(','));
   params.set('limit', '200');
 
+  const metricsQs = useMemo(() => {
+    const p = new URLSearchParams();
+    p.set('users', decoded);
+    if (projectSel.set.size) p.set('projects', [...projectSel.set].join(','));
+    if (itemTypeSel.set.size) p.set('itemTypes', [...itemTypeSel.set].join(','));
+    return p.toString();
+  }, [decoded, projectSel.set, itemTypeSel.set]);
+
+  const metrics = useQuery<MetricsResponse>({
+    queryKey: ['metrics', metricsQs],
+    queryFn: async () => (await api.get(`/v1/metrics?${metricsQs}`)).data,
+  });
+
+  const totals: MetricsTotals = (metrics.data?.series ?? []).reduce(
+    (a, r) => ({
+      events: a.events + r.events_count,
+      closed: a.closed + r.items_closed,
+      passes: a.passes + r.validate_passes,
+      fails: a.fails + r.validate_fails,
+      tokensIn: a.tokensIn + r.tokens_in,
+      tokensOut: a.tokensOut + r.tokens_out,
+      prsOpened: a.prsOpened + (r.prs_opened ?? 0),
+    }),
+    { events: 0, closed: 0, passes: 0, fails: 0, tokensIn: 0, tokensOut: 0, prsOpened: 0 },
+  );
+
   const tl = useQuery<{ events: TimelineRow[] }>({
     queryKey: ['timeline', userKey, [...eventTypeSel.set].sort().join(','), [...projectSel.set].sort().join(','), [...itemTypeSel.set].sort().join(',')],
     queryFn: async () => (await api.get(`/v1/timeline?${params}`)).data,
@@ -150,6 +179,8 @@ export function UserDetailPage() {
           <h1 className="mt-0.5 text-xl font-bold tracking-tight font-mono text-slate-900 dark:text-slate-100 truncate">{decoded}</h1>
         </div>
       </header>
+
+      <MetricsTilesRow totals={totals} />
 
       <section className="space-y-4 p-5 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl">
         <div className="flex items-center gap-2">

--- a/packages/hub-ui/src/pages/UserDetail.tsx
+++ b/packages/hub-ui/src/pages/UserDetail.tsx
@@ -1,5 +1,5 @@
 import { Link, useParams } from 'react-router-dom';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { ArrowLeft, ChevronDown, GitBranch } from 'lucide-react';
 import { api } from '../api';
@@ -11,6 +11,7 @@ import { mergeEventTypes } from '../eventTypes';
 import { fmtDateTime, browserTimezone } from '../dates';
 import { useToggleSet } from '../hooks/useToggleSet';
 import { scrollPageToTop } from '../scroll';
+import { fromIsoForRange, type RangeKey } from '../components/timelineAxis';
 
 interface MetricsResponse { bucket: string; series: Array<{ user_key: string; day: string; events_count: number; items_closed: number; tokens_in: number; tokens_out: number; validate_passes: number; validate_fails: number; prs_opened: number }> }
 
@@ -99,6 +100,7 @@ export function UserDetailPage() {
   const eventTypeSel = useToggleSet(['item.closed'], { storageKey: 'agenfk-hub:user:eventTypes' });
   const projectSel = useToggleSet([], { storageKey: 'agenfk-hub:user:projects' });
   const itemTypeSel = useToggleSet([], { storageKey: 'agenfk-hub:user:itemTypes' });
+  const [range, setRange] = useState<RangeKey>('30d');
 
   const eventTypes = useQuery<EventTypesResponse>({
     queryKey: ['event-types'],
@@ -121,20 +123,25 @@ export function UserDetailPage() {
     queryFn: async () => (await api.get(`/v1/item-types?${itemTypesQs}`)).data,
   });
 
-  const params = new URLSearchParams();
-  params.set('users', decoded);
-  if (eventTypeSel.set.size) params.set('types', [...eventTypeSel.set].join(','));
-  if (projectSel.set.size) params.set('projects', [...projectSel.set].join(','));
-  if (itemTypeSel.set.size) params.set('itemTypes', [...itemTypeSel.set].join(','));
-  params.set('limit', '200');
+  const params = useMemo(() => {
+    const p = new URLSearchParams();
+    p.set('users', decoded);
+    if (eventTypeSel.set.size) p.set('types', [...eventTypeSel.set].join(','));
+    if (projectSel.set.size) p.set('projects', [...projectSel.set].join(','));
+    if (itemTypeSel.set.size) p.set('itemTypes', [...itemTypeSel.set].join(','));
+    p.set('from', fromIsoForRange(new Date(), range));
+    p.set('limit', '200');
+    return p;
+  }, [decoded, eventTypeSel.set, projectSel.set, itemTypeSel.set, range]);
 
   const metricsQs = useMemo(() => {
     const p = new URLSearchParams();
     p.set('users', decoded);
     if (projectSel.set.size) p.set('projects', [...projectSel.set].join(','));
     if (itemTypeSel.set.size) p.set('itemTypes', [...itemTypeSel.set].join(','));
+    p.set('from', fromIsoForRange(new Date(), range));
     return p.toString();
-  }, [decoded, projectSel.set, itemTypeSel.set]);
+  }, [decoded, projectSel.set, itemTypeSel.set, range]);
 
   const metrics = useQuery<MetricsResponse>({
     queryKey: ['metrics', metricsQs],
@@ -155,7 +162,7 @@ export function UserDetailPage() {
   );
 
   const tl = useQuery<{ events: TimelineRow[] }>({
-    queryKey: ['timeline', userKey, [...eventTypeSel.set].sort().join(','), [...projectSel.set].sort().join(','), [...itemTypeSel.set].sort().join(',')],
+    queryKey: ['timeline', userKey, [...eventTypeSel.set].sort().join(','), [...projectSel.set].sort().join(','), [...itemTypeSel.set].sort().join(','), range],
     queryFn: async () => (await api.get(`/v1/timeline?${params}`)).data,
   });
 
@@ -220,6 +227,8 @@ export function UserDetailPage() {
         projects={[...projectSel.set]}
         itemTypes={[...itemTypeSel.set]}
         title="Activity timeline"
+        range={range}
+        onRangeChange={setRange}
       />
 
       <section className="space-y-3">

--- a/packages/hub-ui/src/scroll.ts
+++ b/packages/hub-ui/src/scroll.ts
@@ -1,0 +1,3 @@
+export function scrollPageToTop(): void {
+  window.scrollTo(0, 0);
+}

--- a/packages/hub-ui/src/test/metricsUserDetail.test.ts
+++ b/packages/hub-ui/src/test/metricsUserDetail.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+
+const USER_DETAIL_SRC = readFileSync(
+  path.resolve(__dirname, '../pages/UserDetail.tsx'),
+  'utf8',
+);
+const ORG_SRC = readFileSync(
+  path.resolve(__dirname, '../pages/Org.tsx'),
+  'utf8',
+);
+
+describe('UserDetail — metrics tiles row', () => {
+  it('fetches /v1/metrics filtered by user', () => {
+    expect(USER_DETAIL_SRC).toMatch(/v1\/metrics/);
+    expect(USER_DETAIL_SRC).toMatch(/users.*decoded|decoded.*users/);
+  });
+
+  it('renders a MetricsTilesRow or equivalent tile grid', () => {
+    expect(USER_DETAIL_SRC).toMatch(/MetricsTilesRow|<Tile/);
+  });
+
+  it('shows tokens in/out tiles', () => {
+    expect(USER_DETAIL_SRC).toMatch(/[Tt]okens.in/i);
+    expect(USER_DETAIL_SRC).toMatch(/[Tt]okens.out/i);
+  });
+
+  it('shows prs_opened / PRs tile', () => {
+    expect(USER_DETAIL_SRC).toMatch(/prsOpened|prs_opened|PRs/i);
+  });
+});
+
+describe('Org — prs_opened tile', () => {
+  it('includes prsOpened in the totals reducer', () => {
+    expect(ORG_SRC).toMatch(/prsOpened/);
+  });
+
+  it('renders a PRs tile label', () => {
+    expect(ORG_SRC).toMatch(/PRs/i);
+  });
+});
+
+describe('MetricsTilesRow shared component', () => {
+  it('exists as a shared component file', () => {
+    expect(() =>
+      readFileSync(path.resolve(__dirname, '../components/MetricsTilesRow.tsx'), 'utf8')
+    ).not.toThrow();
+  });
+
+  it('exports MetricsTilesRow', () => {
+    const src = readFileSync(
+      path.resolve(__dirname, '../components/MetricsTilesRow.tsx'),
+      'utf8',
+    );
+    expect(src).toMatch(/export.*MetricsTilesRow/);
+  });
+});

--- a/packages/hub-ui/src/test/orgTokensRemoval.test.ts
+++ b/packages/hub-ui/src/test/orgTokensRemoval.test.ts
@@ -6,17 +6,21 @@ const ORG_PAGE_SRC = readFileSync(
   path.resolve(__dirname, '../pages/Org.tsx'),
   'utf8',
 );
+const TILES_SRC = readFileSync(
+  path.resolve(__dirname, '../components/MetricsTilesRow.tsx'),
+  'utf8',
+);
 
 describe('Org rollup dashboard — tokens in/out tiles present', () => {
-  it('renders a "Tokens in" tile', () => {
-    expect(ORG_PAGE_SRC).toMatch(/Tokens in/i);
+  it('renders a "Tokens in" tile (via MetricsTilesRow)', () => {
+    expect(TILES_SRC).toMatch(/Tokens in/i);
   });
 
-  it('renders a "Tokens out" tile', () => {
-    expect(ORG_PAGE_SRC).toMatch(/Tokens out/i);
+  it('renders a "Tokens out" tile (via MetricsTilesRow)', () => {
+    expect(TILES_SRC).toMatch(/Tokens out/i);
   });
 
-  it('references tokensIn / tokensOut in the totals reducer', () => {
+  it('Org.tsx references tokensIn / tokensOut in the totals reducer', () => {
     expect(ORG_PAGE_SRC).toMatch(/tokensIn/);
     expect(ORG_PAGE_SRC).toMatch(/tokensOut/);
   });

--- a/packages/hub-ui/src/test/orgTokensRemoval.test.ts
+++ b/packages/hub-ui/src/test/orgTokensRemoval.test.ts
@@ -7,17 +7,17 @@ const ORG_PAGE_SRC = readFileSync(
   'utf8',
 );
 
-describe('Org rollup dashboard — tokens in/out tiles removed', () => {
-  it('does not render a "Tokens in" tile', () => {
-    expect(ORG_PAGE_SRC).not.toMatch(/Tokens in/i);
+describe('Org rollup dashboard — tokens in/out tiles present', () => {
+  it('renders a "Tokens in" tile', () => {
+    expect(ORG_PAGE_SRC).toMatch(/Tokens in/i);
   });
 
-  it('does not render a "Tokens out" tile', () => {
-    expect(ORG_PAGE_SRC).not.toMatch(/Tokens out/i);
+  it('renders a "Tokens out" tile', () => {
+    expect(ORG_PAGE_SRC).toMatch(/Tokens out/i);
   });
 
-  it('does not reference tokensIn / tokensOut in the totals reducer', () => {
-    expect(ORG_PAGE_SRC).not.toMatch(/tokensIn/);
-    expect(ORG_PAGE_SRC).not.toMatch(/tokensOut/);
+  it('references tokensIn / tokensOut in the totals reducer', () => {
+    expect(ORG_PAGE_SRC).toMatch(/tokensIn/);
+    expect(ORG_PAGE_SRC).toMatch(/tokensOut/);
   });
 });

--- a/packages/hub-ui/src/test/periodFilter.test.ts
+++ b/packages/hub-ui/src/test/periodFilter.test.ts
@@ -68,4 +68,32 @@ describe('TimelineBar — accepts external range/onRangeChange props', () => {
     // The component must call onRangeChange when range buttons are clicked
     expect(TIMELINE_SRC).toMatch(/onRangeChange/);
   });
+
+  it('hides the range picker when range prop is provided (controlled mode)', () => {
+    // When range is controlled externally the range button group must not render.
+    // Implementation: wrap the range buttons in a conditional on !rangeProp.
+    expect(TIMELINE_SRC).toMatch(/rangeProp.*RANGES|!rangeProp|rangeProp == null|rangeProp === undefined/s);
+  });
+
+  it('accepts tokenSeries prop for a list of daily token buckets', () => {
+    expect(TIMELINE_SRC).toMatch(/tokenSeries/);
+  });
+
+  it('renders a mode toggle (events / tokens) when tokenSeries is provided', () => {
+    // When tokenSeries prop is present the chart must show a mode toggle.
+    expect(TIMELINE_SRC).toMatch(/tokenSeries.*mode|mode.*tokenSeries|'events'.*'tokens'|"events".*"tokens"/s);
+  });
+});
+
+describe('Org.tsx — range picker in Filters panel', () => {
+  it('renders range buttons/chips inside the Filters section (not only in TimelineBar)', () => {
+    // The Filters section must contain the period selector so the timeline range
+    // picker can be hidden inside TimelineBar.
+    // Look for RANGES array reference or inline today/7d/30d/90d in the filters area.
+    expect(ORG_SRC).toMatch(/Period|period|RANGES|today.*7d|7d.*30d/);
+  });
+
+  it('passes tokenSeries to TimelineBar', () => {
+    expect(ORG_SRC).toMatch(/tokenSeries/);
+  });
 });

--- a/packages/hub-ui/src/test/periodFilter.test.ts
+++ b/packages/hub-ui/src/test/periodFilter.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+
+const ORG_SRC = readFileSync(path.resolve(__dirname, '../pages/Org.tsx'), 'utf8');
+const USER_SRC = readFileSync(path.resolve(__dirname, '../pages/UserDetail.tsx'), 'utf8');
+const TIMELINE_SRC = readFileSync(path.resolve(__dirname, '../components/TimelineBar.tsx'), 'utf8');
+
+describe('period filter — OrgPage', () => {
+  it('imports fromIsoForRange (or equivalent) to compute a from ISO string from range', () => {
+    expect(ORG_SRC).toMatch(/fromIsoForRange/);
+  });
+
+  it('passes from to /v1/metrics query', () => {
+    expect(ORG_SRC).toMatch(/from.*metrics|metrics.*from/s);
+    // The metrics query string must include a `from` parameter derived from period state.
+    expect(ORG_SRC).toMatch(/['"']from['"']/);
+  });
+
+  it('passes from to /v1/users query', () => {
+    expect(ORG_SRC).toMatch(/['"']from['"']/);
+    expect(ORG_SRC).toMatch(/v1\/users/);
+  });
+
+  it('period state is lifted: range is defined in OrgPage (not only inside TimelineBar)', () => {
+    // range state must be declared at page level so it can flow to metrics/users queries
+    expect(ORG_SRC).toMatch(/useState.*RangeKey|useState.*'30d'|useState.*"30d"|range.*useState/);
+  });
+
+  it('TimelineBar in OrgPage receives range and onRangeChange props', () => {
+    expect(ORG_SRC).toMatch(/onRangeChange/);
+    expect(ORG_SRC).toMatch(/<TimelineBar[^>]*range=/s);
+  });
+});
+
+describe('period filter — UserDetailPage', () => {
+  it('imports fromIsoForRange (or equivalent) to compute a from ISO string from range', () => {
+    expect(USER_SRC).toMatch(/fromIsoForRange/);
+  });
+
+  it('passes from to /v1/metrics query', () => {
+    expect(USER_SRC).toMatch(/['"']from['"']/);
+    expect(USER_SRC).toMatch(/v1\/metrics/);
+  });
+
+  it('passes from to /v1/timeline query', () => {
+    expect(USER_SRC).toMatch(/['"']from['"']/);
+    expect(USER_SRC).toMatch(/v1\/timeline/);
+  });
+
+  it('period state is lifted: range is defined in UserDetailPage', () => {
+    expect(USER_SRC).toMatch(/useState.*RangeKey|useState.*'30d'|useState.*"30d"|range.*useState/);
+  });
+
+  it('TimelineBar in UserDetailPage receives range and onRangeChange props', () => {
+    expect(USER_SRC).toMatch(/onRangeChange/);
+    expect(USER_SRC).toMatch(/<TimelineBar[^>]*range=/s);
+  });
+});
+
+describe('TimelineBar — accepts external range/onRangeChange props', () => {
+  it('Props interface includes range and onRangeChange', () => {
+    expect(TIMELINE_SRC).toMatch(/onRangeChange/);
+    expect(TIMELINE_SRC).toMatch(/range\??\s*:/);
+  });
+
+  it('uses external onRangeChange when provided instead of internal setState only', () => {
+    // The component must call onRangeChange when range buttons are clicked
+    expect(TIMELINE_SRC).toMatch(/onRangeChange/);
+  });
+});

--- a/packages/hub-ui/src/test/scrollToTop.test.ts
+++ b/packages/hub-ui/src/test/scrollToTop.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { scrollPageToTop } from '../scroll';
+
+describe('scrollPageToTop', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('calls window.scrollTo(0, 0)', () => {
+    const scrollTo = vi.fn();
+    vi.stubGlobal('window', { scrollTo });
+    scrollPageToTop();
+    expect(scrollTo).toHaveBeenCalledWith(0, 0);
+  });
+});

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/hub",
-  "version": "1.0.0",
+  "version": "1.0.1-beta.1",
   "description": "Corporate Hub for AgEnFK — fleet-wide metrics + timeline server",
   "main": "dist/server.js",
   "types": "dist/server.d.ts",
@@ -20,7 +20,7 @@
     "start": "node dist/bin.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.0.0",
+    "@agenfk/core": "1.0.1-beta.1",
     "axios": "^1.13.5",
     "bcryptjs": "^2.4.3",
     "cookie-parser": "^1.4.7",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/hub",
-  "version": "1.0.1-beta.4",
+  "version": "1.0.1-beta.5",
   "description": "Corporate Hub for AgEnFK — fleet-wide metrics + timeline server",
   "main": "dist/server.js",
   "types": "dist/server.d.ts",
@@ -20,7 +20,7 @@
     "start": "node dist/bin.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.0.1-beta.4",
+    "@agenfk/core": "1.0.1-beta.5",
     "axios": "^1.13.5",
     "bcryptjs": "^2.4.3",
     "cookie-parser": "^1.4.7",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/hub",
-  "version": "1.0.1-beta.3",
+  "version": "1.0.1-beta.4",
   "description": "Corporate Hub for AgEnFK — fleet-wide metrics + timeline server",
   "main": "dist/server.js",
   "types": "dist/server.d.ts",
@@ -20,7 +20,7 @@
     "start": "node dist/bin.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.0.1-beta.3",
+    "@agenfk/core": "1.0.1-beta.4",
     "axios": "^1.13.5",
     "bcryptjs": "^2.4.3",
     "cookie-parser": "^1.4.7",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/hub",
-  "version": "1.0.1-beta.5",
+  "version": "1.0.1-beta.6",
   "description": "Corporate Hub for AgEnFK — fleet-wide metrics + timeline server",
   "main": "dist/server.js",
   "types": "dist/server.d.ts",
@@ -20,7 +20,7 @@
     "start": "node dist/bin.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.0.1-beta.5",
+    "@agenfk/core": "1.0.1-beta.6",
     "axios": "^1.13.5",
     "bcryptjs": "^2.4.3",
     "cookie-parser": "^1.4.7",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/hub",
-  "version": "1.0.1-beta.6",
+  "version": "1.0.1-beta.7",
   "description": "Corporate Hub for AgEnFK — fleet-wide metrics + timeline server",
   "main": "dist/server.js",
   "types": "dist/server.d.ts",
@@ -20,7 +20,7 @@
     "start": "node dist/bin.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.0.1-beta.6",
+    "@agenfk/core": "1.0.1-beta.7",
     "axios": "^1.13.5",
     "bcryptjs": "^2.4.3",
     "cookie-parser": "^1.4.7",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/hub",
-  "version": "1.0.1-beta.1",
+  "version": "1.0.1-beta.3",
   "description": "Corporate Hub for AgEnFK — fleet-wide metrics + timeline server",
   "main": "dist/server.js",
   "types": "dist/server.d.ts",
@@ -20,7 +20,7 @@
     "start": "node dist/bin.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.0.1-beta.1",
+    "@agenfk/core": "1.0.1-beta.3",
     "axios": "^1.13.5",
     "bcryptjs": "^2.4.3",
     "cookie-parser": "^1.4.7",

--- a/packages/hub/src/db/postgres.ts
+++ b/packages/hub/src/db/postgres.ts
@@ -69,6 +69,7 @@ const SCHEMA_PG = `
     tokens_out INTEGER NOT NULL DEFAULT 0,
     validate_passes INTEGER NOT NULL DEFAULT 0,
     validate_fails INTEGER NOT NULL DEFAULT 0,
+    prs_opened INTEGER NOT NULL DEFAULT 0,
     PRIMARY KEY (org_id, user_key, day)
   );
 
@@ -265,6 +266,13 @@ async function bootstrap(adapter: HubDb): Promise<void> {
   // delivered each event, so the admin Recent Events view can show stuck-
   // process drift (recent events still tagged with old version after upgrade).
   if (!have.has('reporting_version')) await adapter.exec("ALTER TABLE events ADD COLUMN reporting_version TEXT");
+  // rollups_daily.prs_opened — added with the PR metrics initiative.
+  const rdCols = await adapter.all<{ column_name: string }>(
+    `SELECT column_name FROM information_schema.columns WHERE table_name = 'rollups_daily'`
+  );
+  const rdHave = new Set(rdCols.map(c => c.column_name));
+  if (!rdHave.has('prs_opened')) await adapter.exec("ALTER TABLE rollups_daily ADD COLUMN prs_opened INTEGER NOT NULL DEFAULT 0");
+
   await adapter.exec("CREATE INDEX IF NOT EXISTS idx_events_remote_time ON events(org_id, remote_url, occurred_at)");
   await adapter.exec("CREATE INDEX IF NOT EXISTS idx_events_item_type_time ON events(org_id, item_type, occurred_at)");
   await adapter.exec("CREATE INDEX IF NOT EXISTS idx_events_external_id ON events(org_id, external_id)");

--- a/packages/hub/src/db/sqlite.ts
+++ b/packages/hub/src/db/sqlite.ts
@@ -69,6 +69,7 @@ const SCHEMA_SQLITE = `
     tokens_out INTEGER NOT NULL DEFAULT 0,
     validate_passes INTEGER NOT NULL DEFAULT 0,
     validate_fails INTEGER NOT NULL DEFAULT 0,
+    prs_opened INTEGER NOT NULL DEFAULT 0,
     PRIMARY KEY (org_id, user_key, day)
   );
 
@@ -318,6 +319,11 @@ export async function openSqliteDb(dbPath: string): Promise<HubDb> {
       COMMIT;
     `);
   }
+
+  // rollups_daily.prs_opened — added with the PR metrics initiative.
+  const rdCols = raw.prepare("PRAGMA table_info(rollups_daily)").all() as Array<{ name: string }>;
+  const rdHave = new Set(rdCols.map(c => c.name));
+  if (!rdHave.has('prs_opened')) raw.exec("ALTER TABLE rollups_daily ADD COLUMN prs_opened INTEGER NOT NULL DEFAULT 0");
 
   raw.exec("CREATE INDEX IF NOT EXISTS idx_events_remote_time ON events(org_id, remote_url, occurred_at)");
   raw.exec("CREATE INDEX IF NOT EXISTS idx_events_item_type_time ON events(org_id, item_type, occurred_at)");

--- a/packages/hub/src/queries/metrics-coerce.ts
+++ b/packages/hub/src/queries/metrics-coerce.ts
@@ -7,6 +7,7 @@ const NUMERIC_COLS = [
   'events_count', 'items_closed',
   'tokens_in', 'tokens_out',
   'validate_passes', 'validate_fails',
+  'prs_opened',
 ] as const;
 
 type NumericCol = typeof NUMERIC_COLS[number];
@@ -20,6 +21,7 @@ export interface MetricsRowOut {
   tokens_out: number;
   validate_passes: number;
   validate_fails: number;
+  prs_opened: number;
 }
 
 function toInt(v: unknown): number {

--- a/packages/hub/src/rollup.ts
+++ b/packages/hub/src/rollup.ts
@@ -26,7 +26,9 @@ export async function recomputeRollups(db: DB): Promise<{ days: number }> {
              AND json_extract(payload, '$.payload.toStatus') = 'DONE' THEN item_id
       END) AS items_closed,
       SUM(CASE WHEN type = 'tokens.logged'
-               THEN COALESCE(CAST(json_extract(payload, '$.payload.input') AS INTEGER), 0) ELSE 0 END) AS tokens_in,
+               THEN COALESCE(CAST(json_extract(payload, '$.payload.input') AS INTEGER), 0)
+                  + COALESCE(CAST(json_extract(payload, '$.payload.cachedInput') AS INTEGER), 0)
+               ELSE 0 END) AS tokens_in,
       SUM(CASE WHEN type = 'tokens.logged'
                THEN COALESCE(CAST(json_extract(payload, '$.payload.output') AS INTEGER), 0) ELSE 0 END) AS tokens_out,
       SUM(CASE WHEN type = 'validate.passed' THEN 1 ELSE 0 END) AS validate_passes,

--- a/packages/hub/src/rollup.ts
+++ b/packages/hub/src/rollup.ts
@@ -6,11 +6,11 @@ import { DB } from './db.js';
  * transaction; safe to call frequently.
  */
 export async function recomputeRollups(db: DB): Promise<{ days: number }> {
-  const lastRow = await db.get<{ day: string | null }>('SELECT MAX(day) AS day FROM rollups_daily');
-  const lastDay = lastRow?.day || '1970-01-01';
+  // Always recompute all days so stale rows from prior format changes are
+  // overwritten. The upsert is idempotent; for typical installation sizes
+  // this is fast enough to run on every /v1/metrics call.
   const days = await db.all<{ day: string }>(
-    `SELECT DISTINCT date(occurred_at) AS day FROM events WHERE date(occurred_at) >= ?`,
-    [lastDay],
+    `SELECT DISTINCT date(occurred_at) AS day FROM events`,
   );
 
   const upsertSql = `
@@ -26,11 +26,9 @@ export async function recomputeRollups(db: DB): Promise<{ days: number }> {
              AND json_extract(payload, '$.payload.toStatus') = 'DONE' THEN item_id
       END) AS items_closed,
       SUM(CASE WHEN type = 'tokens.logged'
-               THEN COALESCE(CAST(json_extract(payload, '$.input') AS INTEGER),
-                             CAST(json_extract(payload, '$.payload.tokenUsage[0].input') AS INTEGER), 0) ELSE 0 END) AS tokens_in,
+               THEN COALESCE(CAST(json_extract(payload, '$.payload.input') AS INTEGER), 0) ELSE 0 END) AS tokens_in,
       SUM(CASE WHEN type = 'tokens.logged'
-               THEN COALESCE(CAST(json_extract(payload, '$.output') AS INTEGER),
-                             CAST(json_extract(payload, '$.payload.tokenUsage[0].output') AS INTEGER), 0) ELSE 0 END) AS tokens_out,
+               THEN COALESCE(CAST(json_extract(payload, '$.payload.output') AS INTEGER), 0) ELSE 0 END) AS tokens_out,
       SUM(CASE WHEN type = 'validate.passed' THEN 1 ELSE 0 END) AS validate_passes,
       SUM(CASE WHEN type = 'validate.failed' THEN 1 ELSE 0 END) AS validate_fails,
       SUM(CASE WHEN type = 'pr.opened' THEN 1 ELSE 0 END) AS prs_opened

--- a/packages/hub/src/rollup.ts
+++ b/packages/hub/src/rollup.ts
@@ -26,9 +26,11 @@ export async function recomputeRollups(db: DB): Promise<{ days: number }> {
              AND json_extract(payload, '$.payload.toStatus') = 'DONE' THEN item_id
       END) AS items_closed,
       SUM(CASE WHEN type = 'tokens.logged'
-               THEN COALESCE(CAST(json_extract(payload, '$.payload.tokenUsage[0].input') AS INTEGER), 0) ELSE 0 END) AS tokens_in,
+               THEN COALESCE(CAST(json_extract(payload, '$.input') AS INTEGER),
+                             CAST(json_extract(payload, '$.payload.tokenUsage[0].input') AS INTEGER), 0) ELSE 0 END) AS tokens_in,
       SUM(CASE WHEN type = 'tokens.logged'
-               THEN COALESCE(CAST(json_extract(payload, '$.payload.tokenUsage[0].output') AS INTEGER), 0) ELSE 0 END) AS tokens_out,
+               THEN COALESCE(CAST(json_extract(payload, '$.output') AS INTEGER),
+                             CAST(json_extract(payload, '$.payload.tokenUsage[0].output') AS INTEGER), 0) ELSE 0 END) AS tokens_out,
       SUM(CASE WHEN type = 'validate.passed' THEN 1 ELSE 0 END) AS validate_passes,
       SUM(CASE WHEN type = 'validate.failed' THEN 1 ELSE 0 END) AS validate_fails,
       SUM(CASE WHEN type = 'pr.opened' THEN 1 ELSE 0 END) AS prs_opened

--- a/packages/hub/src/rollup.ts
+++ b/packages/hub/src/rollup.ts
@@ -14,7 +14,7 @@ export async function recomputeRollups(db: DB): Promise<{ days: number }> {
   );
 
   const upsertSql = `
-    INSERT INTO rollups_daily (org_id, user_key, day, events_count, items_closed, tokens_in, tokens_out, validate_passes, validate_fails)
+    INSERT INTO rollups_daily (org_id, user_key, day, events_count, items_closed, tokens_in, tokens_out, validate_passes, validate_fails, prs_opened)
     SELECT
       org_id,
       user_key,
@@ -30,7 +30,8 @@ export async function recomputeRollups(db: DB): Promise<{ days: number }> {
       SUM(CASE WHEN type = 'tokens.logged'
                THEN COALESCE(CAST(json_extract(payload, '$.payload.tokenUsage[0].output') AS INTEGER), 0) ELSE 0 END) AS tokens_out,
       SUM(CASE WHEN type = 'validate.passed' THEN 1 ELSE 0 END) AS validate_passes,
-      SUM(CASE WHEN type = 'validate.failed' THEN 1 ELSE 0 END) AS validate_fails
+      SUM(CASE WHEN type = 'validate.failed' THEN 1 ELSE 0 END) AS validate_fails,
+      SUM(CASE WHEN type = 'pr.opened' THEN 1 ELSE 0 END) AS prs_opened
     FROM events
     WHERE date(occurred_at) = ?
     GROUP BY org_id, user_key, date(occurred_at)
@@ -40,7 +41,8 @@ export async function recomputeRollups(db: DB): Promise<{ days: number }> {
       tokens_in = excluded.tokens_in,
       tokens_out = excluded.tokens_out,
       validate_passes = excluded.validate_passes,
-      validate_fails = excluded.validate_fails
+      validate_fails = excluded.validate_fails,
+      prs_opened = excluded.prs_opened
   `;
 
   await db.transaction(async () => {

--- a/packages/hub/src/routes/queries.ts
+++ b/packages/hub/src/routes/queries.ts
@@ -103,7 +103,9 @@ export function queriesRouter(ctx: HubServerContext): Router {
                        AND json_extract(payload, '$.payload.toStatus') = 'DONE' THEN item_id
                 END) AS items_closed,
                 SUM(CASE WHEN type = 'tokens.logged'
-                         THEN COALESCE(CAST(json_extract(payload, '$.payload.input') AS INTEGER), 0) ELSE 0 END) AS tokens_in,
+                         THEN COALESCE(CAST(json_extract(payload, '$.payload.input') AS INTEGER), 0)
+                            + COALESCE(CAST(json_extract(payload, '$.payload.cachedInput') AS INTEGER), 0)
+                         ELSE 0 END) AS tokens_in,
                 SUM(CASE WHEN type = 'tokens.logged'
                          THEN COALESCE(CAST(json_extract(payload, '$.payload.output') AS INTEGER), 0) ELSE 0 END) AS tokens_out,
                 SUM(CASE WHEN type = 'validate.passed' THEN 1 ELSE 0 END) AS validate_passes,

--- a/packages/hub/src/routes/queries.ts
+++ b/packages/hub/src/routes/queries.ts
@@ -107,7 +107,8 @@ export function queriesRouter(ctx: HubServerContext): Router {
                 SUM(CASE WHEN type = 'tokens.logged'
                          THEN COALESCE(CAST(json_extract(payload, '$.payload.tokenUsage[0].output') AS INTEGER), 0) ELSE 0 END) AS tokens_out,
                 SUM(CASE WHEN type = 'validate.passed' THEN 1 ELSE 0 END) AS validate_passes,
-                SUM(CASE WHEN type = 'validate.failed' THEN 1 ELSE 0 END) AS validate_fails
+                SUM(CASE WHEN type = 'validate.failed' THEN 1 ELSE 0 END) AS validate_fails,
+                SUM(CASE WHEN type = 'pr.opened' THEN 1 ELSE 0 END) AS prs_opened
          FROM events WHERE ${where.join(' AND ')}
          GROUP BY user_key, day
          ORDER BY day ASC, user_key ASC`,
@@ -119,7 +120,7 @@ export function queriesRouter(ctx: HubServerContext): Router {
 
     const { where, params } = applyEventFilters(orgId, f, 'day');
     const rows = await ctx.db.all<Record<string, unknown>>(
-      `SELECT user_key, day, events_count, items_closed, tokens_in, tokens_out, validate_passes, validate_fails
+      `SELECT user_key, day, events_count, items_closed, tokens_in, tokens_out, validate_passes, validate_fails, prs_opened
        FROM rollups_daily WHERE ${where.join(' AND ')}
        ORDER BY day ASC, user_key ASC`,
       params,

--- a/packages/hub/src/routes/queries.ts
+++ b/packages/hub/src/routes/queries.ts
@@ -103,11 +103,9 @@ export function queriesRouter(ctx: HubServerContext): Router {
                        AND json_extract(payload, '$.payload.toStatus') = 'DONE' THEN item_id
                 END) AS items_closed,
                 SUM(CASE WHEN type = 'tokens.logged'
-                         THEN COALESCE(CAST(json_extract(payload, '$.input') AS INTEGER),
-                                       CAST(json_extract(payload, '$.payload.tokenUsage[0].input') AS INTEGER), 0) ELSE 0 END) AS tokens_in,
+                         THEN COALESCE(CAST(json_extract(payload, '$.payload.input') AS INTEGER), 0) ELSE 0 END) AS tokens_in,
                 SUM(CASE WHEN type = 'tokens.logged'
-                         THEN COALESCE(CAST(json_extract(payload, '$.output') AS INTEGER),
-                                       CAST(json_extract(payload, '$.payload.tokenUsage[0].output') AS INTEGER), 0) ELSE 0 END) AS tokens_out,
+                         THEN COALESCE(CAST(json_extract(payload, '$.payload.output') AS INTEGER), 0) ELSE 0 END) AS tokens_out,
                 SUM(CASE WHEN type = 'validate.passed' THEN 1 ELSE 0 END) AS validate_passes,
                 SUM(CASE WHEN type = 'validate.failed' THEN 1 ELSE 0 END) AS validate_fails,
                 SUM(CASE WHEN type = 'pr.opened' THEN 1 ELSE 0 END) AS prs_opened

--- a/packages/hub/src/routes/queries.ts
+++ b/packages/hub/src/routes/queries.ts
@@ -103,9 +103,11 @@ export function queriesRouter(ctx: HubServerContext): Router {
                        AND json_extract(payload, '$.payload.toStatus') = 'DONE' THEN item_id
                 END) AS items_closed,
                 SUM(CASE WHEN type = 'tokens.logged'
-                         THEN COALESCE(CAST(json_extract(payload, '$.payload.tokenUsage[0].input') AS INTEGER), 0) ELSE 0 END) AS tokens_in,
+                         THEN COALESCE(CAST(json_extract(payload, '$.input') AS INTEGER),
+                                       CAST(json_extract(payload, '$.payload.tokenUsage[0].input') AS INTEGER), 0) ELSE 0 END) AS tokens_in,
                 SUM(CASE WHEN type = 'tokens.logged'
-                         THEN COALESCE(CAST(json_extract(payload, '$.payload.tokenUsage[0].output') AS INTEGER), 0) ELSE 0 END) AS tokens_out,
+                         THEN COALESCE(CAST(json_extract(payload, '$.output') AS INTEGER),
+                                       CAST(json_extract(payload, '$.payload.tokenUsage[0].output') AS INTEGER), 0) ELSE 0 END) AS tokens_out,
                 SUM(CASE WHEN type = 'validate.passed' THEN 1 ELSE 0 END) AS validate_passes,
                 SUM(CASE WHEN type = 'validate.failed' THEN 1 ELSE 0 END) AS validate_fails,
                 SUM(CASE WHEN type = 'pr.opened' THEN 1 ELSE 0 END) AS prs_opened

--- a/packages/hub/src/test/hub-pg-parity.test.ts
+++ b/packages/hub/src/test/hub-pg-parity.test.ts
@@ -165,7 +165,7 @@ describe('PG parity: queries + rollup', () => {
       sample({ eventId: 'b1', occurredAt: '2026-05-04T10:00:00Z', type: 'tokens.logged',
         actor: { osUser: 'bob', gitName: 'B', gitEmail: 'bob@acme.com' },
         itemType: 'STORY', remoteUrl: 'git@x:api.git',
-        payload: { tokenUsage: [{ input: 100, output: 50 }] } }),
+        payload: { input: 100, output: 50, model: 'claude-sonnet-4-6', client: 'claude-code' } }),
     ];
     await supertest(fx.app).post('/v1/events')
       .set('Authorization', `Bearer ${fx.token}`)

--- a/packages/hub/src/test/queries.test.ts
+++ b/packages/hub/src/test/queries.test.ts
@@ -65,11 +65,14 @@ describe('hub query endpoints', () => {
       sample({ eventId: 'a3', occurredAt: '2026-05-03T10:00:00Z', type: 'validate.passed',
         itemType: 'BUG', remoteUrl: 'git@github.com:acme/web.git',
         itemTitle: 'Crash on signup' }),
+      // Payload matches the format the spoke server actually emits:
+      // JSON.stringify(fullHubEvent) stored in hub's events.payload column,
+      // so token fields live at $.payload.input / $.payload.output.
       sample({ eventId: 'b1', occurredAt: '2026-05-04T10:00:00Z', type: 'tokens.logged',
         actor: { osUser: 'bob', gitName: 'B', gitEmail: 'bob@acme.com' },
         itemType: 'STORY', remoteUrl: 'git@github.com:acme/api.git',
         itemTitle: 'Pagination',
-        payload: { tokenUsage: [{ input: 100, output: 50 }] } }),
+        payload: { input: 100, output: 50, model: 'claude-sonnet-4-6', client: 'claude-code' } }),
     ]);
   });
 
@@ -347,5 +350,43 @@ describe('hub query endpoints', () => {
     const keys = r.body.series.map((s: any) => s.user_key);
     expect(keys.every((k: string) => k === 'bob@acme.com')).toBe(true);
     expect(keys.length).toBeGreaterThan(0);
+  });
+
+  it('GET /v1/metrics with projects= filter extracts tokens from $.payload.input path', async () => {
+    // With a projects filter, queries.ts falls back to raw-event aggregation
+    // instead of rollups_daily. This path must use the same $.payload.input
+    // extraction as the rollup.
+    const r = await supertest(app)
+      .get('/v1/metrics?projects=git@github.com:acme/api.git')
+      .set('Cookie', cookie);
+    expect(r.status).toBe(200);
+    const row = r.body.series.find((s: any) => s.day === '2026-05-04' && s.user_key === 'bob@acme.com');
+    expect(row).toBeDefined();
+    expect(row.tokens_in).toBe(100);
+    expect(row.tokens_out).toBe(50);
+  });
+
+  it('recomputeRollups re-processes all days so stale rows are overwritten', async () => {
+    // First compute with current data (tokens_in should be 100 from the $.payload.input path).
+    await recomputeRollups(ctx.db);
+    const before = await ctx.db.all<any>('SELECT * FROM rollups_daily WHERE day = ? AND user_key = ?',
+      ['2026-05-04', 'bob@acme.com']);
+    expect(before[0]?.tokens_in).toBe(100);
+
+    // Manually corrupt the rollup row to simulate stale data from an old format.
+    await ctx.db.run(
+      'UPDATE rollups_daily SET tokens_in = 9999 WHERE day = ? AND user_key = ?',
+      ['2026-05-04', 'bob@acme.com'],
+    );
+    const corrupted = await ctx.db.all<any>('SELECT tokens_in FROM rollups_daily WHERE day = ? AND user_key = ?',
+      ['2026-05-04', 'bob@acme.com']);
+    expect(corrupted[0]?.tokens_in).toBe(9999);
+
+    // recomputeRollups must overwrite the corrupted row with the correct value
+    // because it re-processes ALL days (not just days >= MAX(day)).
+    await recomputeRollups(ctx.db);
+    const after = await ctx.db.all<any>('SELECT tokens_in FROM rollups_daily WHERE day = ? AND user_key = ?',
+      ['2026-05-04', 'bob@acme.com']);
+    expect(after[0]?.tokens_in).toBe(100);
   });
 });

--- a/packages/hub/src/test/queries.test.ts
+++ b/packages/hub/src/test/queries.test.ts
@@ -366,6 +366,47 @@ describe('hub query endpoints', () => {
     expect(row.tokens_out).toBe(50);
   });
 
+  it('rollup includes cachedInput in tokens_in', async () => {
+    // Seed a tokens.logged event that has cachedInput (the dominant component
+    // when the model cache is warm). tokens_in must be input + cachedInput.
+    const token = await issueApiKey(ctx.db, 'org', 'cached-test');
+    await supertest(app).post('/v1/events')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ events: [
+        sample({ eventId: 'c1', occurredAt: '2026-05-05T10:00:00Z', type: 'tokens.logged',
+          actor: { osUser: 'carol', gitName: 'C', gitEmail: 'carol@acme.com' },
+          payload: { input: 200, cachedInput: 5000, output: 80, model: 'claude-sonnet-4-6', client: 'claude-code' } }),
+      ]});
+    await recomputeRollups(ctx.db);
+    const row = await ctx.db.get<any>(
+      'SELECT tokens_in, tokens_out FROM rollups_daily WHERE day = ? AND user_key = ?',
+      ['2026-05-05', 'carol@acme.com'],
+    );
+    expect(row?.tokens_in).toBe(5200);  // input(200) + cachedInput(5000)
+    expect(row?.tokens_out).toBe(80);
+  });
+
+  it('GET /v1/metrics with projects= includes cachedInput in tokens_in (direct query path)', async () => {
+    const token = await issueApiKey(ctx.db, 'org', 'cached-test2');
+    await supertest(app).post('/v1/events')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ events: [
+        sample({ eventId: 'd1', occurredAt: '2026-05-06T10:00:00Z', type: 'tokens.logged',
+          actor: { osUser: 'dave', gitName: 'D', gitEmail: 'dave@acme.com' },
+          remoteUrl: 'git@github.com:acme/api.git',
+          payload: { input: 300, cachedInput: 7000, output: 120, model: 'claude-sonnet-4-6', client: 'claude-code' } }),
+      ]});
+    // The projects= filter uses the raw-event aggregation path (not rollups_daily).
+    const r = await supertest(app)
+      .get('/v1/metrics?projects=git@github.com:acme/api.git&users=dave@acme.com')
+      .set('Cookie', cookie);
+    expect(r.status).toBe(200);
+    const row = r.body.series.find((s: any) => s.day === '2026-05-06' && s.user_key === 'dave@acme.com');
+    expect(row).toBeDefined();
+    expect(row.tokens_in).toBe(7300);  // input(300) + cachedInput(7000)
+    expect(row.tokens_out).toBe(120);
+  });
+
   it('recomputeRollups re-processes all days so stale rows are overwritten', async () => {
     // First compute with current data (tokens_in should be 100 from the $.payload.input path).
     await recomputeRollups(ctx.db);

--- a/packages/hub/src/test/queries.test.ts
+++ b/packages/hub/src/test/queries.test.ts
@@ -308,4 +308,44 @@ describe('hub query endpoints', () => {
     expect(r.body.length).toBe(1);
     expect(r.body[0].user_key).toBe('bob@acme.com');
   });
+
+  it('rollup counts pr.opened events in prs_opened', async () => {
+    const token = await issueApiKey(ctx.db, 'org', 'test2');
+    await supertest(app).post('/v1/events')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ events: [
+        sample({ eventId: 'pr1', occurredAt: '2026-05-03T11:00:00Z', type: 'pr.opened',
+          payload: { prNumber: 10, repo: 'acme/web' } }),
+        sample({ eventId: 'pr2', occurredAt: '2026-05-03T12:00:00Z', type: 'pr.opened',
+          payload: { prNumber: 11, repo: 'acme/web' } }),
+      ]});
+    await recomputeRollups(ctx.db);
+    const rows = await ctx.db.all<any>('SELECT * FROM rollups_daily WHERE day = ? AND user_key = ?',
+      ['2026-05-03', 'alice@acme.com']);
+    expect(rows[0]?.prs_opened).toBe(2);
+  });
+
+  it('GET /v1/metrics includes prs_opened in each series row', async () => {
+    const token = await issueApiKey(ctx.db, 'org', 'test3');
+    await supertest(app).post('/v1/events')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ events: [
+        sample({ eventId: 'pr3', occurredAt: '2026-05-03T11:30:00Z', type: 'pr.opened',
+          payload: { prNumber: 20, repo: 'acme/web' } }),
+      ]});
+    const r = await supertest(app).get('/v1/metrics').set('Cookie', cookie);
+    expect(r.status).toBe(200);
+    const row = r.body.series.find((s: any) => s.day === '2026-05-03' && s.user_key === 'alice@acme.com');
+    expect(row).toBeDefined();
+    expect(typeof row.prs_opened).toBe('number');
+    expect(row.prs_opened).toBeGreaterThanOrEqual(1);
+  });
+
+  it('GET /v1/metrics filters by user (used by UserDetail page)', async () => {
+    const r = await supertest(app).get('/v1/metrics?users=bob@acme.com').set('Cookie', cookie);
+    expect(r.status).toBe(200);
+    const keys = r.body.series.map((s: any) => s.user_key);
+    expect(keys.every((k: string) => k === 'bob@acme.com')).toBe(true);
+    expect(keys.length).toBeGreaterThan(0);
+  });
 });

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/server",
-  "version": "1.0.1-beta.1",
+  "version": "1.0.1-beta.3",
   "description": "MCP Server for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -12,9 +12,9 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.0.1-beta.1",
-    "@agenfk/storage-sqlite": "1.0.1-beta.1",
-    "@agenfk/telemetry": "1.0.1-beta.1",
+    "@agenfk/core": "1.0.1-beta.3",
+    "@agenfk/storage-sqlite": "1.0.1-beta.3",
+    "@agenfk/telemetry": "1.0.1-beta.3",
     "@modelcontextprotocol/sdk": "0.6.0",
     "axios": "^1.13.5",
     "body-parser": "^2.2.2",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/server",
-  "version": "1.0.1-beta.6",
+  "version": "1.0.1-beta.7",
   "description": "MCP Server for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -12,9 +12,9 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.0.1-beta.6",
-    "@agenfk/storage-sqlite": "1.0.1-beta.6",
-    "@agenfk/telemetry": "1.0.1-beta.6",
+    "@agenfk/core": "1.0.1-beta.7",
+    "@agenfk/storage-sqlite": "1.0.1-beta.7",
+    "@agenfk/telemetry": "1.0.1-beta.7",
     "@modelcontextprotocol/sdk": "0.6.0",
     "axios": "^1.13.5",
     "body-parser": "^2.2.2",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/server",
-  "version": "1.0.1-beta.3",
+  "version": "1.0.1-beta.4",
   "description": "MCP Server for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -12,9 +12,9 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.0.1-beta.3",
-    "@agenfk/storage-sqlite": "1.0.1-beta.3",
-    "@agenfk/telemetry": "1.0.1-beta.3",
+    "@agenfk/core": "1.0.1-beta.4",
+    "@agenfk/storage-sqlite": "1.0.1-beta.4",
+    "@agenfk/telemetry": "1.0.1-beta.4",
     "@modelcontextprotocol/sdk": "0.6.0",
     "axios": "^1.13.5",
     "body-parser": "^2.2.2",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/server",
-  "version": "1.0.1-beta.5",
+  "version": "1.0.1-beta.6",
   "description": "MCP Server for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -12,9 +12,9 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.0.1-beta.5",
-    "@agenfk/storage-sqlite": "1.0.1-beta.5",
-    "@agenfk/telemetry": "1.0.1-beta.5",
+    "@agenfk/core": "1.0.1-beta.6",
+    "@agenfk/storage-sqlite": "1.0.1-beta.6",
+    "@agenfk/telemetry": "1.0.1-beta.6",
     "@modelcontextprotocol/sdk": "0.6.0",
     "axios": "^1.13.5",
     "body-parser": "^2.2.2",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/server",
-  "version": "1.0.0",
+  "version": "1.0.1-beta.1",
   "description": "MCP Server for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -12,9 +12,9 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.0.0",
-    "@agenfk/storage-sqlite": "1.0.0",
-    "@agenfk/telemetry": "1.0.0",
+    "@agenfk/core": "1.0.1-beta.1",
+    "@agenfk/storage-sqlite": "1.0.1-beta.1",
+    "@agenfk/telemetry": "1.0.1-beta.1",
     "@modelcontextprotocol/sdk": "0.6.0",
     "axios": "^1.13.5",
     "body-parser": "^2.2.2",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/server",
-  "version": "1.0.1-beta.4",
+  "version": "1.0.1-beta.5",
   "description": "MCP Server for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -12,9 +12,9 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.0.1-beta.4",
-    "@agenfk/storage-sqlite": "1.0.1-beta.4",
-    "@agenfk/telemetry": "1.0.1-beta.4",
+    "@agenfk/core": "1.0.1-beta.5",
+    "@agenfk/storage-sqlite": "1.0.1-beta.5",
+    "@agenfk/telemetry": "1.0.1-beta.5",
     "@modelcontextprotocol/sdk": "0.6.0",
     "axios": "^1.13.5",
     "body-parser": "^2.2.2",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -116,6 +116,15 @@ const GetItemSchema = z.object({
   id: z.string(),
 });
 
+const QueryTokenEventsSchema = z.object({
+  itemId: z.string().optional(),
+  projectId: z.string().optional(),
+  client: z.enum(['claude-code', 'codex', 'gemini', 'cursor', 'opencode']).optional(),
+  since: z.string().optional(),
+  until: z.string().optional(),
+  limit: z.number().int().positive().optional(),
+});
+
 const AddContextSchema = z.object({
   itemId: z.string(),
   path: z.string(),
@@ -226,6 +235,22 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           type: "object",
           properties: { id: { type: "string" } },
           required: ["id"],
+        },
+      },
+      {
+        name: "query_token_events",
+        description:
+          "Query the server-side token-event store. Events are written by the token-ingestion worker that parses per-client session log files (Codex, Claude Code, etc.) — agents do not self-report.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            itemId: { type: "string", description: "Filter to events attributed to this item." },
+            projectId: { type: "string" },
+            client: { type: "string", enum: ['claude-code', 'codex', 'gemini', 'cursor', 'opencode'] },
+            since: { type: "string", description: "ISO timestamp inclusive lower bound." },
+            until: { type: "string", description: "ISO timestamp exclusive upper bound." },
+            limit: { type: "number" },
+          },
         },
       },
       {
@@ -780,6 +805,18 @@ async function callToolHandler(request: any): Promise<any> {
         const { id } = z.object({ id: z.string() }).parse(request.params.arguments);
         await api.delete(`/items/${id}`);
         return { content: [{ type: "text", text: `Item ${id} and its children moved to trash.` }] };
+      }
+      case "query_token_events": {
+        const args = QueryTokenEventsSchema.parse(request.params.arguments ?? {});
+        const params: Record<string, string | number> = {};
+        if (args.itemId) params.itemId = args.itemId;
+        if (args.projectId) params.projectId = args.projectId;
+        if (args.client) params.client = args.client;
+        if (args.since) params.since = args.since;
+        if (args.until) params.until = args.until;
+        if (args.limit) params.limit = args.limit;
+        const { data } = await api.get('/token-events', { params });
+        return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
       }
       case "add_comment": {
         const args = AddCommentSchema.parse(request.params.arguments);

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -125,6 +125,26 @@ const QueryTokenEventsSchema = z.object({
   limit: z.number().int().positive().optional(),
 });
 
+const PrSizingSchema = z.object({
+  epic: z.number().int().nonnegative(),
+  story: z.number().int().nonnegative(),
+  task: z.number().int().nonnegative(),
+  bug: z.number().int().nonnegative(),
+});
+
+const RegisterPrSchema = z.object({
+  itemId: z.string(),
+  prNumber: z.number().int().positive(),
+  repo: z.string(),
+  sizing: PrSizingSchema,
+});
+
+const UpdatePrSizingSchema = z.object({
+  prNumber: z.number().int().positive(),
+  repo: z.string(),
+  sizing: PrSizingSchema,
+});
+
 const AddContextSchema = z.object({
   itemId: z.string(),
   path: z.string(),
@@ -235,6 +255,52 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           type: "object",
           properties: { id: { type: "string" } },
           required: ["id"],
+        },
+      },
+      {
+        name: "register_pr",
+        description:
+          "Register a freshly opened PR with agent-declared sizing (cards by type included in the PR). Idempotent on (repo, prNumber) — re-call updates the sizing rather than erroring. Server computes a shadow sizing by walking the item tree from itemId; discrepancies are logged but the agent's number persists.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            itemId: { type: "string", description: "Anchor item id for the PR." },
+            prNumber: { type: "number" },
+            repo: { type: "string", description: "owner/repo" },
+            sizing: {
+              type: "object",
+              properties: {
+                epic: { type: "number" },
+                story: { type: "number" },
+                task: { type: "number" },
+                bug: { type: "number" },
+              },
+              required: ["epic", "story", "task", "bug"],
+            },
+          },
+          required: ["itemId", "prNumber", "repo", "sizing"],
+        },
+      },
+      {
+        name: "update_pr_sizing",
+        description: "Update an already-registered PR's sizing when more items have been piled onto its branch.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            prNumber: { type: "number" },
+            repo: { type: "string" },
+            sizing: {
+              type: "object",
+              properties: {
+                epic: { type: "number" },
+                story: { type: "number" },
+                task: { type: "number" },
+                bug: { type: "number" },
+              },
+              required: ["epic", "story", "task", "bug"],
+            },
+          },
+          required: ["prNumber", "repo", "sizing"],
         },
       },
       {
@@ -805,6 +871,16 @@ async function callToolHandler(request: any): Promise<any> {
         const { id } = z.object({ id: z.string() }).parse(request.params.arguments);
         await api.delete(`/items/${id}`);
         return { content: [{ type: "text", text: `Item ${id} and its children moved to trash.` }] };
+      }
+      case "register_pr": {
+        const args = RegisterPrSchema.parse(request.params.arguments);
+        const { data } = await api.post('/prs', args);
+        return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+      }
+      case "update_pr_sizing": {
+        const args = UpdatePrSizingSchema.parse(request.params.arguments);
+        const { data } = await api.put(`/prs/${encodeURIComponent(args.repo)}/${args.prNumber}`, { sizing: args.sizing });
+        return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
       }
       case "query_token_events": {
         const args = QueryTokenEventsSchema.parse(request.params.arguments ?? {});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -116,17 +116,6 @@ const GetItemSchema = z.object({
   id: z.string(),
 });
 
-const LogTokenUsageSchema = z.object({
-  itemId: z.string(),
-  input: z.number(),
-  output: z.number(),
-  model: z.string(),
-  cost: z.number().optional(),
-  sessionId: z.string().optional(),
-  source: z.string().optional(),
-  timestamp: z.string().optional(),
-});
-
 const AddContextSchema = z.object({
   itemId: z.string(),
   path: z.string(),
@@ -237,24 +226,6 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           type: "object",
           properties: { id: { type: "string" } },
           required: ["id"],
-        },
-      },
-      {
-        name: "log_token_usage",
-        description: "Log token usage for an item. Use this for manual/proactive reporting. Note: Automated hooks will also capture session totals using 'sessionId' for deduplication.",
-        inputSchema: {
-          type: "object",
-          properties: {
-            itemId: { type: "string" },
-            input: { type: "number" },
-            output: { type: "number" },
-            model: { type: "string" },
-            cost: { type: "number" },
-            sessionId: { type: "string", description: "Optional: session ID for deduplication with automated hooks." },
-            source: { type: "string", description: "Optional: source of report (e.g. 'agent', 'manual')." },
-            timestamp: { type: "string", description: "Optional: ISO timestamp." },
-          },
-          required: ["itemId", "input", "output", "model"],
         },
       },
       {
@@ -809,15 +780,6 @@ async function callToolHandler(request: any): Promise<any> {
         const { id } = z.object({ id: z.string() }).parse(request.params.arguments);
         await api.delete(`/items/${id}`);
         return { content: [{ type: "text", text: `Item ${id} and its children moved to trash.` }] };
-      }
-      case "log_token_usage": {
-        const args = LogTokenUsageSchema.parse(request.params.arguments);
-        const { itemId, ...usage } = args;
-        const { data: item } = await api.get(`/items/${itemId}`);
-        const tokenUsage = item.tokenUsage || [];
-        tokenUsage.push(usage);
-        await api.put(`/items/${itemId}`, { tokenUsage });
-        return { content: [{ type: "text", text: "Token usage logged." }] };
       }
       case "add_comment": {
         const args = AddCommentSchema.parse(request.params.arguments);

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -544,10 +544,14 @@ const initStorage = async () => {
     stopIngestionPoller = startIngestionPoller({
       storage,
       sources: ingestionSources,
+      attributeEvents: true,
       onEvent: (ev) => {
         hubClient.recordEvent({
           type: 'tokens.logged',
           occurredAt: ev.ts,
+          projectId: ev.projectId,
+          itemId: ev.itemId,
+          cwd: ev.cwd,
           payload: {
             input: ev.input,
             cachedInput: ev.cachedInput,

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -792,6 +792,99 @@ app.get("/flows", asyncHandler(async (_req: any, res: any) => {
   res.json(flows);
 }));
 
+// ── Observability: PR registration ──────────────────────────────────────────
+// Agent-declared sizing on PR open + re-declares on push. Server computes a
+// shadow sizing by walking the item tree from the anchor item — logged for
+// discrepancy detection but never overrides the agent's number.
+
+async function computeShadowSizing(rootItemId: string): Promise<{ epic: number; story: number; task: number; bug: number }> {
+  const counts = { epic: 0, story: 0, task: 0, bug: 0 };
+  const root = await storage.getItem(rootItemId);
+  if (!root) return counts;
+  const stack: any[] = [root];
+  const seen = new Set<string>();
+  while (stack.length) {
+    const node = stack.pop()!;
+    if (seen.has(node.id)) continue;
+    seen.add(node.id);
+    switch (node.type) {
+      case 'EPIC':  counts.epic++;  break;
+      case 'STORY': counts.story++; break;
+      case 'TASK':  counts.task++;  break;
+      case 'BUG':   counts.bug++;   break;
+    }
+    const children = await storage.listChildren(node.id);
+    for (const c of children) stack.push(c);
+  }
+  return counts;
+}
+
+app.post("/prs", asyncHandler(async (req: any, res: any) => {
+  const { itemId, prNumber, repo, sizing } = req.body || {};
+  if (!itemId || typeof prNumber !== 'number' || !repo || !sizing
+    || typeof sizing.epic !== 'number' || typeof sizing.story !== 'number'
+    || typeof sizing.task !== 'number' || typeof sizing.bug !== 'number') {
+    return res.status(400).json({ error: 'itemId, prNumber, repo, sizing{epic,story,task,bug} required' });
+  }
+
+  const shadow = await computeShadowSizing(itemId);
+  const now = new Date().toISOString();
+  const pr = await storage.insertPr({
+    id: crypto.randomUUID(),
+    prNumber,
+    repo,
+    itemId,
+    openedAt: now,
+    sizing,
+    sizingDeclaredAt: now,
+    sizingShadow: shadow,
+    lastSizingCheckAt: now,
+  });
+
+  const matches =
+    sizing.epic === shadow.epic && sizing.story === shadow.story
+    && sizing.task === shadow.task && sizing.bug === shadow.bug;
+  if (!matches) {
+    console.log(
+      `[PR_SIZING] discrepancy on ${repo}#${prNumber} (item ${itemId}): ` +
+      `agent=${JSON.stringify(sizing)} shadow=${JSON.stringify(shadow)}`,
+    );
+  }
+
+  res.status(201).json(pr);
+}));
+
+app.put("/prs/:repo/:number", asyncHandler(async (req: any, res: any) => {
+  const repo = decodeURIComponent(req.params.repo);
+  const prNumber = Number(req.params.number);
+  if (!Number.isFinite(prNumber)) {
+    return res.status(400).json({ error: 'PR number must be an integer' });
+  }
+  const { sizing } = req.body || {};
+  if (!sizing
+    || typeof sizing.epic !== 'number' || typeof sizing.story !== 'number'
+    || typeof sizing.task !== 'number' || typeof sizing.bug !== 'number') {
+    return res.status(400).json({ error: 'sizing{epic,story,task,bug} required' });
+  }
+
+  const existing = await storage.getPrByRepoNumber(repo, prNumber);
+  if (!existing) return res.status(404).json({ error: `PR ${repo}#${prNumber} not registered` });
+
+  const shadow = await computeShadowSizing(existing.itemId);
+  const updated = await storage.updatePrSizing(repo, prNumber, sizing, shadow);
+
+  const matches =
+    sizing.epic === shadow.epic && sizing.story === shadow.story
+    && sizing.task === shadow.task && sizing.bug === shadow.bug;
+  if (!matches) {
+    console.log(
+      `[PR_SIZING] discrepancy on ${repo}#${prNumber}: agent=${JSON.stringify(sizing)} shadow=${JSON.stringify(shadow)}`,
+    );
+  }
+
+  res.json(updated);
+}));
+
 // ── Observability: token events read API ────────────────────────────────────
 // Writes happen via the server-side ingestion worker (packages/server/src/token-ingestion).
 // This GET route exposes filtered reads to MCP / CLI / UI consumers.

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -28,7 +28,7 @@ export const VERIFY_TOKEN = (() => {
     return ephemeral;
   }
 })();
-import { exec, execSync, execFileSync, spawn } from "child_process";
+import { exec, execSync, spawn } from "child_process";
 import { createServer } from "http";
 import { Server } from "socket.io";
 
@@ -1284,7 +1284,7 @@ app.post("/items/bulk", asyncHandler(async (req: any, res: any) => {
     const currentItem = await storage.getItem(id);
     if (!currentItem) continue;
 
-    const { title, description, status, parentId, tokenUsage, context, implementationPlan, reviews, comments, sortOrder } = bodyUpdates;
+    const { title, description, status, parentId, context, implementationPlan, reviews, comments, sortOrder } = bodyUpdates;
 
     if (!isInternalVerify && status === Status.DONE) continue;
 
@@ -1305,7 +1305,6 @@ app.post("/items/bulk", asyncHandler(async (req: any, res: any) => {
     if (description !== undefined) updates.description = description;
     if (status !== undefined) updates.status = status;
     if (parentId !== undefined) updates.parentId = parentId;
-    if (tokenUsage !== undefined) updates.tokenUsage = tokenUsage;
     if (context !== undefined) updates.context = context;
     if (implementationPlan !== undefined) updates.implementationPlan = implementationPlan;
     if (reviews !== undefined) updates.reviews = reviews;
@@ -1321,14 +1320,6 @@ app.post("/items/bulk", asyncHandler(async (req: any, res: any) => {
         parentIdsToSync.add(updated.parentId);
       }
 
-      if (tokenUsage !== undefined) {
-        recordHubEvent({
-          type: 'tokens.logged',
-          projectId: updated.projectId,
-          itemId: updated.id,
-          payload: { tokenUsage },
-        });
-      }
       if (updated.status === Status.DONE && currentItem.status !== Status.DONE) {
         if (process.env.NODE_ENV !== 'test' && !process.env.VITEST) {
           const proj = await storage.getProject(updated.projectId);
@@ -1355,7 +1346,7 @@ app.post("/items/bulk", asyncHandler(async (req: any, res: any) => {
 
 app.put("/items/:id", asyncHandler(async (req: any, res: any) => {
   console.log(`[API_DEBUG] PUT /items/${req.params.id} body keys: ${Object.keys(req.body).join(', ')}`);
-  const { title, description, status, type, parentId, tokenUsage, context, implementationPlan, reviews, tests, comments, sortOrder, branchName, prUrl, prNumber, prStatus } = req.body;
+  const { title, description, status, type, parentId, context, implementationPlan, reviews, tests, comments, sortOrder, branchName, prUrl, prNumber, prStatus } = req.body;
 
   const currentItem = await storage.getItem(req.params.id);
   if (!currentItem) {
@@ -1419,7 +1410,6 @@ app.put("/items/:id", asyncHandler(async (req: any, res: any) => {
   if (status !== undefined) updates.status = status;
   if (type !== undefined) updates.type = type;
   if (parentId !== undefined) updates.parentId = parentId;
-  if (tokenUsage !== undefined) updates.tokenUsage = tokenUsage;
   if (context !== undefined) updates.context = context;
   if (implementationPlan !== undefined) updates.implementationPlan = implementationPlan;
   if (reviews !== undefined) updates.reviews = reviews;
@@ -1461,14 +1451,6 @@ app.put("/items/:id", asyncHandler(async (req: any, res: any) => {
         projectId: updated.projectId,
         itemId: updated.id,
         payload: { changedFields: Object.keys(updates) },
-      });
-    }
-    if (tokenUsage !== undefined) {
-      recordHubEvent({
-        type: 'tokens.logged',
-        projectId: updated.projectId,
-        itemId: updated.id,
-        payload: { tokenUsage },
       });
     }
     if (Array.isArray(comments) && comments.length > (currentItem.comments?.length ?? 0)) {
@@ -2692,168 +2674,6 @@ io.on('connection', (socket) => {
 });
 /* v8 ignore stop */
 
-// ── Opencode Token Scraper ────────────────────────────────────────────────────
-/* v8 ignore start */
-
-const OPENCODE_DB = path.join(os.homedir(), '.local/share/opencode/opencode.db');
-const OPENCODE_SCRAPE_INTERVAL = 5 * 60 * 1000; // 5 minutes
-
-const PRICING: Record<string, { input: number; output: number; cacheRead: number }> = {
-  'claude-opus-4-6':            { input: 15.0,  output: 75.0,  cacheRead: 1.5  },
-  'claude-sonnet-4-6':          { input: 3.0,   output: 15.0,  cacheRead: 0.3  },
-  'claude-sonnet-4-5-20250929': { input: 3.0,   output: 15.0,  cacheRead: 0.3  },
-  'claude-haiku-4-5-20251001':  { input: 0.8,   output: 4.0,   cacheRead: 0.08 },
-  'gemini-3-flash-preview':     { input: 0.15,  output: 0.60,  cacheRead: 0.02 },
-  'gemini-3-pro-preview':       { input: 1.25,  output: 5.0,   cacheRead: 0.31 },
-  'gemini-3.1-pro-preview':     { input: 1.25,  output: 5.0,   cacheRead: 0.31 },
-};
-const DEFAULT_RATES = PRICING['claude-sonnet-4-6'];
-
-const calcTokenCost = (model: string, input: number, output: number, cacheRead: number): number => {
-  const rates = PRICING[model] || DEFAULT_RATES;
-  return Math.round((input / 1e6 * rates.input + cacheRead / 1e6 * rates.cacheRead + output / 1e6 * rates.output) * 1e6) / 1e6;
-};
-
-const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi;
-
-const sqlite3Query = (db: string, query: string): any[] => {
-  try {
-    const result = execFileSync('sqlite3', ['-json', db, query], { encoding: 'utf8', timeout: 5000 });
-    return JSON.parse(result || '[]');
-  } catch { return []; }
-};
-
-const isAgEnFKDir = (dir: string): boolean => {
-  if (!dir) return false;
-  let d = path.isAbsolute(dir) ? dir : path.resolve(dir);
-  const root = path.parse(d).root;
-  while (d !== root) {
-    if (fs.existsSync(path.join(d, '.agenfk', 'project.json'))) return true;
-    d = path.dirname(d);
-  }
-  return false;
-};
-
-const scrapeOpencodeSessions = async () => {
-  if (!fs.existsSync(OPENCODE_DB)) return;
-
-  const cutoff = Date.now() - 24 * 60 * 60 * 1000;
-  const sessions = sqlite3Query(OPENCODE_DB, `SELECT id, directory FROM session WHERE time_created > ${cutoff}`);
-
-  for (const session of sessions) {
-    if (!isAgEnFKDir(session.directory)) continue;
-
-    // Build task switch timeline from tool call parts, ordered by time
-    const allParts = sqlite3Query(OPENCODE_DB, `
-      SELECT json_extract(data, '$.tool') as tool,
-             json_extract(data, '$.state.input') as input_data,
-             json_extract(data, '$.state.output') as output_data,
-             time_created
-      FROM part WHERE session_id = '${session.id}'
-        AND json_extract(data, '$.tool') IN ('agenfk_update_item', 'agenfk_workflow_gatekeeper')
-      ORDER BY time_created ASC
-    `);
-
-    const taskSwitches: { time: number; taskId: string }[] = [];
-    for (const part of allParts) {
-      let taskId: string | null = null;
-      if (part.tool === 'agenfk_update_item') {
-        try {
-          const inp = JSON.parse(part.input_data || '{}');
-          if (inp.id && inp.status === 'IN_PROGRESS') taskId = inp.id;
-        } catch { /* skip */ }
-      }
-      if (part.tool === 'agenfk_workflow_gatekeeper') {
-        try {
-          const inp = JSON.parse(part.input_data || '{}');
-          if (inp.itemId) taskId = inp.itemId;
-        } catch { /* skip */ }
-        if (!taskId) {
-          const matches = (part.output_data || '').match(UUID_RE);
-          if (matches && matches.length > 0) taskId = matches[0];
-        }
-      }
-      if (taskId) taskSwitches.push({ time: part.time_created, taskId });
-    }
-
-    if (taskSwitches.length === 0) continue;
-
-    // Get all assistant messages ordered by time
-    const messages = sqlite3Query(OPENCODE_DB, `
-      SELECT json_extract(data, '$.modelID') as model,
-             json_extract(data, '$.tokens.input') as inp,
-             json_extract(data, '$.tokens.output') as outp,
-             json_extract(data, '$.tokens.cache.read') as cr,
-             json_extract(data, '$.cost') as cost,
-             time_created
-      FROM message WHERE session_id = '${session.id}'
-        AND json_extract(data, '$.role') = 'assistant'
-      ORDER BY time_created ASC
-    `);
-
-    // Attribute each message to the most recent task switch before it
-    const perTask: Record<string, Record<string, { input: number; output: number; cacheRead: number; cost: number }>> = {};
-    for (const m of messages) {
-      let activeTask: string | null = null;
-      for (const sw of taskSwitches) {
-        if (sw.time <= m.time_created) activeTask = sw.taskId;
-        else break;
-      }
-      if (!activeTask) activeTask = taskSwitches[0].taskId;
-
-      const model = m.model || 'unknown';
-      if (!perTask[activeTask]) perTask[activeTask] = {};
-      if (!perTask[activeTask][model]) perTask[activeTask][model] = { input: 0, output: 0, cacheRead: 0, cost: 0 };
-      perTask[activeTask][model].input += m.inp || 0;
-      perTask[activeTask][model].output += m.outp || 0;
-      perTask[activeTask][model].cacheRead += m.cr || 0;
-      perTask[activeTask][model].cost += m.cost || 0;
-    }
-
-    if (Object.keys(perTask).length === 0) continue;
-
-    const now = new Date().toISOString();
-
-    for (const [taskId, tokensByModel] of Object.entries(perTask)) {
-      try {
-        const item = await storage.getItem(taskId);
-        if (!item) continue;
-
-        const existing = item.tokenUsage || [];
-        let added = 0;
-
-        for (const [model, tokens] of Object.entries(tokensByModel)) {
-          const isDup = existing.some((u: any) => u.sessionId === session.id && u.source === 'opencode' && u.model === model);
-          if (isDup) continue;
-
-          const cost = tokens.cost > 0
-            ? Math.round(tokens.cost * 1e6) / 1e6
-            : calcTokenCost(model, tokens.input, tokens.output, tokens.cacheRead);
-
-          existing.push({
-            input: tokens.input + tokens.cacheRead,
-            output: tokens.output,
-            model,
-            cost,
-            sessionId: session.id,
-            source: 'opencode',
-            timestamp: now,
-          });
-          added++;
-        }
-
-        if (added > 0) {
-          await storage.updateItem(taskId, { tokenUsage: existing });
-          console.log(`[OPENCODE_SCRAPER] Logged ${added} record(s) for task ${taskId} from session ${session.id}`);
-          io.emit('items_updated');
-        }
-      } catch { /* skip unreachable items */ }
-    }
-  }
-};
-
-/* v8 ignore stop */
-
 // ── Init and Listen ──────────────────────────────────────────────────────────
 /* v8 ignore start */
 
@@ -2863,12 +2683,6 @@ if (process.env.NODE_ENV !== 'test' && !process.env.VITEST) {
     setInterval(() => {
       performBackup().catch(e => console.error('[BACKUP] Periodic backup failed:', e.message));
     }, 30 * 60 * 1000);
-
-    // Periodic Opencode token scraping every 5 minutes
-    scrapeOpencodeSessions().catch(e => console.error('[OPENCODE_SCRAPER] Initial scrape failed:', e.message));
-    setInterval(() => {
-      scrapeOpencodeSessions().catch(e => console.error('[OPENCODE_SCRAPER] Periodic scrape failed:', e.message));
-    }, OPENCODE_SCRAPE_INTERVAL);
 
     // Backup on clean shutdown
     const shutdown = async () => {

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -792,6 +792,27 @@ app.get("/flows", asyncHandler(async (_req: any, res: any) => {
   res.json(flows);
 }));
 
+// ── Observability: token events read API ────────────────────────────────────
+// Writes happen via the server-side ingestion worker (packages/server/src/token-ingestion).
+// This GET route exposes filtered reads to MCP / CLI / UI consumers.
+
+app.get("/token-events", asyncHandler(async (req: any, res: any) => {
+  const { itemId, projectId, client, since, until, limit } = req.query as Record<string, string | undefined>;
+  const ALLOWED_CLIENTS = new Set(['claude-code', 'codex', 'gemini', 'cursor', 'opencode']);
+  if (client && !ALLOWED_CLIENTS.has(client)) {
+    return res.status(400).json({ error: `Invalid client '${client}'. Must be one of: ${[...ALLOWED_CLIENTS].join(', ')}` });
+  }
+  const limitNum = limit !== undefined ? Number(limit) : undefined;
+  if (limit !== undefined && (!Number.isFinite(limitNum) || (limitNum as number) <= 0)) {
+    return res.status(400).json({ error: 'limit must be a positive integer' });
+  }
+  const events = await storage.queryTokenEvents({
+    itemId, projectId, client: client as any, since, until,
+    limit: limitNum,
+  });
+  res.json(events);
+}));
+
 const HUB_MANAGED_FLOW_MSG = "Flow is managed by your organization's Hub and cannot be modified locally";
 
 app.post("/flows", asyncHandler(async (req: any, res: any) => {

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -8,6 +8,9 @@ import { HubClient, Flusher, loadHubConfig } from "./hub/index.js";
 import type { RecordEventInput } from "./hub/index.js";
 import { startFlowSync, type FlowSyncHandle } from "./hub/flowSync.js";
 import { startUpgradeSync, replayPendingUpgradeOutcome, type UpgradeSyncHandle } from "./hub/upgradeSync.js";
+import { startIngestionPoller, type IngestionSource } from "./token-ingestion/index.js";
+import { parseClaudeCodeJsonl } from "./token-ingestion/parsers/claude-code.js";
+import { parseCodexJsonl } from "./token-ingestion/parsers/codex.js";
 import { spawnSync } from 'child_process';
 import { v4 as uuidv4 } from "uuid";
 import * as path from "path";
@@ -69,6 +72,7 @@ const hubClient = new HubClient(getInstallationId(), loadHubConfig());
 let hubFlusher: Flusher | null = null;
 let flowSyncHandle: FlowSyncHandle | null = null;
 let upgradeSyncHandle: UpgradeSyncHandle | null = null;
+let stopIngestionPoller: (() => void) | null = null;
 
 // recordHubEvent is a thin wrapper kept at module scope so the many existing
 // io.emit('items_updated', ...) sites can be augmented with one line.
@@ -439,6 +443,7 @@ const initStorage = async () => {
   hubFlusher?.stop();
   flowSyncHandle?.stop();
   upgradeSyncHandle?.stop();
+  stopIngestionPoller?.();
   hubClient.attachStorage(storage as SQLiteStorageProvider);
   if (hubClient.isEnabled && hubClient.hubConfig) {
     hubFlusher = new Flusher(storage as SQLiteStorageProvider, hubClient.hubConfig, getInstallationId());
@@ -518,6 +523,42 @@ const initStorage = async () => {
       }),
     });
     console.log(`[HUB] Upgrade reconciler running against ${hubClient.hubConfig.url}/v1/upgrade-directive`);
+
+    // Token ingestion: parse per-client session logs and forward each event
+    // to the hub as a 'tokens.logged' outbox event.
+    const home = os.homedir();
+    const ingestionSources: IngestionSource[] = [
+      {
+        client: 'claude-code',
+        rootDir: path.join(home, '.claude', 'projects'),
+        matches: (rel) => rel.endsWith('.jsonl'),
+        parser: parseClaudeCodeJsonl,
+      },
+      {
+        client: 'codex',
+        rootDir: path.join(home, '.codex', 'sessions'),
+        matches: (rel) => rel.endsWith('.jsonl'),
+        parser: parseCodexJsonl,
+      },
+    ];
+    stopIngestionPoller = startIngestionPoller({
+      storage,
+      sources: ingestionSources,
+      onEvent: (ev) => {
+        hubClient.recordEvent({
+          type: 'tokens.logged',
+          occurredAt: ev.ts,
+          payload: {
+            input: ev.input,
+            cachedInput: ev.cachedInput,
+            output: ev.output,
+            model: ev.model,
+            client: ev.client,
+          },
+        });
+      },
+    });
+    console.log('[HUB] Token ingestion poller started');
   }
 };
 
@@ -2816,6 +2857,7 @@ if (process.env.NODE_ENV !== 'test' && !process.env.VITEST) {
     const shutdown = async () => {
       console.log('[SHUTDOWN] Writing backup before exit...');
       removeServerPortFile();
+      stopIngestionPoller?.();
       if (hubFlusher) {
         hubFlusher.stop();
         await hubFlusher.flush().catch(e => console.error('[HUB] Shutdown drain failed:', (e as Error).message));

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -851,6 +851,13 @@ app.post("/prs", asyncHandler(async (req: any, res: any) => {
     );
   }
 
+  const item = await storage.getItem(itemId);
+  recordHubEvent({
+    type: 'pr.opened',
+    projectId: item?.projectId,
+    payload: { prNumber, repo, sizing, sizingShadow: shadow },
+  });
+
   res.status(201).json(pr);
 }));
 
@@ -881,6 +888,13 @@ app.put("/prs/:repo/:number", asyncHandler(async (req: any, res: any) => {
       `[PR_SIZING] discrepancy on ${repo}#${prNumber}: agent=${JSON.stringify(sizing)} shadow=${JSON.stringify(shadow)}`,
     );
   }
+
+  const anchorItem = await storage.getItem(existing.itemId);
+  recordHubEvent({
+    type: 'pr.updated',
+    projectId: anchorItem?.projectId,
+    payload: { prNumber, repo, sizing, sizingShadow: shadow },
+  });
 
   res.json(updated);
 }));

--- a/packages/server/src/test/log-token-usage-removal.test.ts
+++ b/packages/server/src/test/log-token-usage-removal.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Asserts the legacy `log_token_usage` MCP tool, its `TokenUsage` type, and
+ * all related CLI/REST surface are removed from the codebase. The replacement
+ * is server-side ingestion of per-client session-log files, landing as
+ * `token_events` in storage.
+ *
+ * These tests fail before the removal and guide it.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(__dirname, '../../../..');
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(ROOT, rel), 'utf8');
+}
+
+describe('legacy token-tracking removal', () => {
+  describe('packages/server/src/index.ts', () => {
+    let src: string;
+    beforeAll(() => {
+      src = read('packages/server/src/index.ts');
+    });
+
+    it('does not register the log_token_usage MCP tool', () => {
+      expect(src).not.toMatch(/name:\s*["']log_token_usage["']/);
+    });
+
+    it('does not handle case "log_token_usage"', () => {
+      expect(src).not.toMatch(/case\s+["']log_token_usage["']/);
+    });
+
+    it('does not declare LogTokenUsageSchema', () => {
+      expect(src).not.toMatch(/LogTokenUsageSchema/);
+    });
+  });
+
+  describe('packages/server/src/server.ts', () => {
+    let src: string;
+    beforeAll(() => {
+      src = read('packages/server/src/server.ts');
+    });
+
+    it('PUT /items/:id no longer destructures or assigns tokenUsage', () => {
+      // Allow the field to exist transiently in unrelated history; just ensure
+      // we are not pulling it from the request body anymore.
+      expect(src).not.toMatch(/\btokenUsage\b\s*[,}]/);
+    });
+  });
+
+  describe('packages/cli/src/index.ts', () => {
+    let src: string;
+    beforeAll(() => {
+      src = read('packages/cli/src/index.ts');
+    });
+
+    it('does not declare a log-tokens command', () => {
+      expect(src).not.toMatch(/\.command\s*\(\s*['"]log-tokens/);
+    });
+
+    it('does not reference mcp__agenfk__log_token_usage', () => {
+      expect(src).not.toMatch(/log_token_usage/);
+    });
+  });
+
+  describe('packages/core/src/types.ts', () => {
+    let src: string;
+    beforeAll(() => {
+      src = read('packages/core/src/types.ts');
+    });
+
+    it('does not define a TokenUsage interface', () => {
+      expect(src).not.toMatch(/export\s+interface\s+TokenUsage\b/);
+    });
+
+    it('BaseItem does not declare a tokenUsage field', () => {
+      // Match within the BaseItem interface block.
+      const baseItemBlock = src.match(/export\s+interface\s+BaseItem\s*\{[\s\S]*?^\}/m)?.[0] ?? '';
+      expect(baseItemBlock).not.toMatch(/\btokenUsage\b/);
+    });
+  });
+
+  describe('per-client instruction docs', () => {
+    const docs = [
+      'clauderules/CLAUDE.md',
+      'codexrules/AGENTS.md',
+      'geminirules/GEMINI.md',
+      'cursorrules/agenfk.mdc',
+    ];
+
+    for (const rel of docs) {
+      it(`${rel} no longer references log_token_usage / log-tokens`, () => {
+        const src = read(rel);
+        expect(src).not.toMatch(/log_token_usage|agenfk\s+log-tokens/);
+      });
+    }
+  });
+});

--- a/packages/server/src/test/pr-hook-classifier.test.ts
+++ b/packages/server/src/test/pr-hook-classifier.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+// Importing the .mjs hook script directly. Pure helpers are exported by name.
+// @ts-ignore — .mjs has no .d.ts; the helpers are JS functions.
+import { classifyTrigger, buildDirective } from '../../../../bin/agenfk-pr-hook.mjs';
+
+describe('classifyTrigger', () => {
+  it('detects gh pr create', () => {
+    expect(classifyTrigger('gh pr create --title foo --body bar')).toEqual({ kind: 'open' });
+    expect(classifyTrigger("gh   pr   create --fill")).toEqual({ kind: 'open' });
+  });
+
+  it('detects git push and extracts branch when present', () => {
+    expect(classifyTrigger('git push -u origin feature/x')).toEqual({ kind: 'push', branch: 'feature/x' });
+    expect(classifyTrigger('git push origin HEAD')).toEqual({ kind: 'push', branch: 'HEAD' });
+    expect(classifyTrigger('git push')).toEqual({ kind: 'push', branch: undefined });
+  });
+
+  it('returns null for unrelated commands', () => {
+    expect(classifyTrigger('ls -la')).toBeNull();
+    expect(classifyTrigger('git status')).toBeNull();
+    expect(classifyTrigger('gh pr view 123')).toBeNull();
+  });
+
+  it('handles multiline / leading whitespace', () => {
+    expect(classifyTrigger('  gh pr create')).toEqual({ kind: 'open' });
+  });
+});
+
+describe('buildDirective', () => {
+  const message = 'You just opened PR #N. Call register_pr(...).';
+
+  it('claude-code: emits additionalContext', () => {
+    expect(buildDirective('claude-code', message)).toEqual({
+      hookSpecificOutput: { hookEventName: 'PostToolUse', additionalContext: message },
+    });
+  });
+
+  it('codex: emits decision/reason envelope', () => {
+    expect(buildDirective('codex', message)).toEqual({
+      decision: 'continue',
+      reason: message,
+    });
+  });
+
+  it('gemini: emits context injection', () => {
+    expect(buildDirective('gemini', message)).toEqual({
+      decision: 'continue',
+      context: message,
+    });
+  });
+
+  it('cursor: emits permission/output shape', () => {
+    expect(buildDirective('cursor', message)).toEqual({
+      permission: 'allow',
+      userMessage: message,
+    });
+  });
+
+  it('opencode: returns shape consumable by tool.execute.after plugin', () => {
+    expect(buildDirective('opencode', message)).toEqual({
+      message,
+    });
+  });
+
+  it('unknown client: falls back to a generic shape', () => {
+    expect(buildDirective('mystery', message)).toEqual({ message });
+  });
+});

--- a/packages/server/src/test/pr-registration-api.test.ts
+++ b/packages/server/src/test/pr-registration-api.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import request from 'supertest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { app, initStorage } from '../server';
+
+vi.mock('axios', () => {
+  const mockAxios = vi.fn() as any;
+  mockAxios.get = vi.fn();
+  mockAxios.post = vi.fn();
+  mockAxios.put = vi.fn();
+  mockAxios.create = vi.fn(() => mockAxios);
+  return { default: mockAxios };
+});
+
+const ROOT = path.resolve(__dirname, '../../../..');
+const TEST_DB = path.resolve('./pr-registration-test-db.sqlite');
+
+describe('register_pr / update_pr_sizing — static registration', () => {
+  let src: string;
+  beforeAll(() => {
+    src = fs.readFileSync(path.join(ROOT, 'packages/server/src/index.ts'), 'utf8');
+  });
+  for (const name of ['register_pr', 'update_pr_sizing']) {
+    it(`declares "${name}" in tools list`, () => {
+      expect(src).toMatch(new RegExp(`name:\\s*["']${name}["']`));
+    });
+    it(`handles "${name}" in case switch`, () => {
+      expect(src).toMatch(new RegExp(`case\\s+["']${name}["']`));
+    });
+  }
+});
+
+describe('CLI: pr-register / pr-resize', () => {
+  let cli: string;
+  beforeAll(() => { cli = fs.readFileSync(path.join(ROOT, 'packages/cli/src/index.ts'), 'utf8'); });
+  it('declares pr-register command', () => {
+    expect(cli).toMatch(/\.command\s*\(\s*['"]pr-register/);
+  });
+  it('declares pr-resize command', () => {
+    expect(cli).toMatch(/\.command\s*\(\s*['"]pr-resize/);
+  });
+});
+
+describe('REST: POST /prs and PUT /prs/:repo/:number', () => {
+  beforeAll(async () => {
+    process.env.AGENFK_DB_PATH = TEST_DB;
+    if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+    await initStorage();
+  });
+  afterAll(() => {
+    if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+  });
+  beforeEach(async () => { await initStorage(); });
+
+  it('POST /prs registers a new PR with declared sizing', async () => {
+    const project = (await request(app).post('/projects').send({ name: 'P' })).body;
+    const item = (await request(app).post('/items').send({ projectId: project.id, type: 'TASK', title: 'T' })).body;
+
+    const res = await request(app).post('/prs').send({
+      itemId: item.id,
+      prNumber: 100,
+      repo: 'foo/bar',
+      sizing: { epic: 0, story: 1, task: 2, bug: 0 },
+    });
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({
+      prNumber: 100,
+      repo: 'foo/bar',
+      itemId: item.id,
+      sizing: { epic: 0, story: 1, task: 2, bug: 0 },
+    });
+    expect(res.body.id).toBeDefined();
+    expect(res.body.openedAt).toBeDefined();
+  });
+
+  it('POST /prs is idempotent on (repo, prNumber) — re-call refreshes sizing', async () => {
+    const project = (await request(app).post('/projects').send({ name: 'P' })).body;
+    const item = (await request(app).post('/items').send({ projectId: project.id, type: 'TASK', title: 'T' })).body;
+
+    await request(app).post('/prs').send({
+      itemId: item.id, prNumber: 200, repo: 'foo/bar',
+      sizing: { epic: 0, story: 1, task: 1, bug: 0 },
+    });
+    const second = await request(app).post('/prs').send({
+      itemId: item.id, prNumber: 200, repo: 'foo/bar',
+      sizing: { epic: 0, story: 1, task: 5, bug: 0 },
+    });
+    expect(second.status).toBe(201);
+    expect(second.body.sizing).toEqual({ epic: 0, story: 1, task: 5, bug: 0 });
+  });
+
+  it('PUT /prs/:repo/:number updates sizing', async () => {
+    const project = (await request(app).post('/projects').send({ name: 'P' })).body;
+    const item = (await request(app).post('/items').send({ projectId: project.id, type: 'TASK', title: 'T' })).body;
+    await request(app).post('/prs').send({
+      itemId: item.id, prNumber: 300, repo: 'foo/bar',
+      sizing: { epic: 0, story: 1, task: 1, bug: 0 },
+    });
+
+    const res = await request(app).put('/prs/foo%2Fbar/300').send({
+      sizing: { epic: 0, story: 1, task: 4, bug: 1 },
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.sizing).toEqual({ epic: 0, story: 1, task: 4, bug: 1 });
+    expect(res.body.lastSizingCheckAt).toBeDefined();
+  });
+
+  it('PUT /prs/:repo/:number returns 404 when PR not registered', async () => {
+    const res = await request(app).put('/prs/foo%2Fbar/999').send({
+      sizing: { epic: 0, story: 0, task: 1, bug: 0 },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('POST /prs validates required fields', async () => {
+    const res = await request(app).post('/prs').send({ prNumber: 1 });
+    expect(res.status).toBe(400);
+  });
+
+  it('POST /prs computes shadow sizing from the item tree', async () => {
+    const project = (await request(app).post('/projects').send({ name: 'P' })).body;
+    const epic = (await request(app).post('/items').send({ projectId: project.id, type: 'EPIC', title: 'E' })).body;
+    const story = (await request(app).post('/items').send({ projectId: project.id, type: 'STORY', title: 'S', parentId: epic.id })).body;
+    await request(app).post('/items').send({ projectId: project.id, type: 'TASK', title: 'T1', parentId: story.id });
+    await request(app).post('/items').send({ projectId: project.id, type: 'TASK', title: 'T2', parentId: story.id });
+    await request(app).post('/items').send({ projectId: project.id, type: 'BUG', title: 'B', parentId: story.id, severity: 'LOW' });
+
+    const res = await request(app).post('/prs').send({
+      itemId: epic.id, prNumber: 400, repo: 'foo/bar',
+      sizing: { epic: 1, story: 1, task: 99, bug: 99 }, // deliberately wrong
+    });
+    expect(res.status).toBe(201);
+    expect(res.body.sizing).toEqual({ epic: 1, story: 1, task: 99, bug: 99 }); // agent's number persists
+    expect(res.body.sizingShadow).toEqual({ epic: 1, story: 1, task: 2, bug: 1 }); // server's truth
+  });
+});

--- a/packages/server/src/test/pr-registration-api.test.ts
+++ b/packages/server/src/test/pr-registration-api.test.ts
@@ -135,3 +135,56 @@ describe('REST: POST /prs and PUT /prs/:repo/:number', () => {
     expect(res.body.sizingShadow).toEqual({ epic: 1, story: 1, task: 2, bug: 1 }); // server's truth
   });
 });
+
+describe('POST /prs emits a hub event into the outbox', () => {
+  beforeAll(async () => {
+    process.env.AGENFK_DB_PATH = TEST_DB;
+    if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+    await initStorage();
+  });
+  afterAll(() => {
+    if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+  });
+
+  it('inserts a pr.opened event into hub_outbox on POST /prs', async () => {
+    const project = (await request(app).post('/projects').send({ name: 'P' })).body;
+    const item = (await request(app).post('/items').send({ projectId: project.id, type: 'TASK', title: 'T' })).body;
+
+    const res = await request(app).post('/prs').send({
+      itemId: item.id, prNumber: 501, repo: 'org/repo',
+      sizing: { epic: 0, story: 0, task: 1, bug: 0 },
+    });
+    expect(res.status).toBe(201);
+
+    // @ts-ignore — access the raw SQLite db for assertion
+    const { SqliteStorage } = await import('@agenfk/storage-sqlite');
+    const db: import('better-sqlite3').Database = (await import('../server')).storage['database'];
+    const rows = db.prepare('SELECT payload FROM hub_outbox').all() as { payload: string }[];
+    const payloads = rows.map(r => JSON.parse(r.payload));
+    const prEvent = payloads.find((p: any) => p.type === 'pr.opened');
+    expect(prEvent).toBeDefined();
+    expect(prEvent.payload?.prNumber).toBe(501);
+    expect(prEvent.payload?.repo).toBe('org/repo');
+  });
+
+  it('inserts a pr.updated event into hub_outbox on PUT /prs/:repo/:number', async () => {
+    const project = (await request(app).post('/projects').send({ name: 'P2' })).body;
+    const item = (await request(app).post('/items').send({ projectId: project.id, type: 'TASK', title: 'T' })).body;
+    await request(app).post('/prs').send({
+      itemId: item.id, prNumber: 502, repo: 'org/repo2',
+      sizing: { epic: 0, story: 0, task: 1, bug: 0 },
+    });
+
+    const res = await request(app).put('/prs/org%2Frepo2/502').send({
+      sizing: { epic: 0, story: 0, task: 3, bug: 0 },
+    });
+    expect(res.status).toBe(200);
+
+    const db: import('better-sqlite3').Database = (await import('../server')).storage['database'];
+    const rows = db.prepare('SELECT payload FROM hub_outbox').all() as { payload: string }[];
+    const payloads = rows.map(r => JSON.parse(r.payload));
+    const updEvent = payloads.find((p: any) => p.type === 'pr.updated' && p.payload?.prNumber === 502);
+    expect(updEvent).toBeDefined();
+    expect(updEvent.payload?.sizing?.task).toBe(3);
+  });
+});

--- a/packages/server/src/test/pr-registration-rule-docs.test.ts
+++ b/packages/server/src/test/pr-registration-rule-docs.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(__dirname, '../../../..');
+
+const DOCS = [
+  'clauderules/CLAUDE.md',
+  'codexrules/AGENTS.md',
+  'geminirules/GEMINI.md',
+  'cursorrules/agenfk.mdc',
+];
+
+describe('PR-registration belt-and-suspenders rule', () => {
+  for (const rel of DOCS) {
+    it(`${rel} mentions register_pr after gh pr create`, () => {
+      const src = fs.readFileSync(path.join(ROOT, rel), 'utf8');
+      expect(src).toMatch(/register_pr/);
+      expect(src).toMatch(/update_pr_sizing/);
+    });
+  }
+});
+
+describe('AFK_ARCHITECTURE.md client matrix', () => {
+  it('no longer claims Codex / Cursor / Gemini are instructional-only on hooks', () => {
+    const src = fs.readFileSync(path.join(ROOT, 'AFK_ARCHITECTURE.md'), 'utf8');
+    // Acceptable: any mention that these clients HAVE hooks now.
+    expect(src).toMatch(/hooks/i);
+    // The phrase "instructional-only" used to apply to Cursor / Codex / Gemini —
+    // ensure that, if present, it is now scoped or disclaimed.
+    if (/instructional[-\s]only/i.test(src)) {
+      expect(src).toMatch(/now\s+(have|support|expose)\s+hooks|hook\s+system\s+(added|added in|since)/i);
+    }
+  });
+});

--- a/packages/server/src/test/server.supplemental.test.ts
+++ b/packages/server/src/test/server.supplemental.test.ts
@@ -1210,14 +1210,13 @@ describe('syncParentStatus advanced scenarios', () => {
 describe('PUT /items/:id with optional fields', () => {
   beforeEach(async () => { await initStorage(); });
 
-  it('updates context, tokenUsage, implementationPlan, comments, sortOrder', async () => {
+  it('updates context, implementationPlan, comments, sortOrder', async () => {
     const p = (await request(app).post('/projects').send({ name: 'P' })).body;
     const item = (await request(app).post('/items').send({ type: 'TASK', title: 'T', projectId: p.id })).body;
     const res = await request(app).put(`/items/${item.id}`).send({
       title: 'Updated',
       description: 'desc',
       context: [{ path: '/foo.ts', content: 'code', description: 'desc' }],
-      tokenUsage: [{ input: 100, output: 50, model: 'claude-sonnet-4-6' }],
       implementationPlan: 'step 1',
       comments: [{ id: 'c1', author: 'Agent', content: 'done', timestamp: new Date() }],
       sortOrder: 5,
@@ -1255,7 +1254,7 @@ describe('POST /items/trash-archived', () => {
 describe('POST /items/bulk - branch coverage', () => {
   beforeEach(async () => { await initStorage(); });
 
-  it('updates item with all optional fields (title, description, parentId, tokenUsage, context, implementationPlan, reviews, comments)', async () => {
+  it('updates item with all optional fields (title, description, parentId, context, implementationPlan, reviews, comments)', async () => {
     const p = (await request(app).post('/projects').send({ name: 'P' })).body;
     const parent = (await request(app).post('/items').send({ type: 'STORY', title: 'Parent', projectId: p.id })).body;
     const item = (await request(app).post('/items').send({ type: 'TASK', title: 'T', projectId: p.id })).body;
@@ -1267,7 +1266,6 @@ describe('POST /items/bulk - branch coverage', () => {
           title: 'New Title',
           description: 'New desc',
           parentId: parent.id,
-          tokenUsage: [{ input: 100, output: 50, model: 'test' }],
           context: [{ path: '/x.ts', content: 'code' }],
           implementationPlan: 'step 1',
           reviews: [{ id: 'r1', content: 'lgtm' }],

--- a/packages/server/src/test/token-events-api.test.ts
+++ b/packages/server/src/test/token-events-api.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import request from 'supertest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { app, initStorage } from '../server';
+
+vi.mock('axios', () => {
+  const mockAxios = vi.fn() as any;
+  mockAxios.get = vi.fn();
+  mockAxios.post = vi.fn();
+  mockAxios.create = vi.fn(() => mockAxios);
+  return { default: mockAxios };
+});
+
+const ROOT = path.resolve(__dirname, '../../../..');
+const TEST_DB = path.resolve('./token-events-api-test-db.sqlite');
+
+describe('query_token_events MCP tool registration', () => {
+  let src: string;
+  beforeAll(() => {
+    src = fs.readFileSync(path.join(ROOT, 'packages/server/src/index.ts'), 'utf8');
+  });
+  it('declares "query_token_events" in the tools list', () => {
+    expect(src).toMatch(/name:\s*["']query_token_events["']/);
+  });
+  it('handles "query_token_events" in the call-tool switch', () => {
+    expect(src).toMatch(/case\s+["']query_token_events["']/);
+  });
+});
+
+describe('agenfk tokens CLI command', () => {
+  it('declares a `tokens` command in packages/cli/src/index.ts', () => {
+    const src = fs.readFileSync(path.join(ROOT, 'packages/cli/src/index.ts'), 'utf8');
+    expect(src).toMatch(/\.command\s*\(\s*['"]tokens/);
+  });
+});
+
+describe('GET /token-events REST', () => {
+  beforeAll(async () => {
+    process.env.AGENFK_DB_PATH = TEST_DB;
+    if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+    await initStorage();
+  });
+  afterAll(() => {
+    if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+  });
+  beforeEach(async () => { await initStorage(); });
+
+  it('returns an empty array when no events exist', async () => {
+    const res = await request(app).get('/token-events');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body).toEqual([]);
+  });
+
+  it('filters by itemId, projectId, since, until, client, limit', async () => {
+    // Use the storage directly via a small test endpoint helper isn't available;
+    // instead poke the storage by importing and inserting. Both tests below
+    // are independent, so we accept that this test exercises only the route's
+    // parameter forwarding.
+    const { storage } = await import('../server');
+    await storage.insertTokenEvent({
+      id: 'a', ts: '2026-05-10T00:00:00Z', client: 'codex', sessionId: 's',
+      model: 'm', input: 1, cachedInput: 0, output: 1, reasoning: 0, total: 2,
+      itemId: 'item-X', projectId: 'proj-1', sourcePath: '/p/a', sourceOffset: 0,
+    });
+    await storage.insertTokenEvent({
+      id: 'b', ts: '2026-05-11T00:00:00Z', client: 'claude-code', sessionId: 's',
+      model: 'm', input: 2, cachedInput: 0, output: 2, reasoning: 0, total: 4,
+      itemId: 'item-X', projectId: 'proj-1', sourcePath: '/p/b', sourceOffset: 0,
+    });
+
+    const byItem = await request(app).get('/token-events').query({ itemId: 'item-X' });
+    expect(byItem.status).toBe(200);
+    expect(byItem.body.map((e: any) => e.id).sort()).toEqual(['a', 'b']);
+
+    const byClient = await request(app).get('/token-events').query({ client: 'codex' });
+    expect(byClient.body.map((e: any) => e.id)).toEqual(['a']);
+
+    const limited = await request(app).get('/token-events').query({ limit: 1 });
+    expect(limited.body).toHaveLength(1);
+  });
+});

--- a/packages/server/src/test/token-ingestion-attribution.test.ts
+++ b/packages/server/src/test/token-ingestion-attribution.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { findActiveItemAt } from '../token-ingestion/attribution';
+import type { AgEnFKItem } from '@agenfk/core';
+
+const FLOW = {
+  steps: [
+    { name: 'TODO', order: 0, isAnchor: true },
+    { name: 'IN_PROGRESS', order: 1 },
+    { name: 'REVIEW', order: 2 },
+    { name: 'DONE', order: 3, isAnchor: true },
+  ],
+};
+
+function makeItem(id: string, history: { from: string; to: string; ts: string }[]): AgEnFKItem {
+  return {
+    id,
+    projectId: 'p1',
+    type: 'TASK',
+    title: id,
+    description: '',
+    status: history[history.length - 1]?.to as any,
+    createdAt: new Date(history[0]?.ts ?? '2026-05-01'),
+    updatedAt: new Date(history[history.length - 1]?.ts ?? '2026-05-01'),
+    history: history.map((h, i) => ({
+      id: `h-${id}-${i}`,
+      fromStatus: h.from as any,
+      toStatus: h.to as any,
+      timestamp: new Date(h.ts),
+    })),
+  } as AgEnFKItem;
+}
+
+describe('findActiveItemAt', () => {
+  it('returns null when no items have transitioned to a working step', () => {
+    const items: AgEnFKItem[] = [
+      makeItem('a', [{ from: 'TODO', to: 'TODO', ts: '2026-05-01T00:00:00Z' }]),
+    ];
+    expect(findActiveItemAt(items, FLOW, '2026-05-10T00:00:00Z')).toBeNull();
+  });
+
+  it('returns the item whose most-recent transition INTO an active step is at or before T', () => {
+    const a = makeItem('a', [
+      { from: 'TODO', to: 'IN_PROGRESS', ts: '2026-05-10T00:00:00Z' },
+    ]);
+    const b = makeItem('b', [
+      { from: 'TODO', to: 'IN_PROGRESS', ts: '2026-05-10T01:00:00Z' },
+    ]);
+    expect(findActiveItemAt([a, b], FLOW, '2026-05-10T02:00:00Z')).toBe('b');
+    expect(findActiveItemAt([a, b], FLOW, '2026-05-10T00:30:00Z')).toBe('a');
+  });
+
+  it('skips items that transitioned out of an active step before T', () => {
+    const a = makeItem('a', [
+      { from: 'TODO', to: 'IN_PROGRESS', ts: '2026-05-10T00:00:00Z' },
+      { from: 'IN_PROGRESS', to: 'DONE', ts: '2026-05-10T01:00:00Z' },
+    ]);
+    const b = makeItem('b', [
+      { from: 'TODO', to: 'IN_PROGRESS', ts: '2026-05-10T00:30:00Z' },
+    ]);
+    // At T = 02:00, a is DONE (anchor), b is IN_PROGRESS → b wins
+    expect(findActiveItemAt([a, b], FLOW, '2026-05-10T02:00:00Z')).toBe('b');
+  });
+
+  it('treats PAUSED/BLOCKED/ARCHIVED/TRASHED/IDEAS as inactive', () => {
+    const a = makeItem('a', [
+      { from: 'TODO', to: 'IN_PROGRESS', ts: '2026-05-10T00:00:00Z' },
+      { from: 'IN_PROGRESS', to: 'PAUSED', ts: '2026-05-10T01:00:00Z' },
+    ]);
+    const b = makeItem('b', [
+      { from: 'TODO', to: 'REVIEW', ts: '2026-05-10T00:30:00Z' },
+    ]);
+    expect(findActiveItemAt([a, b], FLOW, '2026-05-10T02:00:00Z')).toBe('b');
+  });
+
+  it('handles a single item that re-entered an active step', () => {
+    const a = makeItem('a', [
+      { from: 'TODO', to: 'IN_PROGRESS', ts: '2026-05-10T00:00:00Z' },
+      { from: 'IN_PROGRESS', to: 'REVIEW', ts: '2026-05-10T01:00:00Z' },
+      { from: 'REVIEW', to: 'IN_PROGRESS', ts: '2026-05-10T02:00:00Z' },
+    ]);
+    expect(findActiveItemAt([a], FLOW, '2026-05-10T03:00:00Z')).toBe('a');
+  });
+
+  it('ignores items whose only transition is after T', () => {
+    const a = makeItem('a', [
+      { from: 'TODO', to: 'IN_PROGRESS', ts: '2026-05-10T05:00:00Z' },
+    ]);
+    expect(findActiveItemAt([a], FLOW, '2026-05-10T03:00:00Z')).toBeNull();
+  });
+});

--- a/packages/server/src/test/token-ingestion-hub-emit.test.ts
+++ b/packages/server/src/test/token-ingestion-hub-emit.test.ts
@@ -11,6 +11,7 @@ import * as os from 'os';
 import type { TokenEvent, StorageProvider } from '@agenfk/core';
 import { ingestOnce, IngestionPollerOptions } from '../token-ingestion/watcher';
 import { parseClaudeCodeJsonl } from '../token-ingestion/parsers/claude-code';
+import { parseCodexJsonl } from '../token-ingestion/parsers/codex';
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -110,6 +111,103 @@ describe('ingestOnce — onEvent callback', () => {
       }],
     };
     await expect(ingestOnce(opts)).resolves.toBe(1);
+  });
+});
+
+// ── 1b. Codex attribution ────────────────────────────────────────────────────
+
+function makeAttributionStorage(projectRoot: string): StorageProvider & { inserted: TokenEvent[] } {
+  const storage = makeStorage() as any;
+  const project = {
+    id: 'proj-1',
+    name: 'Project One',
+    projectRoot,
+    flowId: 'flow-1',
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+  };
+  const item = {
+    id: 'item-1',
+    projectId: 'proj-1',
+    type: 'TASK',
+    title: 'Active task',
+    status: 'IN_PROGRESS',
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+    history: [{
+      id: 'h-1',
+      fromStatus: 'TODO',
+      toStatus: 'IN_PROGRESS',
+      timestamp: new Date('2026-05-10T00:00:00Z'),
+    }],
+  };
+  storage.listProjects = async () => [project];
+  storage.listItems = async (query: any) => (query?.projectId === 'proj-1' ? [item] : []);
+  storage.getFlow = async () => ({
+    id: 'flow-1',
+    name: 'TDD',
+    steps: [
+      { name: 'TODO', order: 0, isAnchor: true },
+      { name: 'CREATE_UNIT_TESTS', order: 1 },
+      { name: 'IN_PROGRESS', order: 2 },
+      { name: 'DONE', order: 3, isAnchor: true },
+    ],
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+  });
+  return storage;
+}
+
+describe('ingestOnce — Codex attribution', () => {
+  it('attributes Codex token events to the project root and active AgenFK item', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agenfk-codex-'));
+    const projectRoot = path.join(tmpDir, 'repo');
+    fs.mkdirSync(projectRoot);
+    writeTempJsonl(tmpDir, 'codex.jsonl', [
+      { type: 'session_meta', timestamp: '2026-05-10T00:00:00Z', payload: { id: 'sess-codex', cwd: projectRoot } },
+      { type: 'turn_context', timestamp: '2026-05-10T00:00:01Z', payload: { turn_id: 'turn-1', model: 'gpt-5.5', cwd: projectRoot } },
+      {
+        type: 'event_msg',
+        timestamp: '2026-05-10T00:10:00Z',
+        payload: {
+          type: 'token_count',
+          info: {
+            last_token_usage: {
+              input_tokens: 100,
+              cached_input_tokens: 20,
+              output_tokens: 12,
+              reasoning_output_tokens: 5,
+              total_tokens: 112,
+            },
+          },
+        },
+      },
+    ]);
+
+    const storage = makeAttributionStorage(projectRoot);
+    const received: TokenEvent[] = [];
+    const written = await ingestOnce({
+      storage,
+      attributeEvents: true,
+      sources: [{
+        client: 'codex',
+        rootDir: tmpDir,
+        matches: (rel) => rel.endsWith('.jsonl'),
+        parser: parseCodexJsonl,
+      }],
+      onEvent: (ev) => received.push(ev),
+    });
+
+    expect(written).toBe(1);
+    expect(storage.inserted[0]).toMatchObject({
+      client: 'codex',
+      projectId: 'proj-1',
+      itemId: 'item-1',
+      input: 100,
+      cachedInput: 20,
+      output: 12,
+    });
+    expect(received[0]).toMatchObject({ projectId: 'proj-1', itemId: 'item-1' });
   });
 });
 

--- a/packages/server/src/test/token-ingestion-hub-emit.test.ts
+++ b/packages/server/src/test/token-ingestion-hub-emit.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests that:
+ * 1. ingestOnce calls opts.onEvent for every successfully-inserted TokenEvent.
+ * 2. The hub rollup/query token extraction handles the new flat payload format
+ *    ($.input / $.output) as well as the legacy nested format as a fallback.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import type { TokenEvent, StorageProvider } from '@agenfk/core';
+import { ingestOnce, IngestionPollerOptions } from '../token-ingestion/watcher';
+import { parseClaudeCodeJsonl } from '../token-ingestion/parsers/claude-code';
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function makeStorage(insertShouldFail = false): StorageProvider & {
+  inserted: TokenEvent[];
+  states: Record<string, any>;
+} {
+  const inserted: TokenEvent[] = [];
+  const states: Record<string, any> = {};
+  return {
+    inserted,
+    states,
+    async insertTokenEvent(ev) {
+      if (insertShouldFail) throw new Error('duplicate');
+      inserted.push(ev);
+    },
+    async getIngestionState(p) { return states[p] ?? null; },
+    async setIngestionState(s) { states[s.sourcePath] = s; },
+  } as any;
+}
+
+function writeTempJsonl(dir: string, name: string, lines: object[]): string {
+  const p = path.join(dir, name);
+  fs.writeFileSync(p, lines.map(l => JSON.stringify(l)).join('\n') + '\n', 'utf8');
+  return p;
+}
+
+const ASSISTANT_LINE = {
+  type: 'assistant',
+  timestamp: '2026-01-01T00:00:00Z',
+  sessionId: 'sess-1',
+  uuid: 'turn-1',
+  message: {
+    model: 'claude-sonnet-4-5',
+    usage: { input_tokens: 100, output_tokens: 50, cache_creation_input_tokens: 10, cache_read_input_tokens: 5 },
+  },
+};
+
+// ── 1. onEvent callback ───────────────────────────────────────────────────────
+
+describe('ingestOnce — onEvent callback', () => {
+  let tmpDir: string;
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agenfk-hub-emit-'));
+  });
+
+  it('calls onEvent for each successfully inserted TokenEvent', async () => {
+    writeTempJsonl(tmpDir, 'session.jsonl', [ASSISTANT_LINE]);
+    const storage = makeStorage();
+    const received: TokenEvent[] = [];
+    const opts: IngestionPollerOptions = {
+      storage,
+      sources: [{
+        client: 'claude-code',
+        rootDir: tmpDir,
+        matches: (rel) => rel.endsWith('.jsonl'),
+        parser: parseClaudeCodeJsonl,
+      }],
+      onEvent: (ev) => received.push(ev),
+    };
+    const written = await ingestOnce(opts);
+    expect(written).toBe(1);
+    expect(received).toHaveLength(1);
+    expect(received[0].input).toBe(100);
+    expect(received[0].output).toBe(50);
+    expect(received[0].model).toBe('claude-sonnet-4-5');
+  });
+
+  it('does not call onEvent when insertTokenEvent throws (duplicate)', async () => {
+    writeTempJsonl(tmpDir, 'session.jsonl', [ASSISTANT_LINE]);
+    const storage = makeStorage(true);
+    const received: TokenEvent[] = [];
+    const opts: IngestionPollerOptions = {
+      storage,
+      sources: [{
+        client: 'claude-code',
+        rootDir: tmpDir,
+        matches: (rel) => rel.endsWith('.jsonl'),
+        parser: parseClaudeCodeJsonl,
+      }],
+      onEvent: (ev) => received.push(ev),
+    };
+    await ingestOnce(opts);
+    expect(received).toHaveLength(0);
+  });
+
+  it('onEvent is optional — ingestOnce works without it', async () => {
+    writeTempJsonl(tmpDir, 'session.jsonl', [ASSISTANT_LINE]);
+    const storage = makeStorage();
+    const opts: IngestionPollerOptions = {
+      storage,
+      sources: [{
+        client: 'claude-code',
+        rootDir: tmpDir,
+        matches: (rel) => rel.endsWith('.jsonl'),
+        parser: parseClaudeCodeJsonl,
+      }],
+    };
+    await expect(ingestOnce(opts)).resolves.toBe(1);
+  });
+});
+
+// ── 2. Rollup payload format compatibility ────────────────────────────────────
+
+describe('hub rollup — token payload extraction', () => {
+  it('server.ts hub startup block imports and starts the ingestion poller', () => {
+    const src = fs.readFileSync(
+      path.resolve(__dirname, '../server.ts'),
+      'utf8',
+    );
+    expect(src).toMatch(/startIngestionPoller/);
+    expect(src).toMatch(/tokens\.logged/);
+  });
+
+  it('rollup.ts uses COALESCE to handle new flat payload format ($.input)', () => {
+    const src = fs.readFileSync(
+      path.resolve(__dirname, '../../../../packages/hub/src/rollup.ts'),
+      'utf8',
+    );
+    expect(src).toMatch(/json_extract\(payload,\s*['"]\$\.input['"]\)/);
+  });
+
+  it('queries.ts /metrics uses COALESCE to handle new flat payload format', () => {
+    const src = fs.readFileSync(
+      path.resolve(__dirname, '../../../../packages/hub/src/routes/queries.ts'),
+      'utf8',
+    );
+    expect(src).toMatch(/json_extract\(payload,\s*['"]\$\.input['"]\)/);
+  });
+});

--- a/packages/server/src/test/token-ingestion-hub-emit.test.ts
+++ b/packages/server/src/test/token-ingestion-hub-emit.test.ts
@@ -125,19 +125,19 @@ describe('hub rollup — token payload extraction', () => {
     expect(src).toMatch(/tokens\.logged/);
   });
 
-  it('rollup.ts uses COALESCE to handle new flat payload format ($.input)', () => {
+  it('rollup.ts extracts tokens from $.payload.input (the hub stores JSON.stringify(fullEvent))', () => {
     const src = fs.readFileSync(
       path.resolve(__dirname, '../../../../packages/hub/src/rollup.ts'),
       'utf8',
     );
-    expect(src).toMatch(/json_extract\(payload,\s*['"]\$\.input['"]\)/);
+    expect(src).toMatch(/json_extract\(payload,\s*['"]\$\.payload\.input['"]\)/);
   });
 
-  it('queries.ts /metrics uses COALESCE to handle new flat payload format', () => {
+  it('queries.ts /metrics extracts tokens from $.payload.input', () => {
     const src = fs.readFileSync(
       path.resolve(__dirname, '../../../../packages/hub/src/routes/queries.ts'),
       'utf8',
     );
-    expect(src).toMatch(/json_extract\(payload,\s*['"]\$\.input['"]\)/);
+    expect(src).toMatch(/json_extract\(payload,\s*['"]\$\.payload\.input['"]\)/);
   });
 });

--- a/packages/server/src/test/token-ingestion-parser-claude.test.ts
+++ b/packages/server/src/test/token-ingestion-parser-claude.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { parseClaudeCodeJsonl } from '../token-ingestion/parsers/claude-code';
+
+describe('parseClaudeCodeJsonl', () => {
+  it('emits one event per assistant message with usage; ignores other lines', () => {
+    const a1 = {
+      type: 'assistant',
+      timestamp: '2026-05-10T00:00:00.000Z',
+      sessionId: 'sess-1',
+      message: {
+        model: 'claude-opus-4-7',
+        usage: {
+          input_tokens: 100,
+          cache_creation_input_tokens: 50,
+          cache_read_input_tokens: 30,
+          output_tokens: 40,
+        },
+      },
+    };
+    const userMsg = { type: 'user', timestamp: '2026-05-10T00:00:01Z', sessionId: 'sess-1', message: { content: 'hi' } };
+    const a2 = {
+      type: 'assistant',
+      timestamp: '2026-05-10T00:00:02Z',
+      sessionId: 'sess-1',
+      message: {
+        model: 'claude-opus-4-7',
+        usage: { input_tokens: 5, cache_read_input_tokens: 80, output_tokens: 12 },
+      },
+    };
+    const text = [JSON.stringify(a1), JSON.stringify(userMsg), JSON.stringify(a2), ''].join('\n');
+    const events = parseClaudeCodeJsonl(text, '/p/sess.jsonl', 0);
+
+    expect(events).toHaveLength(2);
+    expect(events[0]).toMatchObject({
+      ts: '2026-05-10T00:00:00.000Z',
+      sessionId: 'sess-1',
+      model: 'claude-opus-4-7',
+      input: 100,
+      // cached_input combines cache-creation + cache-read because Claude bills both as "non-fresh" input
+      cachedInput: 80,
+      output: 40,
+      reasoning: 0,
+      total: 100 + 80 + 40,
+      sourcePath: '/p/sess.jsonl',
+    });
+    expect(events[0].sourceOffset).toBe(0);
+
+    // Second event's offset is past the first two lines.
+    const expectedOffset = Buffer.byteLength(JSON.stringify(a1) + '\n' + JSON.stringify(userMsg) + '\n', 'utf8');
+    expect(events[1].sourceOffset).toBe(expectedOffset);
+    expect(events[1].input).toBe(5);
+    expect(events[1].cachedInput).toBe(80);
+    expect(events[1].output).toBe(12);
+  });
+
+  it('handles a slice with a non-zero baseOffset', () => {
+    const a = {
+      type: 'assistant',
+      timestamp: '2026-05-10T00:00:00Z',
+      sessionId: 'sess-1',
+      message: { model: 'claude', usage: { input_tokens: 1, output_tokens: 2 } },
+    };
+    const text = JSON.stringify(a) + '\n';
+    const events = parseClaudeCodeJsonl(text, '/p/sess.jsonl', 1024);
+    expect(events).toHaveLength(1);
+    expect(events[0].sourceOffset).toBe(1024);
+  });
+
+  it('skips malformed JSON lines without throwing', () => {
+    const a = {
+      type: 'assistant',
+      timestamp: '2026-05-10T00:00:00Z',
+      sessionId: 'sess-1',
+      message: { model: 'claude', usage: { input_tokens: 1, output_tokens: 2 } },
+    };
+    const text = ['{not json}', JSON.stringify(a), ''].join('\n');
+    const events = parseClaudeCodeJsonl(text, '/p/sess.jsonl', 0);
+    expect(events).toHaveLength(1);
+  });
+});

--- a/packages/server/src/test/token-ingestion-parser-claude.test.ts
+++ b/packages/server/src/test/token-ingestion-parser-claude.test.ts
@@ -7,6 +7,7 @@ describe('parseClaudeCodeJsonl', () => {
       type: 'assistant',
       timestamp: '2026-05-10T00:00:00.000Z',
       sessionId: 'sess-1',
+      cwd: '/workspace/repo',
       message: {
         model: 'claude-opus-4-7',
         usage: {
@@ -41,6 +42,7 @@ describe('parseClaudeCodeJsonl', () => {
       output: 40,
       reasoning: 0,
       total: 100 + 80 + 40,
+      cwd: '/workspace/repo',
       sourcePath: '/p/sess.jsonl',
     });
     expect(events[0].sourceOffset).toBe(0);

--- a/packages/server/src/test/token-ingestion-parser-codex.test.ts
+++ b/packages/server/src/test/token-ingestion-parser-codex.test.ts
@@ -21,6 +21,70 @@ function ev(ts: string, cum: Partial<{ input: number; cached_input: number; outp
 }
 
 describe('parseCodexJsonl', () => {
+  it('parses the current Codex token_count info shape and carries session metadata', () => {
+    const sessionMeta = JSON.stringify({
+      type: 'session_meta',
+      timestamp: '2026-05-10T00:00:00Z',
+      payload: {
+        id: 'sess-codex-live',
+        cwd: '/workspace/repo',
+      },
+    });
+    const turnContext = JSON.stringify({
+      type: 'turn_context',
+      timestamp: '2026-05-10T00:00:01Z',
+      payload: {
+        turn_id: 'turn-1',
+        model: 'gpt-5.5',
+        cwd: '/workspace/repo',
+      },
+    });
+    const emptyCount = JSON.stringify({
+      type: 'event_msg',
+      timestamp: '2026-05-10T00:00:02Z',
+      payload: { type: 'token_count', info: null },
+    });
+    const tokenCount = JSON.stringify({
+      type: 'event_msg',
+      timestamp: '2026-05-10T00:00:03Z',
+      payload: {
+        type: 'token_count',
+        info: {
+          total_token_usage: {
+            input_tokens: 100,
+            cached_input_tokens: 40,
+            output_tokens: 12,
+            reasoning_output_tokens: 7,
+            total_tokens: 112,
+          },
+          last_token_usage: {
+            input_tokens: 80,
+            cached_input_tokens: 32,
+            output_tokens: 9,
+            reasoning_output_tokens: 5,
+            total_tokens: 89,
+          },
+          model_context_window: 258400,
+        },
+      },
+    });
+    const events = parseCodexJsonl([sessionMeta, turnContext, emptyCount, tokenCount, ''].join('\n'), '/p/codex.jsonl', 0);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      ts: '2026-05-10T00:00:03Z',
+      sessionId: 'sess-codex-live',
+      turnId: 'turn-1',
+      model: 'gpt-5.5',
+      input: 80,
+      cachedInput: 32,
+      output: 9,
+      reasoning: 5,
+      total: 89,
+      cwd: '/workspace/repo',
+    });
+  });
+
   it('emits per-turn deltas from cumulative totals', () => {
     const text = [
       ev('2026-05-10T00:00:00Z', { input: 10, output: 5, total: 15 }),

--- a/packages/server/src/test/token-ingestion-parser-codex.test.ts
+++ b/packages/server/src/test/token-ingestion-parser-codex.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { parseCodexJsonl } from '../token-ingestion/parsers/codex';
+
+/**
+ * Codex writes session JSONL where each `event_msg` with payload.type ==='token_count'
+ * carries cumulative totals. Per-turn deltas are derived by subtracting the
+ * previous cumulative.
+ */
+
+function ev(ts: string, cum: Partial<{ input: number; cached_input: number; output: number; reasoning: number; total: number }>) {
+  return JSON.stringify({
+    type: 'event_msg',
+    timestamp: ts,
+    payload: {
+      type: 'token_count',
+      session_id: 'sess-codex',
+      model: 'gpt-5',
+      ...cum,
+    },
+  });
+}
+
+describe('parseCodexJsonl', () => {
+  it('emits per-turn deltas from cumulative totals', () => {
+    const text = [
+      ev('2026-05-10T00:00:00Z', { input: 10, output: 5, total: 15 }),
+      ev('2026-05-10T00:01:00Z', { input: 30, output: 12, total: 42 }),
+      '',
+    ].join('\n');
+    const events = parseCodexJsonl(text, '/p/codex.jsonl', 0);
+    expect(events).toHaveLength(2);
+    expect(events[0]).toMatchObject({
+      ts: '2026-05-10T00:00:00Z',
+      sessionId: 'sess-codex',
+      model: 'gpt-5',
+      input: 10,
+      output: 5,
+      total: 15,
+    });
+    // Second event delta = current - prev within this slice.
+    expect(events[1]).toMatchObject({
+      ts: '2026-05-10T00:01:00Z',
+      input: 20,
+      output: 7,
+      total: 27,
+    });
+  });
+
+  it('captures cached_input and reasoning when present', () => {
+    const text = [
+      ev('2026-05-10T00:00:00Z', {
+        input: 100,
+        cached_input: 30,
+        output: 50,
+        reasoning: 10,
+        total: 190,
+      }),
+      '',
+    ].join('\n');
+    const events = parseCodexJsonl(text, '/p/codex.jsonl', 0);
+    expect(events[0]).toMatchObject({
+      input: 100,
+      cachedInput: 30,
+      output: 50,
+      reasoning: 10,
+      total: 190,
+    });
+  });
+
+  it('ignores non-token_count event_msg lines', () => {
+    const noise = JSON.stringify({ type: 'event_msg', timestamp: '2026-05-10T00:00:00Z', payload: { type: 'agent_message' } });
+    const real = ev('2026-05-10T00:00:00Z', { input: 1, output: 1, total: 2 });
+    const text = [noise, real, ''].join('\n');
+    expect(parseCodexJsonl(text, '/p/c.jsonl', 0)).toHaveLength(1);
+  });
+
+  it('skips negative deltas (treats as session reset / new file)', () => {
+    // After truncation/rotation, cumulative may go down. Don't emit negative usage.
+    const text = [
+      ev('2026-05-10T00:00:00Z', { input: 100, output: 50, total: 150 }),
+      ev('2026-05-10T00:01:00Z', { input: 30, output: 12, total: 42 }), // smaller — likely session reset
+      '',
+    ].join('\n');
+    const events = parseCodexJsonl(text, '/p/codex.jsonl', 0);
+    expect(events.length).toBe(2);
+    // Second event treated as a fresh baseline (its cumulative IS the delta).
+    expect(events[1]).toMatchObject({ input: 30, output: 12, total: 42 });
+  });
+});

--- a/packages/server/src/test/token-ingestion-processFile.test.ts
+++ b/packages/server/src/test/token-ingestion-processFile.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { processFile } from '../token-ingestion/watcher';
+import type { TokenEvent, IngestionState } from '@agenfk/core';
+
+/**
+ * processFile is the pure-logic core of the file watcher: given the prior
+ * ingestion state for a path, the file's current contents, and a parser, it
+ * returns the new events to insert plus the next ingestion state. No I/O.
+ */
+describe('processFile', () => {
+  const fakeParser = (text: string, basePath: string, baseOffset: number): TokenEvent[] => {
+    // Each line is "<input>,<output>" → one event per non-empty line.
+    const out: TokenEvent[] = [];
+    let off = baseOffset;
+    for (const line of text.split('\n')) {
+      if (line.trim()) {
+        const [i, o] = line.split(',').map(Number);
+        out.push({
+          id: `${basePath}:${off}`,
+          ts: '2026-05-10T00:00:00Z',
+          client: 'codex',
+          sessionId: 'sess',
+          model: 'm',
+          input: i,
+          cachedInput: 0,
+          output: o,
+          reasoning: 0,
+          total: i + o,
+          sourcePath: basePath,
+          sourceOffset: off,
+        });
+      }
+      off += Buffer.byteLength(line, 'utf8') + 1;
+    }
+    return out;
+  };
+
+  it('returns events for the full file on first run (no prior state)', () => {
+    const r = processFile('/p/a.jsonl', '10,20\n30,40\n', null, fakeParser);
+    expect(r.events.map((e) => e.input)).toEqual([10, 30]);
+    expect(r.nextState.lastOffset).toBe(Buffer.byteLength('10,20\n30,40\n', 'utf8'));
+    expect(r.nextState.sourcePath).toBe('/p/a.jsonl');
+  });
+
+  it('returns only newly-appended events on subsequent runs', () => {
+    const initial: IngestionState = {
+      sourcePath: '/p/a.jsonl',
+      lastOffset: Buffer.byteLength('10,20\n', 'utf8'),
+      lastRunAt: '2026-05-10T00:00:00Z',
+    };
+    const r = processFile('/p/a.jsonl', '10,20\n30,40\n', initial, fakeParser);
+    expect(r.events.map((e) => e.input)).toEqual([30]);
+    expect(r.nextState.lastOffset).toBe(Buffer.byteLength('10,20\n30,40\n', 'utf8'));
+  });
+
+  it('returns no events when nothing has been appended', () => {
+    const initial: IngestionState = {
+      sourcePath: '/p/a.jsonl',
+      lastOffset: Buffer.byteLength('10,20\n30,40\n', 'utf8'),
+      lastRunAt: '2026-05-10T00:00:00Z',
+    };
+    const r = processFile('/p/a.jsonl', '10,20\n30,40\n', initial, fakeParser);
+    expect(r.events).toEqual([]);
+    expect(r.nextState.lastOffset).toBe(initial.lastOffset);
+  });
+
+  it('handles file truncation by resetting offset to 0 and re-emitting', () => {
+    // File got truncated/rotated; current contents are smaller than lastOffset.
+    const initial: IngestionState = {
+      sourcePath: '/p/a.jsonl',
+      lastOffset: 999,
+      lastRunAt: '2026-05-10T00:00:00Z',
+    };
+    const r = processFile('/p/a.jsonl', '5,5\n', initial, fakeParser);
+    expect(r.events.map((e) => e.input)).toEqual([5]);
+    expect(r.nextState.lastOffset).toBe(Buffer.byteLength('5,5\n', 'utf8'));
+  });
+});

--- a/packages/server/src/test/token-ingestion-processFile.test.ts
+++ b/packages/server/src/test/token-ingestion-processFile.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { processFile } from '../token-ingestion/watcher';
+import { parseCodexJsonl } from '../token-ingestion/parsers/codex';
 import type { TokenEvent, IngestionState } from '@agenfk/core';
 
 /**
@@ -74,5 +75,44 @@ describe('processFile', () => {
     const r = processFile('/p/a.jsonl', '5,5\n', initial, fakeParser);
     expect(r.events.map((e) => e.input)).toEqual([5]);
     expect(r.nextState.lastOffset).toBe(Buffer.byteLength('5,5\n', 'utf8'));
+  });
+
+  it('parses full-file context while returning only new appended Codex events', () => {
+    const sessionMeta = JSON.stringify({
+      type: 'session_meta',
+      timestamp: '2026-05-10T00:00:00Z',
+      payload: { id: 'sess-codex', cwd: '/workspace/repo' },
+    });
+    const turnContext = JSON.stringify({
+      type: 'turn_context',
+      timestamp: '2026-05-10T00:00:01Z',
+      payload: { turn_id: 'turn-1', model: 'gpt-5.5', cwd: '/workspace/repo' },
+    });
+    const first = JSON.stringify({
+      type: 'event_msg',
+      timestamp: '2026-05-10T00:00:02Z',
+      payload: { type: 'token_count', info: { last_token_usage: { input_tokens: 10, output_tokens: 2, total_tokens: 12 } } },
+    });
+    const priorText = `${sessionMeta}\n${turnContext}\n${first}\n`;
+    const second = JSON.stringify({
+      type: 'event_msg',
+      timestamp: '2026-05-10T00:00:03Z',
+      payload: { type: 'token_count', info: { last_token_usage: { input_tokens: 20, output_tokens: 4, total_tokens: 24 } } },
+    });
+    const r = processFile('/p/codex.jsonl', `${priorText}${second}\n`, {
+      sourcePath: '/p/codex.jsonl',
+      lastOffset: Buffer.byteLength(priorText, 'utf8'),
+      lastRunAt: '2026-05-10T00:00:02Z',
+    }, parseCodexJsonl);
+
+    expect(r.events).toHaveLength(1);
+    expect(r.events[0]).toMatchObject({
+      sessionId: 'sess-codex',
+      turnId: 'turn-1',
+      model: 'gpt-5.5',
+      cwd: '/workspace/repo',
+      input: 20,
+      output: 4,
+    });
   });
 });

--- a/packages/server/src/token-ingestion/attribution.ts
+++ b/packages/server/src/token-ingestion/attribution.ts
@@ -1,0 +1,72 @@
+import type { AgEnFKItem } from '@agenfk/core';
+
+interface MinimalFlow {
+  steps: Array<{ name: string; isAnchor?: boolean }>;
+}
+
+const INACTIVE_STATUSES = new Set(['BLOCKED', 'PAUSED', 'TRASHED', 'ARCHIVED', 'IDEAS']);
+
+function activeStatusSet(flow: MinimalFlow | null): (status: string) => boolean {
+  const anchors = new Set(
+    flow ? flow.steps.filter((s) => s.isAnchor).map((s) => s.name.toUpperCase()) : ['TODO', 'DONE'],
+  );
+  return (status: string) => {
+    const u = status.toUpperCase();
+    return !anchors.has(u) && !INACTIVE_STATUSES.has(u);
+  };
+}
+
+/**
+ * Given the items in a project and a timestamp T, return the id of the item
+ * whose most-recent transition INTO an active step occurred at or before T,
+ * provided the item has not transitioned OUT of the active step before T.
+ *
+ * "Active" = not an anchor (TODO/DONE) and not in the inactive set
+ * (BLOCKED/PAUSED/TRASHED/ARCHIVED/IDEAS).
+ *
+ * Returns null when no item was active at T.
+ */
+export function findActiveItemAt(
+  items: AgEnFKItem[],
+  flow: MinimalFlow | null,
+  ts: string,
+): string | null {
+  const isActive = activeStatusSet(flow);
+  const tMs = new Date(ts).getTime();
+
+  let bestId: string | null = null;
+  let bestActivationMs = -Infinity;
+
+  for (const item of items) {
+    const history = (item.history ?? [])
+      .map((h) => ({ to: String(h.toStatus), tMs: new Date(h.timestamp as any).getTime() }))
+      .filter((h) => h.tMs <= tMs)
+      .sort((a, b) => a.tMs - b.tMs);
+
+    if (history.length === 0) continue;
+
+    // Walk forward; track the latest activation point that is still in effect at T.
+    let activeSince = -Infinity;
+    for (const h of history) {
+      if (isActive(h.to)) {
+        // Only update activation point if we weren't already in an active step,
+        // so the "activation" reflects entry into the active region (handles re-entry).
+        if (activeSince === -Infinity || !isActive(h.to)) {
+          activeSince = h.tMs;
+        } else {
+          activeSince = h.tMs;
+        }
+      } else {
+        activeSince = -Infinity;
+      }
+    }
+
+    if (activeSince === -Infinity) continue;
+    if (activeSince > bestActivationMs) {
+      bestActivationMs = activeSince;
+      bestId = item.id;
+    }
+  }
+
+  return bestId;
+}

--- a/packages/server/src/token-ingestion/index.ts
+++ b/packages/server/src/token-ingestion/index.ts
@@ -11,3 +11,5 @@ export type {
   IngestionPollerOptions,
   ProcessFileResult,
 } from './watcher';
+export { parseClaudeCodeJsonl } from './parsers/claude-code';
+export { parseCodexJsonl } from './parsers/codex';

--- a/packages/server/src/token-ingestion/index.ts
+++ b/packages/server/src/token-ingestion/index.ts
@@ -1,0 +1,13 @@
+export { findActiveItemAt } from './attribution';
+export {
+  processFile,
+  ingestOnce,
+  startIngestionPoller,
+  listSourceFiles,
+} from './watcher';
+export type {
+  SessionLogParser,
+  IngestionSource,
+  IngestionPollerOptions,
+  ProcessFileResult,
+} from './watcher';

--- a/packages/server/src/token-ingestion/parsers/claude-code.ts
+++ b/packages/server/src/token-ingestion/parsers/claude-code.ts
@@ -1,0 +1,61 @@
+import { randomUUID } from 'crypto';
+import type { TokenEvent } from '@agenfk/core';
+import type { SessionLogParser } from '../watcher';
+
+/**
+ * Parses a slice of a Claude Code session JSONL file. Each line is a JSON
+ * object; lines with `type === 'assistant'` and a `message.usage` block
+ * yield one TokenEvent per line.
+ *
+ * Cached input combines `cache_creation_input_tokens` + `cache_read_input_tokens`
+ * because both represent input that was non-fresh at the model's turn.
+ *
+ * `client` is left as 'claude-code' but the runtime watcher will overwrite it
+ * with the configured source name.
+ */
+export const parseClaudeCodeJsonl: SessionLogParser = (text, sourcePath, baseOffset) => {
+  const events: TokenEvent[] = [];
+  let off = baseOffset;
+
+  for (const line of text.split('\n')) {
+    const lineBytes = Buffer.byteLength(line, 'utf8');
+    const lineOffset = off;
+    off += lineBytes + 1; // +1 for the \n delimiter we split on
+
+    if (!line.trim()) continue;
+    let obj: any;
+    try { obj = JSON.parse(line); } catch { continue; }
+
+    if (obj?.type !== 'assistant') continue;
+    const usage = obj?.message?.usage;
+    if (!usage || typeof usage !== 'object') continue;
+
+    const input = numberOr(usage.input_tokens, 0);
+    const cachedInput =
+      numberOr(usage.cache_creation_input_tokens, 0) + numberOr(usage.cache_read_input_tokens, 0);
+    const output = numberOr(usage.output_tokens, 0);
+    const reasoning = 0; // not separated in Claude's wire format
+    const total = input + cachedInput + output;
+
+    events.push({
+      id: randomUUID(),
+      ts: String(obj.timestamp ?? new Date().toISOString()),
+      client: 'claude-code',
+      sessionId: String(obj.sessionId ?? ''),
+      turnId: typeof obj.uuid === 'string' ? obj.uuid : undefined,
+      model: String(obj.message?.model ?? 'unknown'),
+      input,
+      cachedInput,
+      output,
+      reasoning,
+      total,
+      sourcePath,
+      sourceOffset: lineOffset,
+    });
+  }
+  return events;
+};
+
+function numberOr(v: any, fallback: number): number {
+  return typeof v === 'number' && Number.isFinite(v) ? v : fallback;
+}

--- a/packages/server/src/token-ingestion/parsers/claude-code.ts
+++ b/packages/server/src/token-ingestion/parsers/claude-code.ts
@@ -49,6 +49,7 @@ export const parseClaudeCodeJsonl: SessionLogParser = (text, sourcePath, baseOff
       output,
       reasoning,
       total,
+      cwd: typeof obj.cwd === 'string' ? obj.cwd : undefined,
       sourcePath,
       sourceOffset: lineOffset,
     });

--- a/packages/server/src/token-ingestion/parsers/codex.ts
+++ b/packages/server/src/token-ingestion/parsers/codex.ts
@@ -1,0 +1,81 @@
+import { randomUUID } from 'crypto';
+import type { TokenEvent } from '@agenfk/core';
+import type { SessionLogParser } from '../watcher';
+
+/**
+ * Codex session JSONL: each line is an event_msg, and `payload.type === 'token_count'`
+ * lines carry CUMULATIVE totals for the session. Per-turn deltas are recovered
+ * by subtracting the previous cumulative within the same slice.
+ *
+ * If a delta is negative (lower than previous), treat that line's cumulative
+ * as a fresh baseline (likely session reset / file rotation) — emit it as-is
+ * rather than emitting a negative usage.
+ */
+export const parseCodexJsonl: SessionLogParser = (text, sourcePath, baseOffset) => {
+  const events: TokenEvent[] = [];
+  let off = baseOffset;
+
+  let prev = { input: 0, cachedInput: 0, output: 0, reasoning: 0, total: 0 };
+  let havePrev = false;
+
+  for (const line of text.split('\n')) {
+    const lineBytes = Buffer.byteLength(line, 'utf8');
+    const lineOffset = off;
+    off += lineBytes + 1;
+
+    if (!line.trim()) continue;
+    let obj: any;
+    try { obj = JSON.parse(line); } catch { continue; }
+
+    if (obj?.type !== 'event_msg') continue;
+    if (obj?.payload?.type !== 'token_count') continue;
+
+    const cum = {
+      input: numberOr(obj.payload.input, 0),
+      cachedInput: numberOr(obj.payload.cached_input, 0),
+      output: numberOr(obj.payload.output, 0),
+      reasoning: numberOr(obj.payload.reasoning, 0),
+      total: numberOr(obj.payload.total, 0),
+    };
+
+    let delta = havePrev
+      ? {
+          input: cum.input - prev.input,
+          cachedInput: cum.cachedInput - prev.cachedInput,
+          output: cum.output - prev.output,
+          reasoning: cum.reasoning - prev.reasoning,
+          total: cum.total - prev.total,
+        }
+      : { ...cum };
+
+    // Detect session reset: any negative component → treat current cumulative as fresh.
+    const negative =
+      delta.input < 0 || delta.cachedInput < 0 || delta.output < 0 ||
+      delta.reasoning < 0 || delta.total < 0;
+    if (negative) delta = { ...cum };
+
+    events.push({
+      id: randomUUID(),
+      ts: String(obj.timestamp ?? obj.payload.timestamp ?? new Date().toISOString()),
+      client: 'codex',
+      sessionId: String(obj.payload.session_id ?? obj.session_id ?? ''),
+      turnId: typeof obj.payload.turn_id === 'string' ? obj.payload.turn_id : undefined,
+      model: String(obj.payload.model ?? 'unknown'),
+      input: delta.input,
+      cachedInput: delta.cachedInput,
+      output: delta.output,
+      reasoning: delta.reasoning,
+      total: delta.total,
+      sourcePath,
+      sourceOffset: lineOffset,
+    });
+
+    prev = cum;
+    havePrev = true;
+  }
+  return events;
+};
+
+function numberOr(v: any, fallback: number): number {
+  return typeof v === 'number' && Number.isFinite(v) ? v : fallback;
+}

--- a/packages/server/src/token-ingestion/parsers/codex.ts
+++ b/packages/server/src/token-ingestion/parsers/codex.ts
@@ -3,9 +3,10 @@ import type { TokenEvent } from '@agenfk/core';
 import type { SessionLogParser } from '../watcher';
 
 /**
- * Codex session JSONL: each line is an event_msg, and `payload.type === 'token_count'`
- * lines carry CUMULATIVE totals for the session. Per-turn deltas are recovered
- * by subtracting the previous cumulative within the same slice.
+ * Codex session JSONL: current CLI builds emit token_count events with
+ * `payload.info.last_token_usage`; older builds emitted flat cumulative totals.
+ * For legacy cumulative totals, per-turn deltas are recovered by subtracting
+ * the previous cumulative value.
  *
  * If a delta is negative (lower than previous), treat that line's cumulative
  * as a fresh baseline (likely session reset / file rotation) — emit it as-is
@@ -17,6 +18,10 @@ export const parseCodexJsonl: SessionLogParser = (text, sourcePath, baseOffset) 
 
   let prev = { input: 0, cachedInput: 0, output: 0, reasoning: 0, total: 0 };
   let havePrev = false;
+  let sessionId = '';
+  let model = 'unknown';
+  let turnId: string | undefined;
+  let cwd: string | undefined;
 
   for (const line of text.split('\n')) {
     const lineBytes = Buffer.byteLength(line, 'utf8');
@@ -27,55 +32,88 @@ export const parseCodexJsonl: SessionLogParser = (text, sourcePath, baseOffset) 
     let obj: any;
     try { obj = JSON.parse(line); } catch { continue; }
 
+    if (obj?.type === 'session_meta') {
+      if (typeof obj.payload?.id === 'string') sessionId = obj.payload.id;
+      if (typeof obj.payload?.cwd === 'string') cwd = obj.payload.cwd;
+      continue;
+    }
+    if (obj?.type === 'turn_context') {
+      if (typeof obj.payload?.turn_id === 'string') turnId = obj.payload.turn_id;
+      if (typeof obj.payload?.model === 'string') model = obj.payload.model;
+      if (typeof obj.payload?.cwd === 'string') cwd = obj.payload.cwd;
+      continue;
+    }
+
     if (obj?.type !== 'event_msg') continue;
     if (obj?.payload?.type !== 'token_count') continue;
 
-    const cum = {
-      input: numberOr(obj.payload.input, 0),
-      cachedInput: numberOr(obj.payload.cached_input, 0),
-      output: numberOr(obj.payload.output, 0),
-      reasoning: numberOr(obj.payload.reasoning, 0),
-      total: numberOr(obj.payload.total, 0),
-    };
+    const usage = obj.payload.info?.last_token_usage;
+    const cumUsage = obj.payload.info?.total_token_usage;
+    const liveUsage = usage && typeof usage === 'object' ? usage : null;
+    const liveCumUsage = cumUsage && typeof cumUsage === 'object' ? cumUsage : null;
+    if (obj.payload.info !== undefined && !liveUsage && !liveCumUsage) continue;
 
-    let delta = havePrev
-      ? {
-          input: cum.input - prev.input,
-          cachedInput: cum.cachedInput - prev.cachedInput,
-          output: cum.output - prev.output,
-          reasoning: cum.reasoning - prev.reasoning,
-          total: cum.total - prev.total,
-        }
-      : { ...cum };
+    let delta: typeof prev;
+    if (liveUsage) {
+      delta = tokenUsageFromCodexInfo(liveUsage);
+    } else {
+      const cum = liveCumUsage ? tokenUsageFromCodexInfo(liveCumUsage) : {
+        input: numberOr(obj.payload.input, 0),
+        cachedInput: numberOr(obj.payload.cached_input, 0),
+        output: numberOr(obj.payload.output, 0),
+        reasoning: numberOr(obj.payload.reasoning, 0),
+        total: numberOr(obj.payload.total, 0),
+      };
 
-    // Detect session reset: any negative component → treat current cumulative as fresh.
-    const negative =
-      delta.input < 0 || delta.cachedInput < 0 || delta.output < 0 ||
-      delta.reasoning < 0 || delta.total < 0;
-    if (negative) delta = { ...cum };
+      delta = havePrev
+        ? {
+            input: cum.input - prev.input,
+            cachedInput: cum.cachedInput - prev.cachedInput,
+            output: cum.output - prev.output,
+            reasoning: cum.reasoning - prev.reasoning,
+            total: cum.total - prev.total,
+          }
+        : { ...cum };
+
+      // Detect session reset: any negative component -> treat current cumulative as fresh.
+      const negative =
+        delta.input < 0 || delta.cachedInput < 0 || delta.output < 0 ||
+        delta.reasoning < 0 || delta.total < 0;
+      if (negative) delta = { ...cum };
+      prev = cum;
+      havePrev = true;
+    }
 
     events.push({
       id: randomUUID(),
       ts: String(obj.timestamp ?? obj.payload.timestamp ?? new Date().toISOString()),
       client: 'codex',
-      sessionId: String(obj.payload.session_id ?? obj.session_id ?? ''),
-      turnId: typeof obj.payload.turn_id === 'string' ? obj.payload.turn_id : undefined,
-      model: String(obj.payload.model ?? 'unknown'),
+      sessionId: String(obj.payload.session_id ?? obj.session_id ?? sessionId),
+      turnId: typeof obj.payload.turn_id === 'string' ? obj.payload.turn_id : turnId,
+      model: String(obj.payload.model ?? model),
       input: delta.input,
       cachedInput: delta.cachedInput,
       output: delta.output,
       reasoning: delta.reasoning,
       total: delta.total,
+      cwd,
       sourcePath,
       sourceOffset: lineOffset,
     });
-
-    prev = cum;
-    havePrev = true;
   }
   return events;
 };
 
 function numberOr(v: any, fallback: number): number {
   return typeof v === 'number' && Number.isFinite(v) ? v : fallback;
+}
+
+function tokenUsageFromCodexInfo(usage: any): { input: number; cachedInput: number; output: number; reasoning: number; total: number } {
+  return {
+    input: numberOr(usage.input_tokens, 0),
+    cachedInput: numberOr(usage.cached_input_tokens, 0),
+    output: numberOr(usage.output_tokens, 0),
+    reasoning: numberOr(usage.reasoning_output_tokens, 0),
+    total: numberOr(usage.total_tokens, 0),
+  };
 }

--- a/packages/server/src/token-ingestion/watcher.ts
+++ b/packages/server/src/token-ingestion/watcher.ts
@@ -93,6 +93,8 @@ export interface IngestionPollerOptions {
   sources: IngestionSource[];
   /** ms between polls. Default 30s. */
   intervalMs?: number;
+  /** Called for each TokenEvent successfully written to storage. */
+  onEvent?: (ev: TokenEvent) => void;
 }
 
 /**
@@ -136,6 +138,7 @@ export async function ingestOnce(opts: IngestionPollerOptions): Promise<number> 
         try {
           await opts.storage.insertTokenEvent(ev);
           written++;
+          opts.onEvent?.(ev);
         } catch {
           // Most likely a duplicate via the unique (client, source_path, source_offset)
           // index — safe to ignore on poll-overlap.

--- a/packages/server/src/token-ingestion/watcher.ts
+++ b/packages/server/src/token-ingestion/watcher.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import type { TokenEvent, IngestionState, StorageProvider } from '@agenfk/core';
+import type { Project, TokenEvent, IngestionState, StorageProvider } from '@agenfk/core';
+import { findActiveItemAt } from './attribution';
 
 /**
  * Parser signature: given the new (un-ingested) text content from a file,
@@ -26,7 +27,8 @@ export interface ProcessFileResult {
  * file's current contents and returns the new events plus the next state.
  *
  * - First run (no prior state): parse the entire file from offset 0.
- * - Normal append: parse only the bytes after lastOffset.
+ * - Normal append: parse the full file for parser context, return only events
+ *   at or after lastOffset.
  * - File truncation/rotation (currentSize < lastOffset): treat as a fresh
  *   file, parse from 0.
  *
@@ -42,8 +44,11 @@ export function processFile(
   const totalBytes = Buffer.byteLength(currentContents, 'utf8');
   const lastOffset = priorState?.lastOffset ?? 0;
   const startOffset = lastOffset > totalBytes ? 0 : lastOffset; // truncation
-  const slice = startOffset === 0 ? currentContents : currentContents.slice(byteOffsetToCharOffset(currentContents, startOffset));
-  const events = slice.length ? parser(slice, sourcePath, startOffset) : [];
+  // Parse the full file so parsers can use session-level metadata that may
+  // appear before the newly appended byte range; then keep only new events.
+  const events = currentContents.length
+    ? parser(currentContents, sourcePath, 0).filter((ev) => ev.sourceOffset >= startOffset)
+    : [];
   return {
     events,
     nextState: {
@@ -52,24 +57,6 @@ export function processFile(
       lastRunAt: new Date().toISOString(),
     },
   };
-}
-
-/**
- * Convert a byte offset (within the UTF-8 encoding of `s`) to the equivalent
- * character offset for `String.prototype.slice`. Optimized for the common ASCII
- * case where byte offset == char offset.
- */
-function byteOffsetToCharOffset(s: string, byteOffset: number): number {
-  if (byteOffset === 0) return 0;
-  // Fast path: if the prefix is all ASCII, byte offset == char offset.
-  let bytes = 0;
-  for (let i = 0; i < s.length; i++) {
-    const b = Buffer.byteLength(s[i], 'utf8');
-    bytes += b;
-    if (bytes === byteOffset) return i + 1;
-    if (bytes > byteOffset) return i; // mid-codepoint; align to char boundary
-  }
-  return s.length;
 }
 
 // ── Runtime poller (wraps processFile + storage) ─────────────────────────────
@@ -93,6 +80,8 @@ export interface IngestionPollerOptions {
   sources: IngestionSource[];
   /** ms between polls. Default 30s. */
   intervalMs?: number;
+  /** Attribute events to the matching project root and active item. */
+  attributeEvents?: boolean;
   /** Called for each TokenEvent successfully written to storage. */
   onEvent?: (ev: TokenEvent) => void;
 }
@@ -135,6 +124,7 @@ export async function ingestOnce(opts: IngestionPollerOptions): Promise<number> 
       // Tag every event with the source's client name (parsers may not know it).
       for (const ev of result.events) {
         ev.client = source.client as any;
+        if (opts.attributeEvents) await attributeTokenEvent(opts.storage, ev);
         try {
           await opts.storage.insertTokenEvent(ev);
           written++;
@@ -162,4 +152,33 @@ export function startIngestionPoller(opts: IngestionPollerOptions): () => void {
   };
   let timer: NodeJS.Timeout = setTimeout(tick, intervalMs);
   return () => { stopped = true; clearTimeout(timer); };
+}
+
+async function attributeTokenEvent(storage: StorageProvider, ev: TokenEvent): Promise<void> {
+  const project = await findProjectForCwd(storage, ev.cwd);
+  if (!project) return;
+
+  ev.projectId = project.id;
+  const flow = project.flowId ? await storage.getFlow(project.flowId) : null;
+  const items = await storage.listItems({ projectId: project.id });
+  const itemId = findActiveItemAt(items, flow, ev.ts);
+  if (itemId) ev.itemId = itemId;
+}
+
+async function findProjectForCwd(storage: StorageProvider, cwd: string | undefined): Promise<Project | null> {
+  if (!cwd) return null;
+  const projects = await storage.listProjects();
+  let best: { project: Project; rootLength: number } | null = null;
+  for (const project of projects) {
+    if (!project.projectRoot) continue;
+    if (!isWithinOrEqual(project.projectRoot, cwd)) continue;
+    const rootLength = path.resolve(project.projectRoot).length;
+    if (!best || rootLength > best.rootLength) best = { project, rootLength };
+  }
+  return best?.project ?? null;
+}
+
+function isWithinOrEqual(root: string, child: string): boolean {
+  const rel = path.relative(path.resolve(root), path.resolve(child));
+  return rel === '' || (!!rel && !rel.startsWith('..') && !path.isAbsolute(rel));
 }

--- a/packages/server/src/token-ingestion/watcher.ts
+++ b/packages/server/src/token-ingestion/watcher.ts
@@ -1,0 +1,162 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import type { TokenEvent, IngestionState, StorageProvider } from '@agenfk/core';
+
+/**
+ * Parser signature: given the new (un-ingested) text content from a file,
+ * the file path, and the byte offset where this slice starts, return the
+ * TokenEvents to insert. Each parser is responsible for its own per-client
+ * format (Codex, Claude Code, etc.) and for setting `sourceOffset` on each
+ * event to the byte offset of the record within the file (so the dedup
+ * unique index in storage rejects double-inserts on retry).
+ */
+export type SessionLogParser = (
+  text: string,
+  sourcePath: string,
+  baseOffset: number,
+) => TokenEvent[];
+
+export interface ProcessFileResult {
+  events: TokenEvent[];
+  nextState: IngestionState;
+}
+
+/**
+ * Pure-logic core of the watcher. Compares prior ingestion state against the
+ * file's current contents and returns the new events plus the next state.
+ *
+ * - First run (no prior state): parse the entire file from offset 0.
+ * - Normal append: parse only the bytes after lastOffset.
+ * - File truncation/rotation (currentSize < lastOffset): treat as a fresh
+ *   file, parse from 0.
+ *
+ * No I/O is performed here — caller passes the current contents in. Tests
+ * exercise this directly without touching the filesystem.
+ */
+export function processFile(
+  sourcePath: string,
+  currentContents: string,
+  priorState: IngestionState | null,
+  parser: SessionLogParser,
+): ProcessFileResult {
+  const totalBytes = Buffer.byteLength(currentContents, 'utf8');
+  const lastOffset = priorState?.lastOffset ?? 0;
+  const startOffset = lastOffset > totalBytes ? 0 : lastOffset; // truncation
+  const slice = startOffset === 0 ? currentContents : currentContents.slice(byteOffsetToCharOffset(currentContents, startOffset));
+  const events = slice.length ? parser(slice, sourcePath, startOffset) : [];
+  return {
+    events,
+    nextState: {
+      sourcePath,
+      lastOffset: totalBytes,
+      lastRunAt: new Date().toISOString(),
+    },
+  };
+}
+
+/**
+ * Convert a byte offset (within the UTF-8 encoding of `s`) to the equivalent
+ * character offset for `String.prototype.slice`. Optimized for the common ASCII
+ * case where byte offset == char offset.
+ */
+function byteOffsetToCharOffset(s: string, byteOffset: number): number {
+  if (byteOffset === 0) return 0;
+  // Fast path: if the prefix is all ASCII, byte offset == char offset.
+  let bytes = 0;
+  for (let i = 0; i < s.length; i++) {
+    const b = Buffer.byteLength(s[i], 'utf8');
+    bytes += b;
+    if (bytes === byteOffset) return i + 1;
+    if (bytes > byteOffset) return i; // mid-codepoint; align to char boundary
+  }
+  return s.length;
+}
+
+// ── Runtime poller (wraps processFile + storage) ─────────────────────────────
+// Discovers session log files under one or more root directories and ingests
+// them into the storage's token_events table. Picks up where it left off via
+// the ingestion_state table.
+
+export interface IngestionSource {
+  /** Stable name used as the `client` field on emitted events (e.g. 'codex'). */
+  client: string;
+  /** Root dir to scan (e.g. ~/.codex/sessions/). */
+  rootDir: string;
+  /** Glob-like predicate for which files to ingest. */
+  matches: (relativePath: string) => boolean;
+  /** Per-client parser. */
+  parser: SessionLogParser;
+}
+
+export interface IngestionPollerOptions {
+  storage: StorageProvider;
+  sources: IngestionSource[];
+  /** ms between polls. Default 30s. */
+  intervalMs?: number;
+}
+
+/**
+ * Walks a directory recursively and yields absolute paths matching `predicate`.
+ * Used at runtime by the poller; not invoked by the pure tests.
+ */
+export function listSourceFiles(rootDir: string, predicate: (rel: string) => boolean): string[] {
+  if (!fs.existsSync(rootDir)) return [];
+  const out: string[] = [];
+  const stack: string[] = [rootDir];
+  while (stack.length) {
+    const dir = stack.pop()!;
+    let entries: fs.Dirent[];
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { continue; }
+    for (const e of entries) {
+      const abs = path.join(dir, e.name);
+      const rel = path.relative(rootDir, abs);
+      if (e.isDirectory()) stack.push(abs);
+      else if (e.isFile() && predicate(rel)) out.push(abs);
+    }
+  }
+  return out;
+}
+
+/**
+ * Single ingestion pass: scan all sources, ingest any new bytes, return the
+ * total number of events written.
+ */
+export async function ingestOnce(opts: IngestionPollerOptions): Promise<number> {
+  let written = 0;
+  for (const source of opts.sources) {
+    const files = listSourceFiles(source.rootDir, source.matches);
+    for (const abs of files) {
+      let contents: string;
+      try { contents = fs.readFileSync(abs, 'utf8'); } catch { continue; }
+      const prior = await opts.storage.getIngestionState(abs);
+      const result = processFile(abs, contents, prior, source.parser);
+      // Tag every event with the source's client name (parsers may not know it).
+      for (const ev of result.events) {
+        ev.client = source.client as any;
+        try {
+          await opts.storage.insertTokenEvent(ev);
+          written++;
+        } catch {
+          // Most likely a duplicate via the unique (client, source_path, source_offset)
+          // index — safe to ignore on poll-overlap.
+        }
+      }
+      await opts.storage.setIngestionState(result.nextState);
+    }
+  }
+  return written;
+}
+
+export function startIngestionPoller(opts: IngestionPollerOptions): () => void {
+  const intervalMs = opts.intervalMs ?? 30_000;
+  let stopped = false;
+  const tick = async () => {
+    if (stopped) return;
+    try { await ingestOnce(opts); } catch (e) {
+      console.error('[TOKEN_INGESTION] tick failed:', (e as Error).message);
+    }
+    if (!stopped) timer = setTimeout(tick, intervalMs);
+  };
+  let timer: NodeJS.Timeout = setTimeout(tick, intervalMs);
+  return () => { stopped = true; clearTimeout(timer); };
+}

--- a/packages/storage-sqlite/package.json
+++ b/packages/storage-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/storage-sqlite",
-  "version": "1.0.0",
+  "version": "1.0.1-beta.1",
   "description": "SQLite storage implementation for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -11,7 +11,7 @@
     "uuid": "^9.0.1"
   },
   "devDependencies": {
-    "@agenfk/core": "1.0.0",
+    "@agenfk/core": "1.0.1-beta.1",
     "@types/node": "^22.0.0",
     "@types/uuid": "^9.0.8",
     "typescript": "^5.3.3"

--- a/packages/storage-sqlite/package.json
+++ b/packages/storage-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/storage-sqlite",
-  "version": "1.0.1-beta.6",
+  "version": "1.0.1-beta.7",
   "description": "SQLite storage implementation for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -11,7 +11,7 @@
     "uuid": "^9.0.1"
   },
   "devDependencies": {
-    "@agenfk/core": "1.0.1-beta.6",
+    "@agenfk/core": "1.0.1-beta.7",
     "@types/node": "^22.0.0",
     "@types/uuid": "^9.0.8",
     "typescript": "^5.3.3"

--- a/packages/storage-sqlite/package.json
+++ b/packages/storage-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/storage-sqlite",
-  "version": "1.0.1-beta.1",
+  "version": "1.0.1-beta.3",
   "description": "SQLite storage implementation for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -11,7 +11,7 @@
     "uuid": "^9.0.1"
   },
   "devDependencies": {
-    "@agenfk/core": "1.0.1-beta.1",
+    "@agenfk/core": "1.0.1-beta.3",
     "@types/node": "^22.0.0",
     "@types/uuid": "^9.0.8",
     "typescript": "^5.3.3"

--- a/packages/storage-sqlite/package.json
+++ b/packages/storage-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/storage-sqlite",
-  "version": "1.0.1-beta.3",
+  "version": "1.0.1-beta.4",
   "description": "SQLite storage implementation for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -11,7 +11,7 @@
     "uuid": "^9.0.1"
   },
   "devDependencies": {
-    "@agenfk/core": "1.0.1-beta.3",
+    "@agenfk/core": "1.0.1-beta.4",
     "@types/node": "^22.0.0",
     "@types/uuid": "^9.0.8",
     "typescript": "^5.3.3"

--- a/packages/storage-sqlite/package.json
+++ b/packages/storage-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/storage-sqlite",
-  "version": "1.0.1-beta.5",
+  "version": "1.0.1-beta.6",
   "description": "SQLite storage implementation for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -11,7 +11,7 @@
     "uuid": "^9.0.1"
   },
   "devDependencies": {
-    "@agenfk/core": "1.0.1-beta.5",
+    "@agenfk/core": "1.0.1-beta.6",
     "@types/node": "^22.0.0",
     "@types/uuid": "^9.0.8",
     "typescript": "^5.3.3"

--- a/packages/storage-sqlite/package.json
+++ b/packages/storage-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/storage-sqlite",
-  "version": "1.0.1-beta.4",
+  "version": "1.0.1-beta.5",
   "description": "SQLite storage implementation for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -11,7 +11,7 @@
     "uuid": "^9.0.1"
   },
   "devDependencies": {
-    "@agenfk/core": "1.0.1-beta.4",
+    "@agenfk/core": "1.0.1-beta.5",
     "@types/node": "^22.0.0",
     "@types/uuid": "^9.0.8",
     "typescript": "^5.3.3"

--- a/packages/storage-sqlite/src/index.ts
+++ b/packages/storage-sqlite/src/index.ts
@@ -412,44 +412,184 @@ export class SQLiteStorageProvider implements StorageProvider {
     return rows.map(r => this.parseFlow(r.data));
   }
 
-  // ── Observability stubs ────────────────────────────────────────────────────
-  // Real implementations land in the next task in the observability initiative.
-  // The schema (token_events, ingestion_state, prs) is created above.
+  // ── Observability: token events ─────────────────────────────────────────────
 
-  async insertTokenEvent(_event: TokenEvent): Promise<void> {
-    throw new Error('insertTokenEvent: not yet implemented');
+  async insertTokenEvent(event: TokenEvent): Promise<void> {
+    this.database.prepare(
+      `INSERT INTO token_events
+        (id, ts, client, session_id, turn_id, model,
+         input, cached_input, output, reasoning, total,
+         item_id, project_id, source_path, source_offset)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      event.id,
+      event.ts,
+      event.client,
+      event.sessionId,
+      event.turnId ?? null,
+      event.model,
+      event.input,
+      event.cachedInput,
+      event.output,
+      event.reasoning,
+      event.total,
+      event.itemId ?? null,
+      event.projectId ?? null,
+      event.sourcePath,
+      event.sourceOffset,
+    );
   }
 
-  async queryTokenEvents(_query: TokenEventQuery): Promise<TokenEvent[]> {
-    throw new Error('queryTokenEvents: not yet implemented');
+  async queryTokenEvents(query: TokenEventQuery): Promise<TokenEvent[]> {
+    const where: string[] = [];
+    const params: any[] = [];
+    if (query.itemId !== undefined) { where.push('item_id = ?'); params.push(query.itemId); }
+    if (query.projectId !== undefined) { where.push('project_id = ?'); params.push(query.projectId); }
+    if (query.client !== undefined) { where.push('client = ?'); params.push(query.client); }
+    if (query.since !== undefined) { where.push('ts >= ?'); params.push(query.since); }
+    if (query.until !== undefined) { where.push('ts < ?'); params.push(query.until); }
+    let sql =
+      `SELECT id, ts, client, session_id, turn_id, model,
+              input, cached_input, output, reasoning, total,
+              item_id, project_id, source_path, source_offset
+         FROM token_events`;
+    if (where.length) sql += ' WHERE ' + where.join(' AND ');
+    sql += ' ORDER BY ts ASC';
+    if (query.limit !== undefined) { sql += ' LIMIT ?'; params.push(query.limit); }
+    const rows = this.database.prepare(sql).all(...params) as any[];
+    return rows.map((r) => ({
+      id: r.id,
+      ts: r.ts,
+      client: r.client,
+      sessionId: r.session_id,
+      turnId: r.turn_id ?? undefined,
+      model: r.model,
+      input: r.input,
+      cachedInput: r.cached_input,
+      output: r.output,
+      reasoning: r.reasoning,
+      total: r.total,
+      itemId: r.item_id ?? undefined,
+      projectId: r.project_id ?? undefined,
+      sourcePath: r.source_path,
+      sourceOffset: r.source_offset,
+    }));
   }
 
-  async getIngestionState(_sourcePath: string): Promise<IngestionState | null> {
-    throw new Error('getIngestionState: not yet implemented');
+  // ── Observability: ingestion state (resumable file-watcher offsets) ────────
+
+  async getIngestionState(sourcePath: string): Promise<IngestionState | null> {
+    const row = this.database.prepare(
+      'SELECT source_path, last_offset, last_run_at FROM ingestion_state WHERE source_path = ?'
+    ).get(sourcePath) as { source_path: string; last_offset: number; last_run_at: string } | undefined;
+    if (!row) return null;
+    return {
+      sourcePath: row.source_path,
+      lastOffset: row.last_offset,
+      lastRunAt: row.last_run_at,
+    };
   }
 
-  async setIngestionState(_state: IngestionState): Promise<void> {
-    throw new Error('setIngestionState: not yet implemented');
+  async setIngestionState(state: IngestionState): Promise<void> {
+    this.database.prepare(
+      `INSERT INTO ingestion_state (source_path, last_offset, last_run_at)
+       VALUES (?, ?, ?)
+       ON CONFLICT(source_path) DO UPDATE SET
+         last_offset = excluded.last_offset,
+         last_run_at = excluded.last_run_at`
+    ).run(state.sourcePath, state.lastOffset, state.lastRunAt);
   }
 
-  async insertPr(_pr: Pr): Promise<Pr> {
-    throw new Error('insertPr: not yet implemented');
+  // ── Observability: PR registration ─────────────────────────────────────────
+
+  private rowToPr(row: any): Pr {
+    return {
+      id: row.id,
+      prNumber: row.pr_number,
+      repo: row.repo,
+      itemId: row.item_id,
+      openedAt: row.opened_at,
+      sizing: JSON.parse(row.sizing_json) as PrSizing,
+      sizingDeclaredAt: row.sizing_declared_at,
+      sizingShadow: row.sizing_shadow_json ? (JSON.parse(row.sizing_shadow_json) as PrSizing) : undefined,
+      lastSizingCheckAt: row.last_sizing_check_at ?? undefined,
+    };
+  }
+
+  async insertPr(pr: Pr): Promise<Pr> {
+    // Idempotent on (repo, pr_number): if row exists, refresh sizing fields
+    // (and itemId/openedAt) instead of throwing on the unique index.
+    this.database.prepare(
+      `INSERT INTO prs
+         (id, pr_number, repo, item_id, opened_at,
+          sizing_json, sizing_declared_at, sizing_shadow_json, last_sizing_check_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(repo, pr_number) DO UPDATE SET
+         item_id = excluded.item_id,
+         opened_at = excluded.opened_at,
+         sizing_json = excluded.sizing_json,
+         sizing_declared_at = excluded.sizing_declared_at,
+         sizing_shadow_json = excluded.sizing_shadow_json,
+         last_sizing_check_at = excluded.last_sizing_check_at`
+    ).run(
+      pr.id,
+      pr.prNumber,
+      pr.repo,
+      pr.itemId,
+      pr.openedAt,
+      JSON.stringify(pr.sizing),
+      pr.sizingDeclaredAt,
+      pr.sizingShadow ? JSON.stringify(pr.sizingShadow) : null,
+      pr.lastSizingCheckAt ?? null,
+    );
+    const row = this.database.prepare(
+      'SELECT * FROM prs WHERE repo = ? AND pr_number = ?'
+    ).get(pr.repo, pr.prNumber) as any;
+    return this.rowToPr(row);
   }
 
   async updatePrSizing(
-    _repo: string,
-    _prNumber: number,
-    _sizing: PrSizing,
-    _shadow?: PrSizing,
+    repo: string,
+    prNumber: number,
+    sizing: PrSizing,
+    shadow?: PrSizing,
   ): Promise<Pr> {
-    throw new Error('updatePrSizing: not yet implemented');
+    const now = new Date().toISOString();
+    const result = this.database.prepare(
+      `UPDATE prs SET
+         sizing_json = ?,
+         sizing_declared_at = ?,
+         sizing_shadow_json = ?,
+         last_sizing_check_at = ?
+       WHERE repo = ? AND pr_number = ?`
+    ).run(
+      JSON.stringify(sizing),
+      now,
+      shadow ? JSON.stringify(shadow) : null,
+      now,
+      repo,
+      prNumber,
+    );
+    if (Number(result.changes ?? 0) === 0) {
+      throw new Error(`updatePrSizing: PR ${repo}#${prNumber} not found`);
+    }
+    const row = this.database.prepare(
+      'SELECT * FROM prs WHERE repo = ? AND pr_number = ?'
+    ).get(repo, prNumber) as any;
+    return this.rowToPr(row);
   }
 
-  async getPrByRepoNumber(_repo: string, _prNumber: number): Promise<Pr | null> {
-    throw new Error('getPrByRepoNumber: not yet implemented');
+  async getPrByRepoNumber(repo: string, prNumber: number): Promise<Pr | null> {
+    const row = this.database.prepare(
+      'SELECT * FROM prs WHERE repo = ? AND pr_number = ?'
+    ).get(repo, prNumber) as any;
+    return row ? this.rowToPr(row) : null;
   }
 
-  async getPrsByItemId(_itemId: string): Promise<Pr[]> {
-    throw new Error('getPrsByItemId: not yet implemented');
+  async getPrsByItemId(itemId: string): Promise<Pr[]> {
+    const rows = this.database.prepare(
+      'SELECT * FROM prs WHERE item_id = ? ORDER BY opened_at ASC'
+    ).all(itemId) as any[];
+    return rows.map((r) => this.rowToPr(r));
   }
 }

--- a/packages/storage-sqlite/src/index.ts
+++ b/packages/storage-sqlite/src/index.ts
@@ -9,7 +9,12 @@ import {
   Status,
   Project,
   PauseSnapshot,
-  Flow
+  Flow,
+  TokenEvent,
+  TokenEventQuery,
+  IngestionState,
+  Pr,
+  PrSizing,
 } from '@agenfk/core';
 
 // node:sqlite is a built-in module available from Node.js v22+.
@@ -88,6 +93,46 @@ export class SQLiteStorageProvider implements StorageProvider {
         created_at TEXT NOT NULL DEFAULT (datetime('now'))
       );
       CREATE INDEX IF NOT EXISTS idx_hub_outbox_occurred ON hub_outbox(occurred_at);
+      CREATE TABLE IF NOT EXISTS token_events (
+        id TEXT PRIMARY KEY,
+        ts TEXT NOT NULL,
+        client TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        turn_id TEXT,
+        model TEXT NOT NULL,
+        input INTEGER NOT NULL DEFAULT 0,
+        cached_input INTEGER NOT NULL DEFAULT 0,
+        output INTEGER NOT NULL DEFAULT 0,
+        reasoning INTEGER NOT NULL DEFAULT 0,
+        total INTEGER NOT NULL DEFAULT 0,
+        item_id TEXT,
+        project_id TEXT,
+        source_path TEXT NOT NULL,
+        source_offset INTEGER NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_token_events_ts ON token_events(ts);
+      CREATE INDEX IF NOT EXISTS idx_token_events_item ON token_events(item_id);
+      CREATE INDEX IF NOT EXISTS idx_token_events_session ON token_events(session_id);
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_token_events_dedup
+        ON token_events(client, source_path, source_offset);
+      CREATE TABLE IF NOT EXISTS ingestion_state (
+        source_path TEXT PRIMARY KEY,
+        last_offset INTEGER NOT NULL,
+        last_run_at TEXT NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS prs (
+        id TEXT PRIMARY KEY,
+        pr_number INTEGER NOT NULL,
+        repo TEXT NOT NULL,
+        item_id TEXT NOT NULL,
+        opened_at TEXT NOT NULL,
+        sizing_json TEXT NOT NULL,
+        sizing_declared_at TEXT NOT NULL,
+        sizing_shadow_json TEXT,
+        last_sizing_check_at TEXT
+      );
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_prs_repo_number ON prs(repo, pr_number);
+      CREATE INDEX IF NOT EXISTS idx_prs_item ON prs(item_id);
     `);
     this.migrateFlowsTable();
   }
@@ -365,5 +410,46 @@ export class SQLiteStorageProvider implements StorageProvider {
   async listFlows(): Promise<Flow[]> {
     const rows = this.database.prepare('SELECT data FROM flows').all() as { data: string }[];
     return rows.map(r => this.parseFlow(r.data));
+  }
+
+  // ── Observability stubs ────────────────────────────────────────────────────
+  // Real implementations land in the next task in the observability initiative.
+  // The schema (token_events, ingestion_state, prs) is created above.
+
+  async insertTokenEvent(_event: TokenEvent): Promise<void> {
+    throw new Error('insertTokenEvent: not yet implemented');
+  }
+
+  async queryTokenEvents(_query: TokenEventQuery): Promise<TokenEvent[]> {
+    throw new Error('queryTokenEvents: not yet implemented');
+  }
+
+  async getIngestionState(_sourcePath: string): Promise<IngestionState | null> {
+    throw new Error('getIngestionState: not yet implemented');
+  }
+
+  async setIngestionState(_state: IngestionState): Promise<void> {
+    throw new Error('setIngestionState: not yet implemented');
+  }
+
+  async insertPr(_pr: Pr): Promise<Pr> {
+    throw new Error('insertPr: not yet implemented');
+  }
+
+  async updatePrSizing(
+    _repo: string,
+    _prNumber: number,
+    _sizing: PrSizing,
+    _shadow?: PrSizing,
+  ): Promise<Pr> {
+    throw new Error('updatePrSizing: not yet implemented');
+  }
+
+  async getPrByRepoNumber(_repo: string, _prNumber: number): Promise<Pr | null> {
+    throw new Error('getPrByRepoNumber: not yet implemented');
+  }
+
+  async getPrsByItemId(_itemId: string): Promise<Pr[]> {
+    throw new Error('getPrsByItemId: not yet implemented');
   }
 }

--- a/packages/storage-sqlite/src/test/observability-storage.test.ts
+++ b/packages/storage-sqlite/src/test/observability-storage.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import { SQLiteStorageProvider } from '../index';
+import type { TokenEvent, IngestionState, Pr } from '@agenfk/core';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const TEST_DB = path.join(os.tmpdir(), `agenfk-sqlite-obs-storage-${process.pid}.sqlite`);
+
+function cleanup() {
+  for (const suffix of ['', '-wal', '-shm']) {
+    const f = TEST_DB + suffix;
+    if (fs.existsSync(f)) fs.unlinkSync(f);
+  }
+}
+
+function makeEvent(over: Partial<TokenEvent> = {}): TokenEvent {
+  return {
+    id: 'e-' + Math.random().toString(36).slice(2),
+    ts: '2026-05-10T00:00:00.000Z',
+    client: 'codex',
+    sessionId: 'sess-1',
+    turnId: 't-1',
+    model: 'gpt-x',
+    input: 100,
+    cachedInput: 20,
+    output: 50,
+    reasoning: 10,
+    total: 180,
+    itemId: 'item-A',
+    projectId: 'proj-1',
+    sourcePath: '/p/sess.jsonl',
+    sourceOffset: 0,
+    ...over,
+  };
+}
+
+describe('SQLiteStorageProvider observability methods', () => {
+  let storage: SQLiteStorageProvider;
+  beforeEach(async () => {
+    cleanup();
+    storage = new SQLiteStorageProvider();
+    await storage.init({ path: TEST_DB });
+  });
+  afterEach(async () => {
+    await storage.shutdown();
+    cleanup();
+  });
+
+  describe('token events', () => {
+    it('inserts and reads a single token event', async () => {
+      const ev = makeEvent();
+      await storage.insertTokenEvent(ev);
+      const rows = await storage.queryTokenEvents({ itemId: 'item-A' });
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        id: ev.id,
+        client: 'codex',
+        input: 100,
+        cachedInput: 20,
+        output: 50,
+        reasoning: 10,
+        total: 180,
+        sessionId: 'sess-1',
+        sourcePath: '/p/sess.jsonl',
+        sourceOffset: 0,
+      });
+    });
+
+    it('queryTokenEvents filters by projectId, since, until, and client', async () => {
+      await storage.insertTokenEvent(makeEvent({ id: 'a', ts: '2026-05-09T00:00:00.000Z', sourceOffset: 1 }));
+      await storage.insertTokenEvent(makeEvent({ id: 'b', ts: '2026-05-10T00:00:00.000Z', sourceOffset: 2 }));
+      await storage.insertTokenEvent(makeEvent({ id: 'c', ts: '2026-05-11T00:00:00.000Z', client: 'claude-code', sourceOffset: 3 }));
+      await storage.insertTokenEvent(makeEvent({ id: 'd', projectId: 'proj-2', sourceOffset: 4 }));
+
+      const inWindow = await storage.queryTokenEvents({ since: '2026-05-09T12:00:00.000Z', until: '2026-05-10T12:00:00.000Z' });
+      expect(inWindow.map((e) => e.id).sort()).toEqual(['b', 'd']);
+
+      const claude = await storage.queryTokenEvents({ client: 'claude-code' });
+      expect(claude.map((e) => e.id)).toEqual(['c']);
+
+      const proj1 = await storage.queryTokenEvents({ projectId: 'proj-1' });
+      expect(proj1.map((e) => e.id).sort()).toEqual(['a', 'b', 'c']);
+
+      const limited = await storage.queryTokenEvents({ projectId: 'proj-1', limit: 2 });
+      expect(limited).toHaveLength(2);
+    });
+
+    it('insertTokenEvent rejects duplicates on (client, sourcePath, sourceOffset)', async () => {
+      await storage.insertTokenEvent(makeEvent({ id: 'first', sourceOffset: 100 }));
+      await expect(storage.insertTokenEvent(makeEvent({ id: 'second', sourceOffset: 100 }))).rejects.toThrow();
+    });
+  });
+
+  describe('ingestion state', () => {
+    it('returns null for unseen source paths', async () => {
+      expect(await storage.getIngestionState('/never/seen')).toBeNull();
+    });
+
+    it('upserts and reads back', async () => {
+      const s1: IngestionState = { sourcePath: '/p/a.jsonl', lastOffset: 100, lastRunAt: '2026-05-10T00:00:00Z' };
+      await storage.setIngestionState(s1);
+      expect(await storage.getIngestionState('/p/a.jsonl')).toEqual(s1);
+
+      const s2: IngestionState = { sourcePath: '/p/a.jsonl', lastOffset: 250, lastRunAt: '2026-05-10T00:05:00Z' };
+      await storage.setIngestionState(s2);
+      expect(await storage.getIngestionState('/p/a.jsonl')).toEqual(s2);
+    });
+  });
+
+  describe('PR registration', () => {
+    function makePr(over: Partial<Pr> = {}): Pr {
+      return {
+        id: 'pr-' + Math.random().toString(36).slice(2),
+        prNumber: 42,
+        repo: 'foo/bar',
+        itemId: 'item-A',
+        openedAt: '2026-05-10T00:00:00Z',
+        sizing: { epic: 0, story: 1, task: 2, bug: 0 },
+        sizingDeclaredAt: '2026-05-10T00:00:00Z',
+        ...over,
+      };
+    }
+
+    it('inserts and looks up by repo+number and by itemId', async () => {
+      const pr = makePr();
+      const inserted = await storage.insertPr(pr);
+      expect(inserted).toMatchObject({ prNumber: 42, repo: 'foo/bar' });
+
+      const byNumber = await storage.getPrByRepoNumber('foo/bar', 42);
+      expect(byNumber).toMatchObject({ id: pr.id, sizing: { epic: 0, story: 1, task: 2, bug: 0 } });
+
+      const byItem = await storage.getPrsByItemId('item-A');
+      expect(byItem).toHaveLength(1);
+      expect(byItem[0].id).toBe(pr.id);
+    });
+
+    it('insertPr is idempotent on (repo, prNumber) — duplicate updates sizing instead of throwing', async () => {
+      await storage.insertPr(makePr({ id: 'pr-1' }));
+      // Re-call with same repo+number, different sizing → should refresh row, not error.
+      const updated = await storage.insertPr(
+        makePr({ id: 'pr-2', sizing: { epic: 1, story: 1, task: 5, bug: 0 } }),
+      );
+      const byNumber = await storage.getPrByRepoNumber('foo/bar', 42);
+      expect(byNumber?.sizing).toEqual({ epic: 1, story: 1, task: 5, bug: 0 });
+      expect(updated.sizing).toEqual({ epic: 1, story: 1, task: 5, bug: 0 });
+    });
+
+    it('updatePrSizing rewrites sizing + shadow + last_sizing_check_at', async () => {
+      await storage.insertPr(makePr());
+      const updated = await storage.updatePrSizing(
+        'foo/bar',
+        42,
+        { epic: 0, story: 0, task: 9, bug: 1 },
+        { epic: 0, story: 0, task: 7, bug: 0 },
+      );
+      expect(updated.sizing).toEqual({ epic: 0, story: 0, task: 9, bug: 1 });
+      expect(updated.sizingShadow).toEqual({ epic: 0, story: 0, task: 7, bug: 0 });
+      expect(updated.lastSizingCheckAt).toBeDefined();
+    });
+
+    it('returns null for unknown PRs', async () => {
+      expect(await storage.getPrByRepoNumber('foo/bar', 999)).toBeNull();
+      expect(await storage.getPrsByItemId('nonexistent')).toEqual([]);
+    });
+  });
+});

--- a/packages/storage-sqlite/src/test/schema-observability.test.ts
+++ b/packages/storage-sqlite/src/test/schema-observability.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { SQLiteStorageProvider } from '../index';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const { DatabaseSync } = require('node:sqlite');
+
+const TEST_DB = path.join(os.tmpdir(), `agenfk-sqlite-observability-${process.pid}.sqlite`);
+
+function cleanup() {
+  for (const suffix of ['', '-wal', '-shm']) {
+    const f = TEST_DB + suffix;
+    if (fs.existsSync(f)) fs.unlinkSync(f);
+  }
+}
+
+function tableColumns(db: any, table: string): string[] {
+  return (db.prepare(`PRAGMA table_info(${table})`).all() as { name: string }[]).map((c) => c.name);
+}
+
+function indexNames(db: any, table: string): string[] {
+  return (db.prepare(`PRAGMA index_list(${table})`).all() as { name: string }[]).map((i) => i.name);
+}
+
+describe('SQLiteStorageProvider observability schema', () => {
+  afterEach(cleanup);
+
+  it('creates token_events table with the expected columns and indexes', async () => {
+    const storage = new SQLiteStorageProvider();
+    await storage.init({ path: TEST_DB });
+    await storage.shutdown();
+
+    const db = new DatabaseSync(TEST_DB);
+    const cols = tableColumns(db, 'token_events');
+    expect(cols).toEqual(
+      expect.arrayContaining([
+        'id', 'ts', 'client', 'session_id', 'turn_id', 'model',
+        'input', 'cached_input', 'output', 'reasoning', 'total',
+        'item_id', 'project_id', 'source_path', 'source_offset',
+      ])
+    );
+
+    const idx = indexNames(db, 'token_events');
+    expect(idx).toEqual(expect.arrayContaining([
+      'idx_token_events_ts',
+      'idx_token_events_item',
+      'idx_token_events_session',
+      'idx_token_events_dedup',
+    ]));
+    db.close();
+  });
+
+  it('token_events dedup index is UNIQUE on (client, source_path, source_offset)', async () => {
+    const storage = new SQLiteStorageProvider();
+    await storage.init({ path: TEST_DB });
+    await storage.shutdown();
+
+    const db = new DatabaseSync(TEST_DB);
+    db.prepare(
+      `INSERT INTO token_events
+       (id, ts, client, session_id, model, input, cached_input, output, reasoning, total, source_path, source_offset)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run('e1', '2026-05-10T00:00:00Z', 'codex', 's1', 'gpt-x', 1, 0, 2, 0, 3, '/p/a.jsonl', 0);
+
+    expect(() => {
+      db.prepare(
+        `INSERT INTO token_events
+         (id, ts, client, session_id, model, input, cached_input, output, reasoning, total, source_path, source_offset)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ).run('e2', '2026-05-10T00:00:00Z', 'codex', 's1', 'gpt-x', 1, 0, 2, 0, 3, '/p/a.jsonl', 0);
+    }).toThrow(/UNIQUE/i);
+
+    db.close();
+  });
+
+  it('creates ingestion_state table with source_path PRIMARY KEY', async () => {
+    const storage = new SQLiteStorageProvider();
+    await storage.init({ path: TEST_DB });
+    await storage.shutdown();
+
+    const db = new DatabaseSync(TEST_DB);
+    const cols = tableColumns(db, 'ingestion_state');
+    expect(cols).toEqual(expect.arrayContaining(['source_path', 'last_offset', 'last_run_at']));
+
+    db.prepare('INSERT INTO ingestion_state (source_path, last_offset, last_run_at) VALUES (?, ?, ?)')
+      .run('/p/a.jsonl', 100, '2026-05-10T00:00:00Z');
+    expect(() =>
+      db.prepare('INSERT INTO ingestion_state (source_path, last_offset, last_run_at) VALUES (?, ?, ?)')
+        .run('/p/a.jsonl', 200, '2026-05-10T00:00:01Z')
+    ).toThrow(/UNIQUE|PRIMARY/i);
+    db.close();
+  });
+
+  it('creates prs table with the expected columns and indexes', async () => {
+    const storage = new SQLiteStorageProvider();
+    await storage.init({ path: TEST_DB });
+    await storage.shutdown();
+
+    const db = new DatabaseSync(TEST_DB);
+    const cols = tableColumns(db, 'prs');
+    expect(cols).toEqual(
+      expect.arrayContaining([
+        'id', 'pr_number', 'repo', 'item_id', 'opened_at',
+        'sizing_json', 'sizing_declared_at', 'sizing_shadow_json',
+        'last_sizing_check_at',
+      ])
+    );
+
+    const idx = indexNames(db, 'prs');
+    expect(idx).toEqual(expect.arrayContaining(['idx_prs_repo_number', 'idx_prs_item']));
+    db.close();
+  });
+
+  it('prs unique constraint covers (repo, pr_number)', async () => {
+    const storage = new SQLiteStorageProvider();
+    await storage.init({ path: TEST_DB });
+    await storage.shutdown();
+
+    const db = new DatabaseSync(TEST_DB);
+    db.prepare(
+      `INSERT INTO prs (id, pr_number, repo, item_id, opened_at, sizing_json, sizing_declared_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`
+    ).run('p1', 42, 'foo/bar', 'item-1', '2026-05-10T00:00:00Z', '{"epic":0,"story":1,"task":2,"bug":0}', '2026-05-10T00:00:00Z');
+
+    expect(() =>
+      db.prepare(
+        `INSERT INTO prs (id, pr_number, repo, item_id, opened_at, sizing_json, sizing_declared_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`
+      ).run('p2', 42, 'foo/bar', 'item-2', '2026-05-10T01:00:00Z', '{"epic":0,"story":0,"task":1,"bug":0}', '2026-05-10T01:00:00Z')
+    ).toThrow(/UNIQUE/i);
+
+    // Same number, different repo — allowed.
+    expect(() =>
+      db.prepare(
+        `INSERT INTO prs (id, pr_number, repo, item_id, opened_at, sizing_json, sizing_declared_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`
+      ).run('p3', 42, 'baz/qux', 'item-3', '2026-05-10T02:00:00Z', '{"epic":0,"story":0,"task":1,"bug":0}', '2026-05-10T02:00:00Z')
+    ).not.toThrow();
+
+    db.close();
+  });
+
+  it('init() is idempotent across re-runs (CREATE TABLE IF NOT EXISTS)', async () => {
+    const storage1 = new SQLiteStorageProvider();
+    await storage1.init({ path: TEST_DB });
+    await storage1.shutdown();
+
+    const storage2 = new SQLiteStorageProvider();
+    await expect(storage2.init({ path: TEST_DB })).resolves.not.toThrow();
+    await storage2.shutdown();
+
+    // After re-init, tables should still be queryable.
+    const db = new DatabaseSync(TEST_DB);
+    expect(() => db.prepare('SELECT 1 FROM token_events LIMIT 1').all()).not.toThrow();
+    expect(() => db.prepare('SELECT 1 FROM ingestion_state LIMIT 1').all()).not.toThrow();
+    expect(() => db.prepare('SELECT 1 FROM prs LIMIT 1').all()).not.toThrow();
+    db.close();
+  });
+});

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/telemetry",
-  "version": "1.0.0",
+  "version": "1.0.1-beta.1",
   "description": "Anonymous telemetry client for AgenFK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/telemetry",
-  "version": "1.0.1-beta.5",
+  "version": "1.0.1-beta.6",
   "description": "Anonymous telemetry client for AgenFK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/telemetry",
-  "version": "1.0.1-beta.6",
+  "version": "1.0.1-beta.7",
   "description": "Anonymous telemetry client for AgenFK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/telemetry",
-  "version": "1.0.1-beta.3",
+  "version": "1.0.1-beta.4",
   "description": "Anonymous telemetry client for AgenFK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/telemetry",
-  "version": "1.0.1-beta.1",
+  "version": "1.0.1-beta.3",
   "description": "Anonymous telemetry client for AgenFK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/telemetry",
-  "version": "1.0.1-beta.4",
+  "version": "1.0.1-beta.5",
   "description": "Anonymous telemetry client for AgenFK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.0.1-beta.4",
+  "version": "1.0.1-beta.5",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -12,7 +12,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.0.1-beta.4",
+    "@agenfk/flow-editor": "1.0.1-beta.5",
     "@tailwindcss/postcss": "^4.2.0",
     "@tailwindcss/typography": "^0.5.19",
     "@tanstack/react-query": "^5.90.21",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1-beta.1",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -12,7 +12,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.0.0",
+    "@agenfk/flow-editor": "1.0.1-beta.1",
     "@tailwindcss/postcss": "^4.2.0",
     "@tailwindcss/typography": "^0.5.19",
     "@tanstack/react-query": "^5.90.21",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.0.1-beta.5",
+  "version": "1.0.1-beta.6",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -12,7 +12,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.0.1-beta.5",
+    "@agenfk/flow-editor": "1.0.1-beta.6",
     "@tailwindcss/postcss": "^4.2.0",
     "@tailwindcss/typography": "^0.5.19",
     "@tanstack/react-query": "^5.90.21",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.0.1-beta.6",
+  "version": "1.0.1-beta.7",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -12,7 +12,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.0.1-beta.6",
+    "@agenfk/flow-editor": "1.0.1-beta.7",
     "@tailwindcss/postcss": "^4.2.0",
     "@tailwindcss/typography": "^0.5.19",
     "@tanstack/react-query": "^5.90.21",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.0.1-beta.3",
+  "version": "1.0.1-beta.4",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -12,7 +12,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.0.1-beta.3",
+    "@agenfk/flow-editor": "1.0.1-beta.4",
     "@tailwindcss/postcss": "^4.2.0",
     "@tailwindcss/typography": "^0.5.19",
     "@tanstack/react-query": "^5.90.21",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.0.1-beta.1",
+  "version": "1.0.1-beta.3",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -12,7 +12,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.0.1-beta.1",
+    "@agenfk/flow-editor": "1.0.1-beta.3",
     "@tailwindcss/postcss": "^4.2.0",
     "@tailwindcss/typography": "^0.5.19",
     "@tanstack/react-query": "^5.90.21",

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -364,6 +364,8 @@ async function run() {
     const gatekeeperDest = os.platform() === 'win32' ? `${gatekeeperDestBase}.cmd` : gatekeeperDestBase;
     const enforcerDestBase = path.join(localBinDir, 'agenfk-mcp-enforcer');
     const enforcerDest = os.platform() === 'win32' ? `${enforcerDestBase}.cmd` : enforcerDestBase;
+    const prHookDestBase = path.join(localBinDir, 'agenfk-pr-hook');
+    const prHookDest = os.platform() === 'win32' ? `${prHookDestBase}.cmd` : prHookDestBase;
 
     // --rules-only: skip steps 3b–12, jump straight to rules installation (step 13)
     if (rulesOnly) {
@@ -964,6 +966,22 @@ process.exit(0);
             }
         }
         console.log(`  Installed: ${enforcerDestBase}${os.platform() === 'win32' ? '.cmd' : ''}`);
+
+        // 12d. Install agenfk-pr-hook script (used by PostToolUse hooks across clients)
+        const prHookSource = path.join(rootDir, 'bin', 'agenfk-pr-hook.mjs');
+        if (os.platform() === 'win32') {
+            await fs.writeFile(`${prHookDestBase}.cmd`, `@echo off\nnode "${prHookSource}" %*`, 'utf8');
+            if (isMinGW) {
+                await fs.writeFile(prHookDestBase, `#!/bin/sh\nnode "${prHookSource}" "$@"`, 'utf8');
+                chmodSync(prHookDestBase, 0o755);
+            }
+        } else {
+            if (existsSync(prHookSource)) {
+                await fs.copyFile(prHookSource, prHookDestBase);
+                chmodSync(prHookDestBase, 0o755);
+            }
+        }
+        console.log(`  Installed: ${prHookDestBase}${os.platform() === 'win32' ? '.cmd' : ''}`);
     }
 
     // 12c. Install Opencode MCP enforcer plugin
@@ -976,6 +994,11 @@ process.exit(0);
             if (existsSync(opencodeEnforcerSource)) {
                 await fs.copyFile(opencodeEnforcerSource, path.join(opencodePluginsDir, 'agenfk-mcp-enforcer.mjs'));
                 console.log(`  Installed Opencode plugin: ${path.join(opencodePluginsDir, 'agenfk-mcp-enforcer.mjs')}`);
+            }
+            const opencodePrHookSource = path.join(rootDir, 'bin', 'agenfk-pr-hook-opencode.mjs');
+            if (existsSync(opencodePrHookSource)) {
+                await fs.copyFile(opencodePrHookSource, path.join(opencodePluginsDir, 'agenfk-pr-hook.mjs'));
+                console.log(`  Installed Opencode plugin: ${path.join(opencodePluginsDir, 'agenfk-pr-hook.mjs')}`);
             }
         } else if (!onlyPlatform) {
             console.log(`  Opencode not found. Skipping Opencode plugin installation.`);
@@ -1175,11 +1198,79 @@ process.exit(0);
             hooks: [{ type: 'command', command: enforcerDest }]
         });
 
+        // PostToolUse hook for PR sizing (fires on Bash so it can react to
+        // `gh pr create` and `git push`).
+        if (!settings.hooks.PostToolUse) settings.hooks.PostToolUse = [];
+        settings.hooks.PostToolUse = settings.hooks.PostToolUse.filter(entry =>
+            !JSON.stringify(entry).includes('agenfk-pr-hook')
+        );
+        settings.hooks.PostToolUse.push({
+            matcher: 'Bash',
+            hooks: [{ type: 'command', command: `${prHookDest} --client claude-code` }]
+        });
+
         // Remove legacy mcpServers key if present (MCP is now registered via `claude mcp add`)
         delete settings.mcpServers;
 
         await fs.writeFile(settingsPath, JSON.stringify(settings, null, 2), 'utf8');
-        console.log(`  Registered PreToolUse hooks in ${settingsPath}`);
+        console.log(`  Registered Pre/PostToolUse hooks in ${settingsPath}`);
+    }
+
+    // 14b. Configure PostToolUse hook for Codex CLI (~/.codex/hooks.json)
+    if (shouldRun('codex')) {
+        const codexHooksPath = path.join(os.homedir(), '.codex', 'hooks.json');
+        if (existsSync(path.dirname(codexHooksPath))) {
+            let config = {};
+            if (existsSync(codexHooksPath)) {
+                try { config = JSON.parse(await fs.readFile(codexHooksPath, 'utf8')); } catch {}
+            }
+            if (!Array.isArray(config.PostToolUse)) config.PostToolUse = [];
+            config.PostToolUse = config.PostToolUse.filter(e => !JSON.stringify(e).includes('agenfk-pr-hook'));
+            config.PostToolUse.push({
+                matcher: 'shell',
+                hooks: [{ type: 'command', command: `${prHookDest} --client codex` }]
+            });
+            await fs.writeFile(codexHooksPath, JSON.stringify(config, null, 2), 'utf8');
+            console.log(`  Registered PostToolUse hook in ${codexHooksPath}`);
+        }
+    }
+
+    // 14c. Configure AfterTool hook for Gemini CLI (~/.gemini/settings.json)
+    if (shouldRun('gemini')) {
+        const geminiSettingsPath = path.join(os.homedir(), '.gemini', 'settings.json');
+        if (existsSync(path.dirname(geminiSettingsPath))) {
+            let settings = {};
+            if (existsSync(geminiSettingsPath)) {
+                try { settings = JSON.parse(await fs.readFile(geminiSettingsPath, 'utf8')); } catch {}
+            }
+            if (!settings.hooks) settings.hooks = {};
+            if (!Array.isArray(settings.hooks.AfterTool)) settings.hooks.AfterTool = [];
+            settings.hooks.AfterTool = settings.hooks.AfterTool.filter(e => !JSON.stringify(e).includes('agenfk-pr-hook'));
+            settings.hooks.AfterTool.push({
+                matcher: 'run_shell_command',
+                command: `${prHookDest} --client gemini`,
+            });
+            await fs.writeFile(geminiSettingsPath, JSON.stringify(settings, null, 2), 'utf8');
+            console.log(`  Registered AfterTool hook in ${geminiSettingsPath}`);
+        }
+    }
+
+    // 14d. Configure afterShellExecution hook for Cursor (~/.cursor/hooks.json, 1.7+)
+    if (shouldRun('cursor')) {
+        const cursorHooksPath = path.join(os.homedir(), '.cursor', 'hooks.json');
+        if (existsSync(path.dirname(cursorHooksPath))) {
+            let config = {};
+            if (existsSync(cursorHooksPath)) {
+                try { config = JSON.parse(await fs.readFile(cursorHooksPath, 'utf8')); } catch {}
+            }
+            if (!Array.isArray(config.afterShellExecution)) config.afterShellExecution = [];
+            config.afterShellExecution = config.afterShellExecution.filter(e => !JSON.stringify(e).includes('agenfk-pr-hook'));
+            config.afterShellExecution.push({
+                command: `${prHookDest} --client cursor`,
+            });
+            await fs.writeFile(cursorHooksPath, JSON.stringify(config, null, 2), 'utf8');
+            console.log(`  Registered afterShellExecution hook in ${cursorHooksPath}`);
+        }
     }
 
     // BUG 174270e6: if a server was running before we replaced the files on


### PR DESCRIPTION
## Context

AgEnFK installations had near-zero per-installation visibility into:

1. **PR-level outcomes and sizing.** No record of how many PRs an installation opens, which items they bundle, or the cards-per-type breakdown.
2. **Accurate token usage.** The legacy \`log_token_usage\` relied on the agent self-reporting at end-of-task — agents skipped or approximated it, missed subagent/background turns entirely, and never broke out cached/reasoning tokens.

This initiative delivers two coordinated tracks sharing infrastructure: deterministic server-side **token ingestion** (no agent in the loop) plus **PR-opened metrics** with agent-declared sizing via hook directives. Outcome: AgEnFK gains accurate per-installation observability without depending on agent honesty for token data, and gains semantic PR sizing where agent judgment beats a graph walk. EPIC tracked as \`ce6291f4-b9fa-4741-abb8-f48a3cbb5c3a\`; plan at \`/Users/daniel/.claude/plans/hashed-rolling-marshmallow.md\`.

## What changed

### Schema (\`packages/storage-sqlite/src/index.ts\`)
- New tables (idempotent \`CREATE TABLE IF NOT EXISTS\`):
  - \`token_events\` — per-turn token telemetry; unique dedup index on \`(client, source_path, source_offset)\`.
  - \`ingestion_state\` — per-file offset bookkeeping for resumable parsing.
  - \`prs\` — agent-declared PR sizing with server-shadow column; unique on \`(repo, pr_number)\`.

### Removals
- Entire legacy token-tracking surface: \`TokenUsage\` interface, \`BaseItem.tokenUsage\` field, \`log_token_usage\` MCP tool + Zod schema + handler, \`tokenUsage\` field acceptance in \`PUT /items/:id\` and \`POST /items/bulk\`, \`agenfk log-tokens\` CLI subcommand, and the entire OpenCode token scraper (~160 lines including the pricing table). Per-client instruction docs updated to redirect.

### Track 2 — token telemetry via session-log ingestion
- New module \`packages/server/src/token-ingestion/\`:
  - \`attribution.ts\` — \`findActiveItemAt(items, flow, ts)\`: walks each item's \`HistoryRecord\`, returns the most-recent active item at T (handles re-entry, anchors, the BLOCKED/PAUSED/TRASHED/ARCHIVED/IDEAS inactive set). Pure function.
  - \`watcher.ts\` — \`processFile\` (pure diff vs prior \`IngestionState\`) + \`ingestOnce\` / \`startIngestionPoller\` runtime wrappers. \`chokidar\` deliberately avoided in favor of node-builtin polling to keep dep surface minimal.
  - \`parsers/claude-code.ts\` — JSONL walker, one event per \`type: 'assistant'\` line with \`message.usage\`. Combines \`cache_creation_input_tokens + cache_read_input_tokens\` into \`cachedInput\`.
  - \`parsers/codex.ts\` — JSONL walker, one event per \`event_msg\` with \`payload.type === 'token_count'\`. Computes per-turn deltas from cumulative; treats negative deltas as session resets.
- New MCP tool \`query_token_events\`, REST \`GET /token-events\`, CLI \`agenfk tokens\`.

### Track 1 — PR-opened metrics with agent-declared sizing
- New MCP tools \`register_pr\` / \`update_pr_sizing\`, REST \`POST /prs\` and \`PUT /prs/:repo/:number\`, CLI \`agenfk pr-register\` / \`pr-resize\`.
- Server computes a shadow sizing by walking the item tree from the anchor item — logged for discrepancy detection but never overrides the agent's declared sizing.
- \`POST /prs\` is idempotent on \`(repo, prNumber)\`; re-call refreshes sizing.
- New \`bin/agenfk-pr-hook.mjs\` — pure helpers \`classifyTrigger\` (detects \`gh pr create\` / \`git push\`) and \`buildDirective\` (per-client output shape). Emits a directive nudging the agent to call \`register_pr\` / \`update_pr_sizing\` after the trigger.
- New \`bin/agenfk-pr-hook-opencode.mjs\` (OpenCode plugin, \`tool.execute.after\`).
- Per-client config bundles under \`clauderules/.claude/settings.json\`, \`codexrules/hooks.json\`, \`geminirules/.gemini/settings.json\`, \`cursorrules/.cursor/hooks.json\`.
- \`scripts/install.mjs\` extended to install the script alongside \`agenfk-gatekeeper\` / \`agenfk-mcp-enforcer\`, copy the OpenCode plugin, and inject \`PostToolUse\` / \`AfterTool\` / \`afterShellExecution\` entries into Claude / Codex / Gemini / Cursor settings — each guarded by \`existsSync(dirname)\` so it skips silently when the client isn't installed.

### Docs
- Per-client instruction docs (\`clauderules/CLAUDE.md\`, \`codexrules/AGENTS.md\`, \`geminirules/GEMINI.md\`, \`cursorrules/agenfk.mdc\`) — each gets a "PR sizing — MANDATORY" section with belt-and-suspenders rules.
- \`AFK_ARCHITECTURE.md\` client matrix rewritten: all five clients (Claude Code, OpenCode, Codex, Gemini, Cursor) now listed with both pre-edit and post-tool hook columns. Notes that as of 2025–2026 all five have hooks (the prior "instructional-only" claim for Codex/Cursor/Gemini is now stale). Codex hook-coverage caveat (shell-only; openai/codex#14882, #16732) called out.

## Replaces

This single PR consolidates and replaces stacked PRs #74, #75, #76, #77, #78, #79, #80, #81, #82 — same commits, all linear, now grouped for one merge.

## Test plan

- [x] New unit/integration tests across 9 task chunks (~70 new test cases): schema observability (6), legacy-removal grep (12), storage methods (9), attribution (6), processFile (4), Claude parser (3), Codex parser (4), token-events API (5), PR-registration API (12), PR-hook classifier (10), doc rule presence (5)
- [x] All existing tests still pass (1259 tests across 118 files)
- [x] \`npm run build\` clean