### PR TITLE
fix(hub): PR events populate remote_url filter dimension (derive from payload.repo)

### DIFF
--- a/packages/hub/src/db/postgres.ts
+++ b/packages/hub/src/db/postgres.ts
@@ -251,6 +251,28 @@ class PgAdapter implements HubDb {
   }
 }
 
+// Backfill: PR events ingested before the repo→remote_url fallback existed have
+// remote_url = NULL, stranding their repo inside the payload JSON and hiding
+// them from the projects filter. Derive remote_url from payload.repo the same
+// way the ingestion path now does. Parsed JS-side so this stays identical to the
+// SQLite backfill and avoids jsonb casting on TEXT payloads. Idempotent (only
+// touches null/empty PR rows) and exported so tests can exercise it against a
+// pg-mem adapter without re-running the (non-reentrant on pg-mem) full schema.
+export async function backfillPrEventRemoteUrls(adapter: HubDb): Promise<void> {
+  const prRows = await adapter.all<{ event_id: string; payload: string }>(
+    "SELECT event_id, payload FROM events WHERE (remote_url IS NULL OR remote_url = '') AND type IN ('pr.opened', 'pr.updated')"
+  );
+  for (const { event_id, payload } of prRows) {
+    let repo: unknown;
+    try { repo = JSON.parse(payload)?.payload?.repo; } catch { continue; }
+    if (typeof repo !== 'string') continue;
+    const derived = remoteUrlFromRepo(repo);
+    if (derived) {
+      await adapter.run("UPDATE events SET remote_url = ? WHERE event_id = ?", [sanitizeRemoteUrl(derived), event_id]);
+    }
+  }
+}
+
 async function bootstrap(adapter: HubDb): Promise<void> {
   await adapter.exec(SCHEMA_PG);
   await adapter.exec("DELETE FROM events WHERE type = 'tokens.logged'");
@@ -299,25 +321,8 @@ async function bootstrap(adapter: HubDb): Promise<void> {
     }
   }
 
-  // Backfill: PR events ingested before the repo→remote_url fallback existed
-  // have remote_url = NULL, stranding their repo inside the payload JSON and
-  // hiding them from the projects filter. Derive remote_url from payload.repo
-  // the same way the ingestion path now does. Parsed JS-side so this stays
-  // identical to the SQLite backfill and avoids jsonb casting on TEXT payloads.
-  {
-    const prRows = await adapter.all<{ event_id: string; payload: string }>(
-      "SELECT event_id, payload FROM events WHERE (remote_url IS NULL OR remote_url = '') AND type IN ('pr.opened', 'pr.updated')"
-    );
-    for (const { event_id, payload } of prRows) {
-      let repo: unknown;
-      try { repo = JSON.parse(payload)?.payload?.repo; } catch { continue; }
-      if (typeof repo !== 'string') continue;
-      const derived = remoteUrlFromRepo(repo);
-      if (derived) {
-        await adapter.run("UPDATE events SET remote_url = ? WHERE event_id = ?", [sanitizeRemoteUrl(derived), event_id]);
-      }
-    }
-  }
+  // PR-event remote_url backfill (see backfillPrEventRemoteUrls).
+  await backfillPrEventRemoteUrls(adapter);
 
   // upgrade_directives audit columns — Story 5 of EPIC 541c12b3.
   const udCols = await adapter.all<{ column_name: string }>(

--- a/packages/hub/src/db/postgres.ts
+++ b/packages/hub/src/db/postgres.ts
@@ -1,6 +1,6 @@
 import type { HubDb, Params, RunResult } from './types';
 import { toPostgres } from './dialect';
-import { sanitizeRemoteUrl } from '../util/remoteUrl.js';
+import { sanitizeRemoteUrl, remoteUrlFromRepo } from '../util/remoteUrl.js';
 
 // `pg` is loaded lazily so installations that only use SQLite don't pay the
 // require cost. The Pool / Client types are imported from `pg` directly.
@@ -295,6 +295,26 @@ async function bootstrap(adapter: HubDb): Promise<void> {
           "UPDATE events SET remote_url = ? WHERE remote_url = ?",
           [canonical, remote_url],
         );
+      }
+    }
+  }
+
+  // Backfill: PR events ingested before the repo→remote_url fallback existed
+  // have remote_url = NULL, stranding their repo inside the payload JSON and
+  // hiding them from the projects filter. Derive remote_url from payload.repo
+  // the same way the ingestion path now does. Parsed JS-side so this stays
+  // identical to the SQLite backfill and avoids jsonb casting on TEXT payloads.
+  {
+    const prRows = await adapter.all<{ event_id: string; payload: string }>(
+      "SELECT event_id, payload FROM events WHERE (remote_url IS NULL OR remote_url = '') AND type IN ('pr.opened', 'pr.updated')"
+    );
+    for (const { event_id, payload } of prRows) {
+      let repo: unknown;
+      try { repo = JSON.parse(payload)?.payload?.repo; } catch { continue; }
+      if (typeof repo !== 'string') continue;
+      const derived = remoteUrlFromRepo(repo);
+      if (derived) {
+        await adapter.run("UPDATE events SET remote_url = ? WHERE event_id = ?", [sanitizeRemoteUrl(derived), event_id]);
       }
     }
   }

