### PR TITLE
fix(hub): force-cancel clears stuck in_progress upgrade directive targets

### DIFF
--- a/packages/hub-ui/src/pages/AdminUpgrades.tsx
+++ b/packages/hub-ui/src/pages/AdminUpgrades.tsx
@@ -85,8 +85,8 @@ export function AdminUpgrades() {
   );
 
   const cancelMut = useMutation({
-    mutationFn: async (directiveId: string) => {
-      const r = await api.post(`/v1/admin/upgrade/${directiveId}/cancel`, {});
+    mutationFn: async ({ directiveId, force }: { directiveId: string; force?: boolean }) => {
+      const r = await api.post(`/v1/admin/upgrade/${directiveId}/cancel`, force ? { force: true } : {});
       return r.data;
     },
     onSuccess: () => {
@@ -99,8 +99,24 @@ export function AdminUpgrades() {
   });
 
   const onCancel = (d: Directive) => {
-    if (!confirm(`Cancel ${d.progress.pending} pending upgrade${d.progress.pending === 1 ? '' : 's'} for v${d.targetVersion}? Installations already running or finished will not be affected.`)) return;
-    cancelMut.mutate(d.directiveId);
+    const { pending, in_progress } = d.progress;
+    if (pending > 0) {
+      if (!confirm(`Cancel ${pending} pending upgrade${pending === 1 ? '' : 's'} for v${d.targetVersion}? Installations already running or finished will not be affected.`)) return;
+    }
+    let force = false;
+    if (in_progress > 0) {
+      // Distinct, explicit opt-in: a running target may be a genuinely live
+      // flight — but it may also be a dead agent wedging the installation
+      // (new directives are refused while it stays in_progress).
+      force = confirm(
+        `⚠️ ${in_progress} target${in_progress === 1 ? ' is' : 's are'} in_progress. ` +
+        `Force-cancel ${in_progress === 1 ? 'it' : 'them'} too?\n\n` +
+        `Only do this when the upgrade is stuck (agent died or never reported back). ` +
+        `A genuinely running upgrade cannot be recalled — force-cancelling just clears its status here.`
+      );
+      if (pending === 0 && !force) return; // nothing else to do
+    }
+    cancelMut.mutate({ directiveId: d.directiveId, force });
   };
 
   const issueMut = useMutation({
@@ -364,13 +380,13 @@ export function AdminUpgrades() {
                   {d.progress.succeeded > 0 && <span className="px-1.5 py-0.5 rounded bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300">{d.progress.succeeded} ok</span>}
                   {d.progress.failed > 0 && <span className="px-1.5 py-0.5 rounded bg-rose-100 dark:bg-rose-900/40 text-rose-700 dark:text-rose-300">{d.progress.failed} failed</span>}
                   {d.progress.cancelled > 0 && <span className="px-1.5 py-0.5 rounded bg-slate-200 dark:bg-slate-700 text-slate-600 dark:text-slate-300">{d.progress.cancelled} cancelled</span>}
-                  {d.progress.pending > 0 && (
+                  {(d.progress.pending > 0 || d.progress.in_progress > 0) && (
                     <button
                       onClick={(e) => { e.stopPropagation(); onCancel(d); }}
                       disabled={cancelMut.isPending}
                       className="ml-1 px-1.5 py-0.5 rounded border border-rose-300 dark:border-rose-700 text-rose-600 dark:text-rose-300 hover:bg-rose-50 dark:hover:bg-rose-900/30 disabled:opacity-50"
-                      title="Cancel pending targets on this directive"
-                    >Cancel pending</button>
+                      title="Cancel pending targets on this directive; offers to force-cancel stuck in_progress ones"
+                    >{d.progress.pending > 0 ? 'Cancel pending' : 'Force-cancel'}</button>
                   )}
                 </span>
               </div>

--- a/packages/hub/src/routes/admin.ts
+++ b/packages/hub/src/routes/admin.ts
@@ -806,9 +806,18 @@ export function adminRouter(ctx: HubServerContext): Router {
   // pending directive. Flips every target still in 'pending' to 'cancelled';
   // leaves in_progress/succeeded/failed alone (those flights have already
   // started or finished — we cannot recall them). Idempotent.
+  //
+  // Body { force: true } additionally flips 'in_progress' targets to
+  // 'cancelled' (BUG 5707f067): an agent that died mid-upgrade — or whose
+  // terminal fleet:upgrade:* event was lost — otherwise wedges its
+  // installation forever, since the single-pending guard on POST /upgrade
+  // treats in_progress as active. Force-cancelled rows get finished_at and
+  // an error_message so the admin view shows when and why they were closed.
+  // succeeded/failed targets are never touched, with or without force.
   router.post('/upgrade/:directiveId/cancel', guard, async (req: Request, res: Response) => {
     const orgId = req.session!.orgId;
     const directiveId = req.params.directiveId;
+    const force = req.body?.force === true;
     const directive = await ctx.db.get<{ id: string }>(
       'SELECT id FROM upgrade_directives WHERE id = ? AND org_id = ?',
       [directiveId, orgId],
@@ -816,6 +825,7 @@ export function adminRouter(ctx: HubServerContext): Router {
     if (!directive) return res.status(404).json({ error: 'Directive not found' });
 
     let cancelledCount = 0;
+    let forcedCount = 0;
     const leftAlone = { in_progress: 0, succeeded: 0, failed: 0 };
     await ctx.db.transaction(async () => {
       const result = await ctx.db.run(
@@ -824,6 +834,19 @@ export function adminRouter(ctx: HubServerContext): Router {
         [directiveId],
       );
       cancelledCount = Number(result.changes ?? 0);
+      if (force) {
+        const now = new Date().toISOString();
+        const forced = await ctx.db.run(
+          `UPDATE upgrade_directive_targets
+             SET state = 'cancelled',
+                 finished_at = ?,
+                 error_message = 'force-cancelled by admin while in_progress'
+           WHERE directive_id = ? AND state = 'in_progress'`,
+          [now, directiveId],
+        );
+        forcedCount = Number(forced.changes ?? 0);
+        cancelledCount += forcedCount;
+      }
       const remaining = await ctx.db.all<{ state: string }>(
         `SELECT state FROM upgrade_directive_targets WHERE directive_id = ?`,
         [directiveId],
@@ -833,7 +856,7 @@ export function adminRouter(ctx: HubServerContext): Router {
       }
     });
 
-    res.json({ directiveId, cancelledCount, leftAlone });
+    res.json({ directiveId, cancelledCount, forcedCount, leftAlone });
   });
 
   return router;

--- a/packages/hub/src/routes/events.ts
+++ b/packages/hub/src/routes/events.ts
@@ -165,6 +165,14 @@ export function eventsRouter(ctx: HubServerContext): Router {
               : 'failed';
             const resultVersion = (e.payload as any)?.resultVersion ?? null;
             const errorMessage = (e.payload as any)?.error ?? null;
+            // A late 'started' from a resurrected agent must not flip a
+            // cancelled (or otherwise terminal) target back to in_progress —
+            // that would re-wedge the installation the admin just force-
+            // cancelled. Terminal succeeded/failed reports stay authoritative:
+            // they are more truthful and cannot block future directives.
+            const stateGuard = nextState === 'in_progress'
+              ? `AND state IN ('pending', 'in_progress')`
+              : '';
             await ctx.db.run(
               `UPDATE upgrade_directive_targets
                  SET state = ?,
@@ -172,7 +180,7 @@ export function eventsRouter(ctx: HubServerContext): Router {
                      finished_at = CASE WHEN ? IN ('succeeded', 'failed') THEN ? ELSE finished_at END,
                      result_version = COALESCE(?, result_version),
                      error_message = COALESCE(?, error_message)
-               WHERE directive_id = ? AND installation_id = ?`,
+               WHERE directive_id = ? AND installation_id = ? ${stateGuard}`,
               [nextState, now, nextState, now, resultVersion, errorMessage, directiveId, e.installationId],
             );
             // Note: do NOT stamp installations.agenfk_version from

--- a/packages/hub/src/routes/events.ts
+++ b/packages/hub/src/routes/events.ts
@@ -170,16 +170,25 @@ export function eventsRouter(ctx: HubServerContext): Router {
             // that would re-wedge the installation the admin just force-
             // cancelled. Terminal succeeded/failed reports stay authoritative:
             // they are more truthful and cannot block future directives.
+            // (Trade-off: an agent retrying after its own 'failed' report
+            // won't show in_progress during the retry; its eventual terminal
+            // report still lands.)
             const stateGuard = nextState === 'in_progress'
               ? `AND state IN ('pending', 'in_progress')`
               : '';
+            // Terminal reports OVERWRITE error_message (null clears it):
+            // otherwise a force-cancel's stamped message would survive a
+            // genuine late failure reason, or linger on a succeeded row.
+            const errorMessageSql = nextState === 'in_progress'
+              ? 'COALESCE(?, error_message)'
+              : '?';
             await ctx.db.run(
               `UPDATE upgrade_directive_targets
                  SET state = ?,
                      attempted_at = COALESCE(attempted_at, ?),
                      finished_at = CASE WHEN ? IN ('succeeded', 'failed') THEN ? ELSE finished_at END,
                      result_version = COALESCE(?, result_version),
-                     error_message = COALESCE(?, error_message)
+                     error_message = ${errorMessageSql}
                WHERE directive_id = ? AND installation_id = ? ${stateGuard}`,
               [nextState, now, nextState, now, resultVersion, errorMessage, directiveId, e.installationId],
             );

--- a/packages/hub/src/test/admin-upgrade-force-cancel.test.ts
+++ b/packages/hub/src/test/admin-upgrade-force-cancel.test.ts
@@ -279,11 +279,71 @@ describe('POST /v1/admin/upgrade/:directiveId/cancel { force: true }', () => {
     expect(r.status).toBe(200);
 
     const row = await ctx.db.get(
-      `SELECT state, result_version FROM upgrade_directive_targets WHERE directive_id = ? AND installation_id = 'inst-1'`,
+      `SELECT state, result_version, error_message FROM upgrade_directive_targets WHERE directive_id = ? AND installation_id = 'inst-1'`,
       [directiveId],
     );
     expect(row!.state).toBe('succeeded');
     expect(row!.result_version).toBe('0.3.1');
+    // The stale force-cancel message must not linger on a succeeded row.
+    expect(row!.error_message).toBeNull();
+  });
+
+  it('a late terminal failed report overwrites the force-cancel error_message with the real reason', async () => {
+    const directiveId = await issueDirectiveAll();
+    await markInProgress(directiveId, 'inst-1');
+    await supertest(app)
+      .post(`/v1/admin/upgrade/${directiveId}/cancel`)
+      .set('Cookie', cookieAdmin)
+      .send({ force: true });
+
+    const r = await supertest(app)
+      .post('/v1/events')
+      .set('Authorization', `Bearer ${fleetTokenInst1}`)
+      .send({ events: [upgradeEvent('fleet:upgrade:failed', 'inst-1', directiveId, { error: 'install.mjs exit 1' })] });
+    expect(r.status).toBe(200);
+
+    const row = await ctx.db.get(
+      `SELECT state, error_message FROM upgrade_directive_targets WHERE directive_id = ? AND installation_id = 'inst-1'`,
+      [directiveId],
+    );
+    expect(row!.state).toBe('failed');
+    expect(row!.error_message).toBe('install.mjs exit 1');
+  });
+
+  it('a late started is also blocked on plain-cancelled and terminal targets', async () => {
+    const directiveId = await issueDirectiveAll();
+    // inst-1: plain cancel while still pending.
+    await supertest(app)
+      .post(`/v1/admin/upgrade/${directiveId}/cancel`)
+      .set('Cookie', cookieAdmin)
+      .send({});
+
+    const r = await supertest(app)
+      .post('/v1/events')
+      .set('Authorization', `Bearer ${fleetTokenInst1}`)
+      .send({ events: [upgradeEvent('fleet:upgrade:started', 'inst-1', directiveId)] });
+    expect(r.status).toBe(200);
+    const cancelled = await ctx.db.get(
+      `SELECT state FROM upgrade_directive_targets WHERE directive_id = ? AND installation_id = 'inst-1'`,
+      [directiveId],
+    );
+    expect(cancelled!.state).toBe('cancelled');
+
+    // And on a terminal row: force a succeeded state, then replay started.
+    await ctx.db.run(
+      `UPDATE upgrade_directive_targets SET state = 'succeeded' WHERE directive_id = ? AND installation_id = 'inst-1'`,
+      [directiveId],
+    );
+    const r2 = await supertest(app)
+      .post('/v1/events')
+      .set('Authorization', `Bearer ${fleetTokenInst1}`)
+      .send({ events: [upgradeEvent('fleet:upgrade:started', 'inst-1', directiveId)] });
+    expect(r2.status).toBe(200);
+    const terminal = await ctx.db.get(
+      `SELECT state FROM upgrade_directive_targets WHERE directive_id = ? AND installation_id = 'inst-1'`,
+      [directiveId],
+    );
+    expect(terminal!.state).toBe('succeeded');
   });
 });
 

--- a/packages/hub/src/test/admin-upgrade-force-cancel.test.ts
+++ b/packages/hub/src/test/admin-upgrade-force-cancel.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Hub admin: FORCE-cancel a fleet upgrade directive (BUG 5707f067).
+ *
+ * A target stuck in state='in_progress' (agent died mid-upgrade or its
+ * terminal fleet:upgrade:* event was lost) wedges the installation forever:
+ * the single-pending guard blocks every new directive and the plain cancel
+ * deliberately leaves in_progress alone.
+ *
+ * POST /v1/admin/upgrade/:directiveId/cancel with { force: true }:
+ *   - flips pending AND in_progress targets to 'cancelled'
+ *   - stamps finished_at + error_message on the force-cancelled in_progress rows
+ *   - reports forcedCount alongside cancelledCount
+ *   - unblocks the single-pending guard for a fresh directive
+ * Without force the behavior is unchanged (in_progress left alone).
+ *
+ * Guard rail: a late `fleet:upgrade:started` event from a resurrected agent
+ * must NOT flip a cancelled target back to in_progress (it would re-wedge);
+ * a late terminal succeeded/failed report stays authoritative.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { randomUUID } from 'crypto';
+import supertest from 'supertest';
+import { createHubApp } from '../server';
+import { createPasswordUser } from '../auth/password';
+import { issueApiKey } from '../auth/apiKey';
+
+const TEST_DB = path.join(os.tmpdir(), `agenfk-hub-upgrade-force-cancel-${process.pid}.sqlite`);
+const SECRET = 'a'.repeat(64);
+const cleanup = () => {
+  for (const suffix of ['', '-wal', '-shm']) {
+    const f = TEST_DB + suffix;
+    if (fs.existsSync(f)) fs.unlinkSync(f);
+  }
+};
+
+const loginAs = async (app: any, email: string, password: string) => {
+  const r = await supertest(app).post('/auth/login').send({ email, password });
+  return r.headers['set-cookie']?.[0] ?? '';
+};
+
+async function seedInstallation(db: any, orgId: string, installationId: string, occurredAt = '2026-05-01T10:00:00Z') {
+  await db.run(
+    `INSERT INTO installations (id, org_id, first_seen, last_seen, os_user)
+     VALUES (?, ?, ?, ?, 'tester')`,
+    [installationId, orgId, occurredAt, occurredAt],
+  );
+}
+
+function upgradeEvent(type: string, installationId: string, directiveId: string, extra: any = {}) {
+  return {
+    eventId: randomUUID(),
+    orgId: 'org-a',
+    installationId,
+    occurredAt: new Date('2026-05-02T10:00:00Z').toISOString(),
+    type,
+    actor: { osUser: 'tester' },
+    payload: { directiveId, ...extra },
+  };
+}
+
+describe('POST /v1/admin/upgrade/:directiveId/cancel { force: true }', () => {
+  let app: any;
+  let ctx: any;
+  let cookieAdmin: string;
+  let cookieView: string;
+  let fleetTokenInst1: string;
+
+  beforeEach(async () => {
+    cleanup();
+    const out = await createHubApp({
+      dbPath: TEST_DB,
+      secretKey: SECRET,
+      sessionSecret: 'test-session-secret',
+      defaultOrgId: 'org-a',
+      releaseExists: async (version: string) => version === '0.3.1',
+    } as any);
+    app = out.app;
+    ctx = out.ctx;
+    await createPasswordUser(ctx.db, 'org-a', 'admin@x', 'longenough1', 'admin');
+    await createPasswordUser(ctx.db, 'org-a', 'view@x', 'longenough1', 'viewer');
+    cookieAdmin = await loginAs(app, 'admin@x', 'longenough1');
+    cookieView = await loginAs(app, 'view@x', 'longenough1');
+
+    await seedInstallation(ctx.db, 'org-a', 'inst-1');
+    await seedInstallation(ctx.db, 'org-a', 'inst-2');
+    await seedInstallation(ctx.db, 'org-a', 'inst-3');
+    fleetTokenInst1 = await issueApiKey(ctx.db, 'org-a', 'inst-1-token', { installationId: 'inst-1' } as any);
+  });
+
+  afterEach(async () => { await ctx.db.close(); cleanup(); });
+
+  async function issueDirectiveAll(): Promise<string> {
+    const r = await supertest(app)
+      .post('/v1/admin/upgrade')
+      .set('Cookie', cookieAdmin)
+      .send({ targetVersion: '0.3.1', scope: { type: 'all' } });
+    expect(r.status).toBe(201);
+    return r.body.directiveId;
+  }
+
+  async function markInProgress(directiveId: string, installationId: string) {
+    await ctx.db.run(
+      `UPDATE upgrade_directive_targets SET state = 'in_progress', attempted_at = '2026-05-02T10:00:00Z'
+       WHERE directive_id = ? AND installation_id = ?`,
+      [directiveId, installationId],
+    );
+  }
+
+  it('force-cancels in_progress targets along with pending ones', async () => {
+    const directiveId = await issueDirectiveAll();
+    await markInProgress(directiveId, 'inst-1');
+
+    const r = await supertest(app)
+      .post(`/v1/admin/upgrade/${directiveId}/cancel`)
+      .set('Cookie', cookieAdmin)
+      .send({ force: true });
+    expect(r.status).toBe(200);
+    expect(r.body.cancelledCount).toBe(3);   // 2 pending + 1 in_progress
+    expect(r.body.forcedCount).toBe(1);      // the in_progress one
+    expect(r.body.leftAlone).toEqual({ in_progress: 0, succeeded: 0, failed: 0 });
+
+    const rows = await ctx.db.all(
+      'SELECT installation_id, state, finished_at, error_message FROM upgrade_directive_targets WHERE directive_id = ?',
+      [directiveId],
+    );
+    expect(rows.every((t: any) => t.state === 'cancelled')).toBe(true);
+    // The force-cancelled in_progress row records when and why it was closed.
+    const forced = rows.find((t: any) => t.installation_id === 'inst-1')!;
+    expect(forced.finished_at).toBeTruthy();
+    expect(forced.error_message).toMatch(/force/i);
+  });
+
+  it('without force, in_progress is still left alone (regression)', async () => {
+    const directiveId = await issueDirectiveAll();
+    await markInProgress(directiveId, 'inst-1');
+
+    const r = await supertest(app)
+      .post(`/v1/admin/upgrade/${directiveId}/cancel`)
+      .set('Cookie', cookieAdmin)
+      .send({});
+    expect(r.status).toBe(200);
+    expect(r.body.cancelledCount).toBe(2);
+    expect(r.body.leftAlone).toEqual({ in_progress: 1, succeeded: 0, failed: 0 });
+
+    const row = await ctx.db.get(
+      `SELECT state FROM upgrade_directive_targets WHERE directive_id = ? AND installation_id = 'inst-1'`,
+      [directiveId],
+    );
+    expect(row!.state).toBe('in_progress');
+  });
+
+  it('force never touches succeeded/failed targets', async () => {
+    const directiveId = await issueDirectiveAll();
+    await ctx.db.run(
+      `UPDATE upgrade_directive_targets SET state = 'succeeded', result_version = '0.3.1'
+       WHERE directive_id = ? AND installation_id = 'inst-2'`,
+      [directiveId],
+    );
+    await ctx.db.run(
+      `UPDATE upgrade_directive_targets SET state = 'failed', error_message = 'boom'
+       WHERE directive_id = ? AND installation_id = 'inst-3'`,
+      [directiveId],
+    );
+
+    const r = await supertest(app)
+      .post(`/v1/admin/upgrade/${directiveId}/cancel`)
+      .set('Cookie', cookieAdmin)
+      .send({ force: true });
+    expect(r.status).toBe(200);
+    expect(r.body.cancelledCount).toBe(1); // only inst-1's pending row
+    expect(r.body.forcedCount).toBe(0);
+    expect(r.body.leftAlone).toEqual({ in_progress: 0, succeeded: 1, failed: 1 });
+
+    const byInst = await ctx.db.all(
+      'SELECT installation_id, state, error_message FROM upgrade_directive_targets WHERE directive_id = ?',
+      [directiveId],
+    );
+    const map = Object.fromEntries(byInst.map((t: any) => [t.installation_id, t]));
+    expect(map['inst-2'].state).toBe('succeeded');
+    expect(map['inst-3'].state).toBe('failed');
+    expect(map['inst-3'].error_message).toBe('boom'); // untouched
+  });
+
+  it('force requires admin (viewer gets 403)', async () => {
+    const directiveId = await issueDirectiveAll();
+    const r = await supertest(app)
+      .post(`/v1/admin/upgrade/${directiveId}/cancel`)
+      .set('Cookie', cookieView)
+      .send({ force: true });
+    expect(r.status).toBe(403);
+  });
+
+  it('force-cancelled in_progress targets unblock the single-pending guard', async () => {
+    const directiveId = await issueDirectiveAll();
+    await markInProgress(directiveId, 'inst-1');
+
+    // Sanity: the wedge exists — a fresh directive 409s on the in_progress target.
+    const blocked = await supertest(app)
+      .post('/v1/admin/upgrade')
+      .set('Cookie', cookieAdmin)
+      .send({ targetVersion: '0.3.1', scope: { type: 'installation', installationId: 'inst-1' }, confirmDowngrade: true });
+    expect(blocked.status).toBe(409);
+    expect(blocked.body.conflicts?.[0]?.conflictingDirectiveId).toBe(directiveId);
+
+    await supertest(app)
+      .post(`/v1/admin/upgrade/${directiveId}/cancel`)
+      .set('Cookie', cookieAdmin)
+      .send({ force: true });
+
+    const fresh = await supertest(app)
+      .post('/v1/admin/upgrade')
+      .set('Cookie', cookieAdmin)
+      .send({ targetVersion: '0.3.1', scope: { type: 'installation', installationId: 'inst-1' }, confirmDowngrade: true });
+    expect(fresh.status).toBe(201);
+  });
+
+  it('is idempotent: repeating force-cancel returns cancelledCount=0, forcedCount=0', async () => {
+    const directiveId = await issueDirectiveAll();
+    await markInProgress(directiveId, 'inst-1');
+    await supertest(app)
+      .post(`/v1/admin/upgrade/${directiveId}/cancel`)
+      .set('Cookie', cookieAdmin)
+      .send({ force: true });
+    const again = await supertest(app)
+      .post(`/v1/admin/upgrade/${directiveId}/cancel`)
+      .set('Cookie', cookieAdmin)
+      .send({ force: true });
+    expect(again.status).toBe(200);
+    expect(again.body.cancelledCount).toBe(0);
+    expect(again.body.forcedCount).toBe(0);
+  });
+
+  it('a late fleet:upgrade:started cannot resurrect a cancelled target (would re-wedge)', async () => {
+    const directiveId = await issueDirectiveAll();
+    await markInProgress(directiveId, 'inst-1');
+    await supertest(app)
+      .post(`/v1/admin/upgrade/${directiveId}/cancel`)
+      .set('Cookie', cookieAdmin)
+      .send({ force: true });
+
+    // The zombie agent comes back and reports "started" for the old directive.
+    const r = await supertest(app)
+      .post('/v1/events')
+      .set('Authorization', `Bearer ${fleetTokenInst1}`)
+      .send({ events: [upgradeEvent('fleet:upgrade:started', 'inst-1', directiveId)] });
+    expect(r.status).toBe(200);
+
+    const row = await ctx.db.get(
+      `SELECT state FROM upgrade_directive_targets WHERE directive_id = ? AND installation_id = 'inst-1'`,
+      [directiveId],
+    );
+    expect(row!.state).toBe('cancelled');
+
+    // And issuing a fresh directive for inst-1 still works.
+    const fresh = await supertest(app)
+      .post('/v1/admin/upgrade')
+      .set('Cookie', cookieAdmin)
+      .send({ targetVersion: '0.3.1', scope: { type: 'installation', installationId: 'inst-1' }, confirmDowngrade: true });
+    expect(fresh.status).toBe(201);
+  });
+
+  it('a late terminal report (succeeded) remains authoritative over a force-cancel', async () => {
+    const directiveId = await issueDirectiveAll();
+    await markInProgress(directiveId, 'inst-1');
+    await supertest(app)
+      .post(`/v1/admin/upgrade/${directiveId}/cancel`)
+      .set('Cookie', cookieAdmin)
+      .send({ force: true });
+
+    // The upgrade actually finished — the terminal report should win: it is
+    // more truthful and, being terminal, cannot re-wedge issuance.
+    const r = await supertest(app)
+      .post('/v1/events')
+      .set('Authorization', `Bearer ${fleetTokenInst1}`)
+      .send({ events: [upgradeEvent('fleet:upgrade:succeeded', 'inst-1', directiveId, { resultVersion: '0.3.1' })] });
+    expect(r.status).toBe(200);
+
+    const row = await ctx.db.get(
+      `SELECT state, result_version FROM upgrade_directive_targets WHERE directive_id = ? AND installation_id = 'inst-1'`,
+      [directiveId],
+    );
+    expect(row!.state).toBe('succeeded');
+    expect(row!.result_version).toBe('0.3.1');
+  });
+});
+
+describe('AdminUpgrades.tsx — force-cancel affordance (source regression)', () => {
+  it('offers the force path when in_progress targets remain', () => {
+    const PAGE_PATH = path.resolve(__dirname, '../../../hub-ui/src/pages/AdminUpgrades.tsx');
+    const src = fs.readFileSync(PAGE_PATH, 'utf8');
+    // The cancel mutation can carry the force flag to the endpoint.
+    expect(src).toMatch(/force/);
+    // A distinct, explicit confirmation for force-cancelling in-flight upgrades.
+    expect(src).toMatch(/[Ff]orce-cancel/);
+    // The cancel control must be reachable when only in_progress targets remain
+    // (previously it keyed off progress.pending alone).
+    expect(src).toMatch(/in_progress/);
+  });
+});


### PR DESCRIPTION
A target stuck in in_progress (agent died mid-upgrade or lost its terminal fleet:upgrade:* event) wedges the installation forever: the single-pending guard in POST /v1/admin/upgrade blocks all new directives for it, and POST /v1/admin/upgrade/:id/cancel only flips pending targets. Fix: cancel endpoint accepts force=true which also flips in_progress targets to cancelled (stamping finished_at + error_message); hub-ui AdminUpgrades offers the force path with a distinct confirmation when in_progress targets remain. Real-world case: directive b42233ca / installation 08e6b2b9 (invite:felipedasilvasantos).