### PR TITLE
feat(flow): agenfk flow show refreshes from Hub on read, falls back to local

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3292,7 +3292,10 @@ flowCommand
           process.exit(1);
           return;
         }
-        ({ data: flow } = await axios.get(`${API_URL}/projects/${projectId}/flow`));
+        // refresh=true → server attempts an on-demand Hub reconcile before
+        // reading, so `flow show` reflects a just-changed Hub assignment without
+        // waiting for the 5-minute poll (falls back to the local flow on error).
+        ({ data: flow } = await axios.get(`${API_URL}/projects/${projectId}/flow?refresh=true`));
       }
       if (program.opts().toon || options.json) {
         console.log(structuredOutput(flow));

--- a/packages/server/src/hub/flowRefresh.ts
+++ b/packages/server/src/hub/flowRefresh.ts
@@ -1,0 +1,55 @@
+/**
+ * On-demand hub flow refresh.
+ *
+ * The 5-minute poll (`startFlowSync`) keeps the local server eventually
+ * consistent with the corp Hub's flow assignments, but a user who just pressed
+ * "Use this flow" in the Hub expects `agenfk flow show` to reflect it now. This
+ * helper performs a single ETag-aware reconcile for one project on demand,
+ * sharing the poller's ETag cache so a fresh pull and the poll never double
+ * work. Any failure is swallowed: the caller then reads whatever local flow it
+ * already had, so a down/slow/unauthorized Hub degrades to the last-known flow
+ * rather than an error.
+ */
+import { reconcileProjectFlow, type FetchLike } from './flowSync.js';
+import type { SQLiteStorageProvider } from '@agenfk/storage-sqlite';
+import type { HubConfig } from './types.js';
+
+export interface RefreshProjectFlowArgs {
+  storage: SQLiteStorageProvider;
+  /** Whether the corp Hub is configured/enabled for this server. */
+  hubEnabled: boolean;
+  hubConfig: HubConfig | null | undefined;
+  projectId: string;
+  fetchImpl: FetchLike;
+  emit: (event: string, payload: any) => void;
+  /** Shared with the polling reconciler so ETags aren't fetched twice. */
+  etagCache: Map<string, string>;
+}
+
+/**
+ * Attempt to pull this project's currently-assigned Hub flow into local storage.
+ * Never throws — on any error it returns having left local state untouched, so
+ * the caller falls back to the local flow.
+ */
+export async function refreshProjectFlowFromHub(args: RefreshProjectFlowArgs): Promise<void> {
+  if (!args.hubEnabled || !args.hubConfig) return;
+  try {
+    const lastEtag = args.etagCache.get(args.projectId) ?? null;
+    const result = await reconcileProjectFlow({
+      storage: args.storage,
+      hubConfig: args.hubConfig,
+      projectId: args.projectId,
+      lastEtag,
+      fetchImpl: args.fetchImpl,
+      emit: args.emit,
+    });
+    if (result.etag) args.etagCache.set(args.projectId, result.etag);
+  } catch (e) {
+    // reconcileProjectFlow already contains transport/HTTP errors as an 'error'
+    // outcome; this guards any unexpected storage throw. Either way: fall back.
+    console.error(
+      `[HUB_FLOW_SYNC] on-demand refresh failed for project ${args.projectId}:`,
+      (e as Error).message,
+    );
+  }
+}

--- a/packages/server/src/hub/flowSync.ts
+++ b/packages/server/src/hub/flowSync.ts
@@ -38,7 +38,34 @@ export type ReconcileOutcome =
   | { outcome: 'no-assignment'; etag: string | null }
   | { outcome: 'error'; etag: string | null; error: string };
 
-export async function reconcileProjectFlow(args: ReconcileProjectArgs): Promise<ReconcileOutcome> {
+// ── Per-project serialization ───────────────────────────────────────────────
+// The reconcile does a read-modify-write (listFlows → find by hubFlowId →
+// create/update → rebind project) with `await` gaps. Two callers now drive it:
+// the polling loop AND on-demand refreshes (GET .../flow?refresh=true). Without
+// serialization, two concurrent reconciles for the same project could both see
+// "no existing row", both createFlow with a fresh uuid, and leave duplicate rows
+// for the same hubFlowId. This lightweight chained-promise mutex, keyed by
+// project, guarantees the critical section runs one-at-a-time per project.
+const reconcileLocks = new Map<string, Promise<unknown>>();
+
+async function runExclusive<T>(key: string, fn: () => Promise<T>): Promise<T> {
+  const prev = reconcileLocks.get(key) ?? Promise.resolve();
+  const run = prev.then(fn, fn); // run after the previous holder settles, either way
+  const guard = run.then(() => undefined, () => undefined); // never rejects → chain survives throws
+  reconcileLocks.set(key, guard);
+  try {
+    return await run;
+  } finally {
+    if (reconcileLocks.get(key) === guard) reconcileLocks.delete(key);
+  }
+}
+
+export function reconcileProjectFlow(args: ReconcileProjectArgs): Promise<ReconcileOutcome> {
+  // One key per project; the org-fallback path (null projectId) shares a key.
+  return runExclusive(args.projectId ?? '__org__', () => reconcileProjectFlowInner(args));
+}
+
+async function reconcileProjectFlowInner(args: ReconcileProjectArgs): Promise<ReconcileOutcome> {
   const { storage, hubConfig, projectId, lastEtag, fetchImpl, emit } = args;
   const baseUrl = `${hubConfig.url.replace(/\/$/, '')}/v1/flows/active`;
   const url = projectId ? `${baseUrl}?projectId=${encodeURIComponent(projectId)}` : baseUrl;
@@ -197,6 +224,12 @@ export interface StartFlowSyncArgs {
   intervalMs?: number;
   fetchImpl?: FetchLike;
   emit: (event: string, payload: any) => void;
+  /**
+   * Optional shared per-project ETag cache. Pass the same Map used by on-demand
+   * refreshes so a poll and a refresh don't re-fetch the same unchanged flow.
+   * Defaults to a private cache when omitted.
+   */
+  etagCache?: Map<string, string>;
 }
 
 const DEFAULT_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
@@ -204,7 +237,7 @@ const DEFAULT_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 export function startFlowSync(args: StartFlowSyncArgs): FlowSyncHandle {
   const baseInterval = args.intervalMs ?? DEFAULT_INTERVAL_MS;
   const fetchImpl = args.fetchImpl ?? (globalThis.fetch as unknown as FetchLike);
-  const etagCache = new Map<string, string>();
+  const etagCache = args.etagCache ?? new Map<string, string>();
   let stopped = false;
   let consecutiveErrors = 0;
   let timer: NodeJS.Timeout | null = null;

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -7,6 +7,7 @@ import { TelemetryClient, getInstallationId, isTelemetryEnabled, getInstallSourc
 import { HubClient, Flusher, loadHubConfig } from "./hub/index.js";
 import type { RecordEventInput } from "./hub/index.js";
 import { startFlowSync, type FlowSyncHandle } from "./hub/flowSync.js";
+import { refreshProjectFlowFromHub } from "./hub/flowRefresh.js";
 import { startUpgradeSync, replayPendingUpgradeOutcome, type UpgradeSyncHandle } from "./hub/upgradeSync.js";
 import { spawnSync } from 'child_process';
 import { v4 as uuidv4 } from "uuid";
@@ -85,6 +86,10 @@ const telemetry = new TelemetryClient();
 const hubClient = new HubClient(getInstallationId(), loadHubConfig());
 let hubFlusher: Flusher | null = null;
 let flowSyncHandle: FlowSyncHandle | null = null;
+// Per-project ETag cache for hub flow reconciles. Shared between the polling
+// reconciler (startFlowSync) and on-demand refreshes (GET .../flow?refresh=true)
+// so the two never re-fetch the same unchanged flow.
+const flowSyncEtagCache = new Map<string, string>();
 let upgradeSyncHandle: UpgradeSyncHandle | null = null;
 
 // recordHubEvent is a thin wrapper kept at module scope so the many existing
@@ -469,6 +474,7 @@ const initStorage = async () => {
       storage: storage as SQLiteStorageProvider,
       hubConfig: hubClient.hubConfig,
       intervalMs,
+      etagCache: flowSyncEtagCache,
       emit: (event, payload) => io.emit(event, payload),
     });
     console.log(`[HUB] Flow reconciler running against ${hubClient.hubConfig.url}/v1/flows/active`);
@@ -818,8 +824,30 @@ app.post("/projects/:id/flow", asyncHandler(async (req: any, res: any) => {
 }));
 
 app.get("/projects/:id/flow", asyncHandler(async (req: any, res: any) => {
-  const project = await storage.getProject(req.params.id);
+  let project = await storage.getProject(req.params.id);
   if (!project) return res.status(404).json({ error: "Project not found" });
+
+  // Opt-in on-demand refresh (used by `agenfk flow show`): pull the project's
+  // currently-assigned Hub flow now instead of waiting for the 5-minute poll.
+  // Never throws — on any Hub error we fall through to the local flow below.
+  const refreshRequested = (() => {
+    const q = req.query.refresh;
+    const v = Array.isArray(q) ? q[q.length - 1] : q; // last value wins on ?refresh=..&refresh=..
+    return v === "true" || v === "1";
+  })();
+  if (refreshRequested && hubClient.isEnabled && hubClient.hubConfig) {
+    await refreshProjectFlowFromHub({
+      storage: storage as SQLiteStorageProvider,
+      hubEnabled: hubClient.isEnabled,
+      hubConfig: hubClient.hubConfig,
+      projectId: req.params.id,
+      fetchImpl: globalThis.fetch as any,
+      emit: (event, payload) => io.emit(event, payload),
+      etagCache: flowSyncEtagCache,
+    });
+    // The reconcile may have rebound the project to a new flow id.
+    project = (await storage.getProject(req.params.id)) ?? project;
+  }
 
   if (!(project as any).flowId) {
     return res.json(DEFAULT_FLOW);

--- a/packages/server/src/test/flow-refresh-on-read.test.ts
+++ b/packages/server/src/test/flow-refresh-on-read.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Tests for on-demand hub flow refresh on read.
+ *
+ * `agenfk flow show` should reflect a hub-side "Use this flow" change without
+ * waiting for the 5-minute poll. The server does this by attempting an
+ * ETag-aware reconcile against the corp Hub when a read asks for it
+ * (`GET /projects/:id/flow?refresh=true`), and — crucially — falling back
+ * silently to the local flow on ANY hub error.
+ *
+ * We test the injectable helper directly (fake fetch + real SQLite storage,
+ * mirroring flowSync.test.ts), plus the route behaviour when the hub is not
+ * configured (the common case) to prove `?refresh=true` never breaks a read.
+ */
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import request from 'supertest';
+import { SQLiteStorageProvider } from '@agenfk/storage-sqlite';
+import { refreshProjectFlowFromHub } from '../hub/flowRefresh';
+import { reconcileProjectFlow } from '../hub/flowSync';
+
+const baseSteps = [
+  { id: 's0', name: 'todo', label: 'Todo', order: 0, isAnchor: true },
+  { id: 's1', name: 'work', label: 'Work', order: 1 },
+  { id: 's2', name: 'done', label: 'Done', order: 2, isAnchor: true },
+];
+
+const HUB_URL = 'http://hub.example.test';
+const HUB_TOKEN = 'agk_test';
+const HUB_ORG = 'org-a';
+const hubConfig = { url: HUB_URL, token: HUB_TOKEN, orgId: HUB_ORG };
+
+function makeFetchSequence(seq: Array<{ status: number; body?: any; etag?: string }>) {
+  let i = 0;
+  return vi.fn(async (_url: string, _opts: any) => {
+    const r = seq[Math.min(i, seq.length - 1)];
+    i++;
+    const headers: Record<string, string> = {};
+    if (r.etag) headers['etag'] = r.etag;
+    return {
+      status: r.status,
+      ok: r.status >= 200 && r.status < 300,
+      headers: { get: (k: string) => headers[k.toLowerCase()] ?? null },
+      json: async () => r.body ?? {},
+    } as any;
+  });
+}
+
+describe('refreshProjectFlowFromHub', () => {
+  let storage: SQLiteStorageProvider;
+  let dbPath: string;
+  let emit: ReturnType<typeof vi.fn>;
+  let etagCache: Map<string, string>;
+
+  beforeEach(async () => {
+    dbPath = path.join(os.tmpdir(), `flow-refresh-test-${process.pid}-${Math.random().toString(36).slice(2)}.sqlite`);
+    storage = new SQLiteStorageProvider();
+    await storage.init({ path: dbPath });
+    emit = vi.fn();
+    etagCache = new Map();
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
+  });
+
+  it('is a no-op when the hub is disabled (never calls fetch)', async () => {
+    const fetchImpl = makeFetchSequence([{ status: 200, body: { flow: { id: 'r', name: 'X', steps: baseSteps } } }]);
+    await refreshProjectFlowFromHub({
+      storage, hubEnabled: false, hubConfig, projectId: 'p1', fetchImpl, emit, etagCache,
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(emit).not.toHaveBeenCalled();
+    expect((await storage.listFlows())).toHaveLength(0);
+  });
+
+  it('is a no-op when hubConfig is null', async () => {
+    const fetchImpl = makeFetchSequence([{ status: 200, body: { flow: { id: 'r', name: 'X', steps: baseSteps } } }]);
+    await refreshProjectFlowFromHub({
+      storage, hubEnabled: true, hubConfig: null, projectId: 'p1', fetchImpl, emit, etagCache,
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect((await storage.listFlows())).toHaveLength(0);
+  });
+
+  it('pulls a changed hub flow into local storage and rebinds the project', async () => {
+    await storage.createProject({ id: 'p1', name: 'p1', description: '', createdAt: new Date(), updatedAt: new Date() } as any);
+    const fetchImpl = makeFetchSequence([
+      { status: 200, etag: 'W/"9"', body: { flow: { id: 'remote-9', name: 'New Org Flow', description: '', steps: baseSteps }, hubVersion: 9 } },
+    ]);
+
+    await refreshProjectFlowFromHub({
+      storage, hubEnabled: true, hubConfig, projectId: 'p1', fetchImpl, emit, etagCache,
+    });
+
+    const flows = await storage.listFlows();
+    expect(flows).toHaveLength(1);
+    expect(flows[0].source).toBe('hub');
+    expect(flows[0].name).toBe('New Org Flow');
+    const proj = await storage.getProject('p1');
+    expect(proj?.flowId).toBe(flows[0].id);
+    // ETag is cached so the next refresh can send If-None-Match.
+    expect(etagCache.get('p1')).toBe('W/"9"');
+    expect(emit).toHaveBeenCalledWith('flow:updated', expect.objectContaining({ flowId: flows[0].id, projectId: 'p1' }));
+  });
+
+  it('sends If-None-Match from the shared cache and no-ops on 304', async () => {
+    etagCache.set('p1', 'W/"9"');
+    const fetchImpl = makeFetchSequence([{ status: 304 }]);
+    await refreshProjectFlowFromHub({
+      storage, hubEnabled: true, hubConfig, projectId: 'p1', fetchImpl, emit, etagCache,
+    });
+    expect((fetchImpl as any).mock.calls[0][1].headers['If-None-Match']).toBe('W/"9"');
+    expect((await storage.listFlows())).toHaveLength(0);
+    expect(emit).not.toHaveBeenCalled();
+    // ETag preserved.
+    expect(etagCache.get('p1')).toBe('W/"9"');
+  });
+
+  it('falls back silently on a hub transport error (does not throw, leaves local state intact)', async () => {
+    // Seed an existing local hub flow bound to the project.
+    await storage.createFlow({
+      id: 'local-existing', name: 'cached', description: '', version: '1', steps: baseSteps,
+      createdAt: new Date(), updatedAt: new Date(), source: 'hub', hubFlowId: 'remote-cached', hubVersion: 5,
+    } as any);
+    await storage.createProject({ id: 'p1', name: 'p1', description: '', flowId: 'local-existing', createdAt: new Date(), updatedAt: new Date() } as any);
+
+    const fetchImpl = vi.fn(async () => { throw new Error('ECONNREFUSED'); });
+    await expect(refreshProjectFlowFromHub({
+      storage, hubEnabled: true, hubConfig, projectId: 'p1', fetchImpl, emit, etagCache,
+    })).resolves.toBeUndefined();
+
+    // Local flow and binding untouched — the read will fall back to this.
+    const proj = await storage.getProject('p1');
+    expect(proj?.flowId).toBe('local-existing');
+    expect((await storage.listFlows())).toHaveLength(1);
+  });
+
+  it('falls back silently on an HTTP error status (401)', async () => {
+    await storage.createProject({ id: 'p1', name: 'p1', description: '', createdAt: new Date(), updatedAt: new Date() } as any);
+    const fetchImpl = makeFetchSequence([{ status: 401, body: { error: 'revoked' } }]);
+    await expect(refreshProjectFlowFromHub({
+      storage, hubEnabled: true, hubConfig, projectId: 'p1', fetchImpl, emit, etagCache,
+    })).resolves.toBeUndefined();
+    expect((await storage.listFlows())).toHaveLength(0);
+  });
+
+  // Regression for the concurrency hazard introduced by having two callers
+  // (poll + on-demand refresh) drive reconcileProjectFlow: the read-modify-write
+  // must be serialized per project so it can't mint duplicate rows for one hub id.
+  it('serializes concurrent reconciles for the same project → exactly one row per hub flow', async () => {
+    await storage.createProject({ id: 'p1', name: 'p1', description: '', createdAt: new Date(), updatedAt: new Date() } as any);
+    const remote = { id: 'remote-dup', name: 'Org', description: '', steps: baseSteps };
+    // makeFetchSequence repeats its last entry, so every concurrent call gets 200.
+    const fetchImpl = makeFetchSequence([{ status: 200, etag: 'W/"1"', body: { flow: remote, hubVersion: 1 } }]);
+
+    await Promise.all([
+      reconcileProjectFlow({ storage, hubConfig, projectId: 'p1', lastEtag: null, fetchImpl, emit }),
+      reconcileProjectFlow({ storage, hubConfig, projectId: 'p1', lastEtag: null, fetchImpl, emit }),
+      reconcileProjectFlow({ storage, hubConfig, projectId: 'p1', lastEtag: null, fetchImpl, emit }),
+    ]);
+
+    const dupes = (await storage.listFlows()).filter((f) => f.hubFlowId === 'remote-dup');
+    expect(dupes).toHaveLength(1);
+    const proj = await storage.getProject('p1');
+    expect(proj?.flowId).toBe(dupes[0].id);
+  });
+});
+
+describe('GET /projects/:id/flow?refresh=true (route wiring)', () => {
+  const TEST_DB = path.resolve('./flow-refresh-route-test-db.sqlite');
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let app: any, initStorage: any;
+
+  beforeAll(async () => {
+    process.env.AGENFK_DB_PATH = TEST_DB;
+    if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+    ({ app, initStorage } = await import('../server'));
+    await initStorage();
+  });
+
+  afterAll(() => {
+    if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+  });
+
+  beforeEach(async () => {
+    if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+    await initStorage();
+    // Whether or not the corp Hub is configured on this machine, keep the route
+    // hermetic: stub fetch so a refresh never makes a live network call. The
+    // exact reconcile semantics are covered by the helper unit tests above.
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      status: 304,
+      ok: false,
+      headers: { get: () => null },
+      json: async () => ({}),
+    })));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const steps = [
+    { id: 's1', name: 'TODO', label: 'TODO', order: 1, isAnchor: true },
+    { id: 's2', name: 'WORK', label: 'Work', order: 2 },
+    { id: 's3', name: 'DONE', label: 'Done', order: 3, isAnchor: true },
+  ];
+
+  it('plain read (no refresh) returns the project local flow', async () => {
+    const flow = (await request(app).post('/flows').send({ name: 'LocalFlow', steps })).body;
+    const project = (await request(app).post('/projects').send({ name: 'proj' })).body;
+    await request(app).post(`/projects/${project.id}/flow`).send({ flowId: flow.id });
+
+    const r = await request(app).get(`/projects/${project.id}/flow`);
+    expect(r.status).toBe(200);
+    expect(r.body.id).toBe(flow.id);
+    expect(r.body.name).toBe('LocalFlow');
+  });
+
+  it('?refresh=true returns a valid flow (hub 304/off → local flow preserved)', async () => {
+    const flow = (await request(app).post('/flows').send({ name: 'LocalFlow', steps })).body;
+    const project = (await request(app).post('/projects').send({ name: 'proj' })).body;
+    await request(app).post(`/projects/${project.id}/flow`).send({ flowId: flow.id });
+
+    const r = await request(app).get(`/projects/${project.id}/flow?refresh=true`);
+    expect(r.status).toBe(200);
+    expect(Array.isArray(r.body.steps)).toBe(true);
+    // A 304 (or hub-off) refresh must not disturb the local binding.
+    expect(r.body.id).toBe(flow.id);
+  });
+
+  it('?refresh=true on a project with no flow still returns a valid default flow', async () => {
+    const project = (await request(app).post('/projects').send({ name: 'proj2' })).body;
+    const r = await request(app).get(`/projects/${project.id}/flow?refresh=true`);
+    expect(r.status).toBe(200);
+    expect(Array.isArray(r.body.steps)).toBe(true);
+    expect(r.body.steps.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/server/src/test/flow-refresh-route-hub-on.test.ts
+++ b/packages/server/src/test/flow-refresh-route-hub-on.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Deterministic end-to-end test of GET /projects/:id/flow?refresh=true with the
+ * corp Hub *enabled*.
+ *
+ * We force hub config via env BEFORE importing the server module (hubClient
+ * captures config at import), and stub global fetch so the "hub" is a controlled
+ * fake — no live network. This exercises the route → refreshProjectFlowFromHub →
+ * reconcile → rebind path that the hub-disabled route tests can't reach.
+ *
+ * Env is saved/restored so hub config doesn't leak into other test files
+ * (process.env is shared across the worker even though modules are isolated).
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import request from 'supertest';
+
+const TEST_DB = path.resolve('./flow-refresh-hubon-test-db.sqlite');
+const savedEnv: Record<string, string | undefined> = {};
+const ENV_KEYS = [
+  'AGENFK_HUB_URL', 'AGENFK_HUB_TOKEN', 'AGENFK_HUB_ORG',
+  'AGENFK_HUB_FLOW_SYNC_FIRST_DELAY_MS', 'AGENFK_DB_PATH',
+];
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let app: any, initStorage: any;
+
+const hubSteps = [
+  { id: 'h1', name: 'BACKLOG', label: 'Backlog', order: 0, isAnchor: true },
+  { id: 'h2', name: 'DOING', label: 'Doing', order: 1 },
+  { id: 'h3', name: 'SHIPPED', label: 'Shipped', order: 2, isAnchor: true },
+];
+
+// Fake hub: return a managed flow for /v1/flows/active, benign for everything
+// else (outbox flush, upgrade directive) so background timers never error.
+function stubHubFetch() {
+  vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+    if (String(url).includes('/v1/flows/active')) {
+      return {
+        status: 200, ok: true,
+        headers: { get: (k: string) => (k.toLowerCase() === 'etag' ? 'W/"hub-1"' : null) },
+        json: async () => ({
+          flow: { id: 'hub-remote-1', name: 'Hub Managed Flow', description: '', steps: hubSteps },
+          hubVersion: 1,
+        }),
+      } as any;
+    }
+    return { status: 204, ok: true, headers: { get: () => null }, json: async () => ({}) } as any;
+  }));
+}
+
+const localSteps = [
+  { id: 's1', name: 'TODO', label: 'TODO', order: 1, isAnchor: true },
+  { id: 's2', name: 'DONE', label: 'Done', order: 2, isAnchor: true },
+];
+
+describe('GET /projects/:id/flow?refresh=true (hub enabled)', () => {
+  beforeAll(async () => {
+    for (const k of ENV_KEYS) savedEnv[k] = process.env[k];
+    process.env.AGENFK_HUB_URL = 'http://hub.example.test';
+    process.env.AGENFK_HUB_TOKEN = 'agk_test';
+    process.env.AGENFK_HUB_ORG = 'org-test';
+    // Keep the 5-min poller from firing during the test window.
+    process.env.AGENFK_HUB_FLOW_SYNC_FIRST_DELAY_MS = '3600000';
+    process.env.AGENFK_DB_PATH = TEST_DB;
+    stubHubFetch(); // stub before import so any startup fetch is intercepted
+    if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+    ({ app, initStorage } = await import('../server'));
+    await initStorage();
+  });
+
+  afterAll(() => {
+    vi.unstubAllGlobals();
+    for (const k of ENV_KEYS) {
+      if (savedEnv[k] === undefined) delete process.env[k];
+      else process.env[k] = savedEnv[k]!;
+    }
+    if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+  });
+
+  beforeEach(async () => {
+    if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+    await initStorage();
+    stubHubFetch(); // resetMocks clears the impl between tests; re-stub
+  });
+
+  it('pulls the hub flow and rebinds the project on read, and it persists', async () => {
+    const local = (await request(app).post('/flows').send({ name: 'LocalFlow', steps: localSteps })).body;
+    const project = (await request(app).post('/projects').send({ name: 'proj' })).body;
+    await request(app).post(`/projects/${project.id}/flow`).send({ flowId: local.id });
+
+    const r = await request(app).get(`/projects/${project.id}/flow?refresh=true`);
+    expect(r.status).toBe(200);
+    expect(r.body.name).toBe('Hub Managed Flow');
+    expect(r.body.source).toBe('hub');
+
+    // A subsequent plain read reflects the rebind — the refresh persisted.
+    const plain = await request(app).get(`/projects/${project.id}/flow`);
+    expect(plain.body.name).toBe('Hub Managed Flow');
+  });
+
+  it('without ?refresh the local flow is returned (no hub pull)', async () => {
+    const local = (await request(app).post('/flows').send({ name: 'LocalOnly', steps: localSteps })).body;
+    const project = (await request(app).post('/projects').send({ name: 'proj2' })).body;
+    await request(app).post(`/projects/${project.id}/flow`).send({ flowId: local.id });
+
+    const r = await request(app).get(`/projects/${project.id}/flow`);
+    expect(r.status).toBe(200);
+    expect(r.body.name).toBe('LocalOnly');
+  });
+});


### PR DESCRIPTION
## Problem

Pressing **"Use this flow"** in the Hub didn't reflect in `agenfk flow show` until up to 5 minutes later. `flow show` reads the local server's storage, and the local server only learns about a Hub flow reassignment on its 5‑minute `flowSync` poll — there was no push, webhook, or on-demand path.

## Change

Make `agenfk flow show` **refresh-on-read** with a **silent local fallback**, no new command:

- **`hub/flowRefresh.ts`** (new) — `refreshProjectFlowFromHub()`: a single ETag-aware reconcile for one project, reusing the existing `reconcileProjectFlow`. Never throws; on any Hub error (down/slow/unauthorized/invalid JSON) it leaves local state untouched so the read falls back to the last-known flow.
- **`server.ts`** — `GET /projects/:id/flow` honors `?refresh=true`: when the Hub is enabled it reconciles now, then re-reads the project (which may have been rebound). Callers without the param are unchanged (UI 30s poll, gatekeeper pre-edit checks, MCP `get_flow` all keep fast local reads).
- **`cli/src/index.ts`** — `agenfk flow show` (project path) always sends `?refresh=true`.
- **Shared ETag cache** — the poller and on-demand refresh share one per-project ETag map, so an unchanged flow is a cheap `304` and the two never double-apply.

## Concurrency fix

Adding a second concurrent caller to `reconcileProjectFlow` exposed a read‑modify‑write race (`listFlows → find by hubFlowId → create`) that could mint **duplicate rows for one hub flow**. Serialized with a per-project chained-promise mutex (`runExclusive`). Regression test asserts exactly one row under concurrent reconciles (verified it fails without the mutex).

## Tests

- `flow-refresh-on-read.test.ts` — helper: hub-disabled no-op, pull+rebind+ETag cache, `If-None-Match`/304, silent fallback on transport error & HTTP 401, concurrency regression; plus route wiring (hub-off).
- `flow-refresh-route-hub-on.test.ts` — deterministic **hub-enabled** route test (env-forced hub + stubbed fetch): `?refresh=true` pulls the Hub flow, rebinds, and persists; plain read does not.

Full suite green (1700/1700); `npm run build` clean.
