### PR TITLE
fix(upgrade): make upgrades actually upgrade — auto-restart + --version flag collision

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -375,7 +375,14 @@ function applyUpgradeTierAction(tier: string, latestVersion: string): void {
 }
 
 program
-  .version(CURRENT_VERSION, '-V, --version', 'output the CLI version number')
+  // BUG 7f85715b: do NOT register a global `--version` flag here. commander's
+  // global version option would intercept `agenfk upgrade --version <ver>`
+  // (the form the hub reconciler always uses) and print the CLI version + exit
+  // instead of pinning the upgrade target — so pinned/hub upgrades never
+  // installed. We bind only `-V` to commander and handle bare `--version`
+  // manually at the top level (see below), leaving the long `--version` free
+  // for the `upgrade` subcommand's `--version <ver>` option.
+  .version(CURRENT_VERSION, '-V', 'output the CLI version number')
   .description('AgEnFK Engineering CLI')
 ;
 
@@ -3717,6 +3724,16 @@ program.helpInformation = function () {
 };
 
 if (process.env.NODE_ENV !== 'test') {
+  // BUG 7f85715b: handle a bare `agenfk --version` / `agenfk -V` here, since we
+  // intentionally did not bind the long `--version` to commander's global flag
+  // (it would otherwise swallow `agenfk upgrade --version <ver>`). Only the
+  // exact top-level, single-arg form prints the version; anything else (e.g.
+  // `agenfk upgrade --version <ver>`) falls through to normal subcommand parse.
+  const rootArgs = process.argv.slice(2);
+  if (rootArgs.length === 1 && (rootArgs[0] === '--version' || rootArgs[0] === '-V')) {
+    console.log(CURRENT_VERSION);
+    process.exit(0);
+  }
   (async () => {
     await checkUpgradeTier();
     program.parse(process.argv);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -592,7 +592,17 @@ program
       const debuglogFlag = options.debuglog ? ' --debuglog' : '';
       log(chalk.gray('Running install script (pre-built mode)...'));
       try {
-        execSync(`node scripts/install.mjs${debuglogFlag}`, { cwd: rootDir, stdio: isJson ? 'ignore' : 'inherit' });
+        // BUG 2f491181: `down` ran above, so install.mjs's own reachability
+        // probe will read the server as gone and skip the post-upgrade
+        // restart. Hand it the pre-`down` truth explicitly so it restarts the
+        // server onto the new code. install.mjs is the single owner of the
+        // restart now (it spawns `agenfk restart --quiet`); we no longer fire
+        // a second `up` here, which would race it for the port.
+        execSync(`node scripts/install.mjs${debuglogFlag}`, {
+          cwd: rootDir,
+          stdio: isJson ? 'ignore' : 'inherit',
+          env: { ...process.env, AGENFK_SERVER_WAS_RUNNING: servicesRunning ? '1' : '0' },
+        });
       } catch (e: any) {
         const msg = `Upgrade failed during installation: ${e?.message ?? e}`;
         emitResult({ status: 'failed', fromVersion: CURRENT_VERSION, toVersion: targetVersion, error: msg });
@@ -601,21 +611,8 @@ program
       }
 
       log(chalk.green(`Successfully upgraded to ${targetVersion}`));
-
       if (servicesRunning) {
-        log(chalk.blue('Starting services with new version...'));
-        try {
-          const start = spawn('node', ['packages/cli/bin/agenfk.js', 'up'], {
-            cwd: rootDir,
-            detached: true,
-            stdio: isJson ? 'ignore' : 'inherit',
-          });
-          start.unref();
-          log(chalk.green('Services started in background.'));
-          await new Promise((resolve) => setTimeout(resolve, 1000));
-        } catch (e) {
-          errLog(chalk.red('Auto-start failed. Please run "agenfk up" manually.'));
-        }
+        log(chalk.green('Server restart was triggered by the installer (running in background).'));
       }
 
       emitResult({ status: 'upgraded', fromVersion: CURRENT_VERSION, toVersion: targetVersion });

--- a/packages/cli/src/test/upgrade-restart-reliability.test.ts
+++ b/packages/cli/src/test/upgrade-restart-reliability.test.ts
@@ -1,0 +1,110 @@
+/**
+ * BUG 2f491181 — upgrade does not auto-restart the server, leaving the
+ * long-running process executing the stale (pre-upgrade) version in memory.
+ *
+ * Root cause: the post-install restart (BUG 174270e6) is gated solely on
+ * `wasReachableBeforeInstall`, a reachability probe taken at install.mjs
+ * start. But the `agenfk upgrade` CLI runs `down` BEFORE invoking
+ * install.mjs, so the probe is always false during an upgrade and the
+ * restart is skipped. The hub-driven path is worse: the spawned CLI's own
+ * `servicesRunning` probe can false-negative, skipping both `down` and its
+ * fallback `up`, so nothing ever restarts.
+ *
+ * The durable fix must live in install.mjs because that is the only piece
+ * that runs as NEW code during the upgrade that ships it (the reconciler and
+ * the CLI `upgrade` command both run as the pre-upgrade process image). The
+ * restart trigger is therefore broadened to fire when ANY of these hold:
+ *   1. the reachability probe succeeds (legacy behavior), OR
+ *   2. the env var AGENFK_SERVER_WAS_RUNNING is set (the CLI passes the
+ *      pre-`down` running state explicitly — fixes the manual path), OR
+ *   3. an in-flight hub upgrade marker exists — `upgrade-state.json` with
+ *      outcome === 'started', which the reconciler writes before spawning
+ *      the CLI. This self-heals the hub path on the delivering upgrade.
+ *
+ * Source-introspection tests, mirroring restart-quiet.test.ts.
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const CLI_SRC = fs.readFileSync(path.join(REPO_ROOT, 'packages/cli/src/index.ts'), 'utf8');
+const INSTALL_SCRIPT = fs.readFileSync(path.join(REPO_ROOT, 'scripts/install.mjs'), 'utf8');
+
+/** The body of the `agenfk upgrade` command action. */
+function upgradeCommandSection(): string {
+  const idx = CLI_SRC.search(/\.command\(['"]upgrade['"]\)/);
+  expect(idx).toBeGreaterThan(-1);
+  // Stop at the next top-level `.command(` so we only inspect `upgrade`.
+  const next = CLI_SRC.indexOf('.command(', idx + 10);
+  return CLI_SRC.slice(idx, next === -1 ? undefined : next);
+}
+
+describe('BUG 2f491181: install.mjs restart trigger is not gated solely on the probe', () => {
+  it('reads the explicit AGENFK_SERVER_WAS_RUNNING signal', () => {
+    expect(INSTALL_SCRIPT).toMatch(/AGENFK_SERVER_WAS_RUNNING/);
+  });
+
+  it('detects an in-flight hub upgrade via the upgrade-state marker', () => {
+    // install.mjs must consult upgrade-state.json (outcome 'started') so a
+    // hub-driven upgrade self-heals even though `down` already ran.
+    expect(INSTALL_SCRIPT).toMatch(/upgrade-state\.json/);
+    expect(INSTALL_SCRIPT).toMatch(/started/);
+  });
+
+  it('age-guards the in-flight marker so a stale one cannot spuriously restart', () => {
+    // An interrupted upgrade leaves upgrade-state.json at outcome 'started';
+    // it is only cleared on the next server boot. Without an age guard a later
+    // unrelated install would read the landmine and start a server. install.mjs
+    // must only trust a *fresh* marker (startedAt within a bounded window).
+    expect(INSTALL_SCRIPT).toMatch(/startedAt/);
+    // A staleness window comparison must exist near the marker read. Anchor on
+    // the quoted code reference so we don't match the explanatory comment.
+    const markerIdx = INSTALL_SCRIPT.indexOf("'upgrade-state.json'");
+    expect(markerIdx).toBeGreaterThan(-1);
+    const window = INSTALL_SCRIPT.slice(markerIdx, markerIdx + 900);
+    expect(window).toMatch(/STALE_MS|Date\.parse|fresh/);
+  });
+
+  it('resolves dbDir via config.json dbPath as well as AGENFK_DB_PATH', () => {
+    // Must mirror the server's dbPath resolution so the marker is found even
+    // when the server was started without AGENFK_DB_PATH but with a config.json.
+    const markerIdx = INSTALL_SCRIPT.indexOf("'upgrade-state.json'");
+    expect(markerIdx).toBeGreaterThan(-1);
+    const before = INSTALL_SCRIPT.slice(Math.max(0, markerIdx - 700), markerIdx);
+    expect(before).toMatch(/AGENFK_DB_PATH/);
+    expect(before).toMatch(/config\.json/);
+  });
+
+  it('gates the restart on a signal broader than wasReachableBeforeInstall', () => {
+    // Find the restart spawn ('restart' via agenfk.js) and walk back to the
+    // enclosing `if (` guard. It must reference an OR with an explicit signal,
+    // not depend on the probe alone.
+    const restartIdx = INSTALL_SCRIPT.search(/agenfk\.js['"][^\n]*['"]restart['"]/);
+    expect(restartIdx).toBeGreaterThan(-1);
+    const guard = INSTALL_SCRIPT.lastIndexOf('if (', restartIdx);
+    expect(guard).toBeGreaterThan(-1);
+    const condition = INSTALL_SCRIPT.slice(guard, restartIdx);
+    // The guard must combine signals (||) — i.e. not be `wasReachableBeforeInstall && !onlyPlatform` alone.
+    expect(condition).toMatch(/\|\|/);
+    expect(condition).toMatch(/AGENFK_SERVER_WAS_RUNNING|upgradeInFlight|serverWasRunning/);
+  });
+});
+
+describe('BUG 2f491181: CLI upgrade hands the pre-down running state to install.mjs', () => {
+  it('sets AGENFK_SERVER_WAS_RUNNING when invoking install.mjs', () => {
+    const section = upgradeCommandSection();
+    // The install.mjs invocation must propagate the env signal.
+    expect(section).toMatch(/AGENFK_SERVER_WAS_RUNNING/);
+    // And it must be wired to the pre-`down` capture, not unconditionally on.
+    expect(section).toMatch(/servicesRunning/);
+  });
+
+  it('does not also fire a separate fallback `up` that races install.mjs restart', () => {
+    // The legacy fallback (`spawn('node', [...'up'])` after install) double-
+    // restarts now that install.mjs reliably owns the restart. It must be
+    // removed/guarded so the two don't race for the port.
+    const section = upgradeCommandSection();
+    expect(section).not.toMatch(/spawn\(\s*['"]node['"]\s*,\s*\[[^\]]*['"]up['"]/);
+  });
+});

--- a/packages/cli/src/test/upgrade-restart-reliability.test.ts
+++ b/packages/cli/src/test/upgrade-restart-reliability.test.ts
@@ -52,6 +52,22 @@ describe('BUG 2f491181: install.mjs restart trigger is not gated solely on the p
     expect(INSTALL_SCRIPT).toMatch(/started/);
   });
 
+  it('detects a live server process directly (timing-robust), not just via the 1s HTTP probe', () => {
+    // BUG 2f491181 follow-up: the 1-second localhost curl can false-negative
+    // under load, and direct/npx installs never run `down`, so a live server is
+    // still up when install.mjs runs. A process-liveness scan (ps/wmic for the
+    // server bin) is the reliable signal that the HTTP probe is not. The restart
+    // must fire whenever the server process is actually alive.
+    expect(INSTALL_SCRIPT).toMatch(/serverProcessAlive/);
+    // It must scan the process table (ps on POSIX, wmic on Windows, pgrep fallback).
+    expect(INSTALL_SCRIPT).toMatch(/ps -ax|ps -ef|pgrep/);
+    expect(INSTALL_SCRIPT).toMatch(/wmic|tasklist/);
+    // It must anchor on an actual node/bun invocation of the bin, not a bare
+    // substring match (else an editor/grep with the path in argv false-positives
+    // and spuriously starts a server on a machine that wasn't running one).
+    expect(INSTALL_SCRIPT).toMatch(/looksLikeServerCmd|node\|bun|node\)/);
+  });
+
   it('age-guards the in-flight marker so a stale one cannot spuriously restart', () => {
     // An interrupted upgrade leaves upgrade-state.json at outcome 'started';
     // it is only cleared on the next server boot. Without an age guard a later

--- a/packages/cli/src/test/upgrade-skill.test.ts
+++ b/packages/cli/src/test/upgrade-skill.test.ts
@@ -73,17 +73,24 @@ describe('agenfk upgrade CLI command', () => {
     expect(stopIdx).toBeLessThan(installIdx);
   });
 
-  it('should start server after install when it was previously running', () => {
+  it('should delegate the post-upgrade restart to install.mjs via AGENFK_SERVER_WAS_RUNNING', () => {
+    // BUG 2f491181: the CLI used to spawn `agenfk up` after install, but that
+    // raced install.mjs's own restart for the port and was skipped whenever
+    // the pre-`down` probe false-negatived. install.mjs is now the single
+    // restart owner; the CLI hands it the pre-`down` running state explicitly
+    // so it restarts even though `down` already made the server unreachable.
     const cli = readCli();
     const upgradeActionStart = cli.indexOf(".command('upgrade')");
     const upgradeActionEnd = cli.indexOf(".command('up')", upgradeActionStart);
     const upgradeSection = cli.slice(upgradeActionStart, upgradeActionEnd);
 
     const installIdx = upgradeSection.indexOf('install.mjs');
-    const startIdx = upgradeSection.search(/agenfk\.js.*up['"]\s*\)|\.js['"]\s*,\s*['"]up['"]/);
     expect(installIdx).toBeGreaterThan(-1);
-    expect(startIdx).toBeGreaterThan(-1);
-    expect(startIdx).toBeGreaterThan(installIdx);
+    // The env signal is passed, derived from the pre-`down` servicesRunning capture.
+    expect(upgradeSection).toMatch(/AGENFK_SERVER_WAS_RUNNING/);
+    expect(upgradeSection).toMatch(/servicesRunning/);
+    // And the CLI no longer fires its own `up` that would race install.mjs.
+    expect(upgradeSection).not.toMatch(/spawn\(\s*['"]node['"]\s*,\s*\[[^\]]*['"]up['"]/);
   });
 
   it('should not delete dist dirs after extracting the tarball', () => {

--- a/packages/cli/src/test/upgrade-version-flag.test.ts
+++ b/packages/cli/src/test/upgrade-version-flag.test.ts
@@ -1,0 +1,68 @@
+/**
+ * BUG 7f85715b — `agenfk upgrade --version <ver>` collided with commander's
+ * GLOBAL `--version` flag (`program.version(CURRENT_VERSION, '-V, --version')`).
+ * commander's global option won, so the CLI printed its own version and exited
+ * 0 without installing anything. The hub reconciler always upgrades via this
+ * exact form (`upgradeSync.ts` DEFAULT_CLI_ARGS: `['upgrade','--version',<v>]`),
+ * so every hub-driven pinned upgrade silently no-op'd and the reconciler
+ * reported "exited 0 but on-disk version is X, expected Y".
+ *
+ * Fix: the global version flag must NOT claim `--version` (so the `upgrade`
+ * subcommand's `--version <ver>` option is the one that binds). Bare
+ * `agenfk --version` / `agenfk -V` is handled manually at the top level.
+ *
+ * Mix of source-introspection (cheap, runs in root suite) and a behavioral
+ * spawn against the built CLI when the dist is present.
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { spawnSync } from 'child_process';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const CLI_SRC = fs.readFileSync(path.join(REPO_ROOT, 'packages/cli/src/index.ts'), 'utf8');
+
+describe('BUG 7f85715b: --version flag no longer collides with the upgrade pin option', () => {
+  it('the upgrade command still declares its --version <ver> pin option', () => {
+    const upIdx = CLI_SRC.search(/\.command\(['"]upgrade['"]\)/);
+    const next = CLI_SRC.indexOf('.command(', upIdx + 10);
+    const section = CLI_SRC.slice(upIdx, next === -1 ? undefined : next);
+    expect(section).toMatch(/\.option\(\s*['"]--version <ver>['"]/);
+  });
+
+  it('commander\'s global version flag does NOT claim the long --version (only -V), so it cannot intercept the subcommand', () => {
+    // The old, broken form bound BOTH: `.version(CURRENT_VERSION, '-V, --version', …)`.
+    // After the fix there must be no global registration of the long `--version`
+    // flag — either no `.version(` call, or one scoped to `-V` only.
+    const versionCalls = [...CLI_SRC.matchAll(/\.version\(\s*CURRENT_VERSION[^)]*\)/g)].map(m => m[0]);
+    for (const call of versionCalls) {
+      expect(call).not.toMatch(/--version/);
+    }
+  });
+
+  it('handles bare -V / --version manually at the top level (so `agenfk --version` still works)', () => {
+    // A manual guard must print CURRENT_VERSION and exit for a bare version
+    // invocation, since we removed commander's auto global flag.
+    expect(CLI_SRC).toMatch(/--version|'-V'/);
+    expect(CLI_SRC).toMatch(/console\.log\(CURRENT_VERSION\)|process\.stdout\.write\(CURRENT_VERSION/);
+  });
+
+  it('built CLI: `upgrade --version <bogus> --json` attempts an upgrade (does NOT just print the version)', () => {
+    const bin = path.join(REPO_ROOT, 'packages/cli/dist/index.js');
+    if (!fs.existsSync(bin)) return; // dist not built in this environment; skip behavioral check
+    const res = spawnSync('node', [bin, 'upgrade', '--version', '0.0.0-no-such-release', '--json'], {
+      encoding: 'utf8',
+      timeout: 30_000,
+      // The CLI's main block is guarded by `NODE_ENV !== 'test'`; vitest sets
+      // NODE_ENV=test and spawnSync would inherit it, short-circuiting the CLI.
+      env: { ...process.env, NODE_ENV: 'production' },
+    });
+    const out = (res.stdout || '').trim();
+    // The broken behavior printed a bare semver (the CLI's own version) and exited.
+    // The fixed behavior tries to resolve the bogus release and emits a JSON
+    // failure object. Either way, the output must NOT be just a bare version.
+    const lastLine = out.split('\n').filter(Boolean).pop() || '';
+    expect(lastLine).not.toMatch(/^v?\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/);
+    expect(out).toMatch(/"status"\s*:\s*"failed"|not found|Failed to resolve/i);
+  });
+});

--- a/packages/server/src/hub/upgradeState.ts
+++ b/packages/server/src/hub/upgradeState.ts
@@ -26,6 +26,10 @@ export interface UpgradeState {
   outcome: UpgradeOutcome;
   resultVersion?: string;
   error?: string;
+  // ISO timestamp written when outcome flips to 'started'. Lets a consumer
+  // (install.mjs) tell a genuinely in-flight upgrade from a stale marker left
+  // behind by an interrupted one. BUG 2f491181.
+  startedAt?: string;
   finishedAt?: string;
 }
 

--- a/packages/server/src/hub/upgradeSync.ts
+++ b/packages/server/src/hub/upgradeSync.ts
@@ -211,10 +211,13 @@ export async function reconcileUpgradeDirective(args: ReconcileArgs): Promise<vo
     });
 
     // 2. Persist intent BEFORE we hand control to a process that might kill us.
+    //    startedAt lets install.mjs distinguish a fresh in-flight upgrade from
+    //    a stale marker left behind by an interrupted one (BUG 2f491181).
     writeUpgradeState(args.dbDir, {
       lastDirectiveId: body.directiveId,
       outcome: 'started',
       resultVersion: body.targetVersion, // intent — replay compares against this.
+      startedAt: occurredAt,
     });
 
     // 3. Drain the outbox so the hub sees `started` before we suicide.

--- a/packages/server/src/test/upgrade-sync.test.ts
+++ b/packages/server/src/test/upgrade-sync.test.ts
@@ -338,6 +338,10 @@ describe('Story 3b — reconcileUpgradeDirective', () => {
     // the upgrade child process, so a self-restarting upgrade can be replayed.
     expect(stateAtFlush?.lastDirectiveId).toBe('d-4');
     expect(stateAtFlush?.outcome).toBe('started');
+    // BUG 2f491181: the started marker must carry a timestamp so a consumer
+    // (install.mjs) can tell a fresh in-flight upgrade from a stale landmine.
+    expect(typeof stateAtFlush?.startedAt).toBe('string');
+    expect(Number.isNaN(Date.parse(stateAtFlush.startedAt))).toBe(false);
   });
 
   it('awaits an async spawnImpl (production uses spawn-as-Promise so the API event loop stays responsive — without await, the same-process success path would observe pre-spawn state)', async () => {

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -148,6 +148,64 @@ async function run() {
         }
     }
 
+    // BUG 2f491181: the reachability probe above is NOT sufficient on its own.
+    // `agenfk upgrade` runs `down` BEFORE invoking install.mjs, so by the time
+    // we probe, the server we must restart is already gone and the probe reads
+    // false. We therefore also honor two explicit, out-of-band signals that a
+    // server was running before the upgrade began:
+    //
+    //   1. AGENFK_SERVER_WAS_RUNNING — set by the `agenfk upgrade` CLI from the
+    //      pre-`down` `servicesRunning` capture. Fixes the manual upgrade path.
+    //   2. An in-flight hub upgrade marker: `upgrade-state.json` with
+    //      outcome === 'started', which the hub reconciler writes before it
+    //      spawns the CLI. This self-heals the hub-driven path on the very
+    //      upgrade that ships this code, because install.mjs is the only part
+    //      of the upgrade that runs as the NEW (just-extracted) version.
+    let upgradeInFlight = false;
+    {
+        const truthy = (v) => !!v && v !== '0' && v.toLowerCase() !== 'false';
+        if (truthy(process.env.AGENFK_SERVER_WAS_RUNNING || '')) {
+            wasReachableBeforeInstall = true;
+        }
+        // Resolve the .agenfk dir the server uses, mirroring the server's own
+        // dbPath resolution (server.ts / start-services.mjs): AGENFK_DB_PATH,
+        // then ~/.agenfk/config.json's dbPath, then <rootDir>/.agenfk.
+        let dbDir = path.join(rootDir, '.agenfk');
+        if (process.env.AGENFK_DB_PATH) {
+            dbDir = path.dirname(process.env.AGENFK_DB_PATH);
+        } else {
+            try {
+                const cfg = JSON.parse(readFileSync(path.join(agenfkHome, 'config.json'), 'utf8'));
+                if (cfg && typeof cfg.dbPath === 'string' && cfg.dbPath) dbDir = path.dirname(cfg.dbPath);
+            } catch { /* no/invalid config → keep default */ }
+        }
+        const upgradeStatePath = path.join(dbDir, 'upgrade-state.json');
+        try {
+            if (existsSync(upgradeStatePath)) {
+                const st = JSON.parse(readFileSync(upgradeStatePath, 'utf8'));
+                // Only treat the marker as "a server is mid-upgrade right now"
+                // when it is genuinely fresh. An interrupted upgrade (install
+                // threw, machine rebooted, Ctrl-C) leaves a 'started' marker
+                // that is only cleared on the next server boot's replay; without
+                // this age guard a later unrelated install would read that stale
+                // landmine and spuriously start a server the user never ran.
+                // BUG 2f491181. Markers from older servers have no startedAt —
+                // those are only ever written moments before install.mjs runs,
+                // so treat a missing timestamp as fresh for back-compat.
+                const STALE_MS = 10 * 60 * 1000;
+                let fresh = true;
+                if (st && typeof st.startedAt === 'string') {
+                    const age = Date.now() - Date.parse(st.startedAt);
+                    fresh = Number.isFinite(age) && age >= 0 && age < STALE_MS;
+                }
+                if (st && st.outcome === 'started' && fresh) {
+                    upgradeInFlight = true;
+                    wasReachableBeforeInstall = true;
+                }
+            }
+        } catch { /* unreadable/malformed marker → ignore */ }
+    }
+
     function shouldRun(platform) {
         if (onlyPlatform) return onlyPlatform.toLowerCase() === platform.toLowerCase();
         if (skipPlatform) return skipPlatform.toLowerCase() !== platform.toLowerCase();
@@ -1449,7 +1507,12 @@ process.exit(0);
     // Strategy: kill processes matching the server bin path, then spawn a
     // detached `agenfk up` so the user's foreground stays free. `agenfk up`
     // also handles the UI process and port persistence.
-    if (wasReachableBeforeInstall && !onlyPlatform) {
+    // BUG 2f491181: restart when the probe saw a live server OR an explicit
+    // out-of-band signal says one was running before `down` ran (the env flag
+    // from the CLI, or the in-flight hub upgrade marker). `upgradeInFlight` is
+    // already folded into wasReachableBeforeInstall above, but we keep it in
+    // the guard so the intent is legible and the trigger is not a lone probe.
+    if ((wasReachableBeforeInstall || upgradeInFlight) && !onlyPlatform) {
         console.log(`${BLUE}Restarting API server (was running on port ${preInstallServerPort} before upgrade)...${NC}`);
         // Delegate to `agenfk up`. It internally calls killPattern (which
         // already handles Windows via wmic and POSIX via ps/pgrep) and then
@@ -1463,6 +1526,16 @@ process.exit(0);
                 [path.join(rootDir, 'packages/cli/bin/agenfk.js'), 'restart', '--quiet'],
                 { cwd: rootDir, detached: true, stdio: 'ignore' },
             );
+            // BUG 2f491181: install.mjs is now the SOLE owner of the post-
+            // upgrade restart (the CLI no longer fires a fallback `up`). A
+            // detached, unref'd child with no 'error' listener would let an
+            // async spawn failure (ENOENT, EAGAIN) escalate to an unhandled
+            // error and crash install.mjs at the finish line. Handle it so we
+            // degrade to printed guidance instead.
+            child.on('error', (e) => {
+                console.log(`${YELLOW}Could not auto-restart server: ${e?.message ?? e}${NC}`);
+                console.log(`${YELLOW}Run \`agenfk restart\` manually to bring the new version online.${NC}`);
+            });
             child.unref();
             console.log(`${GREEN}Server restart triggered (running in background).${NC}`);
         } catch (e) {

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -149,22 +149,61 @@ async function run() {
     }
 
     // BUG 2f491181: the reachability probe above is NOT sufficient on its own.
-    // `agenfk upgrade` runs `down` BEFORE invoking install.mjs, so by the time
-    // we probe, the server we must restart is already gone and the probe reads
-    // false. We therefore also honor two explicit, out-of-band signals that a
-    // server was running before the upgrade began:
+    // An upgrade must restart the running server in EVERY scenario, so we union
+    // four independent signals — if any says a server was running, we restart:
     //
-    //   1. AGENFK_SERVER_WAS_RUNNING — set by the `agenfk upgrade` CLI from the
-    //      pre-`down` `servicesRunning` capture. Fixes the manual upgrade path.
-    //   2. An in-flight hub upgrade marker: `upgrade-state.json` with
+    //   1. The reachability probe above (cheap, but a 1s localhost curl can
+    //      false-negative under install load).
+    //   2. A direct process-liveness scan of the process table for the server
+    //      bin. Timing-robust where the probe is flaky, and the decisive signal
+    //      for direct / `npx` installs that never run `down`, so the server is
+    //      still alive when install.mjs runs.
+    //   3. AGENFK_SERVER_WAS_RUNNING — set by the `agenfk upgrade` CLI from the
+    //      pre-`down` `servicesRunning` capture. Covers the manual path, where
+    //      `down` has already killed the server before install.mjs runs (so 1+2
+    //      both read false).
+    //   4. An in-flight hub upgrade marker: `upgrade-state.json` with
     //      outcome === 'started', which the hub reconciler writes before it
-    //      spawns the CLI. This self-heals the hub-driven path on the very
-    //      upgrade that ships this code, because install.mjs is the only part
-    //      of the upgrade that runs as the NEW (just-extracted) version.
+    //      spawns the CLI. Self-heals the hub-driven path on the very upgrade
+    //      that ships this code, since install.mjs is the only part of the
+    //      upgrade that runs as the NEW (just-extracted) version.
     let upgradeInFlight = false;
     {
         const truthy = (v) => !!v && v !== '0' && v.toLowerCase() !== 'false';
         if (truthy(process.env.AGENFK_SERVER_WAS_RUNNING || '')) {
+            wasReachableBeforeInstall = true;
+        }
+        // Signal 2: is an agenfk server process actually alive right now?
+        // Cross-platform, mirrors the CLI's killPattern detection. This does
+        // not depend on HTTP timing or hub connectivity — if the process is
+        // there, we restart it onto the new code.
+        const SERVER_PATTERN = 'packages/server/dist/server.js';
+        // Only count a line as the live server if it is an actual node/bun
+        // invocation of the server bin — not just any process whose argv happens
+        // to embed the path (an editor with the file open, a `grep`/`tail`, this
+        // install's own tooling). Mirrors killPattern's grep/ps exclusion but
+        // tighter: it must look like `… node|bun … packages/server/dist/server.js`.
+        const looksLikeServerCmd = (line) =>
+            line.includes(SERVER_PATTERN) && /(^|[\/\\\s])(node|node\.exe|bun)([\s.]|$)/i.test(line);
+        function serverProcessAlive() {
+            try {
+                if (process.platform === 'win32' && !(process.env.MSYSTEM || process.env.WSL_DISTRO_NAME)) {
+                    const pat = SERVER_PATTERN.replace(/\//g, '\\\\');
+                    const out = spawnSync('wmic', ['process', 'where', `commandline like '%${pat}%'`, 'get', 'commandline'], { encoding: 'utf8' });
+                    return (out.stdout || '').split('\n').some(looksLikeServerCmd);
+                }
+                const out = spawnSync('ps', ['-ax', '-o', 'command'], { encoding: 'utf8' });
+                if (out.status === 0 && typeof out.stdout === 'string') {
+                    return out.stdout.split('\n').some(looksLikeServerCmd);
+                }
+                // Fallback: pgrep against a node-anchored regex if ps is unavailable.
+                const pg = spawnSync('pgrep', ['-f', `(node|bun).*${SERVER_PATTERN.replace(/\./g, '\\.')}`], { encoding: 'utf8' });
+                return pg.status === 0 && (pg.stdout || '').trim().length > 0;
+            } catch {
+                return false;
+            }
+        }
+        if (!wasReachableBeforeInstall && serverProcessAlive()) {
             wasReachableBeforeInstall = true;
         }
         // Resolve the .agenfk dir the server uses, mirroring the server's own


### PR DESCRIPTION
Makes `agenfk upgrade` reliable end-to-end. Two related defects that together kept upgrades (especially hub-driven) from actually taking effect.

## Bug 1 — upgrade didn't restart the server (stale in-memory version)
After an upgrade the long-running server kept executing the **old code in memory**, so it stamped a stale version on outgoing hub events. The post-install restart was gated on a reachability probe taken *after* `agenfk upgrade` had already run `down`, so it never fired.

Fix (anchored in `scripts/install.mjs`, the only part that runs as *new* code mid-upgrade, so it self-heals): restart when **any** signal says a server was running —
1. HTTP reachability probe,
2. **process-liveness scan** (`ps -ax`/`wmic`/`pgrep` for a real `node`/`bun` invocation of the server bin — timing-robust, anchored so editor/grep decoys can't false-positive),
3. `AGENFK_SERVER_WAS_RUNNING` env (set by the CLI from the pre-`down` capture),
4. fresh in-flight hub `upgrade-state.json` marker (`startedAt` age-guarded against stale landmines).

The CLI now passes the env signal and no longer fires a fallback `up` that raced `install.mjs`'s `agenfk restart --quiet`; `install.mjs` is the single restart owner (with an async spawn-error handler).

## Bug 2 — `agenfk upgrade --version <ver>` never installed (commander flag collision)
`program.version(CURRENT_VERSION, '-V, --version', …)` registered a **global** `--version` that intercepted `agenfk upgrade --version <ver>` — the exact form the hub reconciler uses (`upgradeSync.ts` DEFAULT_CLI_ARGS). The CLI printed its own version and exited 0 without installing, so every hub-driven pinned upgrade silently no-op'd ("exited 0 but on-disk version is X, expected Y").

Fix: bind only `-V` to commander's global flag and handle bare `agenfk --version`/`-V` manually at the top level, leaving the long `--version` free for the `upgrade` subcommand's `--version <ver>` option. **No reconciler change needed** — it already passes `--version`, which now works.

Behavior note: `agenfk --version --json` (a never-meaningful combo) now errors instead of printing a bare version; `agenfk --version` and `agenfk -V` still print the version.

## Tests
- New `upgrade-restart-reliability.test.ts` (8) and `upgrade-version-flag.test.ts` (4, incl. a behavioral spawn of the built CLI).
- Updated `upgrade-skill.test.ts` to the new restart-delegation contract; `upgrade-sync.test.ts` asserts the `started` marker carries `startedAt`.
- Full suite green (1614); written TDD-first with adversarial review on each change.

https://claude.ai/code/session_01W3ct4ECvAzsWVpodPCMjv1