--- a/packages/hub/src/db/sqlite.ts
+++ b/packages/hub/src/db/sqlite.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import type { HubDb, Params, RunResult } from './types';
-import { sanitizeRemoteUrl } from '../util/remoteUrl.js';
+import { sanitizeRemoteUrl, remoteUrlFromRepo } from '../util/remoteUrl.js';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { DatabaseSync } = require('node:sqlite') as typeof import('node:sqlite');
@@ -273,6 +273,24 @@ export async function openSqliteDb(dbPath: string): Promise<HubDb> {
     for (const { remote_url } of distinct) {
       const canonical = sanitizeRemoteUrl(remote_url);
       if (canonical !== remote_url) update.run(canonical, remote_url);
+    }
+  }
+
+  // Backfill: PR events ingested before the repo→remote_url fallback existed
+  // have remote_url = NULL, stranding their repo inside the payload JSON and
+  // hiding them from the projects filter. Derive remote_url from payload.repo
+  // the same way the ingestion path now does. JS-side (SQLite has no regex).
+  {
+    const prRows = raw.prepare(
+      "SELECT event_id, payload FROM events WHERE (remote_url IS NULL OR remote_url = '') AND type IN ('pr.opened', 'pr.updated')"
+    ).all() as Array<{ event_id: string; payload: string }>;
+    const update = raw.prepare("UPDATE events SET remote_url = ? WHERE event_id = ?");
+    for (const { event_id, payload } of prRows) {
+      let repo: unknown;
+      try { repo = JSON.parse(payload)?.payload?.repo; } catch { continue; }
+      if (typeof repo !== 'string') continue;
+      const derived = remoteUrlFromRepo(repo);
+      if (derived) update.run(sanitizeRemoteUrl(derived), event_id);
     }
   }
 

--- a/packages/hub/src/routes/events.ts
+++ b/packages/hub/src/routes/events.ts
@@ -8,7 +8,7 @@ function userKeyFor(actor: HubEvent['actor']): string {
 }
 
 export { sanitizeRemoteUrl } from '../util/remoteUrl.js';
