### PR TITLE
feat(observability): PR Overview analytics — per-developer PR sizing dashboard

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,3 +5,4 @@ export * from "./defaultFlow.js";
 export * from "./gatekeeper.js";
 export * from "./projectHygiene.js";
 export * from "./semver.js";
+export * from "./sizing.js";

--- a/packages/core/src/sizing.ts
+++ b/packages/core/src/sizing.ts
@@ -1,0 +1,79 @@
+// ── PR size model ────────────────────────────────────────────────────────────
+// A PR's "size" is derived from the *leaves* of its item subtree — the lowest
+// item in each branch — so the same work is never counted twice. An EPIC rolls
+// up its STORYs, and a STORY rolls up its TASKs/BUGs; summing all four tiers
+// would double-count. Tasks and bugs are always leaves. A STORY is a leaf only
+// when it has no children (it is itself the unit of work).
+//
+// This module is shared by the spoke (which counts leaf stories while walking
+// the item tree at PR-register time) and the hub (which turns the counts into
+// weighted points and an XS–XL bucket).
+
+export interface SizingCounts {
+  epic: number;
+  story: number;
+  task: number;
+  bug: number;
+  /** STORYs with no child items — counted as atomic work, unlike container stories. */
+  leafStory: number;
+}
+
+export interface SizeInput {
+  leafStory?: number | null;
+  task?: number | null;
+  bug?: number | null;
+}
+
+/** Leaf-only weights. Epic/Story containers are intentionally absent — they are
+ *  scope, not magnitude. A leaf story outweighs a task; a task outweighs a bug. */
+export const SIZE_WEIGHTS = { leafStory: 4, task: 2, bug: 1 } as const;
+
+export const SIZE_BUCKETS = ['xs', 's', 'm', 'l', 'xl'] as const;
+export type SizeBucket = typeof SIZE_BUCKETS[number];
+
+/** Inclusive upper bounds per bucket; anything above the last → 'xl'. */
+export const SIZE_THRESHOLDS: ReadonlyArray<{ bucket: SizeBucket; max: number }> = [
+  { bucket: 'xs', max: 2 },
+  { bucket: 's', max: 6 },
+  { bucket: 'm', max: 14 },
+  { bucket: 'l', max: 30 },
+];
+
+interface TreeItem { id: string; type: string; parentId?: string | null }
+
+/** Count each tier across a set of items, flagging childless STORYs as leaf
+ *  stories. The items must form a closed set (a subtree): a STORY is a leaf when
+ *  no item in the set names it as a parent. */
+export function computeSizingFromItems(items: ReadonlyArray<TreeItem>): SizingCounts {
+  const hasChild = new Set<string>();
+  for (const it of items) if (it.parentId) hasChild.add(it.parentId);
+
+  const counts: SizingCounts = { epic: 0, story: 0, task: 0, bug: 0, leafStory: 0 };
+  for (const it of items) {
+    switch (it.type) {
+      case 'EPIC': counts.epic++; break;
+      case 'STORY':
+        counts.story++;
+        if (!hasChild.has(it.id)) counts.leafStory++;
+        break;
+      case 'TASK': counts.task++; break;
+      case 'BUG': counts.bug++; break;
+    }
+  }
+  return counts;
+}
+
+/** Weighted size points: leafStory×4 + task×2 + bug×1. */
+export function prSizePoints(s: SizeInput): number {
+  return (s.leafStory ?? 0) * SIZE_WEIGHTS.leafStory
+    + (s.task ?? 0) * SIZE_WEIGHTS.task
+    + (s.bug ?? 0) * SIZE_WEIGHTS.bug;
+}
+
+/** Map weighted points to an ordinal XS–XL bucket. */
+export function prSizeBucket(points: number): SizeBucket {
+  for (const t of SIZE_THRESHOLDS) {
+    if (points <= t.max) return t.bucket;
+  }
+  return 'xl';
+}

--- a/packages/core/src/test/sizing.test.ts
+++ b/packages/core/src/test/sizing.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeSizingFromItems,
+  prSizePoints,
+  prSizeBucket,
+  SIZE_BUCKETS,
+  SIZE_WEIGHTS,
+} from '../sizing.js';
+
+describe('computeSizingFromItems', () => {
+  it('counts each tier and flags a story with no children as a leaf story', () => {
+    // EPIC → STORY(container, has tasks/bug) ; plus a standalone leaf STORY
+    const items = [
+      { id: 'e', type: 'EPIC', parentId: null },
+      { id: 's1', type: 'STORY', parentId: 'e' }, // container (has children)
+      { id: 't1', type: 'TASK', parentId: 's1' },
+      { id: 't2', type: 'TASK', parentId: 's1' },
+      { id: 'b1', type: 'BUG', parentId: 's1' },
+      { id: 's2', type: 'STORY', parentId: 'e' }, // LEAF story (no children)
+    ];
+    expect(computeSizingFromItems(items)).toEqual({
+      epic: 1, story: 2, task: 2, bug: 1, leafStory: 1,
+    });
+  });
+
+  it('treats a lone STORY (no subtasks) as a leaf story', () => {
+    const items = [{ id: 's', type: 'STORY', parentId: null }];
+    expect(computeSizingFromItems(items)).toEqual({
+      epic: 0, story: 1, task: 0, bug: 0, leafStory: 1,
+    });
+  });
+
+  it('a STORY with subtasks is a container, not a leaf', () => {
+    const items = [
+      { id: 's', type: 'STORY', parentId: null },
+      { id: 't', type: 'TASK', parentId: 's' },
+    ];
+    const c = computeSizingFromItems(items);
+    expect(c.story).toBe(1);
+    expect(c.leafStory).toBe(0);
+  });
+
+  it('handles an empty set', () => {
+    expect(computeSizingFromItems([])).toEqual({
+      epic: 0, story: 0, task: 0, bug: 0, leafStory: 0,
+    });
+  });
+});
+
+describe('prSizePoints', () => {
+  it('weights leaf stories ×4, tasks ×2, bugs ×1 and never sums Epic/Story containers', () => {
+    expect(SIZE_WEIGHTS).toEqual({ leafStory: 4, task: 2, bug: 1 });
+    // 1 leaf story + 3 tasks + 2 bugs = 4 + 6 + 2 = 12
+    expect(prSizePoints({ leafStory: 1, task: 3, bug: 2 })).toBe(12);
+  });
+
+  it('defaults missing fields to zero', () => {
+    expect(prSizePoints({ task: 1 })).toBe(2);
+    expect(prSizePoints({})).toBe(0);
+  });
+});
+
+describe('prSizeBucket', () => {
+  it('maps points to XS–XL bucket thresholds', () => {
+    expect(SIZE_BUCKETS).toEqual(['xs', 's', 'm', 'l', 'xl']);
+    expect(prSizeBucket(0)).toBe('xs');
+    expect(prSizeBucket(2)).toBe('xs');
+    expect(prSizeBucket(3)).toBe('s');
+    expect(prSizeBucket(6)).toBe('s');
+    expect(prSizeBucket(7)).toBe('m');
+    expect(prSizeBucket(14)).toBe('m');
+    expect(prSizeBucket(15)).toBe('l');
+    expect(prSizeBucket(30)).toBe('l');
+    expect(prSizeBucket(31)).toBe('xl');
+    expect(prSizeBucket(999)).toBe('xl');
+  });
+});

--- a/packages/hub-ui/src/App.tsx
+++ b/packages/hub-ui/src/App.tsx
@@ -5,6 +5,7 @@ import { api, MeResponse, ProvidersResponse } from './api';
 import { LoginPage } from './pages/Login';
 import { SetupPage } from './pages/Setup';
 import { OrgPage } from './pages/Org';
+import { PrOverviewPage } from './pages/PrOverview';
 import { UserDetailPage } from './pages/UserDetail';
 import { ConnectPage } from './pages/Connect';
 import { AdminLayout, AdminAuth, AdminKeys, AdminUsers, AdminInstallations } from './pages/Admin';
