### PR TITLE
fix(upgrade): force hub upgrades through a CLI-independent self-heal

### DIFF
--- a/packages/server/src/hub/upgradeSync.ts
+++ b/packages/server/src/hub/upgradeSync.ts
@@ -72,6 +72,16 @@ async function defaultSelfExtract(input: { installRoot: string; targetVersion: s
   try {
     execSync(`curl -fsSL -o "${tmpFile}" "${url}"`, { stdio: 'pipe' });
     execSync(`tar -xzf "${tmpFile}" -C "${input.installRoot}"`, { stdio: 'pipe' });
+    // BUG bbe794bc: the tarball ships package.json + lockfile + dist/, but NOT
+    // node_modules. A tar-only overlay would advance the on-disk version while
+    // leaving deps unsatisfied if the target added/bumped a production dep — the
+    // server would then boot with a missing module yet we'd have reported
+    // success. Install deps to make the forced recovery a COMPLETE install,
+    // mirroring install.mjs's `npm ci --omit=dev --ignore-scripts`. If this
+    // fails (e.g. offline), we surface it as a failure rather than a false
+    // success.
+    const npmCmd = (os.platform() === 'win32') ? 'npm.cmd' : 'npm';
+    execSync(`${npmCmd} ci --omit=dev --ignore-scripts`, { cwd: input.installRoot, stdio: 'pipe' });
     return { ok: true };
   } catch (e: any) {
     const msg = e?.stderr?.toString?.()?.trim() || e?.message || String(e);
@@ -287,30 +297,32 @@ export async function reconcileUpgradeDirective(args: ReconcileArgs): Promise<vo
       return;
     }
 
-    // ── Stale-CLI bootstrap recovery ──
-    // Old fleet clients (pre-`--version` option) treat `--version <ver>` as
-    // commander's global -V flag: they print their own version and exit 0
-    // with no install side-effects. Detect that signature (exit 0 + no
-    // parsed status + on-disk unchanged + on-disk === currentVersion) and
-    // try a self-extract recovery instead of giving up. Without this, every
-    // future directive on those installations will permanently re-fail.
-    // A stale CLI prints its own version on stdout (commander's -V handler)
-    // and exits 0. We look for that exact footprint: last non-empty line is a
-    // bare semver and equals the on-disk version. This avoids false positives
-    // when the CLI emits arbitrary diagnostics on the same exit path.
-    const lastStdoutLine = (result.stdout || '').trim().split('\n').filter(Boolean).pop() ?? '';
-    const stdoutIsBareSemver = SEMVER_TAG_RE.test(lastStdoutLine);
-    const looksLikeStaleCli =
-      exitOk
-      && !cliReportedSucceeded
-      && !cliReportedFailed
-      && !!onDisk
-      && !onDiskMatchesIntent
-      && stripV(onDisk) === stripV(args.currentVersion)
-      && stdoutIsBareSemver
-      && stripV(lastStdoutLine) === stripV(onDisk);
+    // ── Forced CLI-independent recovery (BUG bbe794bc) ──
+    // We reach here whenever the spawned CLI exited CLEANLY (exit 0) but did
+    // NOT advance the on-disk version to the target and did not itself report a
+    // failure — i.e. an old/buggy CLI that mis-parsed the args (the historical
+    // `--version`-vs-global-flag collision), a silent no-op, or a process
+    // killed mid-emit. Don't trust the CLI to ever self-correct: force the
+    // install through a path the reconciler fully controls — download the
+    // release tarball, extract it in place, and restart so the new code goes
+    // live. This fires for ANY such clean-exit non-advance (not just the narrow
+    // "printed its own version" signature) and REGARDLESS of the running
+    // reconciler's own version, so a fleet wedged behind a CLI flag bug
+    // self-heals on the next directive.
+    //
+    // The forced install is COMPLETE, not a bare overlay: defaultSelfExtract
+    // untars AND runs `npm ci --omit=dev` (node_modules aren't in the tarball),
+    // and only reports ok if both succeed — so a dep-changing target can't
+    // produce a false success. We still do NOT force-extract over a non-zero
+    // exit or an explicit `status:"failed"`: those are the CLI's own genuine
+    // install errors, and retrying the same install blindly would just mask
+    // them; they fall through to the generic failure path below. Single
+    // attempt: the directiveId guard + failed-state write prevent the next poll
+    // from re-running a hopeless target.
+    const cliCleanNonAdvance =
+      exitOk && !cliReportedSucceeded && !cliReportedFailed && !!onDisk && !onDiskMatchesIntent;
 
-    if (looksLikeStaleCli) {
+    if (cliCleanNonAdvance) {
       const installRoot = args.installRoot ?? defaultInstallRoot();
       if (installRoot) {
         const sx = await (args.selfExtractImpl ?? defaultSelfExtract)({
@@ -339,9 +351,9 @@ export async function reconcileUpgradeDirective(args: ReconcileArgs): Promise<vo
           return;
         }
         const reason = sx.ok
-          ? `self-heal extraction completed but on-disk version is ${newOnDisk ?? '<unknown>'}`
-          : `self-heal extraction failed: ${sx.error}`;
-        const error = `fleet CLI predates pinned-version upgrades (does not recognise --version), and ${reason}. Run 'agenfk upgrade --beta' or 'npx github:cglab-public/agenfk' on the host to recover.`;
+          ? `forced self-extract completed but on-disk version is ${newOnDisk ?? '<unknown>'}`
+          : `forced self-extract failed: ${sx.error}`;
+        const error = `agenfk upgrade exited 0 but did not advance on-disk to ${body.targetVersion} (on-disk: ${onDisk}); ${reason}. Recover with 'agenfk upgrade --beta' or 'npx github:cglab-public/agenfk' on the host.`;
         args.recordEvent({
           installationId: args.installationId,
           type: 'fleet:upgrade:failed',

--- a/packages/server/src/test/upgrade-sync.test.ts
+++ b/packages/server/src/test/upgrade-sync.test.ts
@@ -50,6 +50,21 @@ function makeFakes(opts: {
   return { events, flushNowCalls, fetchImpl, recordEvent, flushNow, spawnImpl, readInstalledVersionImpl };
 }
 
+describe('BUG bbe794bc — forced self-extract installs deps (no false success)', () => {
+  // Source-introspection: defaultSelfExtract shells out, so we assert the
+  // production impl runs `npm ci` after the tar, ordered after extraction.
+  // Without this, a dep-changing target would advance the version on disk but
+  // boot with missing node_modules while reporting success.
+  const SRC = fs.readFileSync(path.join(__dirname, '../hub/upgradeSync.ts'), 'utf8');
+  it('runs `npm ci --omit=dev` inside defaultSelfExtract, after the tar extract', () => {
+    const fn = SRC.slice(SRC.indexOf('async function defaultSelfExtract'));
+    const body = fn.slice(0, fn.indexOf('\n}'));
+    expect(body).toMatch(/tar -xzf/);
+    expect(body).toMatch(/ci --omit=dev/);
+    expect(body.indexOf('ci --omit=dev')).toBeGreaterThan(body.indexOf('tar -xzf'));
+  });
+});
+
 describe('Story 3b — reconcileUpgradeDirective', () => {
   it('no-op when the hub returns 204 (no pending directive)', async () => {
     const f = makeFakes({ directive: undefined });
@@ -142,14 +157,17 @@ describe('Story 3b — reconcileUpgradeDirective', () => {
     expect(readUpgradeState(dbDir)?.outcome).toBe('failed');
   });
 
-  it('emits failed when CLI exits 0 + emits no JSON envelope BUT the on-disk version is unchanged (regression for directive→0.3.0-beta.24, 97f4db4c)', async () => {
+  it('CLI exits 0 + no JSON + on-disk unchanged → forces a CLI-independent recovery; if THAT also fails, emits an honest failure (never a false success) — BUG bbe794bc', async () => {
     const f = makeFakes({
       directive: { directiveId: 'd-real', targetVersion: '0.3.0-beta.24' },
       spawnExitCode: 0,
-      // CLI was killed mid-install before emitting JSON.
+      // CLI exited cleanly but never installed (killed mid-emit / silent no-op).
       spawnStdout: 'Some non-JSON noise that snuck in\n',
       installedVersion: '0.2.28', // unchanged — install never landed
     });
+    // Forced recovery is attempted even though this is NOT the bare-semver
+    // "printed its own version" signature — any clean-exit non-advance qualifies.
+    const selfExtractImpl = vi.fn(async () => ({ ok: false as const, error: 'curl: could not download' }));
     await reconcileUpgradeDirective({
       dbDir,
       currentVersion: '0.2.28',
@@ -158,16 +176,58 @@ describe('Story 3b — reconcileUpgradeDirective', () => {
       flushNow: f.flushNow,
       spawnImpl: f.spawnImpl,
       readInstalledVersionImpl: f.readInstalledVersionImpl,
+      installRoot: '/fake/install/root',
+      selfExtractImpl,
       hubUrl: 'http://hub.test',
       installationId: 'inst-1',
       hubToken: 't',
     });
+    expect(selfExtractImpl).toHaveBeenCalledTimes(1);
     const failed = f.events.find(e => e.type === 'fleet:upgrade:failed');
     expect(failed).toBeDefined();
     // Error must mention both the intent and the actual on-disk version.
     expect(failed!.payload.error).toMatch(/0\.3\.0-beta\.24/);
     expect(failed!.payload.error).toMatch(/0\.2\.28/);
+    // And must NOT have falsely reported success.
+    expect(f.events.find(e => e.type === 'fleet:upgrade:succeeded')).toBeUndefined();
     expect(readUpgradeState(dbDir)?.outcome).toBe('failed');
+  });
+
+  it('forced recovery: reproduces the real hub failure (broken CLI printed its own version; running reconciler version differs from on-disk) → self-extract + restart + succeeded — BUG bbe794bc', async () => {
+    // This is the exact shape the user hit: `agenfk upgrade --version` hit the
+    // commander collision, printed the on-disk version and exited 0. The OLD
+    // narrow recovery refused to act because on-disk !== the running reconciler
+    // version. The generalized recovery must act regardless of that.
+    let onDiskNow = '1.1.1-beta.1';
+    const f = makeFakes({
+      directive: { directiveId: 'd-user', targetVersion: '1.1.2' },
+      spawnExitCode: 0,
+      spawnStdout: '1.1.1-beta.1\n',
+    });
+    f.readInstalledVersionImpl.mockImplementation(() => onDiskNow);
+    const selfExtractImpl = vi.fn(async () => { onDiskNow = '1.1.2'; return { ok: true as const }; });
+    const restartServerImpl = vi.fn();
+    await reconcileUpgradeDirective({
+      dbDir,
+      currentVersion: '1.1.0', // running reconciler differs from on-disk — the anomaly
+      fetchImpl: f.fetchImpl,
+      recordEvent: f.recordEvent,
+      flushNow: f.flushNow,
+      spawnImpl: f.spawnImpl,
+      readInstalledVersionImpl: f.readInstalledVersionImpl,
+      installRoot: '/fake/install/root',
+      selfExtractImpl,
+      restartServerImpl,
+      hubUrl: 'http://hub.test',
+      installationId: 'inst-1',
+      hubToken: 't',
+    });
+    expect(selfExtractImpl).toHaveBeenCalledTimes(1);
+    const succeeded = f.events.find(e => e.type === 'fleet:upgrade:succeeded');
+    expect(succeeded?.payload.resultVersion).toBe('1.1.2');
+    expect(restartServerImpl).toHaveBeenCalledTimes(1);
+    expect(f.events.find(e => e.type === 'fleet:upgrade:failed')).toBeUndefined();
+    expect(readUpgradeState(dbDir)).toBeNull();
   });
 
   it('emits succeeded when on-disk version matches intent even if CLI was killed mid-emit (no JSON, exit 0)', async () => {
@@ -315,9 +375,8 @@ describe('Story 3b — reconcileUpgradeDirective', () => {
     expect(selfExtractImpl).toHaveBeenCalledTimes(1);
     const failed = f.events.find(e => e.type === 'fleet:upgrade:failed');
     expect(failed).toBeDefined();
-    // Error must explain WHY (CLI predates --version) and HOW (manual remediation),
-    // not just the cryptic "exited 0 but on-disk version is X" message.
-    expect(failed!.payload.error).toMatch(/predates|does not recognise|--version/i);
+    // Error must reference the target and give a manual remediation path.
+    expect(failed!.payload.error).toMatch(/0\.3\.0-beta\.27/);
     expect(failed!.payload.error).toMatch(/agenfk upgrade --beta|npx github:cglab-public\/agenfk/);
     // Underlying self-extract error should be referenced for diagnosis.
     expect(failed!.payload.error).toMatch(/curl: 404/);


### PR DESCRIPTION
Makes hub-driven upgrades robust against future CLI/flag regressions — so a bug like the `--version` collision can never again silently wedge the fleet.

## Problem
The reconciler delegates the install to the spawnable `agenfk upgrade --version <target>` CLI. A CLI arg/flag bug (the historical `--version`-vs-global-flag collision) made the CLI exit 0 without installing, so hub-driven pinned upgrades silently no-op'd. The previous "stale-CLI recovery" only fired for one narrow signature (CLI printed a bare semver == on-disk == running version) — it didn't catch the real-world failure the user hit (on-disk ≠ running reconciler version), and it only untarred (no `npm ci`, and pre-#100 no restart).

## Fix (`packages/server/src/hub/upgradeSync.ts`)
Generalize the recovery to fire on **any clean-exit non-advance**:
`exitOk && !cliReportedSucceeded && !cliReportedFailed && on-disk !== target`.
When it fires, force a CLI-independent install the reconciler fully controls: **download tarball → extract → `npm ci --omit=dev --ignore-scripts` → re-verify on-disk → restart** (flushing the success event first). 

- Dropped the narrow bare-semver and `on-disk === currentVersion` constraints → catches the real failure shape and self-heals regardless of the running reconciler's version.
- `defaultSelfExtract` now runs `npm ci` after the untar (node_modules aren't in the tarball), and only reports success if both succeed — so a **dependency-changing target can't produce a false success** (the gap caught in review).
- Deliberately does **not** force-extract over a non-zero exit or explicit `status:"failed"` — those are the CLI's genuine install errors and go to the generic failure path, so we don't mask a real problem.
- Single attempt per directive (directiveId guard + failed-state write), so a hopeless target can't loop.

## Scope / limits
Helps every install running this reconciler **onward**; already-deployed old reconcilers have frozen code (the one-time manual `agenfk upgrade` escape hatch still applies to bootstrap onto a fixed version).

## Tests
New: general clean-exit-non-advance recovery; the user's exact mismatch scenario (recovers); `npm ci`-after-tar in `defaultSelfExtract`. Updated the no-JSON/unchanged and self-extract-failure tests to the generalized behavior. upgrade-sync 18/18; full suite 1617 green; written TDD-first with adversarial review.

https://claude.ai/code/session_01W3ct4ECvAzsWVpodPCMjv1