### PR TITLE
fix(upgrade): restart server after self-extract recovery (follow-up to #99)

### DIFF
--- a/packages/server/src/hub/upgradeSync.ts
+++ b/packages/server/src/hub/upgradeSync.ts
@@ -15,7 +15,7 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { execSync } from 'child_process';
+import { execSync, spawn } from 'child_process';
 import {
   readUpgradeState, writeUpgradeState, clearUpgradeState,
   UpgradeState,
@@ -79,6 +79,24 @@ async function defaultSelfExtract(input: { installRoot: string; targetVersion: s
   } finally {
     try { if (fs.existsSync(tmpFile)) fs.rmSync(tmpFile, { force: true }); } catch { /* ignore */ }
   }
+}
+
+/**
+ * Restart the server so a recovered (self-extracted) version actually goes
+ * live. self-extract only overlays files on disk — the running process keeps
+ * executing the old code until cycled. Detached + unref'd so it survives this
+ * process being killed by the restart's own `down`. BUG f3caf48c.
+ */
+function defaultRestartServer(installRoot: string): void {
+  try {
+    const child = spawn('node', [path.join(installRoot, 'packages/cli/bin/agenfk.js'), 'restart', '--quiet'], {
+      cwd: installRoot,
+      detached: true,
+      stdio: 'ignore',
+    });
+    child.on('error', () => { /* best effort — operator can restart manually */ });
+    child.unref();
+  } catch { /* best effort */ }
 }
 
 export interface FetchedDirective {
@@ -155,6 +173,10 @@ export interface ReconcileArgs {
   installRoot?: string;
   // Default downloads the GitHub release tarball and tar -xzf into installRoot.
   selfExtractImpl?: SelfExtractImpl;
+  // Restart the server after a successful self-extract recovery (which only
+  // overlays files). Default spawns a detached `agenfk restart --quiet`; tests
+  // inject a fake. BUG f3caf48c.
+  restartServerImpl?: (installRoot: string) => void;
 }
 
 export interface ReplayArgs {
@@ -308,6 +330,12 @@ export async function reconcileUpgradeDirective(args: ReconcileArgs): Promise<vo
             },
           });
           clearUpgradeState(args.dbDir);
+          // BUG f3caf48c: self-extract only overlaid files on disk; the running
+          // server is still executing the old code. Restart it so the recovered
+          // version goes live. Flush the succeeded event FIRST so the hub records
+          // the outcome before the restart cycles (and possibly kills) us.
+          await args.flushNow(5_000).catch(() => { /* deliver best-effort */ });
+          (args.restartServerImpl ?? defaultRestartServer)(installRoot);
           return;
         }
         const reason = sx.ok

--- a/packages/server/src/test/upgrade-sync.test.ts
+++ b/packages/server/src/test/upgrade-sync.test.ts
@@ -252,6 +252,44 @@ describe('Story 3b — reconcileUpgradeDirective', () => {
     expect(readUpgradeState(dbDir)).toBeNull();
   });
 
+  it('stale CLI: self-extract recovery restarts the server (files alone are not live) and flushes the succeeded event first', async () => {
+    // BUG f3caf48c: self-extract only overlays files on disk; the running
+    // server keeps executing the old code until restarted. The recovery must
+    // trigger a restart, and must flush the succeeded event BEFORE cycling the
+    // process so the hub isn't left without the outcome.
+    let onDiskNow = '0.2.28';
+    const f = makeFakes({
+      directive: { directiveId: 'd-stale-restart', targetVersion: '0.3.0-beta.27' },
+      spawnExitCode: 0,
+      spawnStdout: '0.2.28\n',
+    });
+    f.readInstalledVersionImpl.mockImplementation(() => onDiskNow);
+    const selfExtractImpl = vi.fn(async () => { onDiskNow = '0.3.0-beta.27'; return { ok: true as const }; });
+    const calls: string[] = [];
+    f.flushNow.mockImplementation(async () => { calls.push('flush'); });
+    const restartServerImpl = vi.fn(() => { calls.push('restart'); });
+    await reconcileUpgradeDirective({
+      dbDir,
+      currentVersion: '0.2.28',
+      fetchImpl: f.fetchImpl,
+      recordEvent: f.recordEvent,
+      flushNow: f.flushNow,
+      spawnImpl: f.spawnImpl,
+      readInstalledVersionImpl: f.readInstalledVersionImpl,
+      installRoot: '/fake/install/root',
+      selfExtractImpl,
+      restartServerImpl,
+      hubUrl: 'http://hub.test',
+      installationId: 'inst-1',
+      hubToken: 't',
+    });
+    expect(restartServerImpl).toHaveBeenCalledTimes(1);
+    expect(restartServerImpl.mock.calls[0][0]).toBe('/fake/install/root');
+    // Restart must come AFTER a flush so the succeeded event is delivered first.
+    expect(calls.indexOf('restart')).toBeGreaterThan(calls.indexOf('flush'));
+    expect(calls.indexOf('flush')).toBeGreaterThan(-1);
+  });
+
   it('stale CLI: self-extract failure → emits failed with predates-pinned-version remediation hint', async () => {
     const f = makeFakes({
       directive: { directiveId: 'd-stale-2', targetVersion: '0.3.0-beta.27' },


### PR DESCRIPTION
Follow-up to #99 (upgrade reliability).

## Problem
The hub reconciler's stale-CLI **self-extract recovery** (used when the installed CLI is too old/broken to install — e.g. it hits the `--version` collision and just prints its version) downloads the release tarball and untars it directly. That updates the files **on disk** and reports `succeeded`, but it never **restarts** the server — so the running process keeps executing the old code and stamping the stale in-memory version until a manual restart.

This is the exact gap that leaves an existing install "files fixed, but not live" after a hub-driven recovery.

## Fix (`packages/server/src/hub/upgradeSync.ts`)
After a successful self-extract recovery, the reconciler now:
1. records `fleet:upgrade:succeeded` and clears the marker (unchanged),
2. **flushes the succeeded event first** (`flushNow(5s)`) so the hub records the outcome before we cycle the process,
3. triggers a **restart** via a new injectable `restartServerImpl` (default: detached, unref'd `agenfk restart --quiet` derived from `installRoot`, with an `on('error')` handler — can't crash the reconciler).

Because the marker is cleared before the restart, the rebooted server's `replayPendingUpgradeOutcome` correctly no-ops (no double event). In the stale-CLI path the spawned `agenfk upgrade` never ran `install.mjs`, so this recovery restart is the only restart — no double-restart.

Note: this helps installs running the **fixed reconciler onward**; already-deployed reconcilers have frozen code, so the operator escape hatch (`agenfk upgrade` once) remains the way to bootstrap the very first hop.

## Tests
New `upgrade-sync.test.ts` case asserts the recovery invokes the restart once with `installRoot` and orders it **after** the flush. Full upgrade-sync suite 16/16; server build clean.

https://claude.ai/code/session_01W3ct4ECvAzsWVpodPCMjv1