### PR TITLE
fix(hub): normalize Postgres row shapes in PR Overview aggregator

### DIFF
--- a/packages/hub/src/queries/pr-overview-aggregate.ts
+++ b/packages/hub/src/queries/pr-overview-aggregate.ts
@@ -2,17 +2,61 @@ import { prSizePoints, prSizeBucket, SIZE_BUCKETS, SizeBucket } from '@agenfk/co
 
 // One json_extract-shaped row per pr.opened / pr.updated event. Sizing fields are
 // read from the server-computed shadow (the only source that knows leaf stories).
+//
+// Field types intentionally allow both backends' shapes: SQLite returns TEXT
+// (string) timestamps and INTEGER numerics, while Postgres returns TIMESTAMPTZ as
+// a JS Date and jsonb_extract_path_text numerics as strings. normaliseRow()
+// reconciles them before any aggregation.
 export interface PrEventRow {
   user_key: string;
-  occurred_at: string;
+  occurred_at: string | Date;
   type: string; // 'pr.opened' | 'pr.updated'
   repo: string | null;
-  pr_number: number | null;
-  leaf_story: number | null;
-  task: number | null;
-  bug: number | null;
+  pr_number: number | string | null;
+  leaf_story: number | string | null;
+  task: number | string | null;
+  bug: number | string | null;
   model: string | null;
   harness: string | null;
+}
+
+// Normalised, backend-agnostic event used internally.
+interface NormRow {
+  user_key: string;
+  occurred_at: string; // ISO-8601 UTC
+  type: string;
+  repo: string | null;
+  pr_number: string | null;
+  leafStory: number;
+  task: number;
+  bug: number;
+  model: string | null;
+  harness: string | null;
+}
+
+const toIso = (v: unknown): string =>
+  v instanceof Date ? v.toISOString()
+    : typeof v === 'string' ? v
+      : new Date(v as never).toISOString();
+
+const toNum = (v: unknown): number => {
+  const n = v == null ? 0 : typeof v === 'number' ? v : Number(v);
+  return Number.isFinite(n) ? n : 0;
+};
+
+function normaliseRow(r: PrEventRow): NormRow {
+  return {
+    user_key: r.user_key,
+    occurred_at: toIso(r.occurred_at),
+    type: r.type,
+    repo: r.repo,
+    pr_number: r.pr_number == null ? null : String(r.pr_number),
+    leafStory: toNum(r.leaf_story),
+    task: toNum(r.task),
+    bug: toNum(r.bug),
+    model: r.model,
+    harness: r.harness,
+  };
 }
 
 type SizeDist = Record<SizeBucket, number>;
