### PR TITLE
Support Pi coding agent: register agenfk MCP server in installer/uninstaller

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenfk",
-  "version": "1.0.4",
+  "version": "1.0.5-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenfk",
-      "version": "1.0.4",
+      "version": "1.0.5-beta.1",
       "license": "ISC",
       "workspaces": [
         "packages/core",
@@ -11171,11 +11171,11 @@
     },
     "packages/cli": {
       "name": "@agenfk/cli",
-      "version": "1.0.4",
+      "version": "1.0.5-beta.1",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.0.4",
-        "@agenfk/telemetry": "1.0.4",
+        "@agenfk/core": "1.0.5-beta.1",
+        "@agenfk/telemetry": "1.0.5-beta.1",
         "axios": "^1.13.5",
         "chalk": "^4.1.2",
         "commander": "^12.0.0",
@@ -11195,7 +11195,7 @@
     },
     "packages/core": {
       "name": "@agenfk/core",
-      "version": "1.0.4",
+      "version": "1.0.5-beta.1",
       "license": "ISC",
       "devDependencies": {
         "typescript": "^5.3.3"
@@ -11203,7 +11203,7 @@
     },
     "packages/create": {
       "name": "agenfk",
-      "version": "1.0.4",
+      "version": "1.0.5-beta.1",
       "license": "ISC",
       "bin": {
         "agenfk": "bin/agenfk.js"
@@ -11214,7 +11214,7 @@
     },
     "packages/flow-editor": {
       "name": "@agenfk/flow-editor",
-      "version": "1.0.4",
+      "version": "1.0.5-beta.1",
       "peerDependencies": {
         "@tanstack/react-query": "^5.90.21",
         "clsx": "^2.1.1",
@@ -11226,9 +11226,9 @@
     },
     "packages/hub": {
       "name": "@agenfk/hub",
-      "version": "1.0.4",
+      "version": "1.0.5-beta.1",
       "dependencies": {
-        "@agenfk/core": "1.0.4",
+        "@agenfk/core": "1.0.5-beta.1",
         "axios": "^1.13.5",
         "bcryptjs": "^2.4.3",
         "cookie-parser": "^1.4.7",
@@ -11252,9 +11252,9 @@
       }
     },
     "packages/hub-ui": {
-      "version": "1.0.4",
+      "version": "1.0.5-beta.1",
       "dependencies": {
-        "@agenfk/flow-editor": "1.0.4",
+        "@agenfk/flow-editor": "1.0.5-beta.1",
         "@tailwindcss/postcss": "^4.2.0",
         "@tanstack/react-query": "^5.90.21",
         "@vitejs/plugin-react": "^5.1.1",
@@ -11655,12 +11655,12 @@
     },
     "packages/server": {
       "name": "@agenfk/server",
-      "version": "1.0.4",
+      "version": "1.0.5-beta.1",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.0.4",
-        "@agenfk/storage-sqlite": "1.0.4",
-        "@agenfk/telemetry": "1.0.4",
+        "@agenfk/core": "1.0.5-beta.1",
+        "@agenfk/storage-sqlite": "1.0.5-beta.1",
+        "@agenfk/telemetry": "1.0.5-beta.1",
         "@modelcontextprotocol/sdk": "0.6.0",
         "axios": "^1.13.5",
         "body-parser": "^2.2.2",
@@ -11696,13 +11696,13 @@
     },
     "packages/storage-sqlite": {
       "name": "@agenfk/storage-sqlite",
-      "version": "1.0.4",
+      "version": "1.0.5-beta.1",
       "license": "ISC",
       "dependencies": {
         "uuid": "^9.0.1"
       },
       "devDependencies": {
-        "@agenfk/core": "1.0.4",
+        "@agenfk/core": "1.0.5-beta.1",
         "@types/node": "^22.0.0",
         "@types/uuid": "^9.0.8",
         "typescript": "^5.3.3"
@@ -11720,7 +11720,7 @@
     },
     "packages/telemetry": {
       "name": "@agenfk/telemetry",
-      "version": "1.0.4",
+      "version": "1.0.5-beta.1",
       "license": "ISC",
       "dependencies": {
         "posthog-node": "^4.0.0"
@@ -11731,9 +11731,9 @@
       }
     },
     "packages/ui": {
-      "version": "1.0.4",
+      "version": "1.0.5-beta.1",
       "dependencies": {
-        "@agenfk/flow-editor": "1.0.4",
+        "@agenfk/flow-editor": "1.0.5-beta.1",
         "@tailwindcss/postcss": "^4.2.0",
         "@tailwindcss/typography": "^0.5.19",
         "@tanstack/react-query": "^5.90.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "1.0.4",
+  "version": "1.0.5-beta.1",
   "description": "AgenFK Engineering Framework",
   "private": true,
   "workspaces": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/cli",
-  "version": "1.0.4",
+  "version": "1.0.5-beta.1",
   "description": "CLI for AgenFK Engineering Framework",
   "main": "dist/index.js",
   "bin": {
@@ -12,8 +12,8 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.0.4",
-    "@agenfk/telemetry": "1.0.4",
+    "@agenfk/core": "1.0.5-beta.1",
+    "@agenfk/telemetry": "1.0.5-beta.1",
     "axios": "^1.13.5",
     "chalk": "^4.1.2",
     "commander": "^12.0.0",

--- a/packages/cli/src/test/install-script.test.ts
+++ b/packages/cli/src/test/install-script.test.ts
@@ -298,6 +298,79 @@ describe('install.mjs — npm spawnSync uses shell:true on Windows', () => {
     });
 });
 
+// ---------------------------------------------------------------------------
+// install.mjs + uninstall.mjs — Pi coding agent MCP registration
+// Pi reads MCP servers from ~/.pi/agent/mcp.json ({ settings, mcpServers: {...} }),
+// the same stdio shape as Cursor. Skills already work via ~/.agents/skills/;
+// the gap was registering the agenfk MCP server for Pi.
+// ---------------------------------------------------------------------------
+describe('install.mjs — Pi coding agent MCP config', () => {
+    // Extract the Pi configuration block so assertions don't accidentally match
+    // a different client's section.
+    const piStart = installScript.indexOf('Configure Pi MCP');
+    const piBlock = installScript.slice(piStart, piStart + 2200);
+
+    it('has a dedicated Pi MCP configuration step', () => {
+        expect(piStart).toBeGreaterThan(-1);
+    });
+
+    it('gates the Pi step behind shouldRun(\'pi\')', () => {
+        expect(piBlock).toMatch(/shouldRun\(\s*['"]pi['"]\s*\)/);
+    });
+
+    it('writes to Pi\'s ~/.pi/agent/mcp.json config file', () => {
+        // Pi's MCP config location is ~/.pi/agent/mcp.json.
+        expect(piBlock).toMatch(/['"]\.pi['"]\s*,\s*['"]agent['"]\s*,\s*['"]mcp\.json['"]/);
+    });
+
+    it('registers an agenfk MCP server launched via node + serverPath', () => {
+        expect(piBlock).toMatch(/mcpServers\.agenfk\s*=/);
+        expect(piBlock).toMatch(/command:\s*['"]node['"]/);
+        expect(piBlock).toMatch(/AGENFK_DB_PATH/);
+    });
+
+    it('sets lifecycle to keep-alive for the agenfk server', () => {
+        expect(piBlock).toMatch(/lifecycle:\s*['"]keep-alive['"]/);
+    });
+
+    it('merges into existing config rather than clobbering it', () => {
+        // Must read + JSON.parse any existing mcp.json and preserve other keys,
+        // mirroring the Cursor merge logic.
+        expect(piBlock).toMatch(/JSON\.parse/);
+        expect(piBlock).toMatch(/mcpServers\s*=\s*\{\}|!\w*[Mm]cp\.mcpServers/);
+    });
+
+    it('normalizes paths for MinGW like the other native clients', () => {
+        expect(piBlock).toMatch(/isMinGW/);
+    });
+
+    it('mentions Pi in the final restart guidance', () => {
+        // Users must be told to restart Pi to pick up the new MCP server.
+        const restartIdx = installScript.indexOf('to pick up the new MCP server');
+        expect(restartIdx).toBeGreaterThan(-1);
+        const restartLine = installScript.slice(restartIdx - 200, restartIdx + 50);
+        expect(restartLine).toMatch(/Pi/);
+    });
+});
+
+describe('uninstall.mjs — Pi coding agent MCP config removal', () => {
+    const piStart = uninstallScript.indexOf('MCP config — Pi');
+    const piBlock = uninstallScript.slice(piStart, piStart + 1200);
+
+    it('has a dedicated Pi MCP removal step', () => {
+        expect(piStart).toBeGreaterThan(-1);
+    });
+
+    it('gates the Pi removal behind shouldRun(\'pi\')', () => {
+        expect(piBlock).toMatch(/shouldRun\(\s*['"]pi['"]\s*\)/);
+    });
+
+    it('deletes the agenfk entry from ~/.pi/agent/mcp.json', () => {
+        expect(piBlock).toMatch(/['"]\.pi['"]\s*,\s*['"]agent['"]\s*,\s*['"]mcp\.json['"]/);
+        expect(piBlock).toMatch(/delete\s+\w*[Mm]cp\.mcpServers\.agenfk/);
+    });
+});
+
 describe('install.mjs — restarts running API server after a successful install (BUG 174270e6)', () => {
     it('captures the pre-install reachability of the API server', () => {
         // The pre-check at the top of run() must store its result somewhere

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/core",
-  "version": "1.0.4",
+  "version": "1.0.5-beta.1",
   "description": "Core logic and interfaces for the AgenFK Engineering Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "1.0.4",
+  "version": "1.0.5-beta.1",
   "description": "AgenFK Agentic Engineering Framework — installer",
   "bin": {
     "agenfk": "bin/agenfk.js"

--- a/packages/flow-editor/package.json
+++ b/packages/flow-editor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agenfk/flow-editor",
   "private": true,
-  "version": "1.0.4",
+  "version": "1.0.5-beta.1",
   "type": "module",
   "main": "./src/index.ts",
   "exports": {

--- a/packages/hub-ui/package.json
+++ b/packages/hub-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hub-ui",
   "private": true,
-  "version": "1.0.4",
+  "version": "1.0.5-beta.1",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.0.4",
+    "@agenfk/flow-editor": "1.0.5-beta.1",
     "@tailwindcss/postcss": "^4.2.0",
     "mermaid": "^11.12.3",
     "@tanstack/react-query": "^5.90.21",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/hub",
-  "version": "1.0.4",
+  "version": "1.0.5-beta.1",
   "description": "Corporate Hub for AgEnFK — fleet-wide metrics + timeline server",
   "main": "dist/server.js",
   "types": "dist/server.d.ts",
@@ -20,7 +20,7 @@
     "start": "node dist/bin.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.0.4",
+    "@agenfk/core": "1.0.5-beta.1",
     "axios": "^1.13.5",
     "bcryptjs": "^2.4.3",
     "cookie-parser": "^1.4.7",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/server",
-  "version": "1.0.4",
+  "version": "1.0.5-beta.1",
   "description": "MCP Server for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -12,9 +12,9 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.0.4",
-    "@agenfk/storage-sqlite": "1.0.4",
-    "@agenfk/telemetry": "1.0.4",
+    "@agenfk/core": "1.0.5-beta.1",
+    "@agenfk/storage-sqlite": "1.0.5-beta.1",
+    "@agenfk/telemetry": "1.0.5-beta.1",
     "@modelcontextprotocol/sdk": "0.6.0",
     "axios": "^1.13.5",
     "body-parser": "^2.2.2",

--- a/packages/storage-sqlite/package.json
+++ b/packages/storage-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/storage-sqlite",
-  "version": "1.0.4",
+  "version": "1.0.5-beta.1",
   "description": "SQLite storage implementation for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -11,7 +11,7 @@
     "uuid": "^9.0.1"
   },
   "devDependencies": {
-    "@agenfk/core": "1.0.4",
+    "@agenfk/core": "1.0.5-beta.1",
     "@types/node": "^22.0.0",
     "@types/uuid": "^9.0.8",
     "typescript": "^5.3.3"

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/telemetry",
-  "version": "1.0.4",
+  "version": "1.0.5-beta.1",
   "description": "Anonymous telemetry client for AgenFK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.0.4",
+  "version": "1.0.5-beta.1",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -12,7 +12,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.0.4",
+    "@agenfk/flow-editor": "1.0.5-beta.1",
     "@tailwindcss/postcss": "^4.2.0",
     "@tailwindcss/typography": "^0.5.19",
     "@tanstack/react-query": "^5.90.21",

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -709,6 +709,55 @@ process.exit(0);
         }
     }
 
+    // 6e. Configure Pi MCP
+    if (shouldRun('pi')) {
+        console.log(`${GREEN}[6e/14] Configuring Pi MCP...${NC}`);
+        // Pi reads MCP servers from ~/.pi/agent/mcp.json
+        // ({ settings, mcpServers: { <name>: { command, args, env, lifecycle } } }).
+        const piMcpPath = path.join(os.homedir(), '.pi', 'agent', 'mcp.json');
+        const piConfigDir = path.dirname(piMcpPath);
+        const piCmd = getCliCommand('pi');
+        const piInstalled = existsSync(piConfigDir) ||
+            spawnSync(piCmd, ['--version'], { stdio: 'ignore' }).status === 0;
+        if (piInstalled) {
+            try {
+                let piMcp = {};
+                if (existsSync(piMcpPath)) {
+                    const rawContent = (await fs.readFile(piMcpPath, 'utf8')).trim();
+                    if (rawContent) {
+                        piMcp = JSON.parse(rawContent);
+                    }
+                } else {
+                    await fs.mkdir(piConfigDir, { recursive: true });
+                    console.log(`  Pi config dir not found — creating it.`);
+                }
+                if (!piMcp.mcpServers) piMcp.mcpServers = {};
+
+                // Pi (like Cursor) is a native app and cannot resolve MinGW POSIX
+                // paths (/c/Users/...), so normalize on Windows/Git-Bash.
+                const piServerPath = isMinGW ? toWindowsPath(serverPath) : serverPath;
+                const piDbPath = isMinGW ? toWindowsPath(dbPath) : dbPath;
+
+                piMcp.mcpServers.agenfk = {
+                    command: 'node',
+                    args: [piServerPath],
+                    env: {
+                        NODE_ENV: 'production',
+                        AGENFK_DB_PATH: piDbPath
+                    },
+                    lifecycle: 'keep-alive'
+                };
+
+                await fs.writeFile(piMcpPath, JSON.stringify(piMcp, null, 2));
+                console.log(`  Written: ${piMcpPath}`);
+            } catch (e) {
+                console.error('Error updating Pi mcp.json:', e.message);
+            }
+        } else if (!onlyPlatform) {
+            console.log(`  Pi not found. Skipping Pi MCP configuration.`);
+        }
+    }
+
     // 7. Configure Claude Code MCP (deferred — runs after step 9 once cliDest is known)
 
     // 8. Install AgenFK Skills
@@ -1372,7 +1421,7 @@ process.exit(0);
         console.log(`To opt out at any time: ${BLUE}agenfk config set telemetry false${NC}`);
         console.log("");
         console.log(`${BLUE}=== Usage Instructions ===${NC}`);
-        console.log("1. Restart your AI editor/agent (Opencode, Cursor, Codex, and Gemini CLI need a restart to pick up the new MCP server).");
+        console.log("1. Restart your AI editor/agent (Opencode, Cursor, Codex, Gemini CLI, and Pi need a restart to pick up the new MCP server).");
         console.log("2. Run 'node scripts/start-services.mjs' to start the API and Web UI.");
         console.log("3. Go to ANY project repository and type '/agenfk' (Standard) or '/agenfk-deep' (Multi-Agent) in your AI editor's prompt to initialize your project context and start the workflow.");
         console.log("4. Use '/agenfk-release' or '/agenfk-release-beta' to push to remote and cut a release.");

--- a/scripts/uninstall.mjs
+++ b/scripts/uninstall.mjs
@@ -168,7 +168,7 @@ async function run() {
         console.log(`${YELLOW}This will remove:${NC}`);
         console.log("  - Slash commands from Claude Code, Opencode, and Gemini CLI");
         console.log("  - Opencode skill + plugins (gatekeeper, mcp-enforcer, pr-hook)");
-        console.log("  - MCP server config from Claude Code, Opencode, Cursor, Codex, and Gemini CLI");
+        console.log("  - MCP server config from Claude Code, Opencode, Cursor, Codex, Gemini CLI, and Pi");
         console.log("  - Cursor workflow rules (agenfk.mdc) + afterShellExecution hook");
         console.log("  - Codex workflow rules (~/.codex/AGENTS.md) + PostToolUse hook");
         console.log("  - Gemini CLI workflow rules (~/.gemini/GEMINI.md) + AfterTool hook");
@@ -396,11 +396,30 @@ async function run() {
         return false;
     });
 
+    // 6e. MCP config — Pi
+    await step('Pi MCP config', shouldRun('pi'), async () => {
+        console.log(`${GREEN}[6e] Removing Pi MCP config...${NC}`);
+        const piMcpPath = path.join(os.homedir(), '.pi', 'agent', 'mcp.json');
+        if (existsSync(piMcpPath)) {
+            const piMcp = JSON.parse(await fs.readFile(piMcpPath, 'utf8'));
+            if (piMcp.mcpServers && piMcp.mcpServers.agenfk) {
+                delete piMcp.mcpServers.agenfk;
+                await fs.writeFile(piMcpPath, JSON.stringify(piMcp, null, 2));
+                console.log(`  Removed: agenfk MCP from ${piMcpPath}`);
+                return true;
+            }
+            console.log(`  Not found in ${piMcpPath} (skipping)`);
+        } else {
+            console.log(`  ${piMcpPath} not found (skipping)`);
+        }
+        return false;
+    });
+
     } // end if (!rulesOnly)
 
-    // 6e. Codex workflow rules (AGENTS.md) — clean up from both scopes
+    // 6f. Codex workflow rules (AGENTS.md) — clean up from both scopes
     await step('Codex workflow rules (AGENTS.md)', shouldRun('codex'), async () => {
-        console.log(`${GREEN}[6e] Removing Codex workflow rules (${rulesScope} scope)...${NC}`);
+        console.log(`${GREEN}[6f] Removing Codex workflow rules (${rulesScope} scope)...${NC}`);
         const globalAgentsMd = path.join(os.homedir(), '.codex', 'AGENTS.md');
         const projectAgentsMd = path.join(projectDir, 'AGENTS.md');
         let removed = false;
@@ -423,9 +442,9 @@ async function run() {
         return removed;
     });
 
-    // 6f. Cursor workflow rules (.mdc) — clean up from both scopes
+    // 6g. Cursor workflow rules (.mdc) — clean up from both scopes
     await step('Cursor workflow rules (.mdc)', shouldRun('cursor'), async () => {
-        console.log(`${GREEN}[6f] Removing Cursor workflow rules (${rulesScope} scope)...${NC}`);
+        console.log(`${GREEN}[6g] Removing Cursor workflow rules (${rulesScope} scope)...${NC}`);
         const globalCursorMdc = path.join(getCursorRulesDir(), 'agenfk.mdc');
         const projectCursorMdc = path.join(projectDir, '.cursor', 'rules', 'agenfk.mdc');
         let removed = false;
@@ -438,9 +457,9 @@ async function run() {
         return removed;
     });
 
-    // 6g. Gemini CLI workflow rules (GEMINI.md) — clean up from both scopes
+    // 6h. Gemini CLI workflow rules (GEMINI.md) — clean up from both scopes
     await step('Gemini CLI workflow rules (GEMINI.md)', shouldRun('gemini'), async () => {
-        console.log(`${GREEN}[6g] Removing Gemini CLI workflow rules (${rulesScope} scope)...${NC}`);
+        console.log(`${GREEN}[6h] Removing Gemini CLI workflow rules (${rulesScope} scope)...${NC}`);
         const globalGeminiMd = path.join(os.homedir(), '.gemini', 'GEMINI.md');
         const projectGeminiMd = path.join(projectDir, 'GEMINI.md');
         let removed = false;


### PR DESCRIPTION
## Summary

Makes AgEnFK work with the **Pi** coding agent. Pi already discovered AgEnFK skills via the universal `~/.agents/skills/` path the installer populates — the only gap was registering the `agenfk` MCP server.

Pi reads MCP servers from `~/.pi/agent/mcp.json` (shape `{ settings, mcpServers: { <name>: { command, args, env, lifecycle } } }` — the same stdio shape as Cursor). This change mirrors the existing Cursor MCP handling.

## Changes

- **`scripts/install.mjs`** — new step `[6e/14]` that detects Pi (`~/.pi/agent` exists or `pi --version` succeeds) and merge-writes an `agenfk` entry into `~/.pi/agent/mcp.json`:
  ```json
  "agenfk": {
    "command": "node",
    "args": ["<serverPath>"],
    "env": { "NODE_ENV": "production", "AGENFK_DB_PATH": "<dbPath>" },
    "lifecycle": "keep-alive"
  }
  ```
  Existing `settings` and other servers are preserved; MinGW paths normalized like the Cursor handler. Pi added to the final restart message.
- **`scripts/uninstall.mjs`** — new step `[6e]` removing only `mcpServers.agenfk`; downstream workflow-rules steps renumbered (`6f`/`6g`/`6h`) to avoid collision; Pi added to the summary list.
- **`packages/cli/src/test/install-script.test.ts`** — 11 new tests (written failing first, TDD).

## Verification

- Full suite green: **1363/1363**.
- End-to-end against an isolated temp `HOME` (`--only=pi`): install merged `agenfk` alongside a seeded `chrome-devtools` server with `lifecycle: keep-alive`; uninstall removed only `agenfk`, preserving `settings` and the other server.
- Adversarial senior-engineer review (separate agent): no Critical/High findings.

https://claude.ai/code/session_01DC1kKtR789DpmkxY64sNaZ