@@ -51,6 +52,7 @@ export function App() {
       <Route path="/setup" element={<SetupPage />} />
       <Route path="/connect" element={<RequireAuth><ConnectPage /></RequireAuth>} />
       <Route path="/" element={<RequireAuth><Layout><OrgPage /></Layout></RequireAuth>} />
+      <Route path="/prs" element={<RequireAuth><Layout><PrOverviewPage /></Layout></RequireAuth>} />
       <Route path="/users/:userKey" element={<RequireAuth><Layout><UserDetailPage /></Layout></RequireAuth>} />
       <Route path="/admin" element={<RequireAuth><Layout><AdminLayout /></Layout></RequireAuth>}>
         <Route path="auth" element={<AdminAuth />} />

--- a/packages/hub-ui/src/components/Layout.tsx
+++ b/packages/hub-ui/src/components/Layout.tsx
@@ -1,7 +1,7 @@
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { api, MeResponse } from '../api';
-import { LayoutDashboard, Shield, LogOut, AlertTriangle } from 'lucide-react';
+import { LayoutDashboard, Shield, LogOut, AlertTriangle, GitPullRequest } from 'lucide-react';
 
 function Logo({ version }: { version?: string | null }) {
   return (
@@ -75,6 +75,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
           <Logo version={health.data?.version ?? null} />
         </div>
         <NavItem to="/" icon={<LayoutDashboard className="w-4 h-4" />} label="Org rollup" />
+        <NavItem to="/prs" icon={<GitPullRequest className="w-4 h-4" />} label="PR overview" />
         {me.data?.role === 'admin' && (
           <NavItem to="/admin" icon={<Shield className="w-4 h-4" />} label="Admin" />
         )}

--- a/packages/hub-ui/src/pages/PrOverview.tsx
+++ b/packages/hub-ui/src/pages/PrOverview.tsx
@@ -1,0 +1,389 @@
+import { useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { GitPullRequest, RefreshCw, TrendingUp, TrendingDown } from 'lucide-react';
+import { api } from '../api';
+import { FacetMultiselect } from '../components/FacetMultiselect';
+import { shortRemote } from '../components/facetSearch';
+import { useToggleSet } from '../hooks/useToggleSet';
+import { fromIsoForRange, type RangeKey } from '../components/timelineAxis';
+import { SIZE_META, type SizeKey, buildDayAxis, pctDelta } from '../prOverview';
+
+const RANGES: Array<{ key: RangeKey; label: string }> = [
+  { key: 'today', label: 'today' },
+  { key: '7d', label: '7d' },
+  { key: '30d', label: '30d' },
+  { key: '90d', label: '90d' },
+];
+
+type SizeDist = Record<SizeKey, number>;
+interface PrOverviewResponse {
+  period: { from: string | null; to: string | null };
+  buckets: SizeKey[];
+  totals: { prs: number; sizePoints: number; developers: number; medianBucket: SizeKey | null };
+  resized: { count: number; grew: number; shrank: number };
+  byDay: Array<{ day: string; sizes: SizeDist; total: number }>;
+  byDeveloper: Array<{ user_key: string; prs: number; sizePoints: number; sizes: SizeDist; daily: Record<string, number> }>;
+  byModel: Array<{ model: string; harnesses: string[]; prs: number; sizePoints: number; sizes: SizeDist }>;
+  previous: { prs: number; sizePoints: number } | null;
+}
+interface ProjectsResponse { projects: string[] }
+
+const EMPTY: SizeDist = { xs: 0, s: 0, m: 0, l: 0, xl: 0 };
+const colorOf = (k: SizeKey) => SIZE_META.find(s => s.key === k)!.color;
+
+function DeltaBadge({ value }: { value: number | null }) {
+  if (value == null) return <span className="text-[11px] text-slate-400">— no prior period</span>;
+  const up = value >= 0;
+  return (
+    <span className={`inline-flex items-center gap-1 text-[11px] font-semibold ${up ? 'text-emerald-600 dark:text-emerald-400' : 'text-rose-600 dark:text-rose-400'}`}>
+      {up ? <TrendingUp className="w-3 h-3" /> : <TrendingDown className="w-3 h-3" />}
+      {up ? '+' : ''}{value}%
+    </span>
+  );
+}
+
+function Tile({ label, value, children }: { label: string; value: React.ReactNode; children?: React.ReactNode }) {
+  return (
+    <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl p-4">
+      <div className="text-[10px] uppercase tracking-[0.14em] font-mono text-slate-400 dark:text-slate-500">{label}</div>
+      <div className="mt-2 text-3xl font-bold tabular-nums text-slate-900 dark:text-slate-100">{value}</div>
+      <div className="mt-1.5">{children}</div>
+    </div>
+  );
+}
+
+/** Horizontal stacked size-mix bar for one row of size counts. */
+function MixBar({ sizes, total }: { sizes: SizeDist; total: number }) {
+  if (total === 0) return <div className="h-2 w-full rounded-full bg-slate-100 dark:bg-slate-800" />;
+  return (
+    <div className="flex h-2 w-full rounded-full overflow-hidden bg-slate-100 dark:bg-slate-800">
+      {SIZE_META.filter(s => sizes[s.key] > 0).map(s => (
+        <span key={s.key} title={`${s.label}: ${sizes[s.key]}`} style={{ background: s.color, width: `${(sizes[s.key] / total) * 100}%` }} />
+      ))}
+    </div>
+  );
+}
+
+function SizeCounts({ sizes }: { sizes: SizeDist }) {
+  return (
+    <div className="flex gap-1">
+      {SIZE_META.map(s => (
+        <span
+          key={s.key}
+          title={`${s.label} PRs`}
+          className={`min-w-[26px] text-center rounded-md px-1 py-0.5 font-mono text-[11px] tabular-nums ${sizes[s.key] === 0
+            ? 'text-slate-300 dark:text-slate-600 bg-slate-50 dark:bg-slate-800/40'
+            : 'text-slate-700 dark:text-slate-200 bg-slate-100 dark:bg-slate-800'}`}
+        >
+          {sizes[s.key]}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+/** Tiny inline sparkline of daily PR counts over the period axis. */
+function Sparkline({ daily, axis }: { daily: Record<string, number>; axis: string[] }) {
+  const values = axis.map(d => daily[d] ?? 0);
+  const w = 96, h = 24, max = Math.max(...values, 1);
+  const step = values.length > 1 ? w / (values.length - 1) : w;
+  const pts = values.map((v, i) => `${(i * step).toFixed(1)},${(h - (v / max) * (h - 4) - 2).toFixed(1)}`).join(' ');
+  return (
+    <svg width={w} height={h} viewBox={`0 0 ${w} ${h}`} aria-hidden className="overflow-visible">
+      <polyline points={pts} fill="none" stroke="#6366f1" strokeWidth="1.6" strokeLinejoin="round" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+export function PrOverviewPage() {
+  const projectSel = useToggleSet([], { storageKey: 'agenfk-hub:prs:projects' });
+  const [range, setRange] = useState<RangeKey>('30d');
+  const [model, setModel] = useState<string>('');
+
+  const from = useMemo(() => fromIsoForRange(new Date(), range), [range]);
+
+  const baseQs = useMemo(() => {
+    const p = new URLSearchParams();
+    if (projectSel.set.size) p.set('projects', [...projectSel.set].join(','));
+    p.set('from', from);
+    return p;
+  }, [projectSel.set, from]);
+
+  const dataQs = useMemo(() => {
+    const p = new URLSearchParams(baseQs);
+    if (model) p.set('model', model);
+    return p.toString();
+  }, [baseQs, model]);
+
+  const overview = useQuery<PrOverviewResponse>({
+    queryKey: ['pr-overview', dataQs],
+    queryFn: async () => (await api.get(`/v1/prs/overview?${dataQs}`)).data,
+  });
+
+  // Model dropdown options come from the UNFILTERED overview (same project +
+  // period). When no model is selected the main `overview` already holds the
+  // full list, so we only run a second request once a model is picked.
+  const optionsQuery = useQuery<PrOverviewResponse>({
+    queryKey: ['pr-overview-models', baseQs.toString()],
+    queryFn: async () => (await api.get(`/v1/prs/overview?${baseQs.toString()}`)).data,
+    enabled: !!model,
+  });
+  const modelOptions = (model ? optionsQuery.data : overview.data)?.byModel.map(m => m.model) ?? [];
+  const projects = useQuery<ProjectsResponse>({ queryKey: ['projects'], queryFn: async () => (await api.get('/v1/projects')).data });
+
+  const d = overview.data;
+  const to = d?.period.to ?? new Date().toISOString();
+  const axis = useMemo(() => (d ? buildDayAxis(from, to) : []), [d, from, to]);
+  const maxDayTotal = Math.max(1, ...(d?.byDay.map(x => x.total) ?? [1]));
+  const byDayMap = useMemo(() => new Map((d?.byDay ?? []).map(x => [x.day, x])), [d]);
+
+  return (
+    <div className="max-w-[1200px] mx-auto space-y-6">
+      <header className="flex items-end justify-between gap-4 flex-wrap">
+        <div>
+          <p className="text-[11px] uppercase tracking-[0.18em] text-indigo-600 dark:text-indigo-400 font-semibold">Analytics</p>
+          <h1 className="mt-1 text-2xl font-bold tracking-tight text-slate-900 dark:text-slate-100 flex items-center gap-2">
+            <GitPullRequest className="w-6 h-6 text-indigo-500" /> PR Overview
+          </h1>
+          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">Pull requests per developer, weighted by size — for the selected period, with a daily breakdown.</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <select
+            value={model}
+            onChange={e => setModel(e.target.value)}
+            className="text-[12px] font-medium rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 text-slate-700 dark:text-slate-200 px-2.5 py-1.5"
+          >
+            <option value="">All models</option>
+            {modelOptions.map(m => <option key={m} value={m}>{m}</option>)}
+          </select>
+          <div className="inline-flex rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800 p-0.5 text-[11px] font-medium">
+            {RANGES.map(r => (
+              <button
+                key={r.key}
+                onClick={() => setRange(r.key)}
+                className={`px-2.5 py-1 rounded-md transition-colors ${range === r.key
+                  ? 'bg-white dark:bg-slate-900 text-indigo-600 dark:text-indigo-400 shadow-sm'
+                  : 'text-slate-500 hover:text-slate-700 dark:hover:text-slate-300'}`}
+              >
+                {r.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </header>
+
+      <FacetMultiselect
+        label="Project (git remote)"
+        options={projects.data?.projects ?? []}
+        selected={projectSel.set}
+        onToggle={projectSel.toggle}
+        onClear={projectSel.clear}
+        optionLabel={shortRemote}
+        inlineThreshold={6}
+        placeholder="Search projects…"
+      />
+
+      {overview.isLoading && <div className="text-sm text-slate-500 py-8 text-center">Loading…</div>}
+      {d && d.totals.prs === 0 && (
+        <div className="rounded-2xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 px-5 py-10 text-center text-sm text-slate-500">
+          No PRs registered for this project and period.
+        </div>
+      )}
+
+      {d && d.totals.prs > 0 && (
+        <>
+          {/* KPIs */}
+          <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+            <Tile label="Total PRs" value={d.totals.prs}>
+              <DeltaBadge value={d.previous ? pctDelta(d.totals.prs, d.previous.prs) : null} />
+            </Tile>
+            <Tile label="Weighted size" value={<span>{d.totals.sizePoints}</span>}>
+              <span className="text-[11px] text-slate-400">size points</span>
+            </Tile>
+            <Tile label="Active developers" value={d.totals.developers}>
+              <span className="text-[11px] text-slate-400">{(d.totals.prs / Math.max(1, d.totals.developers)).toFixed(1)} PRs / dev</span>
+            </Tile>
+            <Tile label="Median size" value={<span className="uppercase">{d.totals.medianBucket ?? '—'}</span>}>
+              <span className="text-[11px] text-slate-400">across {d.totals.prs} PRs</span>
+            </Tile>
+          </div>
+
+          {/* Resize strip */}
+          {d.resized.count > 0 && (
+            <div className="flex items-center gap-3 flex-wrap rounded-xl border border-slate-200 dark:border-slate-800 border-l-[3px] border-l-indigo-500 bg-gradient-to-r from-indigo-50/60 to-transparent dark:from-indigo-900/20 px-4 py-3">
+              <RefreshCw className="w-4 h-4 text-indigo-500" />
+              <span className="text-[13px] text-slate-600 dark:text-slate-300">
+                <b className="text-slate-900 dark:text-slate-100">{d.resized.count} PRs re-sized</b> this period —{' '}
+                <span className="text-emerald-600 dark:text-emerald-400 font-semibold">{d.resized.grew} grew ↑</span>,{' '}
+                <span className="text-rose-600 dark:text-rose-400 font-semibold">{d.resized.shrank} shrank ↓</span>.
+              </span>
+              <span className="ml-auto text-[11px] text-slate-400">Each PR counts once, at its latest sizing.</span>
+            </div>
+          )}
+
+          {/* Daily stacked bar */}
+          <section className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl p-5">
+            <div className="flex items-baseline justify-between gap-3 flex-wrap mb-4">
+              <h2 className="text-sm font-semibold text-slate-800 dark:text-slate-100">Daily PR volume by size</h2>
+              <div className="flex gap-3 flex-wrap">
+                {SIZE_META.map(s => (
+                  <span key={s.key} className="inline-flex items-center gap-1.5 text-[11px] text-slate-500 dark:text-slate-400">
+                    <span className="w-3 h-3 rounded-sm" style={{ background: s.color }} /> {s.label}
+                  </span>
+                ))}
+              </div>
+            </div>
+            <div className="overflow-x-auto">
+              <div className="flex items-end gap-1.5 h-44 min-w-[420px]">
+                {axis.map(day => {
+                  const entry = byDayMap.get(day) ?? { sizes: EMPTY, total: 0 };
+                  return (
+                    <div key={day} className="flex-1 flex flex-col justify-end gap-0.5 h-full group" title={`${day}: ${entry.total} PRs`}>
+                      {SIZE_META.slice().reverse().filter(s => entry.sizes[s.key] > 0).map(s => (
+                        <div key={s.key} style={{ background: s.color, height: `${(entry.sizes[s.key] / maxDayTotal) * 100}%` }} className="rounded-[2px]" />
+                      ))}
+                    </div>
+                  );
+                })}
+              </div>
+              <div className="flex gap-1.5 mt-2 min-w-[420px]">
+                {axis.map((day, i) => (
+                  <div key={day} className="flex-1 text-center font-mono text-[9px] text-slate-400">
+                    {i % Math.ceil(axis.length / 10 || 1) === 0 ? day.slice(5) : ''}
+                  </div>
+                ))}
+              </div>
+            </div>
+          </section>
+
+          {/* By developer */}
+          <section className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl overflow-hidden">
+            <div className="px-5 py-4 border-b border-slate-100 dark:border-slate-800">
+              <h2 className="text-sm font-semibold text-slate-800 dark:text-slate-100">By developer</h2>
+            </div>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm min-w-[640px]">
+                <thead>
+                  <tr className="text-left font-mono text-[10px] uppercase tracking-[0.08em] text-slate-400">
+                    <th className="px-5 py-2 font-semibold">Developer</th>
+                    <th className="px-3 py-2 font-semibold text-right">PRs</th>
+                    <th className="px-3 py-2 font-semibold w-[180px]">Size mix</th>
+                    <th className="px-3 py-2 font-semibold">XS · S · M · L · XL</th>
+                    <th className="px-5 py-2 font-semibold text-right">Trend</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
+                  {d.byDeveloper.map(dev => (
+                    <tr key={dev.user_key} className="hover:bg-indigo-50/30 dark:hover:bg-indigo-900/10 transition-colors">
+                      <td className="px-5 py-3">
+                        <div className="flex items-center gap-2.5">
+                          <div className="w-7 h-7 rounded-lg bg-gradient-to-br from-indigo-500 to-violet-500 text-white text-[10px] font-bold flex items-center justify-center shrink-0">
+                            {dev.user_key.slice(0, 2).toUpperCase()}
+                          </div>
+                          <span className="font-mono text-[12px] text-slate-700 dark:text-slate-200 truncate max-w-[200px]">{dev.user_key}</span>
+                        </div>
+                      </td>
+                      <td className="px-3 py-3 text-right font-mono tabular-nums text-lg font-bold text-slate-900 dark:text-slate-100">{dev.prs}</td>
+                      <td className="px-3 py-3"><MixBar sizes={dev.sizes} total={dev.prs} /></td>
+                      <td className="px-3 py-3"><SizeCounts sizes={dev.sizes} /></td>
+                      <td className="px-5 py-3 text-right"><div className="inline-block"><Sparkline daily={dev.daily} axis={axis} /></div></td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          {/* By model */}
+          <section className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl overflow-hidden">
+            <div className="px-5 py-4 border-b border-slate-100 dark:border-slate-800">
+              <h2 className="text-sm font-semibold text-slate-800 dark:text-slate-100">By model</h2>
+              <p className="text-[11px] text-slate-500 mt-0.5">Which agent runtime opened the PRs.</p>
+            </div>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm min-w-[560px]">
+                <thead>
+                  <tr className="text-left font-mono text-[10px] uppercase tracking-[0.08em] text-slate-400">
+                    <th className="px-5 py-2 font-semibold">Model</th>
+                    <th className="px-3 py-2 font-semibold text-right">PRs</th>
+                    <th className="px-3 py-2 font-semibold w-[180px]">Size mix</th>
+                    <th className="px-5 py-2 font-semibold text-right">Share</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
+                  {d.byModel.map(m => (
+                    <tr key={m.model} className="hover:bg-indigo-50/30 dark:hover:bg-indigo-900/10 transition-colors">
+                      <td className="px-5 py-3">
+                        <div className="font-mono text-[12px] text-slate-700 dark:text-slate-200">{m.model}</div>
+                        {m.harnesses.length > 0 && <div className="text-[10px] text-slate-400">via {m.harnesses.join(', ')}</div>}
+                      </td>
+                      <td className="px-3 py-3 text-right font-mono tabular-nums text-lg font-bold text-slate-900 dark:text-slate-100">{m.prs}</td>
+                      <td className="px-3 py-3"><MixBar sizes={m.sizes} total={m.prs} /></td>
+                      <td className="px-5 py-3 text-right font-mono tabular-nums text-slate-600 dark:text-slate-300">{Math.round((m.prs / d.totals.prs) * 100)}%</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          {/* Per developer per day heatmap */}
+          <section className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl p-5">
+            <h2 className="text-sm font-semibold text-slate-800 dark:text-slate-100 mb-1">Per developer, per day</h2>
+            <p className="text-[11px] text-slate-500 mb-4">Cell shade = PRs opened that day.</p>
+            <div className="overflow-x-auto">
+              <div className="space-y-1 min-w-[560px]">
+                {d.byDeveloper.map(dev => {
+                  const max = Math.max(1, ...axis.map(day => dev.daily[day] ?? 0));
+                  return (
+                    <div key={dev.user_key} className="grid items-center gap-2" style={{ gridTemplateColumns: '150px 1fr' }}>
+                      <span className="font-mono text-[11px] text-slate-500 dark:text-slate-400 truncate">{dev.user_key}</span>
+                      <div className="flex gap-1">
+                        {axis.map(day => {
+                          const c = dev.daily[day] ?? 0;
+                          const intensity = c === 0 ? 0 : 0.25 + (c / max) * 0.7;
+                          return (
+                            <div
+                              key={day}
+                              title={`${dev.user_key} · ${day}: ${c} PRs`}
+                              className="flex-1 aspect-square rounded-[3px] min-w-[10px]"
+                              style={{ background: c === 0 ? undefined : `rgba(99,102,241,${intensity.toFixed(2)})` }}
+                            >
+                              {c === 0 && <div className="w-full h-full rounded-[3px] bg-slate-100 dark:bg-slate-800" />}
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </section>
+
+          {/* Size model explainer */}
+          <section className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl p-5">
+            <h2 className="text-sm font-semibold text-slate-800 dark:text-slate-100 mb-3">How size is derived</h2>
+            <div className="font-mono text-[13px] rounded-lg bg-slate-50 dark:bg-slate-950 border border-slate-200 dark:border-slate-800 px-4 py-3 text-slate-700 dark:text-slate-200">
+              <span className="text-slate-400">// count leaves — the unit of work in each branch</span><br />
+              <span className="text-indigo-600 dark:text-indigo-400">size_points</span> = leafStory·<b>4</b> + task·<b>2</b> + bug·<b>1</b>
+            </div>
+            <p className="text-[12px] text-slate-500 dark:text-slate-400 mt-3 max-w-2xl">
+              An Epic rolls up its Stories, and a Story rolls up its Tasks &amp; Bugs — so summing all four tiers
+              double-counts. We size by the atomic deliverables; a Story with no subtasks is itself a leaf and scores ×4.
+              A later re-size re-buckets the same PR (it never adds a second one), and the PR is attributed to its opener.
+            </p>
+            <div className="flex gap-2 flex-wrap mt-3 text-[11px] font-mono">
+              {[{ b: 'XS', r: '0–2' }, { b: 'S', r: '3–6' }, { b: 'M', r: '7–14' }, { b: 'L', r: '15–30' }, { b: 'XL', r: '31+' }].map((x, i) => (
+                <span key={x.b} className="inline-flex items-center gap-1.5 rounded-md border border-slate-200 dark:border-slate-700 px-2 py-1">
+                  <span className="w-2.5 h-2.5 rounded-sm" style={{ background: colorOf(SIZE_META[i].key) }} />
+                  <b>{x.b}</b> <span className="text-slate-400">{x.r} pts</span>
+                </span>
+              ))}
+            </div>
+          </section>
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/hub-ui/src/prOverview.ts
+++ b/packages/hub-ui/src/prOverview.ts
@@ -1,0 +1,35 @@
+// Pure helpers for the PR Overview page — kept out of the component so they can
+// be unit-tested without a DOM.
+
+/** Ordinal PR-size ramp (XS→XL): a single indigo hue climbing in weight, so a
+ *  bigger PR reads as a denser colour. Separate from status colours on purpose. */
+export const SIZE_META = [
+  { key: 'xs', label: 'XS', color: '#c7d2fe' },
+  { key: 's', label: 'S', color: '#818cf8' },
+  { key: 'm', label: 'M', color: '#6366f1' },
+  { key: 'l', label: 'L', color: '#4f46e5' },
+  { key: 'xl', label: 'XL', color: '#3730a3' },
+] as const;
+
+export type SizeKey = typeof SIZE_META[number]['key'];
+
+/** Every calendar day in [from, to] inclusive, as YYYY-MM-DD (UTC). Capped so a
+ *  pathological range can't build an unbounded array. */
+export function buildDayAxis(from: string, to: string): string[] {
+  const start = new Date(from.slice(0, 10) + 'T00:00:00Z');
+  const end = new Date(to.slice(0, 10) + 'T00:00:00Z');
+  const out: string[] = [];
+  const cur = new Date(start);
+  while (cur <= end && out.length < 366) {
+    out.push(cur.toISOString().slice(0, 10));
+    cur.setUTCDate(cur.getUTCDate() + 1);
+  }
+  return out;
+}
+
+/** Rounded percentage change vs a baseline. Returns null when there is no
+ *  baseline to compare against (a 0→N jump isn't a meaningful percentage). */
+export function pctDelta(curr: number, prev: number): number | null {
+  if (!prev || prev <= 0) return null;
+  return Math.round(((curr - prev) / prev) * 100);
+}

--- a/packages/hub-ui/src/test/prOverview.test.ts
+++ b/packages/hub-ui/src/test/prOverview.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { buildDayAxis, pctDelta, SIZE_META } from '../prOverview';
+
+describe('buildDayAxis', () => {
+  it('lists every calendar day in [from, to] inclusive (UTC)', () => {
+    expect(buildDayAxis('2026-05-03T00:00:00Z', '2026-05-05T12:00:00Z')).toEqual([
+      '2026-05-03', '2026-05-04', '2026-05-05',
+    ]);
+  });
+
+  it('returns a single day when from and to are the same date', () => {
+    expect(buildDayAxis('2026-05-03T01:00:00Z', '2026-05-03T23:00:00Z')).toEqual(['2026-05-03']);
+  });
+
+  it('caps the axis length to avoid runaway ranges', () => {
+    const axis = buildDayAxis('2020-01-01T00:00:00Z', '2030-01-01T00:00:00Z');
+    expect(axis.length).toBeLessThanOrEqual(366);
+  });
+});
+
+describe('pctDelta', () => {
+  it('computes a rounded percentage change', () => {
+    expect(pctDelta(63, 50)).toBe(26);
+    expect(pctDelta(45, 60)).toBe(-25);
+  });
+
+  it('returns null when there is no baseline to compare against', () => {
+    expect(pctDelta(5, 0)).toBeNull();
+  });
+
+  it('handles a drop to zero', () => {
+    expect(pctDelta(0, 10)).toBe(-100);
+  });
+});
+
+describe('SIZE_META', () => {
+  it('defines an ordered XS–XL ramp with labels and colors', () => {
+    expect(SIZE_META.map(s => s.key)).toEqual(['xs', 's', 'm', 'l', 'xl']);
+    for (const s of SIZE_META) {
+      expect(s.label).toBeTruthy();
+      expect(s.color).toMatch(/^#/);
+    }
+  });
+});

--- a/packages/hub/src/queries/pr-overview-aggregate.ts
+++ b/packages/hub/src/queries/pr-overview-aggregate.ts
@@ -1,0 +1,159 @@
+import { prSizePoints, prSizeBucket, SIZE_BUCKETS, SizeBucket } from '@agenfk/core';
+
+// One json_extract-shaped row per pr.opened / pr.updated event. Sizing fields are
+// read from the server-computed shadow (the only source that knows leaf stories).
+export interface PrEventRow {
+  user_key: string;
+  occurred_at: string;
+  type: string; // 'pr.opened' | 'pr.updated'
+  repo: string | null;
+  pr_number: number | null;
+  leaf_story: number | null;
+  task: number | null;
+  bug: number | null;
+  model: string | null;
+  harness: string | null;
+}
+
+type SizeDist = Record<SizeBucket, number>;
+
+export interface PrOverviewResult {
+  buckets: readonly SizeBucket[];
+  totals: { prs: number; sizePoints: number; developers: number; medianBucket: SizeBucket | null };
+  resized: { count: number; grew: number; shrank: number };
+  byDay: Array<{ day: string; sizes: SizeDist; total: number }>;
+  byDeveloper: Array<{ user_key: string; prs: number; sizePoints: number; sizes: SizeDist; daily: Record<string, number> }>;
+  byModel: Array<{ model: string; harnesses: string[]; prs: number; sizePoints: number; sizes: SizeDist }>;
+}
+
+const emptyDist = (): SizeDist => ({ xs: 0, s: 0, m: 0, l: 0, xl: 0 });
+const dayOf = (iso: string): string => iso.slice(0, 10);
+const pointsOf = (r: PrEventRow): number =>
+  prSizePoints({ leafStory: r.leaf_story, task: r.task, bug: r.bug });
+
+/** Optional opener-day window + model filter. The window is applied to the PR's
+ *  OPEN time, not to individual events — so a PR opened before `from` is excluded
+ *  even if it was re-sized within the window (the update alone must not make it
+ *  look new). Pass rows fetched WITHOUT a lower time bound so true openers are
+ *  visible. The model filter likewise matches the OPENER's model, so a PR re-sized
+ *  by a different runtime stays attributed to whoever opened it. */
+export interface PrWindow { from?: string | null; to?: string | null; model?: string | null }
+
+interface ResolvedPr {
+  user_key: string;
+  model: string;
+  harness: string | null;
+  openerAt: string;
+  day: string;
+  points: number;       // latest sizing
+  bucket: SizeBucket;   // from latest sizing
+  openerPoints: number; // first sizing
+  events: number;
+}
+
+// Collapse the raw event stream into one record per PR. A pr.updated never adds a
+// new PR — it re-sizes the existing one. The PR is counted once, placed on its
+// OPEN day at its LATEST size, and attributed to whoever OPENED it.
+function resolvePrs(rows: ReadonlyArray<PrEventRow>): ResolvedPr[] {
+  const groups = new Map<string, PrEventRow[]>();
+  for (const r of rows) {
+    if (!r.repo || r.pr_number == null) continue; // not a sizeable PR event
+    const key = `${r.repo}#${r.pr_number}`;
+    const g = groups.get(key);
+    if (g) g.push(r); else groups.set(key, [r]);
+  }
+
+  const resolved: ResolvedPr[] = [];
+  for (const events of groups.values()) {
+    const sorted = [...events].sort((a, b) => a.occurred_at.localeCompare(b.occurred_at));
+    // Opener: the pr.opened event if present, else the earliest event.
+    const opener = sorted.find(e => e.type === 'pr.opened') ?? sorted[0];
+    const latest = sorted[sorted.length - 1];
+    const points = pointsOf(latest);
+    resolved.push({
+      user_key: opener.user_key,
+      model: opener.model ?? 'unknown',
+      harness: opener.harness ?? null,
+      openerAt: opener.occurred_at,
+      day: dayOf(opener.occurred_at),
+      points,
+      bucket: prSizeBucket(points),
+      openerPoints: pointsOf(opener),
+      events: sorted.length,
+    });
+  }
+  return resolved;
+}
+
+export function aggregatePrOverview(rows: ReadonlyArray<PrEventRow>, window?: PrWindow): PrOverviewResult {
+  const from = window?.from ?? null;
+  const to = window?.to ?? null;
+  const model = window?.model ?? null;
+  const prs = resolvePrs(rows).filter(pr =>
+    (!from || pr.openerAt >= from)
+    && (!to || pr.openerAt <= to)
+    && (!model || pr.model === model),
+  );
+
+  const byDayMap = new Map<string, SizeDist>();
+  const devMap = new Map<string, { prs: number; sizePoints: number; sizes: SizeDist; daily: Record<string, number> }>();
+  const modelMap = new Map<string, { prs: number; sizePoints: number; sizes: SizeDist; harnesses: Set<string> }>();
+  const resized = { count: 0, grew: 0, shrank: 0 };
+  const developers = new Set<string>();
+  let sizePoints = 0;
+
+  for (const pr of prs) {
+    sizePoints += pr.points;
+    developers.add(pr.user_key);
+
+    const day = byDayMap.get(pr.day) ?? emptyDist();
+    day[pr.bucket]++;
+    byDayMap.set(pr.day, day);
+
+    const dev = devMap.get(pr.user_key) ?? { prs: 0, sizePoints: 0, sizes: emptyDist(), daily: {} };
+    dev.prs++; dev.sizePoints += pr.points; dev.sizes[pr.bucket]++;
+    dev.daily[pr.day] = (dev.daily[pr.day] ?? 0) + 1;
+    devMap.set(pr.user_key, dev);
+
+    const mdl = modelMap.get(pr.model) ?? { prs: 0, sizePoints: 0, sizes: emptyDist(), harnesses: new Set<string>() };
+    mdl.prs++; mdl.sizePoints += pr.points; mdl.sizes[pr.bucket]++;
+    if (pr.harness) mdl.harnesses.add(pr.harness);
+    modelMap.set(pr.model, mdl);
+
+    // A PR is "resized" when a later sizing differs from the opener's.
+    if (pr.events > 1 && pr.points !== pr.openerPoints) {
+      resized.count++;
+      if (pr.points > pr.openerPoints) resized.grew++; else resized.shrank++;
+    }
+  }
+
+  // Median bucket across all PRs (ordinal on the XS–XL ramp). For an even count
+  // we take the lower of the two central buckets (no averaging — buckets are
+  // ordinal, not numeric).
+  let medianBucket: SizeBucket | null = null;
+  if (prs.length) {
+    const idx = prs.map(p => SIZE_BUCKETS.indexOf(p.bucket)).sort((a, b) => a - b);
+    medianBucket = SIZE_BUCKETS[idx[Math.floor((idx.length - 1) / 2)]];
+  }
+
+  const byDay = [...byDayMap.entries()]
+    .map(([day, sizes]) => ({ day, sizes, total: SIZE_BUCKETS.reduce((a, b) => a + sizes[b], 0) }))
+    .sort((a, b) => a.day.localeCompare(b.day));
+
+  const byDeveloper = [...devMap.entries()]
+    .map(([user_key, v]) => ({ user_key, ...v }))
+    .sort((a, b) => b.prs - a.prs || b.sizePoints - a.sizePoints || a.user_key.localeCompare(b.user_key));
+
+  const byModel = [...modelMap.entries()]
+    .map(([model, v]) => ({ model, prs: v.prs, sizePoints: v.sizePoints, sizes: v.sizes, harnesses: [...v.harnesses].sort() }))
+    .sort((a, b) => b.prs - a.prs || a.model.localeCompare(b.model));
+
+  return {
+    buckets: SIZE_BUCKETS,
+    totals: { prs: prs.length, sizePoints, developers: developers.size, medianBucket },
+    resized,
+    byDay,
+    byDeveloper,
+    byModel,
+  };
+}

--- a/packages/hub/src/routes/queries.ts
+++ b/packages/hub/src/routes/queries.ts
@@ -4,6 +4,7 @@ import { requireSession } from '../auth/session.js';
 import { recomputeRollups } from '../rollup.js';
 import { aggregateHistogramRows } from '../queries/histogram-aggregate.js';
 import { coerceMetricsRow } from '../queries/metrics-coerce.js';
+import { aggregatePrOverview, PrEventRow } from '../queries/pr-overview-aggregate.js';
 import { sanitizeRemoteUrl } from './events.js';
 
 function parseList(s: string | undefined): string[] | null {
@@ -202,6 +203,61 @@ export function queriesRouter(ctx: HubServerContext): Router {
     );
 
     res.json({ bucket, buckets: aggregateHistogramRows(rows) });
+  });
+
+  // PR Overview: total PRs per developer per size (XS–XL, derived from leaf
+  // items), per period, total + daily, with a model breakdown/filter. pr.updated
+  // re-sizes the same PR (counted once, at its latest sizing, attributed to the
+  // opener).
+  router.get('/prs/overview', guard, async (req: Request, res: Response) => {
+    const orgId = req.session!.orgId;
+    const f = readEventFilters(req);
+    const model = ((req.query.model as string | undefined) ?? '').trim() || null;
+
+    // Fetch PR events with only the UPPER time bound applied in SQL (`upTo`). The
+    // lower bound (`from`) and the model filter are intentionally NOT pushed down:
+    // the aggregator needs each PR's true opener to decide window membership and
+    // attribution, and a PR re-sized by a different runtime must still be matched
+    // by its OPENER's model — pushing model into SQL would fetch only the matching
+    // event and corrupt the opener. When `upTo` is null (open-ended), all events
+    // are read so "latest sizing wins" reflects every re-size.
+    const fetchRows = async (upTo: string | null): Promise<PrEventRow[]> => {
+      const base = applyEventFilters(orgId, { ...f, types: null, itemTypes: null, from: null, to: upTo });
+      const where = [...base.where, `type IN ('pr.opened', 'pr.updated')`];
+      return ctx.db.all<PrEventRow>(
+        `SELECT user_key, occurred_at, type,
+                json_extract(payload, '$.payload.repo') AS repo,
+                json_extract(payload, '$.payload.prNumber') AS pr_number,
+                json_extract(payload, '$.payload.leafStory') AS leaf_story,
+                json_extract(payload, '$.payload.sizingShadow.task') AS task,
+                json_extract(payload, '$.payload.sizingShadow.bug') AS bug,
+                json_extract(payload, '$.payload.model') AS model,
+                json_extract(payload, '$.payload.harness') AS harness
+         FROM events WHERE ${where.join(' AND ')}
+         ORDER BY occurred_at ASC`,
+        base.params,
+      );
+    };
+
+    const result = aggregatePrOverview(await fetchRows(f.to), { from: f.from, to: f.to, model });
+
+    // Previous equal-length window for deltas — only when a lower bound is set.
+    // The previous window's upper bound is EXCLUSIVE of `from` so a PR opened
+    // exactly at `from` is counted in the current window only, never both.
+    let previous: { prs: number; sizePoints: number } | null = null;
+    if (f.from) {
+      const toMs = (f.to ? new Date(f.to) : new Date()).getTime();
+      const fromMs = new Date(f.from).getTime();
+      if (Number.isFinite(toMs) && Number.isFinite(fromMs) && toMs > fromMs) {
+        const span = toMs - fromMs;
+        const prevFrom = new Date(fromMs - span).toISOString();
+        const prevTo = new Date(fromMs - 1).toISOString();
+        const prev = aggregatePrOverview(await fetchRows(prevTo), { from: prevFrom, to: prevTo, model });
+        previous = { prs: prev.totals.prs, sizePoints: prev.totals.sizePoints };
+      }
+    }
+
+    res.json({ period: { from: f.from, to: f.to }, ...result, previous });
   });
 
   return router;

--- a/packages/hub/src/test/pr-overview-aggregate.test.ts
+++ b/packages/hub/src/test/pr-overview-aggregate.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from 'vitest';
+import { aggregatePrOverview, PrEventRow } from '../queries/pr-overview-aggregate';
+
+// Helper to build a raw json_extract-shaped row.
+const row = (o: Partial<PrEventRow>): PrEventRow => ({
+  user_key: 'alice@acme.com',
+  occurred_at: '2026-05-03T10:00:00Z',
+  type: 'pr.opened',
+  repo: 'acme/api',
+  pr_number: 1,
+  leaf_story: 0,
+  task: 1,
+  bug: 0,
+  model: 'claude-opus-4-8',
+  harness: 'claude-code',
+  ...o,
+});
+
+describe('aggregatePrOverview', () => {
+  it('counts a single PR once and buckets it by size points', () => {
+    // 1 leaf story (×4) + 1 task (×2) = 6 → 's'
+    const r = aggregatePrOverview([row({ leaf_story: 1, task: 1 })]);
+    expect(r.totals.prs).toBe(1);
+    expect(r.totals.sizePoints).toBe(6);
+    expect(r.totals.developers).toBe(1);
+    expect(r.byDay).toEqual([
+      { day: '2026-05-03', sizes: { xs: 0, s: 1, m: 0, l: 0, xl: 0 }, total: 1 },
+    ]);
+    expect(r.byDeveloper[0].user_key).toBe('alice@acme.com');
+    expect(r.byDeveloper[0].sizes.s).toBe(1);
+  });
+
+  it('dedupes pr.updated onto the same PR — counts once, at the LATEST sizing', () => {
+    const rows = [
+      row({ pr_number: 7, type: 'pr.opened', occurred_at: '2026-05-03T10:00:00Z', task: 1, leaf_story: 0 }), // 2 pts → xs
+      row({ pr_number: 7, type: 'pr.updated', occurred_at: '2026-05-04T10:00:00Z', task: 4, leaf_story: 1 }), // 12 pts → m
+    ];
+    const r = aggregatePrOverview(rows);
+    expect(r.totals.prs).toBe(1); // counted ONCE
+    expect(r.totals.sizePoints).toBe(12); // latest sizing wins
+    // placed on the OPEN day, at its final (latest) size
+    expect(r.byDay).toEqual([
+      { day: '2026-05-03', sizes: { xs: 0, s: 0, m: 1, l: 0, xl: 0 }, total: 1 },
+    ]);
+    expect(r.resized).toEqual({ count: 1, grew: 1, shrank: 0 });
+  });
+
+  it('attributes a resized PR to its OPENER, not the later updater', () => {
+    const rows = [
+      row({ pr_number: 9, type: 'pr.opened', user_key: 'alice@acme.com', occurred_at: '2026-05-03T10:00:00Z', model: 'claude-opus-4-8' }),
+      row({ pr_number: 9, type: 'pr.updated', user_key: 'bob@acme.com', occurred_at: '2026-05-05T10:00:00Z', model: 'glm-5.2', task: 1, bug: 1 }),
+    ];
+    const r = aggregatePrOverview(rows);
+    expect(r.totals.developers).toBe(1);
+    expect(r.byDeveloper).toHaveLength(1);
+    expect(r.byDeveloper[0].user_key).toBe('alice@acme.com');
+    // model attribution also follows the opener
+    expect(r.byModel).toHaveLength(1);
+    expect(r.byModel[0].model).toBe('claude-opus-4-8');
+  });
+
+  it('rolls up per developer and per model with size distributions', () => {
+    const rows = [
+      row({ pr_number: 1, user_key: 'alice@acme.com', model: 'claude-opus-4-8', task: 1 }),        // 2 → xs
+      row({ pr_number: 2, user_key: 'alice@acme.com', model: 'claude-opus-4-8', leaf_story: 1, task: 4 }), // 12 → m
+      row({ pr_number: 3, user_key: 'bob@acme.com', model: 'claude-sonnet-4-6', task: 2 }),         // 4 → s
+    ];
+    const r = aggregatePrOverview(rows);
+    const alice = r.byDeveloper.find(d => d.user_key === 'alice@acme.com')!;
+    expect(alice.prs).toBe(2);
+    expect(alice.sizes).toEqual({ xs: 1, s: 0, m: 1, l: 0, xl: 0 });
+    expect(alice.sizePoints).toBe(14);
+    // byDeveloper sorted by prs desc → alice first
+    expect(r.byDeveloper[0].user_key).toBe('alice@acme.com');
+
+    const opus = r.byModel.find(m => m.model === 'claude-opus-4-8')!;
+    expect(opus.prs).toBe(2);
+    expect(opus.harnesses).toEqual(['claude-code']);
+    const sonnet = r.byModel.find(m => m.model === 'claude-sonnet-4-6')!;
+    expect(sonnet.prs).toBe(1);
+  });
+
+  it('classifies a PR that shrank on update', () => {
+    const rows = [
+      row({ pr_number: 5, type: 'pr.opened', occurred_at: '2026-05-03T10:00:00Z', leaf_story: 1, task: 4 }), // 12 → m
+      row({ pr_number: 5, type: 'pr.updated', occurred_at: '2026-05-04T10:00:00Z', leaf_story: 0, task: 1 }), // 2 → xs
+    ];
+    const r = aggregatePrOverview(rows);
+    expect(r.totals.sizePoints).toBe(2); // latest (smaller) sizing wins
+    expect(r.resized).toEqual({ count: 1, grew: 0, shrank: 1 });
+  });
+
+  it('a re-size that keeps the same points is not counted as resized', () => {
+    const rows = [
+      row({ pr_number: 6, type: 'pr.opened', occurred_at: '2026-05-03T10:00:00Z', task: 2 }),
+      row({ pr_number: 6, type: 'pr.updated', occurred_at: '2026-05-04T10:00:00Z', task: 2 }),
+    ];
+    expect(aggregatePrOverview(rows).resized).toEqual({ count: 0, grew: 0, shrank: 0 });
+  });
+
+  it('omits harness from a model row when no harness was reported', () => {
+    const r = aggregatePrOverview([row({ harness: null })]);
+    expect(r.byModel[0].harnesses).toEqual([]);
+  });
+
+  it('keeps a PR opened in-window even if a later event would fall outside it', () => {
+    const rows = [
+      row({ pr_number: 8, type: 'pr.opened', occurred_at: '2026-05-03T10:00:00Z' }),
+      row({ pr_number: 8, type: 'pr.updated', occurred_at: '2026-05-09T10:00:00Z', task: 3 }),
+    ];
+    // opener 05-03 is inside [05-01, 05-05]; the PR is kept and sized by the latest event.
+    const r = aggregatePrOverview(rows, { from: '2026-05-01T00:00:00Z', to: '2026-05-05T00:00:00Z' });
+    expect(r.totals.prs).toBe(1);
+    expect(r.byDay[0].day).toBe('2026-05-03');
+  });
+
+  it('excludes a PR opened before the window even if it was re-sized inside it', () => {
+    const rows = [
+      row({ pr_number: 10, type: 'pr.opened', occurred_at: '2026-04-20T10:00:00Z' }),
+      row({ pr_number: 10, type: 'pr.updated', occurred_at: '2026-05-03T10:00:00Z', task: 3 }),
+    ];
+    const r = aggregatePrOverview(rows, { from: '2026-05-01T00:00:00Z', to: '2026-05-05T00:00:00Z' });
+    expect(r.totals.prs).toBe(0); // opener is before `from`
+  });
+
+  it('model filter matches the OPENER model, even when a later re-size used another model', () => {
+    const rows = [
+      row({ pr_number: 11, type: 'pr.opened', user_key: 'alice@acme.com', occurred_at: '2026-05-03T10:00:00Z', model: 'claude-opus-4-8' }),
+      row({ pr_number: 11, type: 'pr.updated', user_key: 'bob@acme.com', occurred_at: '2026-05-04T10:00:00Z', model: 'glm-5.2', task: 3 }),
+      row({ pr_number: 12, type: 'pr.opened', user_key: 'bob@acme.com', occurred_at: '2026-05-03T11:00:00Z', model: 'glm-5.2' }),
+    ];
+    const opus = aggregatePrOverview(rows, { model: 'claude-opus-4-8' });
+    expect(opus.totals.prs).toBe(1); // PR#11 only (opened with opus); the glm re-size does not drop it
+    expect(opus.byDeveloper[0].user_key).toBe('alice@acme.com');
+
+    const glm = aggregatePrOverview(rows, { model: 'glm-5.2' });
+    expect(glm.totals.prs).toBe(1); // PR#12 only — PR#11 was OPENED with opus, not glm
+    expect(glm.byDeveloper[0].user_key).toBe('bob@acme.com');
+  });
+
+  it('computes the median bucket for an even number of PRs (lower-middle)', () => {
+    const rows = [
+      row({ pr_number: 1, task: 1 }),                 // xs (2)
+      row({ pr_number: 2, task: 2 }),                 // s (4)
+      row({ pr_number: 3, leaf_story: 1, task: 4 }),  // m (12)
+      row({ pr_number: 4, leaf_story: 4, task: 4 }),  // l (24)
+    ];
+    // 4 PRs → buckets [xs,s,m,l]; lower-middle of the two centres (s,m) → s
+    expect(aggregatePrOverview(rows).totals.medianBucket).toBe('s');
+  });
+
+  it('computes the median bucket across PRs', () => {
+    const rows = [
+      row({ pr_number: 1, task: 1 }),                 // xs (2)
+      row({ pr_number: 2, task: 2 }),                 // s (4)
+      row({ pr_number: 3, leaf_story: 1, task: 4 }),  // m (12)
+    ];
+    const r = aggregatePrOverview(rows);
+    expect(r.totals.medianBucket).toBe('s');
+  });
+
+  it('labels missing model as "unknown" and tolerates missing leafStory (old events)', () => {
+    const r = aggregatePrOverview([row({ model: null, leaf_story: null, task: 1 })]);
+    expect(r.byModel[0].model).toBe('unknown');
+    expect(r.totals.sizePoints).toBe(2); // leaf_story null treated as 0
+  });
+
+  it('ignores rows without a repo/prNumber', () => {
+    const r = aggregatePrOverview([row({ repo: null }), row({ pr_number: null })]);
+    expect(r.totals.prs).toBe(0);
+    expect(r.totals.medianBucket).toBeNull();
+  });
+});

--- a/packages/hub/src/test/queries.test.ts
+++ b/packages/hub/src/test/queries.test.ts
@@ -422,3 +422,94 @@ describe('hub query endpoints', () => {
     expect(after[0]?.tokens_in).toBe(0);
   });
 });
+
+describe('GET /v1/prs/overview', () => {
+  let app: any;
+  let ctx: any;
+  let cookie: string;
+
+  beforeEach(async () => {
+    cleanup();
+    const out = await createHubApp({
+      dbPath: TEST_DB,
+      secretKey: SECRET,
+      sessionSecret: 'test-session-secret',
+      defaultOrgId: 'org',
+    });
+    app = out.app;
+    ctx = out.ctx;
+    await createPasswordUser(ctx.db, 'org', 'admin@x', 'longenough1', 'admin');
+    const login = await supertest(app).post('/auth/login').send({ email: 'admin@x', password: 'longenough1' });
+    cookie = login.headers['set-cookie']?.[0] ?? '';
+
+    const token = await issueApiKey(ctx.db, 'org', 'test');
+    const send = (events: any[]) =>
+      supertest(app).post('/v1/events').set('Authorization', `Bearer ${token}`).send({ events });
+
+    const pr = (over: any) => sample({
+      type: 'pr.opened',
+      remoteUrl: 'git@github.com:acme/api.git',
+      ...over,
+      payload: { prNumber: over.prNumber, repo: 'acme/api', model: over.model, harness: 'claude-code',
+        sizing: over.sizing, sizingShadow: over.sizing, leafStory: over.leafStory ?? 0 },
+    });
+
+    await send([
+      // alice: PR#1 opened small (1 task → 2pts → xs)
+      pr({ eventId: 'p1', occurredAt: '2026-05-03T10:00:00Z',
+        actor: { osUser: 'alice', gitName: 'A', gitEmail: 'alice@acme.com' },
+        prNumber: 1, model: 'claude-opus-4-8', sizing: { epic: 0, story: 0, task: 1, bug: 0 } }),
+      // alice: PR#2 opened then resized bigger (leafStory 1 + task 4 → 12pts → m)
+      pr({ eventId: 'p2a', occurredAt: '2026-05-03T11:00:00Z',
+        actor: { osUser: 'alice', gitName: 'A', gitEmail: 'alice@acme.com' },
+        prNumber: 2, model: 'claude-opus-4-8', sizing: { epic: 0, story: 1, task: 1, bug: 0 }, leafStory: 1 }),
+      pr({ eventId: 'p2b', type: 'pr.updated', occurredAt: '2026-05-04T09:00:00Z',
+        actor: { osUser: 'alice', gitName: 'A', gitEmail: 'alice@acme.com' },
+        prNumber: 2, model: 'claude-opus-4-8', sizing: { epic: 0, story: 1, task: 4, bug: 0 }, leafStory: 1 }),
+      // bob: PR#3 (2 tasks → 4pts → s) via a different model
+      pr({ eventId: 'p3', occurredAt: '2026-05-04T10:00:00Z',
+        actor: { osUser: 'bob', gitName: 'B', gitEmail: 'bob@acme.com' },
+        prNumber: 3, model: 'claude-sonnet-4-6', sizing: { epic: 0, story: 0, task: 2, bug: 0 } }),
+    ]);
+  });
+
+  afterEach(async () => { await ctx.db.close(); cleanup(); });
+
+  it('requires a session', async () => {
+    const r = await supertest(app).get('/v1/prs/overview');
+    expect(r.status).toBe(401);
+  });
+
+  it('returns totals, per-developer, per-model, daily and resize breakdowns', async () => {
+    const r = await supertest(app).get('/v1/prs/overview').set('Cookie', cookie);
+    expect(r.status).toBe(200);
+    expect(r.body.buckets).toEqual(['xs', 's', 'm', 'l', 'xl']);
+    // 3 distinct PRs (the pr.updated must NOT add a 4th)
+    expect(r.body.totals.prs).toBe(3);
+    expect(r.body.totals.developers).toBe(2);
+    expect(r.body.resized).toEqual({ count: 1, grew: 1, shrank: 0 });
+
+    const alice = r.body.byDeveloper.find((d: any) => d.user_key === 'alice@acme.com');
+    expect(alice.prs).toBe(2);
+    expect(alice.sizes).toEqual({ xs: 1, s: 0, m: 1, l: 0, xl: 0 }); // PR#2 counted at its LATEST (m) size
+
+    const opus = r.body.byModel.find((m: any) => m.model === 'claude-opus-4-8');
+    expect(opus.prs).toBe(2);
+  });
+
+  it('filters by model', async () => {
+    const r = await supertest(app).get('/v1/prs/overview?model=claude-sonnet-4-6').set('Cookie', cookie);
+    expect(r.status).toBe(200);
+    expect(r.body.totals.prs).toBe(1);
+    expect(r.body.byModel).toHaveLength(1);
+    expect(r.body.byModel[0].model).toBe('claude-sonnet-4-6');
+  });
+
+  it('filters by date range', async () => {
+    const r = await supertest(app).get('/v1/prs/overview?from=2026-05-04T00:00:00Z').set('Cookie', cookie);
+    expect(r.status).toBe(200);
+    // Only bob's PR#3 was opened on 05-04 (alice's PRs opened 05-03)
+    expect(r.body.totals.prs).toBe(1);
+    expect(r.body.byDeveloper[0].user_key).toBe('bob@acme.com');
+  });
+});

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -2,7 +2,7 @@ import express from "express";
 import cors from "cors";
 import bodyParser from "body-parser";
 import { SQLiteStorageProvider } from "@agenfk/storage-sqlite";
-import { StorageProvider, ItemType, Status, AgEnFKItem, Project, ReviewRecord, migrateCardsToFlow, Flow, DEFAULT_FLOW, getActiveFlow, getActiveStepItems } from "@agenfk/core";
+import { StorageProvider, ItemType, Status, AgEnFKItem, Project, ReviewRecord, migrateCardsToFlow, Flow, DEFAULT_FLOW, getActiveFlow, getActiveStepItems, computeSizingFromItems, SizingCounts } from "@agenfk/core";
 import { TelemetryClient, getInstallationId, isTelemetryEnabled, getInstallSource, findAvailablePort, writeServerPortFile, removeServerPortFile, DEFAULT_API_PORT } from "@agenfk/telemetry";
 import { HubClient, Flusher, loadHubConfig } from "./hub/index.js";
 import type { RecordEventInput } from "./hub/index.js";
@@ -847,26 +847,25 @@ app.get("/flows", asyncHandler(async (_req: any, res: any) => {
 // shadow sizing by walking the item tree from the anchor item — logged for
 // discrepancy detection but never overrides the agent's number.
 
-async function computeShadowSizing(rootItemId: string): Promise<{ epic: number; story: number; task: number; bug: number }> {
-  const counts = { epic: 0, story: 0, task: 0, bug: 0 };
+// Walks the item subtree anchored at `rootItemId` and returns per-tier counts,
+// including `leafStory` (STORYs with no children). The leaf-story count lets the
+// hub size a PR by its atomic work without double-counting container tiers.
+async function computeShadowSizing(rootItemId: string): Promise<SizingCounts> {
+  const empty: SizingCounts = { epic: 0, story: 0, task: 0, bug: 0, leafStory: 0 };
   const root = await storage.getItem(rootItemId);
-  if (!root) return counts;
+  if (!root) return empty;
+  const collected: Array<{ id: string; type: string; parentId?: string | null }> = [];
   const stack: any[] = [root];
   const seen = new Set<string>();
   while (stack.length) {
     const node = stack.pop()!;
     if (seen.has(node.id)) continue;
     seen.add(node.id);
-    switch (node.type) {
-      case 'EPIC':  counts.epic++;  break;
-      case 'STORY': counts.story++; break;
-      case 'TASK':  counts.task++;  break;
-      case 'BUG':   counts.bug++;   break;
-    }
+    collected.push({ id: node.id, type: node.type, parentId: node.parentId ?? null });
     const children = await storage.listChildren(node.id);
     for (const c of children) stack.push(c);
   }
-  return counts;
+  return computeSizingFromItems(collected);
 }
 
 app.post("/prs", asyncHandler(async (req: any, res: any) => {
@@ -894,7 +893,10 @@ app.post("/prs", asyncHandler(async (req: any, res: any) => {
   // therefore can't both see "not registered" and both emit pr.opened — exactly
   // one wins the unique index. (Security: bug fe03d054.)
   const newId = crypto.randomUUID();
-  const shadow = await computeShadowSizing(itemId);
+  const shadowCounts = await computeShadowSizing(itemId);
+  // Stored sizingShadow keeps the flat PrSizing shape; leafStory rides separately
+  // in the hub payload so the hub can size by leaf work.
+  const shadow = { epic: shadowCounts.epic, story: shadowCounts.story, task: shadowCounts.task, bug: shadowCounts.bug };
   const effectiveSizing = sizingProvided ? sizing : shadow;
   const now = new Date().toISOString();
   const pr = await storage.insertPr({
@@ -928,6 +930,7 @@ app.post("/prs", asyncHandler(async (req: any, res: any) => {
     // the server process cannot infer them). Optional — omitted when not supplied.
     payload: {
       prNumber, repo, sizing: effectiveSizing, sizingShadow: shadow,
+      leafStory: shadowCounts.leafStory,
       ...(typeof model === 'string' && model ? { model } : {}),
       ...(typeof harness === 'string' && harness ? { harness } : {}),
     },
@@ -955,7 +958,8 @@ app.put("/prs/:repo/:number", asyncHandler(async (req: any, res: any) => {
   const existing = await storage.getPrByRepoNumber(repo, prNumber);
   if (!existing) return res.status(404).json({ error: `PR ${repo}#${prNumber} not registered` });
 
-  const shadow = await computeShadowSizing(existing.itemId);
+  const shadowCounts = await computeShadowSizing(existing.itemId);
+  const shadow = { epic: shadowCounts.epic, story: shadowCounts.story, task: shadowCounts.task, bug: shadowCounts.bug };
   const updated = await storage.updatePrSizing(repo, prNumber, sizing, shadow);
 
   const matches =
@@ -973,6 +977,7 @@ app.put("/prs/:repo/:number", asyncHandler(async (req: any, res: any) => {
     projectId: anchorItem?.projectId,
     payload: {
       prNumber, repo, sizing, sizingShadow: shadow,
+      leafStory: shadowCounts.leafStory,
       ...(typeof model === 'string' && model ? { model } : {}),
       ...(typeof harness === 'string' && harness ? { harness } : {}),
     },

--- a/packages/server/src/test/pr-registration-api.test.ts
+++ b/packages/server/src/test/pr-registration-api.test.ts
@@ -171,6 +171,28 @@ describe('REST: POST /prs and PUT /prs/:repo/:number', () => {
     expect(res.body.sizing).toEqual({ epic: 1, story: 1, task: 99, bug: 99 }); // agent's number persists
     expect(res.body.sizingShadow).toEqual({ epic: 1, story: 1, task: 2, bug: 1 }); // server's truth
   });
+
+  it('POST /prs emits a leafStory count (stories with no subtasks) in the pr.opened payload', async () => {
+    process.env.AGENFK_DB_PATH = TEST_DB;
+    await initStorage();
+    const project = (await request(app).post('/projects').send({ name: 'PLS' })).body;
+    const epic = (await request(app).post('/items').send({ projectId: project.id, type: 'EPIC', title: 'E' })).body;
+    // s1 is a container (has a task); s2 is a LEAF story (no children).
+    const s1 = (await request(app).post('/items').send({ projectId: project.id, type: 'STORY', title: 'S1', parentId: epic.id })).body;
+    await request(app).post('/items').send({ projectId: project.id, type: 'TASK', title: 'T', parentId: s1.id });
+    await request(app).post('/items').send({ projectId: project.id, type: 'STORY', title: 'S2 (leaf)', parentId: epic.id });
+
+    const res = await request(app).post('/prs').send({
+      itemId: epic.id, prNumber: 800, repo: 'foo/leaf',
+      model: 'claude-opus-4-8', harness: 'claude-code',
+    });
+    expect(res.status).toBe(201);
+
+    const ev = await waitForOutboxPayload((p: any) => p.type === 'pr.opened' && p.payload?.prNumber === 800);
+    expect(ev).toBeDefined();
+    expect(ev.payload?.leafStory).toBe(1); // only S2 is a leaf story
+    expect(ev.payload?.sizingShadow).toEqual({ epic: 1, story: 2, task: 1, bug: 0 });
+  });
 });
 
 describe('agent-declared model + harness on PR events', () => {


### PR DESCRIPTION
## What

A new **PR Overview** analytics page in the hub UI (`/prs`): total PRs per developer, by size (XS–XL), per period — total and daily — with a model breakdown/filter.

## Size model (leaf-based, no double-counting)

`size_points = leafStory×4 + task×2 + bug×1`

An Epic rolls up its Stories, and a Story rolls up its Tasks/Bugs, so summing all four tiers double-counts. We size by the **atomic leaves**; a Story with no children is itself a leaf and scores ×4. Buckets: XS 0–2 · S 3–6 · M 7–14 · L 15–30 · XL 31+.

`pr.updated` re-buckets the **same** PR (counted once, at its latest sizing); attribution and open-day stay with the **opener**.

## Changes

- **core** (`sizing.ts`): shared `computeSizingFromItems` / `prSizePoints` / `prSizeBucket`.
- **server**: `computeShadowSizing` now counts leaf stories and emits `leafStory` in the `pr.opened`/`pr.updated` payload. `sizingShadow` keeps its flat `{epic,story,task,bug}` shape.
- **hub**: `GET /v1/prs/overview` — dedup on `pr.updated`, opener attribution, daily / per-developer / per-model rollups, equal-length previous-period deltas (exclusive boundary so `from` isn't double-counted), model filter matched on the opener's model.
- **hub-ui**: PR Overview page + nav entry.

## Tests

Full suite green (1680 passing) + clean build. New coverage: core sizing math & bucket thresholds, hub aggregator (dedup, opener attribution, model filter, window semantics, even/odd median, resize grew/shrank), the `/v1/prs/overview` endpoint, spoke `leafStory` emission, and hub-ui helpers.

Went through an adversarial senior review; the two real defects it surfaced (previous-period boundary double-count, model-filter opener-attribution corruption) are fixed and regression-tested.

https://claude.ai/code/session_01W3ct4ECvAzsWVpodPCMjv1