@@ -28,8 +72,8 @@ export interface PrOverviewResult {
 
 const emptyDist = (): SizeDist => ({ xs: 0, s: 0, m: 0, l: 0, xl: 0 });
 const dayOf = (iso: string): string => iso.slice(0, 10);
-const pointsOf = (r: PrEventRow): number =>
-  prSizePoints({ leafStory: r.leaf_story, task: r.task, bug: r.bug });
+const pointsOf = (r: NormRow): number =>
+  prSizePoints({ leafStory: r.leafStory, task: r.task, bug: r.bug });
 
 /** Optional opener-day window + model filter. The window is applied to the PR's
  *  OPEN time, not to individual events — so a PR opened before `from` is excluded
@@ -55,8 +99,9 @@ interface ResolvedPr {
 // new PR — it re-sizes the existing one. The PR is counted once, placed on its
 // OPEN day at its LATEST size, and attributed to whoever OPENED it.
 function resolvePrs(rows: ReadonlyArray<PrEventRow>): ResolvedPr[] {
-  const groups = new Map<string, PrEventRow[]>();
-  for (const r of rows) {
+  const groups = new Map<string, NormRow[]>();
+  for (const raw of rows) {
+    const r = normaliseRow(raw);
     if (!r.repo || r.pr_number == null) continue; // not a sizeable PR event
     const key = `${r.repo}#${r.pr_number}`;
     const g = groups.get(key);

--- a/packages/hub/src/test/pr-overview-aggregate.test.ts
+++ b/packages/hub/src/test/pr-overview-aggregate.test.ts
@@ -165,6 +165,48 @@ describe('aggregatePrOverview', () => {
     expect(r.totals.sizePoints).toBe(2); // leaf_story null treated as 0
   });
 
+  it('handles Postgres row shapes — Date occurred_at and string-typed numerics', () => {
+    // On Postgres, occurred_at (TIMESTAMPTZ) comes back as a JS Date and
+    // jsonb_extract_path_text numerics come back as strings. The aggregator must
+    // normalise both rather than calling .slice()/.localeCompare() on a Date or
+    // doing string math. (Regression: prod 500 "iso.slice is not a function".)
+    const pgRow = (o: Record<string, unknown>) => ({
+      user_key: 'alice@acme.com',
+      occurred_at: new Date('2026-05-03T10:00:00Z'),
+      type: 'pr.opened',
+      repo: 'acme/api',
+      pr_number: '7',          // pg returns text
+      leaf_story: '1',
+      task: '4',
+      bug: '0',
+      model: 'claude-opus-4-8',
+      harness: 'claude-code',
+      ...o,
+    }) as unknown as PrEventRow;
+
+    const r = aggregatePrOverview([
+      pgRow({}),
+      pgRow({ type: 'pr.updated', occurred_at: new Date('2026-05-04T10:00:00Z'), task: '1', leaf_story: '0' }),
+    ]);
+    expect(r.totals.prs).toBe(1);
+    expect(r.totals.sizePoints).toBe(2); // latest: leafStory 0 + task 1 → 2
+    expect(r.byDay).toEqual([
+      { day: '2026-05-03', sizes: { xs: 1, s: 0, m: 0, l: 0, xl: 0 }, total: 1 },
+    ]);
+    expect(r.resized).toEqual({ count: 1, grew: 0, shrank: 1 });
+  });
+
+  it('applies the opener-day window correctly when occurred_at is a Date (Postgres)', () => {
+    const r = aggregatePrOverview(
+      [{
+        user_key: 'a@x', occurred_at: new Date('2026-05-03T10:00:00Z'), type: 'pr.opened',
+        repo: 'acme/api', pr_number: 1, leaf_story: 0, task: 1, bug: 0, model: 'm', harness: 'h',
+      } as unknown as PrEventRow],
+      { from: '2026-05-01T00:00:00Z', to: '2026-05-05T00:00:00Z' },
+    );
+    expect(r.totals.prs).toBe(1); // Date openerAt must compare correctly against ISO bounds
+  });
+
   it('ignores rows without a repo/prNumber', () => {
     const r = aggregatePrOverview([row({ repo: null }), row({ pr_number: null })]);
     expect(r.totals.prs).toBe(0);


### PR DESCRIPTION
## Bug

The PR Overview endpoint (`GET /v1/prs/overview`, merged in #104) returned **HTTP 500 — `iso.slice is not a function`** on the Postgres-backed (enterprise) hub.

## Cause

`aggregatePrOverview` assumed SQLite row shapes, but Postgres returns them differently:
- `occurred_at` (`TIMESTAMPTZ`) → a JS **`Date`**, so `iso.slice(...)` and `.localeCompare(...)` threw.
- `json_extract` → `jsonb_extract_path_text`, so `leaf_story`/`task`/`bug` came back as **strings**.
- The opener-day window `openerAt >= from` compared a `Date` to an ISO string → coerced to `NaN` and **silently dropped every row**.

SQLite (TEXT/INTEGER) masked all three, so the suite was green.

## Fix

Normalize every row up front (`Date`→ISO string, numeric strings→numbers) so the aggregator is backend-agnostic. Pure-function change; no SQL or API change.

## Tests

Added Postgres-shaped regression tests (Date `occurred_at`, string numerics). Full suite green (1682).

https://claude.ai/code/session_01W3ct4ECvAzsWVpodPCMjv1