-import { sanitizeRemoteUrl } from '../util/remoteUrl.js';
+import { sanitizeRemoteUrl, remoteUrlFromRepo } from '../util/remoteUrl.js';
 
 
 function isValidEvent(e: any): e is HubEvent {
@@ -133,9 +133,23 @@ export function eventsRouter(ctx: HubServerContext): Router {
         // different fleet machines store the URL with different casing or
         // accidental whitespace in their git config.
         const remoteUrlRaw = (e as any).remoteUrl ?? null;
-        const remoteUrl = typeof remoteUrlRaw === 'string'
+        let remoteUrl = typeof remoteUrlRaw === 'string'
           ? sanitizeRemoteUrl(remoteUrlRaw)
           : remoteUrlRaw;
+        // Prefer the emitter-resolved git remote; fall back to the repo the
+        // agent declared in the payload (PR events) when it's absent. The
+        // emitter resolves remoteUrl by shelling out `git remote get-url
+        // origin`, which yields null when the project has no origin / projectRoot
+        // — stranding the PR's repo inside the JSON blob and hiding it from the
+        // remote_url project filter. Deriving from payload.repo lands the PR
+        // event on the SAME chip as the repo's other events. (BUG 418ee7bd.)
+        if (!remoteUrl) {
+          const repo = e.payload && typeof (e.payload as any).repo === 'string'
+            ? (e.payload as any).repo
+            : null;
+          const derived = repo ? remoteUrlFromRepo(repo) : null;
+          if (derived) remoteUrl = sanitizeRemoteUrl(derived);
+        }
         const itemTitle = (e as any).itemTitle
           ?? (e.payload && typeof (e.payload as any).title === 'string' ? (e.payload as any).title : null);
         const externalId = (e as any).externalId

--- a/packages/hub/src/test/hub-pg-parity.test.ts
+++ b/packages/hub/src/test/hub-pg-parity.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import supertest from 'supertest';
 import { createHubApp } from '../server';
-import { openPgMemDb } from '../db/postgres';
+import { openPgMemDb, backfillPrEventRemoteUrls } from '../db/postgres';
 import { issueApiKey } from '../auth/apiKey';
 import { createPasswordUser } from '../auth/password';
 import { recomputeRollups } from '../rollup';
@@ -266,5 +266,58 @@ describe('PG parity: queries + rollup', () => {
     const day4bob = rows.find((x) => x.day === '2026-05-04' && x.user_key === 'bob@acme.com');
     expect(Number(day4bob?.tokens_in)).toBe(0);
     expect(Number(day4bob?.tokens_out)).toBe(0);
+  });
+});
+
+// BUG 418ee7bd — the boot-time backfill that derives remote_url from a PR
+// event's payload.repo is hand-mirrored across the SQLite and Postgres
+// bootstraps. The SQLite copy is covered in pr-event-remote-url.test.ts; this
+// locks down the PG copy so the two can't silently diverge. We seed a legacy
+// row then invoke the exported backfill helper (the same one bootstrap() runs)
+// against the pg-mem adapter — re-running full bootstrap isn't reentrant on
+// pg-mem (its CREATE TABLE IF NOT EXISTS AST check rejects the second pass).
+describe('PG parity: PR-event remote_url backfill', () => {
+  let db: HubDb;
+  afterEach(async () => { try { await db.close(); } catch { /* */ } });
+
+  it('derives remote_url from payload.repo for historical null PR rows', async () => {
+    db = await openPgMemDb();
+    // payload column stores the WHOLE event, so repo lives at $.payload.repo.
+    const legacyPayload = JSON.stringify({
+      eventId: 'legacy-pr', type: 'pr.opened',
+      payload: { prNumber: 99, repo: 'carsales-PRIVATE/dataservice' },
+    });
+    await db.run(
+      `INSERT INTO events (event_id, org_id, installation_id, user_key, occurred_at, received_at, type, remote_url, payload)
+       VALUES ('legacy-pr', 'org', 'inst-1', 'tester', ?, ?, 'pr.opened', NULL, ?)`,
+      ['2026-07-01T00:00:00Z', '2026-07-01T00:00:00Z', legacyPayload],
+    );
+
+    await backfillPrEventRemoteUrls(db);
+
+    const row = await db.get<{ remote_url: string }>(
+      "SELECT remote_url FROM events WHERE event_id = 'legacy-pr'",
+    );
+    expect(row?.remote_url).toBe('git@github.com:carsales-private/dataservice.git');
+  });
+
+  it('leaves a non-PR null-remote row untouched (backfill is type-scoped)', async () => {
+    db = await openPgMemDb();
+    const payload = JSON.stringify({
+      eventId: 'legacy-item', type: 'item.created',
+      payload: { repo: 'carsales-PRIVATE/dataservice' },
+    });
+    await db.run(
+      `INSERT INTO events (event_id, org_id, installation_id, user_key, occurred_at, received_at, type, remote_url, payload)
+       VALUES ('legacy-item', 'org', 'inst-1', 'tester', ?, ?, 'item.created', NULL, ?)`,
+      ['2026-07-01T00:00:00Z', '2026-07-01T00:00:00Z', payload],
+    );
+
+    await backfillPrEventRemoteUrls(db);
+
+    const row = await db.get<{ remote_url: string | null }>(
+      "SELECT remote_url FROM events WHERE event_id = 'legacy-item'",
+    );
+    expect(row?.remote_url ?? null).toBeNull();
   });
 });

