### PR TITLE
fix: repair uninstaller (#88) — handle all 3 hook variants, mirror every install step, safe summary + confirmation

### DIFF
--- a/packages/cli/src/test/uninstall-issue88.test.ts
+++ b/packages/cli/src/test/uninstall-issue88.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Tests for issue #88 — the uninstaller leaves artifacts behind.
+ *
+ * Part A: pure decision logic (scripts/uninstall-helpers.mjs).
+ * Part B: end-to-end behavior — run scripts/uninstall.mjs against a throwaway
+ *   $HOME populated with every artifact the installer creates, and assert the
+ *   uninstaller removes ALL of them (all 3 hook variants, opencode plugins,
+ *   codex/gemini/cursor hook entries, the ~/.agenfk dir) and exits 0.
+ *
+ * These reflect future functionality and are expected to fail until uninstall.mjs
+ * is wired to the helpers and mirrors every install step.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  HOOK_VARIANTS,
+  hookBinFilenames,
+  opencodePluginFilenames,
+  isAgenfkHookEntry,
+  stripAgenfkHookEntries,
+  resolveConfirmation,
+  summarizeResults,
+} from '../../../../scripts/uninstall-helpers.mjs';
+
+const ROOT = path.resolve(__dirname, '../../../..');
+const UNINSTALL = path.join(ROOT, 'scripts', 'uninstall.mjs');
+
+// ---------------------------------------------------------------------------
+// Part A — pure helpers
+// ---------------------------------------------------------------------------
+describe('issue #88 — uninstall-helpers', () => {
+  it('tracks all three hook variants, not just the gatekeeper (Bug 2)', () => {
+    expect(HOOK_VARIANTS).toEqual(
+      expect.arrayContaining(['agenfk-gatekeeper', 'agenfk-mcp-enforcer', 'agenfk-pr-hook'])
+    );
+    expect(HOOK_VARIANTS).toHaveLength(3);
+  });
+
+  it('hookBinFilenames includes the CLI symlink + all 3 hooks, with .cmd on win32', () => {
+    expect(hookBinFilenames('linux')).toEqual([
+      'agenfk', 'agenfk-gatekeeper', 'agenfk-mcp-enforcer', 'agenfk-pr-hook',
+    ]);
+    expect(hookBinFilenames('win32')).toEqual([
+      'agenfk.cmd', 'agenfk-gatekeeper.cmd', 'agenfk-mcp-enforcer.cmd', 'agenfk-pr-hook.cmd',
+    ]);
+  });
+
+  it('opencodePluginFilenames are the three .mjs plugins (Bug 3)', () => {
+    expect(opencodePluginFilenames()).toEqual([
+      'agenfk-gatekeeper.mjs', 'agenfk-mcp-enforcer.mjs', 'agenfk-pr-hook.mjs',
+    ]);
+  });
+
+  it('isAgenfkHookEntry recognizes every variant and ignores unrelated entries', () => {
+    expect(isAgenfkHookEntry({ hooks: [{ command: '/x/agenfk-gatekeeper' }] })).toBe(true);
+    expect(isAgenfkHookEntry({ hooks: [{ command: '/x/agenfk-mcp-enforcer' }] })).toBe(true);
+    expect(isAgenfkHookEntry({ command: '/x/agenfk-pr-hook --client codex' })).toBe(true);
+    expect(isAgenfkHookEntry({ hooks: [{ command: '/x/some-other-tool' }] })).toBe(false);
+  });
+
+  it('stripAgenfkHookEntries removes all variants but preserves unrelated entries', () => {
+    const entries = [
+      { hooks: [{ command: '/b/agenfk-gatekeeper' }] },
+      { hooks: [{ command: '/b/agenfk-mcp-enforcer' }] },
+      { command: '/b/agenfk-pr-hook --client codex' },
+      { hooks: [{ command: '/b/user-hook' }] },
+    ];
+    const out = stripAgenfkHookEntries(entries);
+    expect(out).toEqual([{ hooks: [{ command: '/b/user-hook' }] }]);
+  });
+
+  it('resolveConfirmation: -y proceeds without prompting (Bug 5)', () => {
+    expect(resolveConfirmation({ skipConfirm: true, isTTY: false })).toEqual({
+      proceed: true, shouldPrompt: false,
+    });
+  });
+
+  it('resolveConfirmation: interactive TTY prompts, does not auto-proceed (Bug 5)', () => {
+    expect(resolveConfirmation({ skipConfirm: false, isTTY: true })).toEqual({
+      proceed: false, shouldPrompt: true,
+    });
+  });
+
+  it('resolveConfirmation: non-TTY without -y aborts instead of assuming yes (Bug 5)', () => {
+    expect(resolveConfirmation({ skipConfirm: false, isTTY: false })).toEqual({
+      proceed: false, shouldPrompt: false,
+    });
+  });
+
+  it('summarizeResults aggregates counts and exits non-zero on any failure (Bug 4)', () => {
+    const ok = summarizeResults([
+      { label: 'a', status: 'removed' },
+      { label: 'b', status: 'skipped' },
+    ]);
+    expect(ok).toMatchObject({ removed: 1, skipped: 1, failed: 0, exitCode: 0 });
+
+    const bad = summarizeResults([
+      { label: 'a', status: 'removed' },
+      { label: 'c', status: 'failed', error: 'boom' },
+    ]);
+    expect(bad).toMatchObject({ removed: 1, failed: 1, exitCode: 1 });
+    expect(bad.failures[0]).toMatchObject({ label: 'c', error: 'boom' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Part B — end-to-end uninstall against a throwaway HOME
+// ---------------------------------------------------------------------------
+describe('issue #88 — uninstall.mjs removes every installed artifact', () => {
+  let home: string;
+
+  const p = (...segs: string[]) => path.join(home, ...segs);
+  const hookEntry = (cmd: string) => ({ matcher: 'X', hooks: [{ type: 'command', command: cmd }] });
+  const UNRELATED = { matcher: 'X', hooks: [{ type: 'command', command: '/usr/bin/user-hook' }] };
+
+  function seedInstall() {
+    // bins
+    mkdirSync(p('.local', 'bin'), { recursive: true });
+    for (const f of ['agenfk', 'agenfk-gatekeeper', 'agenfk-mcp-enforcer', 'agenfk-pr-hook']) {
+      writeFileSync(p('.local', 'bin', f), '#!/bin/sh\n');
+    }
+    // opencode plugins
+    mkdirSync(p('.config', 'opencode', 'plugins'), { recursive: true });
+    for (const f of ['agenfk-gatekeeper.mjs', 'agenfk-mcp-enforcer.mjs', 'agenfk-pr-hook.mjs']) {
+      writeFileSync(p('.config', 'opencode', 'plugins', f), '// plugin\n');
+    }
+    // claude settings.json — Pre (gatekeeper + enforcer) and Post (pr-hook)
+    mkdirSync(p('.claude'), { recursive: true });
+    writeFileSync(p('.claude', 'settings.json'), JSON.stringify({
+      hooks: {
+        PreToolUse: [hookEntry('/h/agenfk-gatekeeper'), hookEntry('/h/agenfk-mcp-enforcer'), UNRELATED],
+        PostToolUse: [hookEntry('/h/agenfk-pr-hook --client claude-code'), UNRELATED],
+      },
+    }, null, 2));
+    // codex hooks.json
+    mkdirSync(p('.codex'), { recursive: true });
+    writeFileSync(p('.codex', 'hooks.json'), JSON.stringify({
+      PostToolUse: [{ matcher: 'shell', hooks: [{ type: 'command', command: '/h/agenfk-pr-hook --client codex' }] }, UNRELATED],
+    }, null, 2));
+    // gemini settings.json — AfterTool
+    mkdirSync(p('.gemini'), { recursive: true });
+    writeFileSync(p('.gemini', 'settings.json'), JSON.stringify({
+      hooks: { AfterTool: [{ matcher: 'run_shell_command', command: '/h/agenfk-pr-hook --client gemini' }, { matcher: 'run_shell_command', command: '/usr/bin/user-hook' }] },
+    }, null, 2));
+    // cursor hooks.json — afterShellExecution
+    mkdirSync(p('.cursor'), { recursive: true });
+    writeFileSync(p('.cursor', 'hooks.json'), JSON.stringify({
+      afterShellExecution: [{ command: '/h/agenfk-pr-hook --client cursor' }, { command: '/usr/bin/user-hook' }],
+    }, null, 2));
+    // ~/.agenfk data dir
+    mkdirSync(p('.agenfk'), { recursive: true });
+    writeFileSync(p('.agenfk', 'config.json'), JSON.stringify({ rulesScope: 'global' }));
+    writeFileSync(p('.agenfk', 'verify-token'), 'tok');
+    // framework dir
+    mkdirSync(p('.agenfk-system', 'scripts'), { recursive: true });
+    writeFileSync(p('.agenfk-system', 'marker'), 'x');
+  }
+
+  function runUninstall(args: string[]) {
+    return spawnSync(process.execPath, [UNINSTALL, ...args], {
+      encoding: 'utf8',
+      // Empty PATH so the script can't find/spawn real claude/codex/gemini CLIs;
+      // those steps self-skip. process.execPath is absolute so node still runs.
+      env: { HOME: home, USERPROFILE: home, PATH: '' },
+    });
+  }
+
+  const readJson = (...segs: string[]) => JSON.parse(readFileSync(p(...segs), 'utf8'));
+
+  beforeEach(() => {
+    home = mkdtempSync(path.join(os.tmpdir(), 'agenfk-uninstall-'));
+    seedInstall();
+  });
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it('removes all three hook bins and the agenfk CLI symlink (Bug 2)', () => {
+    const r = runUninstall(['-y']);
+    expect(r.status).toBe(0);
+    for (const f of hookBinFilenames(os.platform())) {
+      expect(existsSync(p('.local', 'bin', f))).toBe(false);
+    }
+  });
+
+  it('removes all three opencode plugins (Bug 3)', () => {
+    runUninstall(['-y']);
+    for (const f of opencodePluginFilenames()) {
+      expect(existsSync(p('.config', 'opencode', 'plugins', f))).toBe(false);
+    }
+  });
+
+  it('strips gatekeeper + mcp-enforcer (Pre) and pr-hook (Post) from claude settings, keeping unrelated (Bug 2)', () => {
+    runUninstall(['-y']);
+    const s = readJson('.claude', 'settings.json');
+    expect(JSON.stringify(s.hooks.PreToolUse)).not.toContain('agenfk-');
+    expect(JSON.stringify(s.hooks.PostToolUse)).not.toContain('agenfk-');
+    expect(JSON.stringify(s.hooks.PreToolUse)).toContain('user-hook');
+    expect(JSON.stringify(s.hooks.PostToolUse)).toContain('user-hook');
+  });
+
+  it('strips pr-hook from codex hooks.json, gemini AfterTool, and cursor afterShellExecution (Bug 3)', () => {
+    runUninstall(['-y']);
+    const codex = readJson('.codex', 'hooks.json');
+    expect(JSON.stringify(codex.PostToolUse)).not.toContain('agenfk-');
+    expect(JSON.stringify(codex.PostToolUse)).toContain('user-hook');
+
+    const gemini = readJson('.gemini', 'settings.json');
+    expect(JSON.stringify(gemini.hooks.AfterTool)).not.toContain('agenfk-');
+    expect(JSON.stringify(gemini.hooks.AfterTool)).toContain('user-hook');
+
+    const cursor = readJson('.cursor', 'hooks.json');
+    expect(JSON.stringify(cursor.afterShellExecution)).not.toContain('agenfk-');
+    expect(JSON.stringify(cursor.afterShellExecution)).toContain('user-hook');
+  });
+
+  it('removes the entire ~/.agenfk data dir, not just verify-token (Bug 3)', () => {
+    runUninstall(['-y']);
+    expect(existsSync(p('.agenfk'))).toBe(false);
+  });
+
+  it('removes ~/.agenfk-system and reports success', () => {
+    const r = runUninstall(['-y']);
+    expect(existsSync(p('.agenfk-system'))).toBe(false);
+    expect(r.status).toBe(0);
+  });
+
+  it('aborts without -y on non-interactive stdin and leaves artifacts intact (Bug 5)', () => {
+    const r = runUninstall([]); // no -y, spawned => stdin not a TTY
+    expect(r.status).not.toBe(0);
+    // nothing destructive should have happened
+    expect(existsSync(p('.agenfk-system'))).toBe(true);
+    expect(existsSync(p('.local', 'bin', 'agenfk-gatekeeper'))).toBe(true);
+  });
+});

--- a/scripts/uninstall-helpers.mjs
+++ b/scripts/uninstall-helpers.mjs
@@ -1,0 +1,64 @@
+// Pure, side-effect-free helpers extracted from uninstall.mjs so the removal
+// decision logic can be unit-tested as real behavior (issue #88).
+//
+// The bugs these guard against:
+//   #2 the uninstaller removed only the `agenfk-gatekeeper` hook variant, leaving
+//      `agenfk-mcp-enforcer` and `agenfk-pr-hook` bins + settings entries behind.
+//   #4 a partial uninstall was silent — no per-step result tracking, no summary.
+//   #5 without `-y`, the destructive run "assumed yes" instead of prompting/aborting.
+
+// Every hook variant the installer writes. Used both for bin removal and for
+// filtering hook entries out of every client's settings/hooks file.
+export const HOOK_VARIANTS = ['agenfk-gatekeeper', 'agenfk-mcp-enforcer', 'agenfk-pr-hook'];
+
+// Bin filenames the installer drops into ~/.local/bin. The `agenfk` CLI symlink
+// plus all three hook variants. On Windows each is a `.cmd` shim.
+export function hookBinFilenames(platform) {
+  const suffix = platform === 'win32' ? '.cmd' : '';
+  return ['agenfk', ...HOOK_VARIANTS].map((n) => `${n}${suffix}`);
+}
+
+// Opencode plugin filenames the installer copies into ~/.config/opencode/plugins.
+export function opencodePluginFilenames() {
+  return HOOK_VARIANTS.map((n) => `${n}.mjs`);
+}
+
+// True if a single hook entry (from any client's hook array) references an AgenFK
+// hook script. JSON.stringify mirrors how the installer itself matches entries.
+export function isAgenfkHookEntry(entry) {
+  const json = JSON.stringify(entry);
+  return HOOK_VARIANTS.some((marker) => json.includes(marker));
+}
+
+// Remove every AgenFK hook entry from a client hook array, returning a new array.
+// Non-AgenFK entries are preserved untouched. Accepts non-arrays defensively.
+export function stripAgenfkHookEntries(entries) {
+  if (!Array.isArray(entries)) return entries;
+  return entries.filter((e) => !isAgenfkHookEntry(e));
+}
+
+// Decide whether a destructive uninstall may proceed, and whether to prompt first.
+// Precedence: explicit -y/--yes → proceed without prompt; else interactive TTY →
+// prompt; else (non-interactive, no flag) → abort rather than assuming consent (#5).
+// Returns { proceed, shouldPrompt }.
+export function resolveConfirmation({ skipConfirm, isTTY } = {}) {
+  if (skipConfirm) return { proceed: true, shouldPrompt: false };
+  if (isTTY) return { proceed: false, shouldPrompt: true };
+  return { proceed: false, shouldPrompt: false };
+}
+
+// Aggregate per-step results into a summary (#4). `results` is an array of
+// { label, status: 'removed' | 'skipped' | 'failed', error? }. exitCode is non-zero
+// when any step failed so a partial uninstall surfaces in CI / scripts.
+export function summarizeResults(results = []) {
+  const removed = results.filter((r) => r.status === 'removed').length;
+  const skipped = results.filter((r) => r.status === 'skipped').length;
+  const failed = results.filter((r) => r.status === 'failed');
+  return {
+    removed,
+    skipped,
+    failed: failed.length,
+    failures: failed,
+    exitCode: failed.length > 0 ? 1 : 0,
+  };
+}

--- a/scripts/uninstall.mjs
+++ b/scripts/uninstall.mjs
@@ -2,8 +2,15 @@ import fs from 'fs/promises';
 import { existsSync } from 'fs';
 import os from 'os';
 import path from 'path';
-import { spawnSync, execSync } from 'child_process';
+import readline from 'readline';
+import { spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
+import {
+    HOOK_VARIANTS,
+    stripAgenfkHookEntries,
+    resolveConfirmation,
+    summarizeResults,
+} from './uninstall-helpers.mjs';
 
 const RED = '\x1b[31m';
 const GREEN = '\x1b[32m';
@@ -40,6 +47,58 @@ function getCursorRulesDir() {
     }
 }
 
+function promptYesNo(question) {
+    return new Promise((resolve) => {
+        const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+        rl.question(question, (answer) => {
+            rl.close();
+            resolve(/^y(es)?$/i.test(answer.trim()));
+        });
+    });
+}
+
+// Remove a file or directory if present; returns true if something was removed.
+async function rmIfExists(target) {
+    if (!existsSync(target)) return false;
+    await fs.rm(target, { recursive: true, force: true });
+    return true;
+}
+
+// Strip AgenFK hook entries from a JSON config file. `paths` is a list of dotted
+// key paths into the parsed object that each hold a hook array (e.g.
+// 'hooks.PreToolUse', 'PostToolUse', 'afterShellExecution'). Returns true if the
+// file changed. Non-AgenFK entries are preserved.
+async function stripHooksFromJsonFile(filePath, hookArrayPaths) {
+    if (!existsSync(filePath)) return false;
+    let config;
+    try {
+        config = JSON.parse(await fs.readFile(filePath, 'utf8'));
+    } catch {
+        return false; // unreadable / not JSON — leave it alone
+    }
+    let changed = false;
+    for (const dotted of hookArrayPaths) {
+        const keys = dotted.split('.');
+        let parent = config;
+        for (let i = 0; i < keys.length - 1; i++) {
+            parent = parent?.[keys[i]];
+        }
+        const leaf = keys[keys.length - 1];
+        const arr = parent?.[leaf];
+        if (Array.isArray(arr)) {
+            const filtered = stripAgenfkHookEntries(arr);
+            if (filtered.length !== arr.length) {
+                parent[leaf] = filtered;
+                changed = true;
+            }
+        }
+    }
+    if (changed) {
+        await fs.writeFile(filePath, JSON.stringify(config, null, 2), 'utf8');
+    }
+    return changed;
+}
+
 async function run() {
     console.log(`${BLUE}=== AgenFK Uninstaller ===${NC}`);
     console.log("");
@@ -48,6 +107,45 @@ async function run() {
     const rulesScopeArg = process.argv.find(arg => arg.startsWith('--rules-scope='))?.split('=')[1];
     const rulesOnly = process.argv.includes('--rules-only');
     const projectDir = rulesOnly ? process.cwd() : rootDir;
+
+    // Hoisted to function scope so every step can use it. Previously declared
+    // inside the `if (!rulesOnly)` block, which made it undefined for the hook
+    // removal step further down and crashed the uninstall mid-run (issue #88).
+    const localBinDir = path.join(os.homedir(), '.local', 'bin');
+
+    // Per-step results so a partial uninstall is reported instead of dying silently (#88).
+    const results = [];
+    async function step(label, enabled, fn) {
+        if (enabled === false) {
+            results.push({ label, status: 'skipped' });
+            return;
+        }
+        try {
+            const outcome = await fn();
+            results.push({ label, status: outcome === false ? 'skipped' : 'removed' });
+        } catch (e) {
+            const msg = e?.message ?? String(e);
+            results.push({ label, status: 'failed', error: msg });
+            console.error(`  ${RED}Failed: ${label} — ${msg}${NC}`);
+        }
+    }
+
+    function finish(headline) {
+        const summary = summarizeResults(results);
+        console.log("");
+        console.log(`${headline}`);
+        console.log(
+            `  ${GREEN}removed: ${summary.removed}${NC}  ` +
+            `${YELLOW}skipped: ${summary.skipped}${NC}  ` +
+            `${summary.failed ? RED : GREEN}failed: ${summary.failed}${NC}`
+        );
+        if (summary.failed) {
+            for (const f of summary.failures) {
+                console.log(`  ${RED}- ${f.label}: ${f.error}${NC}`);
+            }
+        }
+        process.exit(summary.exitCode);
+    }
 
     // Read rulesScope from config to know where rules were installed
     let rulesScope = rulesScopeArg || '';
@@ -69,23 +167,34 @@ async function run() {
     if (!onlyPlatform) {
         console.log(`${YELLOW}This will remove:${NC}`);
         console.log("  - Slash commands from Claude Code, Opencode, and Gemini CLI");
-        console.log("  - Opencode skill");
+        console.log("  - Opencode skill + plugins (gatekeeper, mcp-enforcer, pr-hook)");
         console.log("  - MCP server config from Claude Code, Opencode, Cursor, Codex, and Gemini CLI");
-        console.log("  - Cursor workflow rules (agenfk.mdc)");
-        console.log("  - Codex workflow rules (~/.codex/AGENTS.md)");
-        console.log("  - Gemini CLI workflow rules (~/.gemini/GEMINI.md)");
+        console.log("  - Cursor workflow rules (agenfk.mdc) + afterShellExecution hook");
+        console.log("  - Codex workflow rules (~/.codex/AGENTS.md) + PostToolUse hook");
+        console.log("  - Gemini CLI workflow rules (~/.gemini/GEMINI.md) + AfterTool hook");
         console.log("  - AgenFK workflow rules from ~/.claude/CLAUDE.md");
-        console.log("  - AgenFK PreToolUse hook from ~/.claude/settings.json");
-        console.log("  - ~/.agenfk-system (the framework files)");
+        console.log("  - AgenFK Pre/PostToolUse hooks from ~/.claude/settings.json");
+        console.log("  - Hook scripts (gatekeeper, mcp-enforcer, pr-hook) from ~/.local/bin");
+        console.log("  - ~/.agenfk (config + verify token) and ~/.agenfk-system (the framework files)");
         console.log("");
     }
 
+    // Confirmation gate (#88 Bug 5): -y/--yes proceeds; an interactive TTY prompts;
+    // a non-interactive run without -y aborts rather than assuming consent.
     const skipConfirm = process.argv.includes('-y') || process.argv.includes('--yes');
-    if (!skipConfirm) {
-        // Since we can't easily do interactive input here, we'll assume skipConfirm if run in this environment
-        // or just proceed if it's a script. But for a real CLI, we'd use 'readline'.
-        // Let's just assume we want to proceed if not in a TTY or if requested.
-        console.log(`${YELLOW}Proceeding with uninstallation...${NC}`);
+    const { proceed, shouldPrompt } = resolveConfirmation({ skipConfirm, isTTY: Boolean(process.stdin.isTTY) });
+    if (!proceed) {
+        if (shouldPrompt) {
+            const ok = await promptYesNo(`${YELLOW}Proceed with uninstallation? [y/N] ${NC}`);
+            if (!ok) {
+                console.log(`${YELLOW}Aborted. Nothing was removed.${NC}`);
+                process.exit(1);
+            }
+        } else {
+            console.error(`${RED}Refusing to uninstall without confirmation.${NC}`);
+            console.error(`Re-run with ${YELLOW}-y${NC} (or ${YELLOW}--yes${NC}) to proceed non-interactively.`);
+            process.exit(1);
+        }
     }
 
     // --rules-only: skip steps 1–6d, jump straight to rules removal
@@ -95,68 +204,62 @@ async function run() {
 
     if (!rulesOnly) {
     // 1. Slash commands — Claude Code
-    if (shouldRun('claude')) {
-        console.log(`${GREEN}[1/10] Removing Claude Code slash commands...${NC}`);
+    await step('Claude Code slash commands', shouldRun('claude'), async () => {
+        console.log(`${GREEN}[1] Removing Claude Code slash commands...${NC}`);
         const claudeCommandsDir = path.join(os.homedir(), '.claude', 'commands');
+        let removed = false;
         if (existsSync(claudeCommandsDir)) {
             const files = await fs.readdir(claudeCommandsDir);
             for (const file of files) {
                 if (file.startsWith('agenfk') && file.endsWith('.md')) {
-                    const fullPath = path.join(claudeCommandsDir, file);
-                    await fs.unlink(fullPath);
-                    console.log(`  Removed: ${fullPath}`);
+                    await fs.unlink(path.join(claudeCommandsDir, file));
+                    console.log(`  Removed: ${path.join(claudeCommandsDir, file)}`);
+                    removed = true;
                 }
             }
         }
-    }
+        return removed;
+    });
 
     // 2. Slash commands — Opencode
-    if (shouldRun('opencode')) {
-        console.log(`${GREEN}[2/10] Removing Opencode slash commands...${NC}`);
+    await step('Opencode slash commands', shouldRun('opencode'), async () => {
+        console.log(`${GREEN}[2] Removing Opencode slash commands...${NC}`);
         const opencodeCommandsDir = path.join(os.homedir(), '.config', 'opencode', 'commands');
+        let removed = false;
         if (existsSync(opencodeCommandsDir)) {
             const files = await fs.readdir(opencodeCommandsDir);
             for (const file of files) {
                 if (file.startsWith('agenfk') && file.endsWith('.md')) {
-                    const fullPath = path.join(opencodeCommandsDir, file);
-                    await fs.unlink(fullPath);
-                    console.log(`  Removed: ${fullPath}`);
+                    await fs.unlink(path.join(opencodeCommandsDir, file));
+                    console.log(`  Removed: ${path.join(opencodeCommandsDir, file)}`);
+                    removed = true;
                 }
             }
         }
-    }
+        return removed;
+    });
 
     // 2b. Slash commands — Gemini CLI
-    if (shouldRun('gemini')) {
-        console.log(`${GREEN}[2b/10] Removing Gemini CLI slash commands...${NC}`);
+    await step('Gemini CLI slash commands', shouldRun('gemini'), async () => {
+        console.log(`${GREEN}[2b] Removing Gemini CLI slash commands...${NC}`);
         const geminiCommandsBase = path.join(os.homedir(), '.gemini', 'commands');
-        const geminiAgenfkToml = path.join(geminiCommandsBase, 'agenfk.toml');
-        if (existsSync(geminiAgenfkToml)) {
-            await fs.unlink(geminiAgenfkToml);
-            console.log(`  Removed: ${geminiAgenfkToml}`);
-        }
-        const geminiAgenfkSubdir = path.join(geminiCommandsBase, 'agenfk');
-        if (existsSync(geminiAgenfkSubdir)) {
-            await fs.rm(geminiAgenfkSubdir, { recursive: true, force: true });
-            console.log(`  Removed: ${geminiAgenfkSubdir}`);
-        }
-    }
+        let removed = false;
+        removed = (await rmIfExists(path.join(geminiCommandsBase, 'agenfk.toml'))) || removed;
+        removed = (await rmIfExists(path.join(geminiCommandsBase, 'agenfk'))) || removed;
+        return removed;
+    });
 
     // 3. Opencode skill (legacy single-dir format)
-    if (shouldRun('opencode')) {
-        console.log(`${GREEN}[3/10] Removing Opencode skill...${NC}`);
-        const skillDir = path.join(os.homedir(), '.config', 'opencode', 'skills', 'agenfk');
-        if (existsSync(skillDir)) {
-            await fs.rm(skillDir, { recursive: true, force: true });
-            console.log(`  Removed: ${skillDir}`);
-        }
-    }
+    await step('Opencode skill', shouldRun('opencode'), async () => {
+        console.log(`${GREEN}[3] Removing Opencode skill...${NC}`);
+        return rmIfExists(path.join(os.homedir(), '.config', 'opencode', 'skills', 'agenfk'));
+    });
 
-    // 3b. Skills (new skills/<name>/SKILL.md format)
+    // 3b. Skills (new skills/<name>/SKILL.md format).
     // When --only=<platform> is set, only remove that platform's skills dir.
     // The universal shared skills dir is only wiped on full uninstall (no --only flag).
-    {
-        console.log(`${GREEN}[3b/10] Removing agenfk skills...${NC}`);
+    await step('agenfk skills', true, async () => {
+        console.log(`${GREEN}[3b] Removing agenfk skills...${NC}`);
         const platformSkillsDirs = {
             claude: path.join(os.homedir(), '.claude', 'skills'),
             opencode: path.join(os.homedir(), '.config', 'opencode', 'skills'),
@@ -170,131 +273,140 @@ async function run() {
                 ...Object.values(platformSkillsDirs),
                 path.join(os.homedir(), '.agents', 'skills'),
               ];
+        let removed = false;
         for (const dir of skillsDirs) {
             if (!existsSync(dir)) continue;
             const entries = await fs.readdir(dir);
             for (const entry of entries) {
                 if (entry.startsWith('agenfk')) {
-                    const fullPath = path.join(dir, entry);
-                    await fs.rm(fullPath, { recursive: true, force: true });
-                    console.log(`  Removed: ${fullPath}`);
+                    await fs.rm(path.join(dir, entry), { recursive: true, force: true });
+                    console.log(`  Removed: ${path.join(dir, entry)}`);
+                    removed = true;
                 }
             }
         }
-    }
+        return removed;
+    });
 
-    // 4. CLI symlink
-    const localBinDir = path.join(os.homedir(), '.local', 'bin');
-    if (!onlyPlatform) {
-        console.log(`${GREEN}[4/10] Removing agenfk CLI symlink...${NC}`);
-        const cliDest = path.join(localBinDir, os.platform() === 'win32' ? 'agenfk.cmd' : 'agenfk');
-        if (existsSync(cliDest)) {
-            await fs.unlink(cliDest);
-            console.log(`  Removed: ${cliDest}`);
+    // 4. CLI symlink + all hook scripts in ~/.local/bin (#88 Bug 2: was gatekeeper-only)
+    await step('~/.local/bin scripts (agenfk CLI + hooks)', !onlyPlatform, async () => {
+        console.log(`${GREEN}[4] Removing agenfk CLI symlink and hook scripts from ~/.local/bin...${NC}`);
+        const suffix = os.platform() === 'win32' ? '.cmd' : '';
+        let removed = false;
+        for (const name of ['agenfk', ...HOOK_VARIANTS]) {
+            const dest = path.join(localBinDir, `${name}${suffix}`);
+            if (await rmIfExists(dest)) {
+                console.log(`  Removed: ${dest}`);
+                removed = true;
+            }
         }
-    }
+        return removed;
+    });
 
     // 5. MCP config — Claude Code
-    if (shouldRun('claude')) {
-        console.log(`${GREEN}[5/10] Removing Claude Code MCP config...${NC}`);
-        try {
-            const claudeCmd = getCliCommand('claude');
-            const claudeCheck = spawnSync(claudeCmd, ['--version'], { stdio: 'ignore' });
-            if (claudeCheck.status === 0) {
-                spawnSync(claudeCmd, ['mcp', 'remove', 'agenfk'], { stdio: 'inherit' });
-                console.log("  Removed: agenfk MCP from Claude Code");
-            }
-        } catch (e) {
-            console.log("  Claude Code CLI not found (skipping)");
+    await step('Claude Code MCP config', shouldRun('claude'), async () => {
+        console.log(`${GREEN}[5] Removing Claude Code MCP config...${NC}`);
+        const claudeCmd = getCliCommand('claude');
+        const claudeCheck = spawnSync(claudeCmd, ['--version'], { stdio: 'ignore' });
+        if (claudeCheck.status === 0) {
+            spawnSync(claudeCmd, ['mcp', 'remove', 'agenfk'], { stdio: 'inherit' });
+            console.log("  Removed: agenfk MCP from Claude Code");
+            return true;
         }
-    }
+        console.log("  Claude Code CLI not found (skipping)");
+        return false;
+    });
 
     // 6. MCP config — Opencode
-    if (shouldRun('opencode')) {
-        console.log(`${GREEN}[6/10] Removing Opencode MCP config...${NC}`);
+    await step('Opencode MCP config', shouldRun('opencode'), async () => {
+        console.log(`${GREEN}[6] Removing Opencode MCP config...${NC}`);
         const opencodeConfigPath = path.join(os.homedir(), '.config', 'opencode', 'opencode.json');
         if (existsSync(opencodeConfigPath)) {
-            try {
-                const config = JSON.parse(await fs.readFile(opencodeConfigPath, 'utf8'));
-                if (config.mcp && config.mcp.agenfk) {
-                    delete config.mcp.agenfk;
-                    await fs.writeFile(opencodeConfigPath, JSON.stringify(config, null, 2));
-                    console.log('  Removed: agenfk MCP from opencode.json');
-                } else {
-                    console.log('  Not found in opencode.json (skipping)');
-                }
-            } catch (e) {
-                console.error('  Error updating opencode.json:', e.message);
+            const config = JSON.parse(await fs.readFile(opencodeConfigPath, 'utf8'));
+            if (config.mcp && config.mcp.agenfk) {
+                delete config.mcp.agenfk;
+                await fs.writeFile(opencodeConfigPath, JSON.stringify(config, null, 2));
+                console.log('  Removed: agenfk MCP from opencode.json');
+                return true;
+            }
+            console.log('  Not found in opencode.json (skipping)');
+        }
+        return false;
+    });
+
+    // 6a. Opencode plugins (gatekeeper / mcp-enforcer / pr-hook) — #88 Bug 3
+    await step('Opencode plugins', shouldRun('opencode'), async () => {
+        console.log(`${GREEN}[6a] Removing Opencode plugins...${NC}`);
+        const pluginsDir = path.join(os.homedir(), '.config', 'opencode', 'plugins');
+        let removed = false;
+        for (const variant of HOOK_VARIANTS) {
+            const dest = path.join(pluginsDir, `${variant}.mjs`);
+            if (await rmIfExists(dest)) {
+                console.log(`  Removed: ${dest}`);
+                removed = true;
             }
         }
-    }
+        return removed;
+    });
 
     // 6b. MCP config — Cursor
-    if (shouldRun('cursor')) {
-        console.log(`${GREEN}[6b/10] Removing Cursor MCP config...${NC}`);
+    await step('Cursor MCP config', shouldRun('cursor'), async () => {
+        console.log(`${GREEN}[6b] Removing Cursor MCP config...${NC}`);
         const cursorMcpPath = getCursorMcpPath();
         if (existsSync(cursorMcpPath)) {
-            try {
-                const cursorMcp = JSON.parse(await fs.readFile(cursorMcpPath, 'utf8'));
-                if (cursorMcp.mcpServers && cursorMcp.mcpServers.agenfk) {
-                    delete cursorMcp.mcpServers.agenfk;
-                    await fs.writeFile(cursorMcpPath, JSON.stringify(cursorMcp, null, 2));
-                    console.log(`  Removed: agenfk MCP from ${cursorMcpPath}`);
-                } else {
-                    console.log(`  Not found in ${cursorMcpPath} (skipping)`);
-                }
-            } catch (e) {
-                console.error('  Error updating Cursor mcp.json:', e.message);
+            const cursorMcp = JSON.parse(await fs.readFile(cursorMcpPath, 'utf8'));
+            if (cursorMcp.mcpServers && cursorMcp.mcpServers.agenfk) {
+                delete cursorMcp.mcpServers.agenfk;
+                await fs.writeFile(cursorMcpPath, JSON.stringify(cursorMcp, null, 2));
+                console.log(`  Removed: agenfk MCP from ${cursorMcpPath}`);
+                return true;
             }
+            console.log(`  Not found in ${cursorMcpPath} (skipping)`);
         } else {
             console.log(`  ${cursorMcpPath} not found (skipping)`);
         }
-    }
+        return false;
+    });
 
     // 6c. MCP config — Codex
-    if (shouldRun('codex')) {
-        console.log(`${GREEN}[6c/10] Removing Codex MCP config...${NC}`);
-        try {
-            const codexCmd = getCliCommand('codex');
-            const codexCheck = spawnSync(codexCmd, ['--version'], { stdio: 'ignore' });
-            if (codexCheck.status === 0) {
-                spawnSync(codexCmd, ['mcp', 'remove', 'agenfk'], { stdio: 'inherit' });
-                console.log("  Removed: agenfk MCP from Codex");
-            } else {
-                console.log("  Codex CLI not found (skipping)");
-            }
-        } catch (e) {
-            console.log("  Codex CLI not found (skipping)");
+    await step('Codex MCP config', shouldRun('codex'), async () => {
+        console.log(`${GREEN}[6c] Removing Codex MCP config...${NC}`);
+        const codexCmd = getCliCommand('codex');
+        const codexCheck = spawnSync(codexCmd, ['--version'], { stdio: 'ignore' });
+        if (codexCheck.status === 0) {
+            spawnSync(codexCmd, ['mcp', 'remove', 'agenfk'], { stdio: 'inherit' });
+            console.log("  Removed: agenfk MCP from Codex");
+            return true;
         }
-    }
+        console.log("  Codex CLI not found (skipping)");
+        return false;
+    });
 
     // 6d. MCP config — Gemini CLI
-    if (shouldRun('gemini')) {
-        console.log(`${GREEN}[6d/10] Removing Gemini CLI MCP config...${NC}`);
-        try {
-            const geminiCmd = getCliCommand('gemini');
-            const geminiCheck = spawnSync(geminiCmd, ['--version'], { stdio: 'ignore' });
-            if (geminiCheck.status === 0) {
-                spawnSync(geminiCmd, ['mcp', 'remove', '-s', 'user', 'agenfk'], { stdio: 'inherit' });
-                console.log("  Removed: agenfk MCP from Gemini CLI");
-            } else {
-                console.log("  Gemini CLI not found (skipping)");
-            }
-        } catch (e) {
-            console.log("  Gemini CLI not found (skipping)");
+    await step('Gemini CLI MCP config', shouldRun('gemini'), async () => {
+        console.log(`${GREEN}[6d] Removing Gemini CLI MCP config...${NC}`);
+        const geminiCmd = getCliCommand('gemini');
+        const geminiCheck = spawnSync(geminiCmd, ['--version'], { stdio: 'ignore' });
+        if (geminiCheck.status === 0) {
+            spawnSync(geminiCmd, ['mcp', 'remove', '-s', 'user', 'agenfk'], { stdio: 'inherit' });
+            console.log("  Removed: agenfk MCP from Gemini CLI");
+            return true;
         }
-    }
+        console.log("  Gemini CLI not found (skipping)");
+        return false;
+    });
 
     } // end if (!rulesOnly)
 
     // 6e. Codex workflow rules (AGENTS.md) — clean up from both scopes
-    if (shouldRun('codex')) {
-        console.log(`${GREEN}[6e/10] Removing Codex workflow rules (${rulesScope} scope)...${NC}`);
+    await step('Codex workflow rules (AGENTS.md)', shouldRun('codex'), async () => {
+        console.log(`${GREEN}[6e] Removing Codex workflow rules (${rulesScope} scope)...${NC}`);
         const globalAgentsMd = path.join(os.homedir(), '.codex', 'AGENTS.md');
         const projectAgentsMd = path.join(projectDir, 'AGENTS.md');
+        let removed = false;
         for (const agentsMdPath of [globalAgentsMd, projectAgentsMd]) {
             if (existsSync(agentsMdPath)) {
-                let content = await fs.readFile(agentsMdPath, 'utf8');
+                const content = await fs.readFile(agentsMdPath, 'utf8');
                 const cleaned = content.replace(/\n?<!-- agenfk:start -->[\s\S]*?<!-- agenfk:end -->\n?/g, '');
                 if (cleaned !== content) {
                     if (cleaned.trim()) {
@@ -304,32 +416,37 @@ async function run() {
                         await fs.unlink(agentsMdPath);
                         console.log(`  Removed: ${agentsMdPath} (was AgenFK-only)`);
                     }
+                    removed = true;
                 }
             }
         }
-    }
+        return removed;
+    });
 
     // 6f. Cursor workflow rules (.mdc) — clean up from both scopes
-    if (shouldRun('cursor')) {
-        console.log(`${GREEN}[6f/10] Removing Cursor workflow rules (${rulesScope} scope)...${NC}`);
+    await step('Cursor workflow rules (.mdc)', shouldRun('cursor'), async () => {
+        console.log(`${GREEN}[6f] Removing Cursor workflow rules (${rulesScope} scope)...${NC}`);
         const globalCursorMdc = path.join(getCursorRulesDir(), 'agenfk.mdc');
         const projectCursorMdc = path.join(projectDir, '.cursor', 'rules', 'agenfk.mdc');
+        let removed = false;
         for (const mdcPath of [globalCursorMdc, projectCursorMdc]) {
-            if (existsSync(mdcPath)) {
-                await fs.unlink(mdcPath);
+            if (await rmIfExists(mdcPath)) {
                 console.log(`  Removed: ${mdcPath}`);
+                removed = true;
             }
         }
-    }
+        return removed;
+    });
 
     // 6g. Gemini CLI workflow rules (GEMINI.md) — clean up from both scopes
-    if (shouldRun('gemini')) {
-        console.log(`${GREEN}[6g/10] Removing Gemini CLI workflow rules (${rulesScope} scope)...${NC}`);
+    await step('Gemini CLI workflow rules (GEMINI.md)', shouldRun('gemini'), async () => {
+        console.log(`${GREEN}[6g] Removing Gemini CLI workflow rules (${rulesScope} scope)...${NC}`);
         const globalGeminiMd = path.join(os.homedir(), '.gemini', 'GEMINI.md');
         const projectGeminiMd = path.join(projectDir, 'GEMINI.md');
+        let removed = false;
         for (const geminiMdPath of [globalGeminiMd, projectGeminiMd]) {
             if (existsSync(geminiMdPath)) {
-                let content = await fs.readFile(geminiMdPath, 'utf8');
+                const content = await fs.readFile(geminiMdPath, 'utf8');
                 const cleaned = content.replace(/\n?<!-- agenfk:start -->[\s\S]*?<!-- agenfk:end -->\n?/g, '');
                 if (cleaned !== content) {
                     if (cleaned.trim()) {
@@ -339,88 +456,95 @@ async function run() {
                         await fs.unlink(geminiMdPath);
                         console.log(`  Removed: ${geminiMdPath} (was AgenFK-only)`);
                     }
+                    removed = true;
                 }
             }
         }
-    }
-
-    // 7. Gatekeeper hook script
-    if (!onlyPlatform) {
-        console.log(`${GREEN}[7/10] Removing agenfk-gatekeeper hook script...${NC}`);
-        const gatekeeperDest = path.join(localBinDir, os.platform() === 'win32' ? 'agenfk-gatekeeper.cmd' : 'agenfk-gatekeeper');
-        if (existsSync(gatekeeperDest)) {
-            await fs.unlink(gatekeeperDest);
-            console.log(`  Removed: ${gatekeeperDest}`);
-        }
-    }
+        return removed;
+    });
 
     // 8. CLAUDE.md workflow rules (clean up from active scope + opposite)
-    if (shouldRun('claude')) {
-        console.log(`${GREEN}[8/10] Removing AgenFK rules from CLAUDE.md (${rulesScope} scope)...${NC}`);
+    await step('AgenFK rules in CLAUDE.md', shouldRun('claude'), async () => {
+        console.log(`${GREEN}[8] Removing AgenFK rules from CLAUDE.md (${rulesScope} scope)...${NC}`);
         const globalClaudeMd = path.join(os.homedir(), '.claude', 'CLAUDE.md');
         const projectClaudeMd = path.join(projectDir, '.claude', 'CLAUDE.md');
+        let removed = false;
         for (const mdPath of [globalClaudeMd, projectClaudeMd]) {
             if (existsSync(mdPath)) {
-                let content = await fs.readFile(mdPath, 'utf8');
+                const content = await fs.readFile(mdPath, 'utf8');
                 const cleaned = content.replace(/\n?<!-- agenfk:start -->[\s\S]*?<!-- agenfk:end -->\n?/g, '');
                 if (cleaned !== content) {
                     await fs.writeFile(mdPath, cleaned, 'utf8');
                     console.log(`  Removed AgenFK block from ${mdPath}`);
+                    removed = true;
                 }
             }
         }
-    }
+        return removed;
+    });
 
     if (rulesOnly) {
-        console.log(`${GREEN}Done. Workflow rules removed (${rulesScope}).${NC}`);
+        finish(`${GREEN}Done. Workflow rules removed (${rulesScope}).${NC}`);
         return;
     }
 
-    // 9. Verify token
-    if (!onlyPlatform) {
-        console.log(`${GREEN}[9/10] Removing verify token...${NC}`);
-        const agenfkHome = path.join(os.homedir(), '.agenfk');
-        const tokenPath = path.join(agenfkHome, 'verify-token');
-        if (existsSync(tokenPath)) {
-            await fs.unlink(tokenPath);
-            console.log(`  Removed: ${tokenPath}`);
-        }
-    }
+    // 9. ~/.agenfk data dir (config.json + verify-token) — #88 Bug 3 (was token-only)
+    await step('~/.agenfk data dir', !onlyPlatform, async () => {
+        console.log(`${GREEN}[9] Removing ~/.agenfk data dir...${NC}`);
+        const removed = await rmIfExists(path.join(os.homedir(), '.agenfk'));
+        if (removed) console.log(`  Removed: ${path.join(os.homedir(), '.agenfk')}`);
+        return removed;
+    });
 
-    // 10. PreToolUse hook in ~/.claude/settings.json
-    if (shouldRun('claude')) {
-        console.log(`${GREEN}[10/10] Removing PreToolUse hook from ~/.claude/settings.json...${NC}`);
+    // 10. Pre/PostToolUse hooks in ~/.claude/settings.json — #88 Bug 2
+    // Strip ALL hook variants from BOTH arrays (was: gatekeeper-only, PreToolUse-only).
+    await step('Claude settings.json hooks', shouldRun('claude'), async () => {
+        console.log(`${GREEN}[10] Removing Pre/PostToolUse hooks from ~/.claude/settings.json...${NC}`);
         const settingsPath = path.join(os.homedir(), '.claude', 'settings.json');
-        if (existsSync(settingsPath)) {
-            try {
-                let settings = JSON.parse(await fs.readFile(settingsPath, 'utf8'));
-                if (settings.hooks && settings.hooks.PreToolUse) {
-                    settings.hooks.PreToolUse = settings.hooks.PreToolUse.filter(entry =>
-                        !JSON.stringify(entry).includes('agenfk-gatekeeper')
-                    );
-                    await fs.writeFile(settingsPath, JSON.stringify(settings, null, 2), 'utf8');
-                    console.log(`  Removed agenfk-gatekeeper hook from ${settingsPath}`);
-                }
-            } catch (e) {}
-        }
-    }
+        const changed = await stripHooksFromJsonFile(settingsPath, ['hooks.PreToolUse', 'hooks.PostToolUse']);
+        if (changed) console.log(`  Removed AgenFK hooks from ${settingsPath}`);
+        return changed;
+    });
+
+    // 10b. Codex PostToolUse hook (~/.codex/hooks.json) — #88 Bug 3
+    await step('Codex hooks.json pr-hook', shouldRun('codex'), async () => {
+        console.log(`${GREEN}[10b] Removing PostToolUse hook from ~/.codex/hooks.json...${NC}`);
+        const codexHooksPath = path.join(os.homedir(), '.codex', 'hooks.json');
+        const changed = await stripHooksFromJsonFile(codexHooksPath, ['PostToolUse']);
+        if (changed) console.log(`  Removed AgenFK hook from ${codexHooksPath}`);
+        return changed;
+    });
+
+    // 10c. Gemini AfterTool hook (~/.gemini/settings.json) — #88 Bug 3
+    await step('Gemini settings.json AfterTool hook', shouldRun('gemini'), async () => {
+        console.log(`${GREEN}[10c] Removing AfterTool hook from ~/.gemini/settings.json...${NC}`);
+        const geminiSettingsPath = path.join(os.homedir(), '.gemini', 'settings.json');
+        const changed = await stripHooksFromJsonFile(geminiSettingsPath, ['hooks.AfterTool']);
+        if (changed) console.log(`  Removed AgenFK hook from ${geminiSettingsPath}`);
+        return changed;
+    });
+
+    // 10d. Cursor afterShellExecution hook (~/.cursor/hooks.json) — #88 Bug 3
+    await step('Cursor hooks.json afterShellExecution', shouldRun('cursor'), async () => {
+        console.log(`${GREEN}[10d] Removing afterShellExecution hook from ~/.cursor/hooks.json...${NC}`);
+        const cursorHooksPath = path.join(os.homedir(), '.cursor', 'hooks.json');
+        const changed = await stripHooksFromJsonFile(cursorHooksPath, ['afterShellExecution']);
+        if (changed) console.log(`  Removed AgenFK hook from ${cursorHooksPath}`);
+        return changed;
+    });
 
     if (!onlyPlatform) {
-        console.log("");
-        console.log(`${RED}Removing ~/.agenfk-system...${NC}`);
-        const systemDir = path.join(os.homedir(), '.agenfk-system');
-        if (existsSync(systemDir)) {
-            await fs.rm(systemDir, { recursive: true, force: true });
-            console.log(`  Removed: ${systemDir}`);
-        }
-
-        console.log("");
-        console.log(`${GREEN}AgenFK uninstalled successfully.${NC}`);
-        console.log("Restart your AI editor to complete the removal.");
+        await step('~/.agenfk-system framework files', true, async () => {
+            console.log("");
+            console.log(`${RED}Removing ~/.agenfk-system...${NC}`);
+            const systemDir = path.join(os.homedir(), '.agenfk-system');
+            const removed = await rmIfExists(systemDir);
+            if (removed) console.log(`  Removed: ${systemDir}`);
+            return removed;
+        });
+        finish(`${GREEN}AgenFK uninstalled. Restart your AI editor to complete the removal.${NC}`);
     } else {
-        console.log("");
-        console.log(`${GREEN}Integration '${onlyPlatform}' uninstalled successfully.${NC}`);
-        console.log(`Restart ${onlyPlatform} to complete the removal.`);
+        finish(`${GREEN}Integration '${onlyPlatform}' uninstalled. Restart ${onlyPlatform} to complete the removal.${NC}`);
     }
 }
 


### PR DESCRIPTION
Fixes #88.

`scripts/uninstall.mjs` crashed partway through and left most artifacts behind. This rewrites it to remove everything the installer creates, fail safe, and confirm before destroying anything.

### Bug 1 — `ReferenceError: localBinDir is not defined` (crash at step 7)
`localBinDir` was declared **inside** the `if (!rulesOnly)` block, so the hook-removal step that runs after the block aborted the whole uninstall mid-run. Hoisted it to function scope.

### Bug 2 — only the `gatekeeper` variant was handled
- `~/.local/bin` cleanup now removes the `agenfk` CLI symlink **and all three** hook scripts (`agenfk-gatekeeper`, `agenfk-mcp-enforcer`, `agenfk-pr-hook`).
- `~/.claude/settings.json` cleanup now strips every variant from **both** `PreToolUse` and `PostToolUse` (was gatekeeper-only, PreToolUse-only).

### Bug 3 — several installed artifacts were never removed
Now mirrored: Opencode plugins (`~/.config/opencode/plugins/agenfk-*.mjs`), the Codex `~/.codex/hooks.json` PostToolUse entry, the Gemini `~/.gemini/settings.json` `AfterTool` hook, the Cursor `~/.cursor/hooks.json` `afterShellExecution` hook (also previously unhandled), and the full `~/.agenfk` data dir (was `verify-token` only).

### Bug 4 — partial uninstall was silent
Every step runs in a `try/catch` that records a result; a final summary prints `removed / skipped / failed` and the process exits non-zero if any step failed.

### Bug 5 — destructive run auto-confirmed without `-y`
`-y`/`--yes` proceeds; an interactive TTY prompts; a non-interactive run without `-y` now **aborts** instead of assuming consent. All programmatic callers (`packages/cli/src/index.ts`) already pass `--yes`.

### Tests
New `packages/cli/src/test/uninstall-issue88.test.ts`:
- Pure-logic unit tests for the extracted `scripts/uninstall-helpers.mjs`.
- End-to-end tests that run the real `uninstall.mjs` against a throwaway `$HOME` seeded with every install artifact and assert full removal, hook-entry stripping (preserving unrelated entries), exit codes, and the abort-without-`-y` path.

Full suite green: 128 files / 1348 tests. Manually smoke-tested the abort and full-removal paths.
