### PR TITLE
feat(hub): PR Overview per-slice tooltip + developer & date-range filters

### DIFF
--- a/packages/hub-ui/src/pages/PrOverview.tsx
+++ b/packages/hub-ui/src/pages/PrOverview.tsx
@@ -21,7 +21,12 @@ interface PrOverviewResponse {
   buckets: SizeKey[];
   totals: { prs: number; sizePoints: number; developers: number; medianBucket: SizeKey | null };
   resized: { count: number; grew: number; shrank: number };
-  byDay: Array<{ day: string; sizes: SizeDist; total: number }>;
+  byDay: Array<{
+    day: string;
+    sizes: SizeDist;
+    total: number;
+    devBySize: Record<SizeKey, Array<{ user_key: string; count: number }>>;
+  }>;
   byDeveloper: Array<{ user_key: string; prs: number; sizePoints: number; sizes: SizeDist; daily: Record<string, number> }>;
   byModel: Array<{ model: string; harnesses: string[]; prs: number; sizePoints: number; sizes: SizeDist }>;
   previous: { prs: number; sizePoints: number } | null;
@@ -29,6 +34,8 @@ interface PrOverviewResponse {
 interface ProjectsResponse { projects: string[] }
 
 const EMPTY: SizeDist = { xs: 0, s: 0, m: 0, l: 0, xl: 0 };
+// XL→XS so the stacked bar renders largest at the bottom. Hoisted out of render.
+const SIZE_META_DESC = [...SIZE_META].reverse();
 const colorOf = (k: SizeKey) => SIZE_META.find(s => s.key === k)!.color;
 
 function DeltaBadge({ value }: { value: number | null }) {
@@ -97,42 +104,66 @@ function Sparkline({ daily, axis }: { daily: Record<string, number>; axis: strin
 
 export function PrOverviewPage() {
   const projectSel = useToggleSet([], { storageKey: 'agenfk-hub:prs:projects' });
+  const devSel = useToggleSet([], { storageKey: 'agenfk-hub:prs:developers' });
   const [range, setRange] = useState<RangeKey>('30d');
   const [model, setModel] = useState<string>('');
+  // Explicit date range (YYYY-MM-DD); when set it overrides the preset range.
+  const [customFrom, setCustomFrom] = useState<string>('');
+  const [customTo, setCustomTo] = useState<string>('');
 
-  const from = useMemo(() => fromIsoForRange(new Date(), range), [range]);
+  const from = useMemo(
+    () => (customFrom ? `${customFrom}T00:00:00.000Z` : fromIsoForRange(new Date(), range)),
+    [customFrom, range],
+  );
+  // Inclusive end-of-day so a PR opened any time on `customTo` is counted.
+  const toParam = customTo ? `${customTo}T23:59:59.999Z` : '';
 
+  // Shared filters (project + date window). Model and developer are NOT here —
+  // they're applied only to the data query, so the options query can list the
+  // full set of models/developers available in the window.
   const baseQs = useMemo(() => {
     const p = new URLSearchParams();
     if (projectSel.set.size) p.set('projects', [...projectSel.set].join(','));
     p.set('from', from);
+    if (toParam) p.set('to', toParam);
     return p;
-  }, [projectSel.set, from]);
+  }, [projectSel.set, from, toParam]);
 
   const dataQs = useMemo(() => {
     const p = new URLSearchParams(baseQs);
     if (model) p.set('model', model);
+    if (devSel.set.size) p.set('users', [...devSel.set].join(','));
     return p.toString();
-  }, [baseQs, model]);
+  }, [baseQs, model, devSel.set]);
 
   const overview = useQuery<PrOverviewResponse>({
     queryKey: ['pr-overview', dataQs],
     queryFn: async () => (await api.get(`/v1/prs/overview?${dataQs}`)).data,
   });
 
-  // Model dropdown options come from the UNFILTERED overview (same project +
-  // period). When no model is selected the main `overview` already holds the
-  // full list, so we only run a second request once a model is picked.
+  // Model + developer dropdown options come from the overview UNFILTERED by
+  // model/developer (same project + window). When neither filter is active the
+  // main `overview` already holds the full lists, so the extra request only runs
+  // once a model or developer is selected.
+  const filtersActive = !!model || devSel.set.size > 0;
   const optionsQuery = useQuery<PrOverviewResponse>({
-    queryKey: ['pr-overview-models', baseQs.toString()],
+    queryKey: ['pr-overview-opts', baseQs.toString()],
     queryFn: async () => (await api.get(`/v1/prs/overview?${baseQs.toString()}`)).data,
-    enabled: !!model,
+    enabled: filtersActive,
+    placeholderData: prev => prev, // keep prior options during refetch — don't blank the facet
   });
-  const modelOptions = (model ? optionsQuery.data : overview.data)?.byModel.map(m => m.model) ?? [];
+  // While the unfiltered options query is still loading, fall back to the main
+  // overview so the Developer/Model controls (and the selected chip) never vanish.
+  const optionsData = (filtersActive ? optionsQuery.data : overview.data) ?? overview.data;
+  const modelOptions = optionsData?.byModel.map(m => m.model) ?? [];
+  const devOptions = optionsData?.byDeveloper.map(x => x.user_key) ?? [];
   const projects = useQuery<ProjectsResponse>({ queryKey: ['projects'], queryFn: async () => (await api.get('/v1/projects')).data });
 
+  // Picking a preset clears any explicit date range so the two don't fight.
+  const pickRange = (r: RangeKey) => { setRange(r); setCustomFrom(''); setCustomTo(''); };
+
   const d = overview.data;
-  const to = d?.period.to ?? new Date().toISOString();
+  const to = d?.period.to ?? (toParam || new Date().toISOString());
   const axis = useMemo(() => (d ? buildDayAxis(from, to) : []), [d, from, to]);
   const maxDayTotal = Math.max(1, ...(d?.byDay.map(x => x.total) ?? [1]));
   const byDayMap = useMemo(() => new Map((d?.byDay ?? []).map(x => [x.day, x])), [d]);
@@ -157,17 +188,48 @@ export function PrOverviewPage() {
             {modelOptions.map(m => <option key={m} value={m}>{m}</option>)}
           </select>
           <div className="inline-flex rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800 p-0.5 text-[11px] font-medium">
-            {RANGES.map(r => (
+            {RANGES.map(r => {
+              const active = !customFrom && !customTo && range === r.key;
+              return (
+                <button
+                  key={r.key}
+                  onClick={() => pickRange(r.key)}
+                  className={`px-2.5 py-1 rounded-md transition-colors ${active
+                    ? 'bg-white dark:bg-slate-900 text-indigo-600 dark:text-indigo-400 shadow-sm'
+                    : 'text-slate-500 hover:text-slate-700 dark:hover:text-slate-300'}`}
+                >
+                  {r.label}
+                </button>
+              );
+            })}
+          </div>
+          <div className="inline-flex items-center gap-1 text-[11px] text-slate-500 dark:text-slate-400">
+            <input
+              type="date"
+              value={customFrom}
+              max={customTo || undefined}
+              onChange={e => setCustomFrom(e.target.value)}
+              aria-label="From date"
+              className="rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 text-slate-700 dark:text-slate-200 px-2 py-1"
+            />
+            <span>→</span>
+            <input
+              type="date"
+              value={customTo}
+              min={customFrom || undefined}
+              onChange={e => setCustomTo(e.target.value)}
+              aria-label="To date"
+              className="rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 text-slate-700 dark:text-slate-200 px-2 py-1"
+            />
+            {(customFrom || customTo) && (
               <button
-                key={r.key}
-                onClick={() => setRange(r.key)}
-                className={`px-2.5 py-1 rounded-md transition-colors ${range === r.key
-                  ? 'bg-white dark:bg-slate-900 text-indigo-600 dark:text-indigo-400 shadow-sm'
-                  : 'text-slate-500 hover:text-slate-700 dark:hover:text-slate-300'}`}
+                onClick={() => { setCustomFrom(''); setCustomTo(''); }}
+                className="ml-0.5 px-1.5 py-1 rounded-md text-slate-400 hover:text-rose-600 dark:hover:text-rose-400"
+                title="Clear date range"
               >
-                {r.label}
+                ✕
               </button>
-            ))}
+            )}
           </div>
         </div>
       </header>
@@ -181,6 +243,16 @@ export function PrOverviewPage() {
         optionLabel={shortRemote}
         inlineThreshold={6}
         placeholder="Search projects…"
+      />
+
+      <FacetMultiselect
+        label="Developer"
+        options={devOptions}
+        selected={devSel.set}
+        onToggle={devSel.toggle}
+        onClear={devSel.clear}
+        inlineThreshold={6}
+        placeholder="Search developers…"
       />
 
       {overview.isLoading && <div className="text-sm text-slate-500 py-8 text-center">Loading…</div>}
@@ -236,11 +308,24 @@ export function PrOverviewPage() {
             <div className="overflow-x-auto">
               <div className="flex items-end gap-1.5 h-44 min-w-[420px]">
                 {axis.map(day => {
-                  const entry = byDayMap.get(day) ?? { sizes: EMPTY, total: 0 };
+                  const entry = byDayMap.get(day);
+                  const sizes = entry?.sizes ?? EMPTY;
+                  const total = entry?.total ?? 0;
+                  const sliceTitle = (key: SizeKey, label: string) => {
+                    const devs = entry?.devBySize?.[key] ?? [];
+                    const head = `${label} · ${day} · ${sizes[key]} PR${sizes[key] === 1 ? '' : 's'}`;
+                    const lines = devs.map(x => `  ${x.user_key}: ${x.count}`).join('\n');
+                    return lines ? `${head}\n${lines}` : head;
+                  };
                   return (
-                    <div key={day} className="flex-1 flex flex-col justify-end gap-0.5 h-full group" title={`${day}: ${entry.total} PRs`}>
-                      {SIZE_META.slice().reverse().filter(s => entry.sizes[s.key] > 0).map(s => (
-                        <div key={s.key} style={{ background: s.color, height: `${(entry.sizes[s.key] / maxDayTotal) * 100}%` }} className="rounded-[2px]" />
+                    <div key={day} className="flex-1 flex flex-col justify-end gap-0.5 h-full group" title={`${day}: ${total} PR${total === 1 ? '' : 's'}`}>
+                      {SIZE_META_DESC.filter(s => sizes[s.key] > 0).map(s => (
+                        <div
+                          key={s.key}
+                          style={{ background: s.color, height: `${(sizes[s.key] / maxDayTotal) * 100}%` }}
+                          className="rounded-[2px] hover:opacity-80 transition-opacity cursor-default"
+                          title={sliceTitle(s.key, s.label)}
+                        />
                       ))}
                     </div>
                   );

--- a/packages/hub/src/queries/pr-overview-aggregate.ts
+++ b/packages/hub/src/queries/pr-overview-aggregate.ts
@@ -65,7 +65,14 @@ export interface PrOverviewResult {
   buckets: readonly SizeBucket[];
   totals: { prs: number; sizePoints: number; developers: number; medianBucket: SizeBucket | null };
   resized: { count: number; grew: number; shrank: number };
-  byDay: Array<{ day: string; sizes: SizeDist; total: number }>;
+  byDay: Array<{
+    day: string;
+    sizes: SizeDist;
+    total: number;
+    // Per-size developer breakdown for slice tooltips: devBySize[size] = the
+    // developers who opened a PR of that size on that day, with their counts.
+    devBySize: Record<SizeBucket, Array<{ user_key: string; count: number }>>;
+  }>;
   byDeveloper: Array<{ user_key: string; prs: number; sizePoints: number; sizes: SizeDist; daily: Record<string, number> }>;
   byModel: Array<{ model: string; harnesses: string[]; prs: number; sizePoints: number; sizes: SizeDist }>;
 }
@@ -80,8 +87,15 @@ const pointsOf = (r: NormRow): number =>
  *  even if it was re-sized within the window (the update alone must not make it
  *  look new). Pass rows fetched WITHOUT a lower time bound so true openers are
  *  visible. The model filter likewise matches the OPENER's model, so a PR re-sized
- *  by a different runtime stays attributed to whoever opened it. */
-export interface PrWindow { from?: string | null; to?: string | null; model?: string | null }
+ *  by a different runtime stays attributed to whoever opened it. The developer
+ *  filter is likewise opener-based — a PR opened by X but re-sized by Y still
+ *  belongs to X, so filtering by Y must not pull it in. */
+export interface PrWindow {
+  from?: string | null;
+  to?: string | null;
+  model?: string | null;
+  developers?: string[] | null;
+}
 
 interface ResolvedPr {
   user_key: string;
@@ -134,13 +148,17 @@ export function aggregatePrOverview(rows: ReadonlyArray<PrEventRow>, window?: Pr
   const from = window?.from ?? null;
   const to = window?.to ?? null;
   const model = window?.model ?? null;
+  const devFilter = window?.developers && window.developers.length ? new Set(window.developers) : null;
   const prs = resolvePrs(rows).filter(pr =>
     (!from || pr.openerAt >= from)
     && (!to || pr.openerAt <= to)
-    && (!model || pr.model === model),
+    && (!model || pr.model === model)
+    && (!devFilter || devFilter.has(pr.user_key)),
   );
 
   const byDayMap = new Map<string, SizeDist>();
+  // day → size bucket → (developer → count), for slice tooltips.
+  const dayDevMap = new Map<string, Record<SizeBucket, Map<string, number>>>();
   const devMap = new Map<string, { prs: number; sizePoints: number; sizes: SizeDist; daily: Record<string, number> }>();
   const modelMap = new Map<string, { prs: number; sizePoints: number; sizes: SizeDist; harnesses: Set<string> }>();
   const resized = { count: 0, grew: 0, shrank: 0 };
@@ -154,6 +172,11 @@ export function aggregatePrOverview(rows: ReadonlyArray<PrEventRow>, window?: Pr
     const day = byDayMap.get(pr.day) ?? emptyDist();
     day[pr.bucket]++;
     byDayMap.set(pr.day, day);
+
+    let dayDev = dayDevMap.get(pr.day);
+    if (!dayDev) { dayDev = { xs: new Map(), s: new Map(), m: new Map(), l: new Map(), xl: new Map() }; dayDevMap.set(pr.day, dayDev); }
+    const devCounts = dayDev[pr.bucket];
+    devCounts.set(pr.user_key, (devCounts.get(pr.user_key) ?? 0) + 1);
 
     const dev = devMap.get(pr.user_key) ?? { prs: 0, sizePoints: 0, sizes: emptyDist(), daily: {} };
     dev.prs++; dev.sizePoints += pr.points; dev.sizes[pr.bucket]++;
@@ -182,7 +205,19 @@ export function aggregatePrOverview(rows: ReadonlyArray<PrEventRow>, window?: Pr
   }
 
   const byDay = [...byDayMap.entries()]
-    .map(([day, sizes]) => ({ day, sizes, total: SIZE_BUCKETS.reduce((a, b) => a + sizes[b], 0) }))
+    .map(([day, sizes]) => {
+      const dayDev = dayDevMap.get(day);
+      const devBySize = {} as Record<SizeBucket, Array<{ user_key: string; count: number }>>;
+      for (const b of SIZE_BUCKETS) {
+        const m = dayDev?.[b];
+        devBySize[b] = m
+          ? [...m.entries()]
+            .map(([user_key, count]) => ({ user_key, count }))
+            .sort((x, y) => y.count - x.count || x.user_key.localeCompare(y.user_key))
+          : [];
+      }
+      return { day, sizes, total: SIZE_BUCKETS.reduce((a, b) => a + sizes[b], 0), devBySize };
+    })
     .sort((a, b) => a.day.localeCompare(b.day));
 
   const byDeveloper = [...devMap.entries()]

--- a/packages/hub/src/routes/queries.ts
+++ b/packages/hub/src/routes/queries.ts
@@ -221,8 +221,11 @@ export function queriesRouter(ctx: HubServerContext): Router {
     // by its OPENER's model — pushing model into SQL would fetch only the matching
     // event and corrupt the opener. When `upTo` is null (open-ended), all events
     // are read so "latest sizing wins" reflects every re-size.
+    // users (developer) filter is opener-based, applied in the aggregator — not
+    // pushed to SQL, for the same reason as model: filtering events by user_key
+    // would hide the opener of a PR re-sized by someone else and misattribute it.
     const fetchRows = async (upTo: string | null): Promise<PrEventRow[]> => {
-      const base = applyEventFilters(orgId, { ...f, types: null, itemTypes: null, from: null, to: upTo });
+      const base = applyEventFilters(orgId, { ...f, types: null, itemTypes: null, users: null, from: null, to: upTo });
       const where = [...base.where, `type IN ('pr.opened', 'pr.updated')`];
       return ctx.db.all<PrEventRow>(
         `SELECT user_key, occurred_at, type,
@@ -239,7 +242,7 @@ export function queriesRouter(ctx: HubServerContext): Router {
       );
     };
 
-    const result = aggregatePrOverview(await fetchRows(f.to), { from: f.from, to: f.to, model });
+    const result = aggregatePrOverview(await fetchRows(f.to), { from: f.from, to: f.to, model, developers: f.users });
 
     // Previous equal-length window for deltas — only when a lower bound is set.
     // The previous window's upper bound is EXCLUSIVE of `from` so a PR opened
@@ -252,7 +255,7 @@ export function queriesRouter(ctx: HubServerContext): Router {
         const span = toMs - fromMs;
         const prevFrom = new Date(fromMs - span).toISOString();
         const prevTo = new Date(fromMs - 1).toISOString();
-        const prev = aggregatePrOverview(await fetchRows(prevTo), { from: prevFrom, to: prevTo, model });
+        const prev = aggregatePrOverview(await fetchRows(prevTo), { from: prevFrom, to: prevTo, model, developers: f.users });
         previous = { prs: prev.totals.prs, sizePoints: prev.totals.sizePoints };
       }
     }

--- a/packages/hub/src/test/pr-overview-aggregate.test.ts
+++ b/packages/hub/src/test/pr-overview-aggregate.test.ts
@@ -23,7 +23,7 @@ describe('aggregatePrOverview', () => {
     expect(r.totals.prs).toBe(1);
     expect(r.totals.sizePoints).toBe(6);
     expect(r.totals.developers).toBe(1);
-    expect(r.byDay).toEqual([
+    expect(r.byDay).toMatchObject([
       { day: '2026-05-03', sizes: { xs: 0, s: 1, m: 0, l: 0, xl: 0 }, total: 1 },
     ]);
     expect(r.byDeveloper[0].user_key).toBe('alice@acme.com');
@@ -39,7 +39,7 @@ describe('aggregatePrOverview', () => {
     expect(r.totals.prs).toBe(1); // counted ONCE
     expect(r.totals.sizePoints).toBe(12); // latest sizing wins
     // placed on the OPEN day, at its final (latest) size
-    expect(r.byDay).toEqual([
+    expect(r.byDay).toMatchObject([
       { day: '2026-05-03', sizes: { xs: 0, s: 0, m: 1, l: 0, xl: 0 }, total: 1 },
     ]);
     expect(r.resized).toEqual({ count: 1, grew: 1, shrank: 0 });
@@ -165,6 +165,50 @@ describe('aggregatePrOverview', () => {
     expect(r.totals.sizePoints).toBe(2); // leaf_story null treated as 0
   });
 
+  it('byDay carries a per-size developer breakdown (for slice tooltips)', () => {
+    const rows = [
+      row({ pr_number: 1, user_key: 'alice@acme.com', occurred_at: '2026-05-03T10:00:00Z', task: 1 }),               // xs
+      row({ pr_number: 2, user_key: 'bob@acme.com', occurred_at: '2026-05-03T11:00:00Z', task: 1 }),                 // xs
+      row({ pr_number: 3, user_key: 'alice@acme.com', occurred_at: '2026-05-03T12:00:00Z', leaf_story: 1, task: 4 }), // m
+    ];
+    const day = aggregatePrOverview(rows).byDay.find(d => d.day === '2026-05-03')!;
+    expect(day.devBySize.xs).toEqual([
+      { user_key: 'alice@acme.com', count: 1 },
+      { user_key: 'bob@acme.com', count: 1 },
+    ]);
+    expect(day.devBySize.m).toEqual([{ user_key: 'alice@acme.com', count: 1 }]);
+    expect(day.devBySize.s).toEqual([]);
+  });
+
+  it('per-size developer breakdown sorts by count desc', () => {
+    const rows = [
+      row({ pr_number: 1, user_key: 'alice@acme.com', task: 1 }),
+      row({ pr_number: 2, user_key: 'alice@acme.com', task: 1 }),
+      row({ pr_number: 3, user_key: 'bob@acme.com', task: 1 }),
+    ];
+    const day = aggregatePrOverview(rows).byDay[0];
+    expect(day.devBySize.xs).toEqual([
+      { user_key: 'alice@acme.com', count: 2 },
+      { user_key: 'bob@acme.com', count: 1 },
+    ]);
+  });
+
+  it('filters by developer on the opener (multi-select)', () => {
+    const rows = [
+      row({ pr_number: 1, user_key: 'alice@acme.com' }),
+      row({ pr_number: 2, user_key: 'bob@acme.com' }),
+      row({ pr_number: 3, user_key: 'carol@acme.com' }),
+      // opened by alice, re-sized by bob → filtering bob must NOT pull it in
+      row({ pr_number: 4, type: 'pr.opened', user_key: 'alice@acme.com', occurred_at: '2026-05-03T09:00:00Z' }),
+      row({ pr_number: 4, type: 'pr.updated', user_key: 'bob@acme.com', occurred_at: '2026-05-04T09:00:00Z', task: 2 }),
+    ];
+    const r = aggregatePrOverview(rows, { developers: ['alice@acme.com', 'bob@acme.com'] });
+    expect(r.totals.prs).toBe(3); // alice #1 #4, bob #2 — carol excluded
+    expect(r.byDeveloper.map(d => d.user_key).sort()).toEqual(['alice@acme.com', 'bob@acme.com']);
+    const alice = r.byDeveloper.find(d => d.user_key === 'alice@acme.com')!;
+    expect(alice.prs).toBe(2); // #4 attributed to its opener, not bob
+  });
+
   it('handles Postgres row shapes — Date occurred_at and string-typed numerics', () => {
     // On Postgres, occurred_at (TIMESTAMPTZ) comes back as a JS Date and
     // jsonb_extract_path_text numerics come back as strings. The aggregator must
@@ -190,7 +234,7 @@ describe('aggregatePrOverview', () => {
     ]);
     expect(r.totals.prs).toBe(1);
     expect(r.totals.sizePoints).toBe(2); // latest: leafStory 0 + task 1 → 2
-    expect(r.byDay).toEqual([
+    expect(r.byDay).toMatchObject([
       { day: '2026-05-03', sizes: { xs: 1, s: 0, m: 0, l: 0, xl: 0 }, total: 1 },
     ]);
     expect(r.resized).toEqual({ count: 1, grew: 0, shrank: 1 });

--- a/packages/hub/src/test/queries.test.ts
+++ b/packages/hub/src/test/queries.test.ts
@@ -512,4 +512,31 @@ describe('GET /v1/prs/overview', () => {
     expect(r.body.totals.prs).toBe(1);
     expect(r.body.byDeveloper[0].user_key).toBe('bob@acme.com');
   });
+
+  it('filters by an explicit from/to date range', async () => {
+    // Window covers only 05-03 → alice's two PRs, bob's 05-04 PR excluded.
+    const r = await supertest(app)
+      .get('/v1/prs/overview?from=2026-05-03T00:00:00Z&to=2026-05-03T23:59:59Z')
+      .set('Cookie', cookie);
+    expect(r.status).toBe(200);
+    expect(r.body.totals.prs).toBe(2);
+    expect(r.body.byDeveloper.every((d: any) => d.user_key === 'alice@acme.com')).toBe(true);
+  });
+
+  it('filters by developer (users param)', async () => {
+    const r = await supertest(app).get('/v1/prs/overview?users=bob@acme.com').set('Cookie', cookie);
+    expect(r.status).toBe(200);
+    expect(r.body.totals.prs).toBe(1); // only bob's PR#3
+    expect(r.body.byDeveloper).toHaveLength(1);
+    expect(r.body.byDeveloper[0].user_key).toBe('bob@acme.com');
+  });
+
+  it('byDay slices carry a per-size developer breakdown', async () => {
+    const r = await supertest(app).get('/v1/prs/overview').set('Cookie', cookie);
+    expect(r.status).toBe(200);
+    const may3 = r.body.byDay.find((d: any) => d.day === '2026-05-03');
+    // alice opened PR#1 (xs) and PR#2 (m, latest) on 05-03
+    expect(may3.devBySize.xs).toEqual([{ user_key: 'alice@acme.com', count: 1 }]);
+    expect(may3.devBySize.m).toEqual([{ user_key: 'alice@acme.com', count: 1 }]);
+  });
 });


### PR DESCRIPTION
Enhancements to the PR Overview dashboard (follow-up to #104 / #105).

### Added
- **Per-slice tooltip** on *Daily PR volume by size* — each size segment shows the developers who opened a PR of that size that day, with counts. Backed by a new `devBySize` breakdown on the `/v1/prs/overview` `byDay` rollup.
- **Filter by developer** — opener-attributed (same model as the existing model filter): a PR opened by X and re-sized by Y stays under X. The endpoint keeps `users` out of SQL and filters on the resolved opener in the aggregator, for both the main and previous-period (delta) queries.
- **Filter by explicit date range** — from/to date pickers (inclusive end-of-day) that override the preset range; presets and custom range are mutually exclusive.

### Tests
Aggregator: `devBySize` breakdown + sort, opener-based developer filter (incl. cross-author re-size). Endpoint: developer filter, explicit from/to range, `devBySize` shape. Full suite green (1688) + clean build.

Adversarial review fix: options query keeps prior data and falls back to the main overview so the Developer/Model controls never blank out on selection.

https://claude.ai/code/session_01W3ct4ECvAzsWVpodPCMjv1