--- a/packages/hub/src/test/pr-event-remote-url.test.ts
+++ b/packages/hub/src/test/pr-event-remote-url.test.ts
@@ -1,0 +1,173 @@
+/**
+ * BUG 418ee7bd — PR events (`pr.opened` / `pr.updated`) frequently arrive with
+ * `remoteUrl: null` because the emitter's `git remote get-url origin` shell-out
+ * failed, stranding the PR's authoritative `owner/repo` (declared by the agent)
+ * inside the JSON payload where the `remote_url` filter dimension can't see it.
+ *
+ * Fix: at hub ingestion, PREFER the resolved `remoteUrl`; when it's absent,
+ * derive it from `payload.repo` (owner/repo → canonical `git@github.com:…`,
+ * collapsed via sanitizeRemoteUrl) so PR events land on the SAME project-filter
+ * chip as the repo's other events. A boot-time backfill repairs historical rows.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import supertest from 'supertest';
+import { createHubApp } from '../server';
+import { createPasswordUser } from '../auth/password';
+import { issueApiKey } from '../auth/apiKey';
+import { remoteUrlFromRepo, sanitizeRemoteUrl } from '../util/remoteUrl';
+
+const TEST_DB = path.join(os.tmpdir(), `agenfk-hub-pr-remote-${process.pid}.sqlite`);
+const SECRET = 'a'.repeat(64);
+const cleanup = () => {
+  for (const suffix of ['', '-wal', '-shm']) {
+    const f = TEST_DB + suffix;
+    if (fs.existsSync(f)) fs.unlinkSync(f);
+  }
+};
+
+const prEvent = (overrides: any = {}) => ({
+  eventId: 'e-' + Math.random().toString(36).slice(2),
+  installationId: 'inst-1',
+  orgId: 'org-a',
+  occurredAt: '2026-07-14T10:00:00Z',
+  actor: { osUser: 'tester' },
+  type: 'pr.opened',
+  payload: { prNumber: 434, repo: 'carsales-PRIVATE/dataservice', sizing: { epic: 0, story: 1, task: 1, bug: 0 } },
+  ...overrides,
+});
+
+describe('remoteUrlFromRepo (unit)', () => {
+  it('derives a canonical github remote from a bare owner/repo slug', () => {
+    expect(remoteUrlFromRepo('carsales-PRIVATE/dataservice'))
+      .toBe('git@github.com:carsales-PRIVATE/dataservice.git');
+  });
+
+  it('strips a trailing .git from the repo name', () => {
+    expect(remoteUrlFromRepo('owner/repo.git')).toBe('git@github.com:owner/repo.git');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(remoteUrlFromRepo('  owner/repo  ')).toBe('git@github.com:owner/repo.git');
+  });
+
+  it('returns null for a host-qualified path (not a bare slug)', () => {
+    expect(remoteUrlFromRepo('github.com/owner/repo')).toBeNull();
+  });
+
+  it('returns null for a full URL', () => {
+    expect(remoteUrlFromRepo('https://github.com/owner/repo')).toBeNull();
+  });
+
+  it('returns null for junk with no slash', () => {
+    expect(remoteUrlFromRepo('not-a-repo')).toBeNull();
+  });
+
+  it('composes with sanitizeRemoteUrl onto the same chip as a real git remote', () => {
+    const derived = sanitizeRemoteUrl(remoteUrlFromRepo('carsales-PRIVATE/dataservice')!);
+    const fromGit = sanitizeRemoteUrl('git@github.com:carsales-private/dataservice.git');
+    expect(derived).toBe(fromGit);
+    expect(derived).toBe('git@github.com:carsales-private/dataservice.git');
+  });
+});
+
+describe('Hub: PR events populate the remote_url filter dimension', { hookTimeout: 30_000 }, () => {
+  let app: any;
+  let ctx: any;
+  let cookieAdmin: string;
+  let token: string;
+
+  beforeEach(async () => {
+    cleanup();
+    const out = await createHubApp({
+      dbPath: TEST_DB,
+      secretKey: SECRET,
+      sessionSecret: 'test-session-secret',
+      defaultOrgId: 'org-a',
+    });
+    app = out.app;
+    ctx = out.ctx;
+    await createPasswordUser(ctx.db, 'org-a', 'admin@x', 'longenough1', 'admin');
+    const login = await supertest(app).post('/auth/login').send({ email: 'admin@x', password: 'longenough1' });
+    cookieAdmin = login.headers['set-cookie']?.[0] ?? '';
+    token = await issueApiKey(ctx.db, 'org-a', 'inst-1');
+  });
+  afterEach(async () => { await ctx.db.close(); cleanup(); });
+
+  it('derives remote_url from payload.repo when the event has no remoteUrl', async () => {
+    await supertest(app)
+      .post('/v1/events').set('Authorization', `Bearer ${token}`)
+      .send({ events: [prEvent()] });
+    const row = await ctx.db.get<{ remote_url: string }>('SELECT remote_url FROM events LIMIT 1');
+    expect(row.remote_url).toBe('git@github.com:carsales-private/dataservice.git');
+  });
+
+  it('prefers the emitter-resolved remoteUrl over the payload repo', async () => {
+    // remoteUrl points at one repo, payload.repo at another: the resolved
+    // remote wins (it may be a non-github / GHE host we can't infer from repo).
+    await supertest(app)
+      .post('/v1/events').set('Authorization', `Bearer ${token}`)
+      .send({ events: [prEvent({
+        remoteUrl: 'git@ghe.internal:team/service.git',
+        payload: { prNumber: 1, repo: 'carsales-PRIVATE/dataservice' },
+      })] });
+    const row = await ctx.db.get<{ remote_url: string }>('SELECT remote_url FROM events LIMIT 1');
+    expect(row.remote_url).toBe('git@ghe.internal:team/service.git');
+  });
+
+  it('leaves remote_url null when payload.repo is not a bare owner/repo slug', async () => {
+    await supertest(app)
+      .post('/v1/events').set('Authorization', `Bearer ${token}`)
+      .send({ events: [prEvent({ payload: { prNumber: 2, repo: 'not-a-repo' } })] });
+    const row = await ctx.db.get<{ remote_url: string | null }>('SELECT remote_url FROM events LIMIT 1');
+    expect(row.remote_url).toBeNull();
+  });
+
+  it('surfaces the derived repo as a project chip and matches the ?projects filter', async () => {
+    await supertest(app)
+      .post('/v1/events').set('Authorization', `Bearer ${token}`)
+      .send({ events: [prEvent()] });
+
+    const projects = await supertest(app).get('/v1/projects').set('Cookie', cookieAdmin);
+    expect(projects.status).toBe(200);
+    expect(projects.body.projects).toEqual(['git@github.com:carsales-private/dataservice.git']);
+
+    // The UI filters by the chip value returned from /v1/projects (the
+    // canonical remote form), and https/ssh variants canonicalise to it too.
+    const timeline = await supertest(app)
+      .get('/v1/timeline?projects=' + encodeURIComponent('https://github.com/carsales-private/dataservice'))
+      .set('Cookie', cookieAdmin);
+    expect(timeline.status).toBe(200);
+    expect(timeline.body.events.length).toBe(1);
+  });
+
+  it('boot-time backfill repairs historical PR rows with null remote_url', async () => {
+    // Simulate a pre-fix row: PR event stored with remote_url NULL, repo only
+    // inside the payload blob (payload column holds the whole event, so repo is
+    // at $.payload.repo).
+    const legacyPayload = JSON.stringify({
+      eventId: 'legacy-pr', type: 'pr.opened',
+      payload: { prNumber: 99, repo: 'carsales-PRIVATE/dataservice' },
+    });
+    await ctx.db.run(
+      `INSERT INTO events (event_id, org_id, installation_id, user_key, occurred_at, received_at, type, remote_url, payload)
+       VALUES ('legacy-pr', 'org-a', 'inst-1', 'tester', ?, ?, 'pr.opened', NULL, ?)`,
+      ['2026-07-01T00:00:00Z', '2026-07-01T00:00:00Z', legacyPayload],
+    );
+    await ctx.db.close();
+
+    const out = await createHubApp({
+      dbPath: TEST_DB,
+      secretKey: SECRET,
+      sessionSecret: 'test-session-secret',
+      defaultOrgId: 'org-a',
+    });
+    ctx = out.ctx;
+    const row = await ctx.db.get<{ remote_url: string }>(
+      "SELECT remote_url FROM events WHERE event_id = 'legacy-pr'",
+    );
+    expect(row.remote_url).toBe('git@github.com:carsales-private/dataservice.git');
+  });
+});

--- a/packages/hub/src/util/remoteUrl.ts
+++ b/packages/hub/src/util/remoteUrl.ts
@@ -18,3 +18,22 @@ export function sanitizeRemoteUrl(input: string): string {
   const [, host, owner, repo] = m;
   return `git@${host}:${owner}/${repo}.git`;
 }
+
+// A bare `owner/repo` slug: exactly two non-empty, slash-free segments, with an
+// optional trailing `.git` on the repo. A host-qualified path (`host/owner/repo`)
+// or a full URL has more segments / a scheme and therefore does NOT match — we
+// leave those to the emitter-resolved remote rather than guessing.
+const REPO_SLUG_RE = /^([^/\s]+)\/([^/\s]+?)(?:\.git)?$/;
+
+// Derive a canonical git remote from the `owner/repo` slug an agent declares in
+// a PR payload. PR events often arrive with remoteUrl=null because the emitter's
+// `git remote get-url origin` shell-out failed; without this the PR's repo would
+// live only in the JSON payload and never reach the remote_url filter dimension.
+// owner/repo carries no host, so we assume github.com — where AgEnFK PRs open.
+// Returns null for anything that isn't a bare owner/repo. Pass the result
+// through sanitizeRemoteUrl to collapse it onto the same chip as real remotes.
+export function remoteUrlFromRepo(repo: string): string | null {
+  const m = repo.trim().match(REPO_SLUG_RE);
+  if (!m) return null;
+  return `git@github.com:${m[1]}/${m[2]}.git`;
+}


### PR DESCRIPTION
## Problem

`pr.opened` / `pr.updated` hub events arrive with `remoteUrl: null` whenever the emitter's `git remote get-url origin` shell-out fails (project has no `origin`/`projectRoot`). The PR's authoritative `owner/repo` — declared by the agent and present in `payload.repo` — then lives **only** inside the serialized JSON `payload` blob and never reaches the `remote_url` column the hub's projects filter uses. Result: the repo is recorded but invisible to filtering.

Concretely, a real `pr.opened` event for `carsales-PRIVATE/dataservice` came in with `remoteUrl: null`, so it dropped out of the git-remote/project filter entirely.

## Fix (hub-side, at the filter boundary)

**Prefer the emitter-resolved git remote; fall back to the declared repo.** At ingestion the hub already receives the resolved `remoteUrl` (or `null`) plus the payload, so the decision lives exactly there:

- New `remoteUrlFromRepo()` helper (`util/remoteUrl.ts`): `owner/repo` → canonical `git@github.com:owner/repo.git` (assumes github.com, since a bare slug carries no host). Returns `null` for anything that isn't a bare `owner/repo` (host-qualified paths, full URLs, junk), leaving those to the resolved remote.
- Ingestion fallback (`routes/events.ts`): when `remoteUrl` is absent, derive it from `payload.repo` and canonicalize with `sanitizeRemoteUrl` so PR events land on the **same** project-filter chip as the repo's other events.
- Boot-time backfill (`db/sqlite.ts` + `db/postgres.ts`): repairs historical PR rows with null `remote_url` by deriving from `payload.repo`. Idempotent, scoped to `remote_url IS NULL OR ''` + PR types, never clobbers a resolved value. JS-side JSON parse keeps both backends identical.

No client/emit change and no schema change — the existing `remote_url` dimension is reused rather than adding a parallel `repo` column.

## Tests

New `packages/hub/src/test/pr-event-remote-url.test.ts` (12 tests): `remoteUrlFromRepo` unit edges, ingestion derive-when-null, prefer-resolved-over-repo, null-for-non-slug, chip surfaces in `/v1/projects` + matches `?projects` filter, and boot-time backfill of historical null rows. Full hub suite green (402/402); tsc build clean.

https://claude.ai/code/session_01NW5PibVgKbdyz9xYAGAqbK