### PR TITLE
fix: ship uninstaller + helpers in dist tarball so `agenfk upgrade` delivers the #88 fix

### DIFF
--- a/packages/cli/src/test/dist-ships-uninstaller.test.ts
+++ b/packages/cli/src/test/dist-ships-uninstaller.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Regression test for the dist-packaging gap that let the #88 uninstaller fix
+ * ship without ever reaching users via `agenfk upgrade`.
+ *
+ * `agenfk upgrade` only extracts agenfk-dist.tar.gz; it does NOT copy source
+ * (unlike the `npx github:` path). So any script the uninstaller/installer needs
+ * at runtime MUST be listed in scripts/package-dist.mjs's `include` array, or the
+ * old copy from the original install survives forever.
+ *
+ * These assert (1) the uninstaller + its helpers are shipped, and (2) closure:
+ * every shipped scripts/*.mjs has all of its local `./*.mjs` imports shipped too.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+
+const ROOT = path.resolve(__dirname, '../../../..');
+const packageDist = readFileSync(path.join(ROOT, 'scripts', 'package-dist.mjs'), 'utf8');
+
+// Extract the string literals inside the `const include = [ ... ]` array.
+function parseIncludeList(src: string): string[] {
+  const start = src.indexOf('const include = [');
+  expect(start).toBeGreaterThan(-1);
+  const end = src.indexOf('];', start);
+  expect(end).toBeGreaterThan(start);
+  const block = src.slice(start, end);
+  return [...block.matchAll(/['"]([^'"]+)['"]/g)].map((m) => m[1]);
+}
+
+// Local `./x.mjs` imports of a script file.
+function localMjsImports(scriptRelPath: string): string[] {
+  const src = readFileSync(path.join(ROOT, scriptRelPath), 'utf8');
+  return [...src.matchAll(/(?:from|import)\s*['"](\.\/[A-Za-z0-9_-]+\.mjs)['"]/g)].map((m) =>
+    path.posix.join(path.posix.dirname(scriptRelPath), m[1].replace(/^\.\//, ''))
+  );
+}
+
+describe('package-dist.mjs — ships the uninstaller and its helpers', () => {
+  const include = parseIncludeList(packageDist);
+
+  it('includes scripts/uninstall.mjs so `agenfk upgrade` can deliver uninstaller fixes', () => {
+    expect(include).toContain('scripts/uninstall.mjs');
+  });
+
+  it('includes the helper modules imported by the shipped scripts', () => {
+    expect(include).toContain('scripts/uninstall-helpers.mjs');
+    expect(include).toContain('scripts/install-helpers.mjs');
+  });
+
+  it('still ships the installer and service launcher', () => {
+    expect(include).toContain('scripts/install.mjs');
+    expect(include).toContain('scripts/start-services.mjs');
+  });
+
+  // Closure: any local ./*.mjs imported by a shipped script must also be shipped,
+  // else the tarball-only `upgrade` path produces an ERR_MODULE_NOT_FOUND at runtime.
+  it('ships every local .mjs import of every shipped script (import closure)', () => {
+    const shippedScripts = include.filter((p) => /^scripts\/.+\.mjs$/.test(p));
+    const missing: string[] = [];
+    for (const script of shippedScripts) {
+      for (const imp of localMjsImports(script)) {
+        if (!include.includes(imp)) missing.push(`${script} imports ${imp} (not shipped)`);
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+});

--- a/scripts/package-dist.mjs
+++ b/scripts/package-dist.mjs
@@ -28,6 +28,14 @@ async function run() {
         'bin/',
         'scripts/start-services.mjs',
         'scripts/install.mjs',
+        // The installer/uninstaller and their helper modules must travel in the
+        // tarball — `agenfk upgrade` only extracts the dist and never copies
+        // source, so anything omitted here can never be updated post-install
+        // (e.g. the #88 uninstaller fix). Keep this in sync with every local
+        // ./*.mjs import of the shipped scripts (enforced by dist-ships-uninstaller.test).
+        'scripts/install-helpers.mjs',
+        'scripts/uninstall.mjs',
+        'scripts/uninstall-helpers.mjs',
         'commands/',
         'clauderules/',
         'codexrules/',


### PR DESCRIPTION
## Problem

The #88 uninstaller fix (PR #89) could never reach users via `agenfk upgrade`.

`agenfk upgrade` downloads and extracts **only** `agenfk-dist.tar.gz` — it does not copy source (unlike the `npx github:` install path, which `fs.cpSync`s the whole tree). But `scripts/package-dist.mjs` shipped only `scripts/install.mjs` + `scripts/start-services.mjs` and **omitted `scripts/uninstall.mjs`, `scripts/uninstall-helpers.mjs`, and `scripts/install-helpers.mjs`**.

Result, confirmed in a clean Docker round trip (install v1.0.3 → `agenfk upgrade --beta` 1.0.4-beta.1 → uninstall): the upgrade reported success, but the **buggy uninstaller from the original install survived** and crashed with the original `ReferenceError: localBinDir is not defined`. `install-helpers.mjs` had the same latent gap — it only survives today because the npx path copies it from source.

## Fix

Add the three `.mjs` files to the `package-dist.mjs` include list, and add a regression test (`dist-ships-uninstaller.test.ts`) that:
- asserts the uninstaller + helpers are shipped, and
- enforces **import closure**: every local `./*.mjs` imported by a shipped `scripts/*.mjs` must itself be shipped — so a future script can't silently reintroduce this class of bug.

Verified the rebuilt tarball now contains all five `scripts/` files. Full suite green (129 files / 1352 tests).
