### PR TITLE
Async validate runs — agenfk verify no longer bounded by a single-request timeout

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -10,6 +10,7 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import { stageJsonMigration } from './db-migration.js';
+import { followValidateRun } from './verifyRun.js';
 import { registerHubCommands } from './commands/hub.js';
 import { toonEncode } from './toon.js';
 
@@ -3019,14 +3020,42 @@ program
       }
     }
 
+    // Follow an async validate run to completion, streaming output. No overall
+    // deadline — the verifyCommand may legitimately run for a long time.
+    const follow = async (runId: string) => {
+      const final = await followValidateRun({
+        poll: async () => (await axios.get(`${API_URL}/items/validate-runs/${runId}`, { headers: { 'x-agenfk-internal': verifyToken }, timeout: 10000 })).data,
+        onOutput: (chunk: string) => process.stdout.write(chunk),
+      });
+      if (final.status === 'passed') {
+        console.log(chalk.green(final.message || `\n✅ Validation passed.`));
+      } else {
+        console.error(chalk.red(`\n❌ ${final.message || 'Validation failed.'}`));
+        process.exit(1);
+      }
+    };
+
     try {
-      const body: any = { evidence: options.evidence };
+      const body: any = { evidence: options.evidence, async: true };
       if (command) body.command = command;
-      const { data } = await axios.post(`${API_URL}/items/${targetId}/validate`, body, { headers: { 'x-agenfk-internal': verifyToken }, timeout: 300000 });
-      if (data.output) console.log(data.output);
-      console.log(chalk.green(data.message || `\n✅ Validation passed.`));
+      const res = await axios.post(`${API_URL}/items/${targetId}/validate`, body, { headers: { 'x-agenfk-internal': verifyToken }, timeout: 30000 });
+      if (res.status === 202 && res.data?.runId) {
+        console.log(chalk.blue(res.data.message || `⏳ Validation running in background…`));
+        await follow(res.data.runId);
+        return;
+      }
+      // Synchronous fast-path (no command executed: anchor advance, sibling
+      // propagation, intermediate step without command).
+      if (res.data.output) console.log(res.data.output);
+      console.log(chalk.green(res.data.message || `\n✅ Validation passed.`));
     } catch (error: any) {
       const errData = error.response?.data;
+      // A run is already active for this item — follow it instead of failing.
+      if (errData?.error === 'VALIDATE_RUN_ACTIVE' && errData.runId) {
+        console.log(chalk.yellow(errData.message || 'A validation run is already active — following it.'));
+        await follow(errData.runId);
+        return;
+      }
       if (errData?.output) console.error(errData.output);
       console.error(chalk.red(`\n❌ ${errData?.message || errData?.error || error.message}`));
       process.exit(1);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3024,7 +3024,20 @@ program
     // deadline — the verifyCommand may legitimately run for a long time.
     const follow = async (runId: string) => {
       const final = await followValidateRun({
-        poll: async () => (await axios.get(`${API_URL}/items/validate-runs/${runId}`, { headers: { 'x-agenfk-internal': verifyToken }, timeout: 10000 })).data,
+        poll: async () => {
+          try {
+            return (await axios.get(`${API_URL}/items/validate-runs/${runId}`, { headers: { 'x-agenfk-internal': verifyToken }, timeout: 10000 })).data;
+          } catch (e: any) {
+            // 404 is a definitive answer (run expired / server restarted mid-run),
+            // not a connection blip — don't retry, surface the server's guidance.
+            if (e.response?.status === 404) {
+              const fatal: any = new Error(e.response.data?.message || 'The validation run is unknown to the server (it may have restarted). Check the item\'s comments for the persisted outcome before re-running verify.');
+              fatal.fatal = true;
+              throw fatal;
+            }
+            throw e;
+          }
+        },
         onOutput: (chunk: string) => process.stdout.write(chunk),
       });
       if (final.status === 'passed') {
@@ -3038,7 +3051,10 @@ program
     try {
       const body: any = { evidence: options.evidence, async: true };
       if (command) body.command = command;
-      const res = await axios.post(`${API_URL}/items/${targetId}/validate`, body, { headers: { 'x-agenfk-internal': verifyToken }, timeout: 30000 });
+      // 5-minute POST timeout: a NEW server answers 202 in milliseconds, but an
+      // OLD server (upgrade window) ignores async:true and blocks for the whole
+      // command — keep the previous ceiling so that path doesn't regress.
+      const res = await axios.post(`${API_URL}/items/${targetId}/validate`, body, { headers: { 'x-agenfk-internal': verifyToken }, timeout: 300000 });
       if (res.status === 202 && res.data?.runId) {
         console.log(chalk.blue(res.data.message || `⏳ Validation running in background…`));
         await follow(res.data.runId);
@@ -3053,7 +3069,12 @@ program
       // A run is already active for this item — follow it instead of failing.
       if (errData?.error === 'VALIDATE_RUN_ACTIVE' && errData.runId) {
         console.log(chalk.yellow(errData.message || 'A validation run is already active — following it.'));
-        await follow(errData.runId);
+        try {
+          await follow(errData.runId);
+        } catch (followErr: any) {
+          console.error(chalk.red(`\n❌ ${followErr?.message || followErr}`));
+          process.exit(1);
+        }
         return;
       }
       if (errData?.output) console.error(errData.output);

--- a/packages/cli/src/test/install-script.test.ts
+++ b/packages/cli/src/test/install-script.test.ts
@@ -185,7 +185,11 @@ describe('install.mjs — Windows tar --force-local', () => {
 });
 
 // ---------------------------------------------------------------------------
-// MCP server + CLI — validate_progress 5-minute timeout (task 9c5d2fbe)
+// MCP server + CLI — validate paths follow ASYNC runs (CGLAB-10).
+// Historically these pinned a 5-minute single-request timeout (task 9c5d2fbe);
+// that cap was still too short for long verifyCommands and dropped the
+// connection while the server kept running. The contract is now: post with
+// async: true and follow the run — no bounded single request anywhere.
 // ---------------------------------------------------------------------------
 const mcpServerScript = readFileSync(
     path.resolve(__dirname, '../../../server/src/index.ts'),
@@ -197,37 +201,38 @@ const cliScript = readFileSync(
     'utf8'
 );
 
-describe('MCP server — validate_progress uses 5-minute timeout', () => {
-    it('validate_progress post call has a 300000ms timeout', () => {
-        // 30s is too short for npm run build && npm test; must be 5 minutes.
+describe('MCP server — validate paths follow async runs', () => {
+    it('validate_progress delegates to the async follow helper', () => {
         const validateIdx = mcpServerScript.indexOf('case "validate_progress"');
         expect(validateIdx).toBeGreaterThan(-1);
         const block = mcpServerScript.slice(validateIdx, validateIdx + 500);
-        expect(block).toMatch(/300000/);
+        expect(block).toMatch(/validateViaApi/);
+        expect(block).not.toMatch(/300000/);
     });
 
-    it('review_changes post call has a 300000ms timeout', () => {
+    it('review_changes delegates to the async follow helper', () => {
         const idx = mcpServerScript.indexOf('case "review_changes"');
         expect(idx).toBeGreaterThan(-1);
         const block = mcpServerScript.slice(idx, idx + 400);
-        expect(block).toMatch(/300000/);
+        expect(block).toMatch(/validateViaApi/);
     });
 
-    it('test_changes post call has a 300000ms timeout', () => {
+    it('test_changes delegates to the async follow helper', () => {
         const idx = mcpServerScript.indexOf('case "test_changes"');
         expect(idx).toBeGreaterThan(-1);
         const block = mcpServerScript.slice(idx, idx + 400);
-        expect(block).toMatch(/300000/);
+        expect(block).toMatch(/validateViaApi/);
     });
 });
 
-describe('CLI — agenfk verify uses 5-minute timeout', () => {
-    it('verify command axios.post has a 300000ms timeout', () => {
-        // The verify command calls /items/:id/validate — must not time out on long builds.
+describe('CLI — agenfk verify follows async runs', () => {
+    it('verify command posts async and follows the run without an overall deadline', () => {
         const verifyIdx = cliScript.indexOf(".command('verify");
         expect(verifyIdx).toBeGreaterThan(-1);
-        const block = cliScript.slice(verifyIdx, verifyIdx + 2000);
-        expect(block).toMatch(/300000/);
+        const block = cliScript.slice(verifyIdx, verifyIdx + 4000);
+        expect(block).toMatch(/async:\s*true/);
+        expect(block).toMatch(/followValidateRun/);
+        expect(block).not.toMatch(/300000/);
     });
 });
 

--- a/packages/cli/src/test/install-script.test.ts
+++ b/packages/cli/src/test/install-script.test.ts
@@ -229,10 +229,13 @@ describe('CLI — agenfk verify follows async runs', () => {
     it('verify command posts async and follows the run without an overall deadline', () => {
         const verifyIdx = cliScript.indexOf(".command('verify");
         expect(verifyIdx).toBeGreaterThan(-1);
-        const block = cliScript.slice(verifyIdx, verifyIdx + 4000);
+        const block = cliScript.slice(verifyIdx, verifyIdx + 5000);
         expect(block).toMatch(/async:\s*true/);
         expect(block).toMatch(/followValidateRun/);
-        expect(block).not.toMatch(/300000/);
+        // The POST keeps the old 5-minute ceiling ONLY for the upgrade window
+        // (an old server ignores async:true and blocks synchronously); the
+        // follow loop itself has no overall deadline.
+        expect(block).toMatch(/timeout:\s*300000/);
     });
 });
 

--- a/packages/cli/src/test/verify-run.test.ts
+++ b/packages/cli/src/test/verify-run.test.ts
@@ -1,0 +1,96 @@
+/**
+ * TDD for the CLI/MCP side of async validate runs (CGLAB-10).
+ *
+ * followValidateRun is the dependency-injected follow loop shared by
+ * `agenfk verify` and the MCP validate_progress path: it polls a run until it
+ * finishes, streams only NEW output, tolerates transient poll errors, and has
+ * NO overall deadline — a verifyCommand may legitimately run for an hour.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { followValidateRun, type RunSnapshot } from '../verifyRun';
+
+const ROOT = path.resolve(__dirname, '../../../..');
+
+function seq(snapshots: Array<RunSnapshot | Error>) {
+  let i = 0;
+  return vi.fn(async () => {
+    const s = snapshots[Math.min(i++, snapshots.length - 1)];
+    if (s instanceof Error) throw s;
+    return s;
+  });
+}
+
+describe('followValidateRun', () => {
+  it('polls until the run leaves running and resolves with the final snapshot', async () => {
+    const poll = seq([
+      { status: 'running', output: '' },
+      { status: 'running', output: 'building…\n' },
+      { status: 'passed', output: 'building…\ndone\n', itemStatus: 'DONE' },
+    ]);
+    const res = await followValidateRun({ poll, onOutput: () => {}, intervalMs: 1 });
+    expect(res.status).toBe('passed');
+    expect(res.itemStatus).toBe('DONE');
+    expect(poll).toHaveBeenCalledTimes(3);
+  });
+
+  it('streams only the incremental part of the output', async () => {
+    const chunks: string[] = [];
+    const poll = seq([
+      { status: 'running', output: 'line1\n' },
+      { status: 'running', output: 'line1\nline2\n' },
+      { status: 'failed', output: 'line1\nline2\nline3\n' },
+    ]);
+    await followValidateRun({ poll, onOutput: c => chunks.push(c), intervalMs: 1 });
+    expect(chunks).toEqual(['line1\n', 'line2\n', 'line3\n']);
+  });
+
+  it('has no overall deadline — hundreds of polls are fine', async () => {
+    const snapshots: Array<RunSnapshot> = Array.from({ length: 300 }, () => ({ status: 'running' as const, output: '' }));
+    snapshots.push({ status: 'passed', output: 'ok' });
+    const poll = seq(snapshots);
+    const res = await followValidateRun({ poll, onOutput: () => {}, intervalMs: 0 });
+    expect(res.status).toBe('passed');
+    expect(poll).toHaveBeenCalledTimes(301);
+  });
+
+  it('survives transient poll errors below the consecutive-error cap', async () => {
+    const poll = seq([
+      { status: 'running', output: '' },
+      new Error('ECONNRESET'),
+      new Error('ECONNRESET'),
+      { status: 'running', output: 'still here\n' },
+      { status: 'passed', output: 'still here\nok\n' },
+    ]);
+    const res = await followValidateRun({ poll, onOutput: () => {}, intervalMs: 0, maxConsecutiveErrors: 5 });
+    expect(res.status).toBe('passed');
+  });
+
+  it('gives up after maxConsecutiveErrors with a "may still be in progress" error', async () => {
+    const poll = seq([new Error('ECONNREFUSED')]);
+    await expect(
+      followValidateRun({ poll, onOutput: () => {}, intervalMs: 0, maxConsecutiveErrors: 3 }),
+    ).rejects.toThrow(/still be in progress/i);
+    expect(poll).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('async verify wiring — no more bounded single-POST verifies', () => {
+  it('the CLI verify command requests an async run', () => {
+    const src = readFileSync(path.join(ROOT, 'packages/cli/src/index.ts'), 'utf8');
+    expect(src).toMatch(/async:\s*true/);
+    expect(src).toContain('followValidateRun');
+  });
+
+  it('the MCP validate path no longer relies on a 5-minute single request', () => {
+    const src = readFileSync(path.join(ROOT, 'packages/server/src/index.ts'), 'utf8');
+    expect(src).toMatch(/async:\s*true/);
+    expect(src).not.toContain('timeout: 300000');
+  });
+
+  it('the CLI verify path no longer carries the 5-minute cap', () => {
+    const src = readFileSync(path.join(ROOT, 'packages/cli/src/index.ts'), 'utf8');
+    expect(src).not.toContain('timeout: 300000');
+  });
+});

--- a/packages/cli/src/test/verify-run.test.ts
+++ b/packages/cli/src/test/verify-run.test.ts
@@ -74,6 +74,16 @@ describe('followValidateRun', () => {
     ).rejects.toThrow(/still be in progress/i);
     expect(poll).toHaveBeenCalledTimes(3);
   });
+
+  it('rethrows fatal poll errors immediately (definitive 404, not a connection blip)', async () => {
+    const fatal: any = new Error('Unknown run — server restarted; check the item comments.');
+    fatal.fatal = true;
+    const poll = seq([{ status: 'running', output: '' }, fatal]);
+    await expect(
+      followValidateRun({ poll, onOutput: () => {}, intervalMs: 0, maxConsecutiveErrors: 10 }),
+    ).rejects.toThrow(/server restarted/i);
+    expect(poll).toHaveBeenCalledTimes(2); // no retry burn on a definitive answer
+  });
 });
 
 describe('async verify wiring — no more bounded single-POST verifies', () => {
@@ -83,14 +93,21 @@ describe('async verify wiring — no more bounded single-POST verifies', () => {
     expect(src).toContain('followValidateRun');
   });
 
-  it('the MCP validate path no longer relies on a 5-minute single request', () => {
+  it('the MCP validate path posts async and follows the run', () => {
     const src = readFileSync(path.join(ROOT, 'packages/server/src/index.ts'), 'utf8');
     expect(src).toMatch(/async:\s*true/);
-    expect(src).not.toContain('timeout: 300000');
+    expect(src).toContain('followValidateRunViaApi');
+    // The POST keeps a 5-minute ceiling ONLY as upgrade-window compat (an old
+    // server ignores async:true and blocks synchronously); the follow loop is
+    // what must be unbounded — assert it has no deadline knob.
+    expect(src).not.toMatch(/followValidateRunViaApi[^]*?overallTimeout/);
   });
 
-  it('the CLI verify path no longer carries the 5-minute cap', () => {
+  it('the CLI verify outcome is decided by the follow loop, not the POST', () => {
     const src = readFileSync(path.join(ROOT, 'packages/cli/src/index.ts'), 'utf8');
-    expect(src).not.toContain('timeout: 300000');
+    const verifyIdx = src.indexOf(".command('verify");
+    const block = src.slice(verifyIdx, verifyIdx + 5000);
+    expect(block).toMatch(/followValidateRun/);
+    expect(block).toMatch(/runId/);
   });
 });

--- a/packages/cli/src/verifyRun.ts
+++ b/packages/cli/src/verifyRun.ts
@@ -1,0 +1,61 @@
+// Follow loop for async validate runs (CGLAB-10), shared by `agenfk verify`
+// and the MCP validate_progress path. Dependency-injected (poll/onOutput) so
+// it is unit-testable without HTTP. Deliberately has NO overall deadline — a
+// verifyCommand may legitimately run for an hour; only *consecutive* poll
+// failures abort, and that error says the run may still be in progress.
+
+export interface RunSnapshot {
+  status: 'running' | 'passed' | 'failed';
+  output?: string;
+  message?: string;
+  itemStatus?: string;
+}
+
+export interface FollowOptions {
+  /** Fetch the current run snapshot (one short-timeout HTTP GET). */
+  poll: () => Promise<RunSnapshot>;
+  /** Receives only the NEW portion of output on each poll. */
+  onOutput: (chunk: string) => void;
+  /** Delay between polls (default 1500ms). */
+  intervalMs?: number;
+  /** Consecutive poll failures tolerated before giving up (default 10). */
+  maxConsecutiveErrors?: number;
+}
+
+const sleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
+
+export async function followValidateRun(opts: FollowOptions): Promise<RunSnapshot> {
+  const intervalMs = opts.intervalMs ?? 1500;
+  const maxConsecutiveErrors = opts.maxConsecutiveErrors ?? 10;
+  let emitted = 0;
+  let consecutiveErrors = 0;
+  let lastError: unknown;
+
+  for (;;) {
+    let snapshot: RunSnapshot;
+    try {
+      snapshot = await opts.poll();
+      consecutiveErrors = 0;
+    } catch (err) {
+      lastError = err;
+      consecutiveErrors++;
+      if (consecutiveErrors >= maxConsecutiveErrors) {
+        const reason = (lastError as any)?.message || String(lastError);
+        throw new Error(
+          `Lost contact with the AgEnFK server while following the validation run (${reason}). ` +
+          `The run may still be in progress on the server — check the item's comments before re-running verify.`,
+        );
+      }
+      await sleep(intervalMs);
+      continue;
+    }
+
+    const output = snapshot.output ?? '';
+    if (output.length > emitted) {
+      opts.onOutput(output.slice(emitted));
+      emitted = output.length;
+    }
+    if (snapshot.status !== 'running') return snapshot;
+    await sleep(intervalMs);
+  }
+}

--- a/packages/cli/src/verifyRun.ts
+++ b/packages/cli/src/verifyRun.ts
@@ -37,6 +37,10 @@ export async function followValidateRun(opts: FollowOptions): Promise<RunSnapsho
       snapshot = await opts.poll();
       consecutiveErrors = 0;
     } catch (err) {
+      // A poll can mark its error as fatal (e.g. the server answered 404
+      // RUN_NOT_FOUND after a restart) — retrying won't change a definitive
+      // answer, so surface it immediately instead of burning the retry budget.
+      if ((err as any)?.fatal) throw err;
       lastError = err;
       consecutiveErrors++;
       if (consecutiveErrors >= maxConsecutiveErrors) {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -37,6 +37,49 @@ const api = axios.create({
   timeout: 30000,
 });
 
+// ── Async verify follow (CGLAB-10) ───────────────────────────────────────────
+// validate requests run the project's verifyCommand, which can take far longer
+// than any sane single-request timeout. We post with async: true (202 + runId
+// when a command executes; sync response otherwise) and poll the run with
+// short per-request timeouts and NO overall deadline.
+async function followValidateRunViaApi(runId: string): Promise<any> {
+  let consecutiveErrors = 0;
+  for (;;) {
+    try {
+      const { data: run } = await api.get(`/items/validate-runs/${runId}`, { headers: { 'x-agenfk-internal': VERIFY_TOKEN }, timeout: 10000 });
+      consecutiveErrors = 0;
+      if (run.status !== 'running') return run;
+    } catch (e: any) {
+      if (++consecutiveErrors >= 10) {
+        throw new Error(`Lost contact with the validation run (${e?.message || e}). The run may still be in progress — check the item's comments before re-running validate_progress.`);
+      }
+    }
+    await new Promise(r => setTimeout(r, 1500));
+  }
+}
+
+/** POST a validate request in async mode and follow it to completion.
+ *  Returns { ok, text } ready for an MCP tool response. */
+async function validateViaApi(itemId: string, body: any): Promise<{ ok: boolean; text: string }> {
+  const headers = { 'x-agenfk-internal': VERIFY_TOKEN };
+  try {
+    const resp = await api.post(`/items/${itemId}/validate`, { ...body, async: true }, { headers });
+    if (resp.status === 202 && resp.data?.runId) {
+      const run = await followValidateRunViaApi(resp.data.runId);
+      return { ok: run.status === 'passed', text: run.message || (run.status === 'passed' ? '✅ Validation passed.' : '❌ Validation failed.') };
+    }
+    return { ok: true, text: resp.data.message };
+  } catch (error: any) {
+    const errData = error.response?.data;
+    // Someone already started a run for this item — follow it instead of failing.
+    if (errData?.error === 'VALIDATE_RUN_ACTIVE' && errData.runId) {
+      const run = await followValidateRunViaApi(errData.runId);
+      return { ok: run.status === 'passed', text: run.message || (run.status === 'passed' ? '✅ Validation passed.' : '❌ Validation failed.') };
+    }
+    return { ok: false, text: errData?.message || errData?.error || error.message };
+  }
+}
+
 const findProjectRoot = (startDir: string): string => {
   if (process.env.AGENFK_PROJECT_ROOT) {
     return process.env.AGENFK_PROJECT_ROOT;
@@ -647,33 +690,21 @@ async function callToolHandler(request: any): Promise<any> {
       }
       case "validate_progress": {
         const { itemId, evidence, command } = z.object({ itemId: z.string(), evidence: z.string(), command: z.string().optional() }).parse(request.params.arguments);
-        try {
-          const { data } = await api.post(`/items/${itemId}/validate`, { evidence, command, cwd: process.cwd() }, { headers: { 'x-agenfk-internal': VERIFY_TOKEN }, timeout: 300000 });
-          return { content: [{ type: "text", text: data.message }] };
-        } catch (error: any) {
-          const msg = error.response?.data?.message || error.response?.data?.error || error.message;
-          return { isError: true, content: [{ type: "text", text: msg }] };
-        }
+        const result = await validateViaApi(itemId, { evidence, command, cwd: process.cwd() });
+        if (!result.ok) return { isError: true, content: [{ type: "text", text: result.text }] };
+        return { content: [{ type: "text", text: result.text }] };
       }
       case "review_changes": {
         const { itemId, command } = z.object({ itemId: z.string(), command: z.string() }).parse(request.params.arguments);
-        try {
-          const { data } = await api.post(`/items/${itemId}/validate`, { command }, { headers: { 'x-agenfk-internal': VERIFY_TOKEN }, timeout: 300000 });
-          return { content: [{ type: "text", text: `[DEPRECATED: use validate_progress] ${data.message}` }] };
-        } catch (error: any) {
-          const msg = error.response?.data?.message || error.response?.data?.error || error.message;
-          return { isError: true, content: [{ type: "text", text: msg }] };
-        }
+        const result = await validateViaApi(itemId, { command });
+        if (!result.ok) return { isError: true, content: [{ type: "text", text: `[DEPRECATED: use validate_progress] ${result.text}` }] };
+        return { content: [{ type: "text", text: `[DEPRECATED: use validate_progress] ${result.text}` }] };
       }
       case "test_changes": {
         const { itemId } = z.object({ itemId: z.string() }).parse(request.params.arguments);
-        try {
-          const { data } = await api.post(`/items/${itemId}/validate`, {}, { headers: { 'x-agenfk-internal': VERIFY_TOKEN }, timeout: 300000 });
-          return { content: [{ type: "text", text: `[DEPRECATED: use validate_progress] ${data.message}` }] };
-        } catch (error: any) {
-          const msg = error.response?.data?.message || error.response?.data?.error || error.message;
-          return { isError: true, content: [{ type: "text", text: msg }] };
-        }
+        const result = await validateViaApi(itemId, {});
+        if (!result.ok) return { isError: true, content: [{ type: "text", text: `[DEPRECATED: use validate_progress] ${result.text}` }] };
+        return { content: [{ type: "text", text: `[DEPRECATED: use validate_progress] ${result.text}` }] };
       }
       case "workflow_gatekeeper": {
         const { intent, role, itemId } = z.object({

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -50,6 +50,11 @@ async function followValidateRunViaApi(runId: string): Promise<any> {
       consecutiveErrors = 0;
       if (run.status !== 'running') return run;
     } catch (e: any) {
+      // 404 is definitive (run expired / server restarted mid-run) — surface
+      // the server's guidance immediately instead of burning retries.
+      if (e?.response?.status === 404) {
+        throw new Error(e.response.data?.message || 'The validation run is unknown to the server (it may have restarted). Check the item\'s comments for the persisted outcome before re-running validate_progress.');
+      }
       if (++consecutiveErrors >= 10) {
         throw new Error(`Lost contact with the validation run (${e?.message || e}). The run may still be in progress — check the item's comments before re-running validate_progress.`);
       }
@@ -63,7 +68,10 @@ async function followValidateRunViaApi(runId: string): Promise<any> {
 async function validateViaApi(itemId: string, body: any): Promise<{ ok: boolean; text: string }> {
   const headers = { 'x-agenfk-internal': VERIFY_TOKEN };
   try {
-    const resp = await api.post(`/items/${itemId}/validate`, { ...body, async: true }, { headers });
+    // 5-minute POST ceiling: a NEW server answers 202 in milliseconds, but an
+    // OLD server (upgrade window) ignores async:true and blocks synchronously
+    // for the whole command — keep the previous ceiling for that path.
+    const resp = await api.post(`/items/${itemId}/validate`, { ...body, async: true }, { headers, timeout: 300000 });
     if (resp.status === 202 && resp.data?.runId) {
       const run = await followValidateRunViaApi(resp.data.runId);
       return { ok: run.status === 'passed', text: run.message || (run.status === 'passed' ? '✅ Validation passed.' : '❌ Validation failed.') };

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1886,10 +1886,12 @@ function pruneValidateRuns() {
 // ── validate_progress: unified exit-criteria gate (flow-aware) ───────────────
 // command is optional; if omitted, project.verifyCommand is used.
 // Advances item to the next flow step. On failure, moves back to the coding step.
-// asyncMode only changes behaviour when a command actually executes; every
-// other path (anchor advance, sibling propagation, no-command step, errors)
-// responds synchronously as before.
-async function handleValidateProgress(itemId: string, command: string | undefined, res: any, evidence?: string, asyncMode = false) {
+// `asyncRun` (pre-reserved by the route so the concurrency guard has no
+// check-then-set window) only changes behaviour when a command actually
+// executes; every other path (anchor advance, sibling propagation, no-command
+// step, errors) responds synchronously as before — the route discards the
+// unused reservation in that case.
+async function handleValidateProgress(itemId: string, command: string | undefined, res: any, evidence?: string, asyncRun?: ValidateRun) {
   const item = await storage.getItem(itemId);
   if (!item) return res.status(404).json({ error: "Item not found" });
 
@@ -2013,21 +2015,51 @@ async function handleValidateProgress(itemId: string, command: string | undefine
   // `res2` — the real HTTP response on the sync path, or a recorder that
   // captures the outcome into a ValidateRun on the async path.
   const runCommandAndFinalize = async (res2: any, run?: ValidateRun) => {
-  const { output, code } = await new Promise<{ output: string; code: number | null }>((resolve) => {
+  const { output, code, timedOut } = await new Promise<{ output: string; code: number | null; timedOut?: boolean }>((resolve) => {
     const child = spawn(resolvedCommand, { shell: true, cwd: projectRoot, env: { ...process.env, FORCE_COLOR: '1' } });
     let out = '';
-    const onData = (d: Buffer) => { out += d.toString(); if (run) run.output = out; };
+    let killed = false;
+    // Hard runtime cap: without it a hung verifyCommand (e.g. a test suite
+    // waiting on stdin) would leave an async run 'running' forever, and the
+    // 409 guard would lock the item's verify verb until a server restart.
+    const maxMs = Number(process.env.AGENFK_VERIFY_MAX_MS) > 0 ? Number(process.env.AGENFK_VERIFY_MAX_MS) : 60 * 60 * 1000;
+    const killer = setTimeout(() => {
+      killed = true;
+      out += `\n[agenfk] verifyCommand exceeded the ${Math.round(maxMs / 60000)}min cap (AGENFK_VERIFY_MAX_MS) and was killed.\n`;
+      try { child.kill('SIGKILL'); } catch { /* already gone */ }
+    }, maxMs);
+    if (typeof killer.unref === 'function') killer.unref();
+    // Live output for run followers, capped so a verbose command can't pin
+    // hundreds of MB in the run map; the full output still goes to the log file.
+    const LIVE_CAP = 1024 * 1024;
+    const onData = (d: Buffer) => { out += d.toString(); if (run && out.length <= LIVE_CAP) run.output = out; };
     child.stdout.on('data', onData);
     child.stderr.on('data', onData);
-    child.on('close', (c) => resolve({ output: out, code: c }));
-    child.on('error', (err) => resolve({ output: err.message, code: 1 }));
+    child.on('close', (c) => { clearTimeout(killer); resolve({ output: out, code: killed ? 124 : c, timedOut: killed }); });
+    child.on('error', (err) => { clearTimeout(killer); resolve({ output: err.message, code: 1 }); });
   });
 
   const testId = uuidv4();
   const logPath = writeValidationLog(itemId, testId, output);
   const preview = buildOutputPreview(output, logPath);
-  const passed = code === 0;
+  const passed = code === 0 && !timedOut;
   const exitNote = exitCriteria ? `\n**Exit criteria**: ${exitCriteria}` : '';
+
+  // The command may have run for a long time — re-read the item so we merge
+  // comments added meanwhile instead of clobbering them, and refuse to apply a
+  // transition computed from a flow position the item no longer occupies
+  // (e.g. someone rolled it back mid-run).
+  const freshItem = await storage.getItem(itemId);
+  if (!freshItem) {
+    return res2.status(404).json({ status: item.status, message: `❌ Item was deleted while the validation command ran.`, output: preview });
+  }
+  if (freshItem.status !== item.status) {
+    const staleComment = { id: uuidv4(), author: 'ValidateTool', content: `### Validation ${passed ? 'PASSED' : 'FAILED'} (not applied)\n\nItem moved ${item.status} → ${freshItem.status} while the command ran; the computed transition is stale and was NOT applied. Re-run verify from the current step.\n**Command**: \`${resolvedCommand}\`\n\n**Output**:\n\`\`\`\n${preview}\n\`\`\``, timestamp: new Date() };
+    await storage.updateItem(itemId, { comments: [...(freshItem.comments || []), staleComment] });
+    io.emit('items_updated');
+    return res2.status(409).json({ status: freshItem.status, message: `⚠️ Validation ${passed ? 'passed' : 'failed'}, but the item changed step (${item.status} → ${freshItem.status}) while the command ran — no transition applied. Re-run verify from the current step.`, output: preview });
+  }
+  Object.assign(item, freshItem);
 
   const comments = [...(item.comments || []), {
     id: uuidv4(),
@@ -2045,7 +2077,10 @@ async function handleValidateProgress(itemId: string, command: string | undefine
       io.emit('items_updated');
       if (updated.parentId) await syncParentStatus(updated.parentId);
       if (nextStatus === Status.DONE && process.env.NODE_ENV !== 'test' && !process.env.VITEST) {
-        await autoGitCommit(updated, projectRoot);
+        // Advisory: a git-commit failure must not report a PASSED validation
+        // (whose transition already landed) as failed to the run follower.
+        try { await autoGitCommit(updated, projectRoot); }
+        catch (e: any) { console.error(`[validate] autoGitCommit failed after DONE: ${e?.message || e}`); }
       }
       recordHubEvent({
       type: 'validate.passed',
@@ -2099,12 +2134,10 @@ async function handleValidateProgress(itemId: string, command: string | undefine
   }
   }; // end runCommandAndFinalize
 
-  if (asyncMode) {
-    pruneValidateRuns();
-    const runId = uuidv4();
-    const run: ValidateRun = { runId, itemId, status: 'running', output: '', startedAt: new Date() };
-    validateRuns.set(runId, run);
-    activeValidateRunByItem.set(itemId, runId);
+  if (asyncRun) {
+    const run = asyncRun;
+    const runId = run.runId;
+    (run as any).started = true;
     // Answer immediately — the client follows the run instead of holding this
     // request open for the command's whole lifetime.
     res.status(202).json({
@@ -2161,21 +2194,46 @@ app.post("/items/:id/validate", asyncHandler(async (req: any, res: any) => {
     const item = await storage.getItem(req.params.id);
     if (item) await storage.updateProject(item.projectId, { projectRoot: cwd });
   }
+  // One active run per item — a second verify while one runs is almost always
+  // an agent misreading slowness as failure. Applies to sync requests too so
+  // an old client can't race a background run on the same item.
+  const activeGuard = rejectIfRunActive(req.params.id, res);
+  if (activeGuard) return;
   const asyncMode = req.body.async === true || req.body.async === 'true';
   if (asyncMode) {
-    // One active run per item — a second verify while one runs is almost
-    // always an agent misreading slowness as failure. Point it at the run.
-    const activeRunId = activeValidateRunByItem.get(req.params.id);
-    if (activeRunId && validateRuns.get(activeRunId)?.status === 'running') {
-      return res.status(409).json({
-        error: 'VALIDATE_RUN_ACTIVE',
-        runId: activeRunId,
-        message: `A validation run is already active for this item. Follow it with GET /items/validate-runs/${activeRunId} instead of starting another.`,
-      });
+    // Reserve the run in the SAME tick as the guard — a check-then-set gap
+    // spanning the handler's awaits would let a double-submit spawn twice.
+    pruneValidateRuns();
+    const run: ValidateRun = { runId: uuidv4(), itemId: req.params.id, status: 'running', output: '', startedAt: new Date() };
+    validateRuns.set(run.runId, run);
+    activeValidateRunByItem.set(req.params.id, run.runId);
+    try {
+      return await handleValidateProgress(req.params.id, req.body.command || undefined, res, req.body.evidence || undefined, run);
+    } finally {
+      // A sync fast-path (anchor, sibling propagation, no-command, error)
+      // responded without ever starting the command — discard the reservation.
+      if (!(run as any).started) {
+        validateRuns.delete(run.runId);
+        if (activeValidateRunByItem.get(req.params.id) === run.runId) activeValidateRunByItem.delete(req.params.id);
+      }
     }
   }
-  return handleValidateProgress(req.params.id, req.body.command || undefined, res, req.body.evidence || undefined, asyncMode);
+  return handleValidateProgress(req.params.id, req.body.command || undefined, res, req.body.evidence || undefined);
 }));
+
+/** 409 if the item already has a live background validate run. Returns true when it responded. */
+function rejectIfRunActive(itemId: string, res: any): boolean {
+  const activeRunId = activeValidateRunByItem.get(itemId);
+  if (activeRunId && validateRuns.get(activeRunId)?.status === 'running') {
+    res.status(409).json({
+      error: 'VALIDATE_RUN_ACTIVE',
+      runId: activeRunId,
+      message: `A validation run is already active for this item. Follow it with GET /items/validate-runs/${activeRunId} instead of starting another.`,
+    });
+    return true;
+  }
+  return false;
+}
 
 // ── review_changes: DEPRECATED — delegates to validate_progress ──────────────
 app.post("/items/:id/review", asyncHandler(async (req: any, res: any) => {
@@ -2185,6 +2243,7 @@ app.post("/items/:id/review", asyncHandler(async (req: any, res: any) => {
   if (!req.body.command || typeof req.body.command !== 'string') {
     return res.status(400).json({ error: "Missing required field: command" });
   }
+  if (rejectIfRunActive(req.params.id, res)) return;
   return handleValidateProgress(req.params.id, req.body.command, res);
 }));
 
@@ -2193,6 +2252,7 @@ app.post("/items/:id/test", asyncHandler(async (req: any, res: any) => {
   if (req.headers['x-agenfk-internal'] !== VERIFY_TOKEN) {
     return res.status(403).json({ error: "Forbidden: test endpoint requires internal token." });
   }
+  if (rejectIfRunActive(req.params.id, res)) return;
   return handleValidateProgress(req.params.id, undefined, res);
 }));
 

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1853,10 +1853,43 @@ app.post("/items/:id/move", asyncHandler(async (req: any, res: any) => {
 
 // ── Verify Endpoints ─────────────────────────────────────────────────────────
 
+// ── Async validate runs (CGLAB-10) ───────────────────────────────────────────
+// A verifyCommand can legitimately run for many minutes; holding the HTTP
+// response open for its whole lifetime meant clients timed out while the
+// server finished anyway (and agents misread slow success as failure). With
+// `async: true`, the validate endpoint answers 202 + runId as soon as a
+// command must execute, runs it in the background, and exposes live status
+// and output at GET /items/validate-runs/:runId. Outcomes are additionally
+// persisted through the normal comment/transition path, so a lost run record
+// (server restart) never loses the result itself.
+export interface ValidateRun {
+  runId: string;
+  itemId: string;
+  status: 'running' | 'passed' | 'failed';
+  output: string;
+  message?: string;
+  itemStatus?: string;
+  startedAt: Date;
+  finishedAt?: Date;
+}
+const validateRuns = new Map<string, ValidateRun>();
+const activeValidateRunByItem = new Map<string, string>();
+const VALIDATE_RUN_TTL_MS = 60 * 60 * 1000;
+// Prune on creation instead of timers — keeps tests deterministic and the map bounded.
+function pruneValidateRuns() {
+  const now = Date.now();
+  for (const [id, run] of validateRuns) {
+    if (run.finishedAt && now - run.finishedAt.getTime() > VALIDATE_RUN_TTL_MS) validateRuns.delete(id);
+  }
+}
+
 // ── validate_progress: unified exit-criteria gate (flow-aware) ───────────────
 // command is optional; if omitted, project.verifyCommand is used.
 // Advances item to the next flow step. On failure, moves back to the coding step.
-async function handleValidateProgress(itemId: string, command: string | undefined, res: any, evidence?: string) {
+// asyncMode only changes behaviour when a command actually executes; every
+// other path (anchor advance, sibling propagation, no-command step, errors)
+// responds synchronously as before.
+async function handleValidateProgress(itemId: string, command: string | undefined, res: any, evidence?: string, asyncMode = false) {
   const item = await storage.getItem(itemId);
   if (!item) return res.status(404).json({ error: "Item not found" });
 
@@ -1975,11 +2008,17 @@ async function handleValidateProgress(itemId: string, command: string | undefine
   }
 
   const projectRoot = (project as any)?.projectRoot || findProjectRoot(process.cwd());
+
+  // Runs the command and applies the pass/fail side effects, reporting through
+  // `res2` — the real HTTP response on the sync path, or a recorder that
+  // captures the outcome into a ValidateRun on the async path.
+  const runCommandAndFinalize = async (res2: any, run?: ValidateRun) => {
   const { output, code } = await new Promise<{ output: string; code: number | null }>((resolve) => {
     const child = spawn(resolvedCommand, { shell: true, cwd: projectRoot, env: { ...process.env, FORCE_COLOR: '1' } });
     let out = '';
-    child.stdout.on('data', (d: Buffer) => { out += d.toString(); });
-    child.stderr.on('data', (d: Buffer) => { out += d.toString(); });
+    const onData = (d: Buffer) => { out += d.toString(); if (run) run.output = out; };
+    child.stdout.on('data', onData);
+    child.stderr.on('data', onData);
     child.on('close', (c) => resolve({ output: out, code: c }));
     child.on('error', (err) => resolve({ output: err.message, code: 1 }));
   });
@@ -2036,7 +2075,7 @@ async function handleValidateProgress(itemId: string, command: string | undefine
       itemId,
       payload: { command: resolvedCommand, status: 'PASSED', testId },
     });
-    return res.json({ status: nextStatus, message: `✅ Validation Passed!\n\nCommand: \`${resolvedCommand}\`\nItem moved to ${nextStatus}.${mandatoryInstructions}${pushInstruction}`, output: preview });
+    return res2.json({ status: nextStatus, message: `✅ Validation Passed!\n\nCommand: \`${resolvedCommand}\`\nItem moved to ${nextStatus}.${mandatoryInstructions}${pushInstruction}`, output: preview });
   } else {
     const updates: any = { status: failureStatus, comments };
     if (nextStatus === Status.DONE) {
@@ -2056,9 +2095,62 @@ async function handleValidateProgress(itemId: string, command: string | undefine
       itemId,
       payload: { command: resolvedCommand, status: 'FAILED', testId },
     });
-    return res.status(422).json({ status: failureStatus, message: `❌ Validation Failed!\n\nCommand: \`${resolvedCommand}\`\nRoot: \`${projectRoot}\`\n\nOutput:\n${preview}`, output: preview });
+    return res2.status(422).json({ status: failureStatus, message: `❌ Validation Failed!\n\nCommand: \`${resolvedCommand}\`\nRoot: \`${projectRoot}\`\n\nOutput:\n${preview}`, output: preview });
   }
+  }; // end runCommandAndFinalize
+
+  if (asyncMode) {
+    pruneValidateRuns();
+    const runId = uuidv4();
+    const run: ValidateRun = { runId, itemId, status: 'running', output: '', startedAt: new Date() };
+    validateRuns.set(runId, run);
+    activeValidateRunByItem.set(itemId, runId);
+    // Answer immediately — the client follows the run instead of holding this
+    // request open for the command's whole lifetime.
+    res.status(202).json({
+      runId,
+      command: resolvedCommand,
+      message: `⏳ Validation running in background (run ${runId.slice(0, 8)}…). Follow with GET /items/validate-runs/${runId}.`,
+    });
+    const recorder = {
+      _code: 200,
+      status(code: number) { this._code = code; return this; },
+      json(payload: any) {
+        run.status = this._code === 200 ? 'passed' : 'failed';
+        run.itemStatus = payload?.status;
+        run.message = payload?.message;
+        // Keep the live full output when we have it; fall back to the preview.
+        if (!run.output && payload?.output) run.output = payload.output;
+        run.finishedAt = new Date();
+        return this;
+      },
+    };
+    void runCommandAndFinalize(recorder, run)
+      .catch((err: any) => {
+        run.status = 'failed';
+        run.message = `Internal error during background validation: ${err?.message || err}`;
+        run.finishedAt = new Date();
+      })
+      .finally(() => {
+        if (activeValidateRunByItem.get(itemId) === runId) activeValidateRunByItem.delete(itemId);
+      });
+    return;
+  }
+
+  return runCommandAndFinalize(res);
 }
+
+// Live status/output of a background validate run. Registered before use in
+// the CLI follow loop; unknown ids 404 (a restarted server forgets runs — the
+// outcome itself is persisted on the item regardless).
+app.get("/items/validate-runs/:runId", asyncHandler(async (req: any, res: any) => {
+  if (req.headers['x-agenfk-internal'] !== VERIFY_TOKEN) {
+    return res.status(403).json({ error: "Forbidden: validate-runs endpoint requires internal token." });
+  }
+  const run = validateRuns.get(req.params.runId);
+  if (!run) return res.status(404).json({ error: 'RUN_NOT_FOUND', message: 'Unknown or expired validation run. If the server restarted, check the item\'s comments — the outcome is persisted there.' });
+  return res.json(run);
+}));
 
 app.post("/items/:id/validate", asyncHandler(async (req: any, res: any) => {
   if (req.headers['x-agenfk-internal'] !== VERIFY_TOKEN) {
@@ -2069,7 +2161,20 @@ app.post("/items/:id/validate", asyncHandler(async (req: any, res: any) => {
     const item = await storage.getItem(req.params.id);
     if (item) await storage.updateProject(item.projectId, { projectRoot: cwd });
   }
-  return handleValidateProgress(req.params.id, req.body.command || undefined, res, req.body.evidence || undefined);
+  const asyncMode = req.body.async === true || req.body.async === 'true';
+  if (asyncMode) {
+    // One active run per item — a second verify while one runs is almost
+    // always an agent misreading slowness as failure. Point it at the run.
+    const activeRunId = activeValidateRunByItem.get(req.params.id);
+    if (activeRunId && validateRuns.get(activeRunId)?.status === 'running') {
+      return res.status(409).json({
+        error: 'VALIDATE_RUN_ACTIVE',
+        runId: activeRunId,
+        message: `A validation run is already active for this item. Follow it with GET /items/validate-runs/${activeRunId} instead of starting another.`,
+      });
+    }
+  }
+  return handleValidateProgress(req.params.id, req.body.command || undefined, res, req.body.evidence || undefined, asyncMode);
 }));
 
 // ── review_changes: DEPRECATED — delegates to validate_progress ──────────────

--- a/packages/server/src/test/async-validate.test.ts
+++ b/packages/server/src/test/async-validate.test.ts
@@ -75,7 +75,7 @@ describe('POST /items/:id/validate — async runs', () => {
 
   it('returns 202 + runId immediately when a command must run', async () => {
     if (!VERIFY_TOKEN) return;
-    const item = await itemOnFinalStep('AV1', 'sleep 1 && echo slow-ok');
+    const item = await itemOnFinalStep('AV1', 'sleep 2 && echo slow-ok');
 
     const t0 = Date.now();
     const res = await request(app)
@@ -85,13 +85,36 @@ describe('POST /items/:id/validate — async runs', () => {
 
     expect(res.status).toBe(202);
     expect(res.body.runId).toBeTruthy();
-    // Immediately = well under the command's own runtime.
-    expect(Date.now() - t0).toBeLessThan(900);
+    // Immediately = well under the command's own runtime (generous margin for loaded CI).
+    expect(Date.now() - t0).toBeLessThan(1900);
 
     // While the command sleeps, the run reports running and the item is unchanged.
     const mid = await request(app).get(`/items/validate-runs/${res.body.runId}`).set('x-agenfk-internal', VERIFY_TOKEN);
     expect(mid.status).toBe(200);
     expect(['running', 'passed']).toContain(mid.body.status);
+
+    // Don't leak the background run into the next test.
+    await waitForRun(res.body.runId);
+  });
+
+  it('blocks a SYNC validate while a background run is active (old-client race)', async () => {
+    if (!VERIFY_TOKEN) return;
+    const item = await itemOnFinalStep('AV1b', 'sleep 2 && echo guard-ok');
+
+    const first = await request(app)
+      .post(`/items/${item.id}/validate`)
+      .set('x-agenfk-internal', VERIFY_TOKEN)
+      .send({ async: true });
+    expect(first.status).toBe(202);
+
+    const sync = await request(app)
+      .post(`/items/${item.id}/validate`)
+      .set('x-agenfk-internal', VERIFY_TOKEN)
+      .send({}); // no async flag — old client
+    expect(sync.status).toBe(409);
+    expect(sync.body.runId).toBe(first.body.runId);
+
+    await waitForRun(first.body.runId);
   });
 
   it('applies the pass side effects in the background (transition + comment + captured output)', async () => {

--- a/packages/server/src/test/async-validate.test.ts
+++ b/packages/server/src/test/async-validate.test.ts
@@ -1,0 +1,193 @@
+/**
+ * TDD for async validate runs (CGLAB-10).
+ *
+ * `agenfk verify` used to hold one HTTP POST open while the server ran the
+ * verifyCommand; commands longer than the client's 5-minute axios timeout
+ * dropped the connection client-side while the server finished anyway, so
+ * agents misread slow success as failure (and could double-transition).
+ *
+ * Contract under test:
+ *  - POST /items/:id/validate with `async: true` returns 202 + { runId }
+ *    IMMEDIATELY when a command must execute; the command runs in background.
+ *  - GET /items/validate-runs/:runId reports { status: 'running' | 'passed' |
+ *    'failed', output } and, once finished, { itemStatus }.
+ *  - The background completion applies the SAME side effects as the sync path
+ *    (item transition on pass, rollback on fail, validation comment).
+ *  - Only one active run per item: a second async validate while one is
+ *    running returns 409 with the existing runId.
+ *  - Paths that never execute a command (intermediate step with no command)
+ *    stay synchronous even when `async: true` is passed — no runId.
+ *  - Unknown runId → 404.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import request from 'supertest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+vi.mock('axios', () => {
+  const mockAxios = vi.fn() as any;
+  mockAxios.get = vi.fn();
+  mockAxios.post = vi.fn();
+  mockAxios.create = vi.fn(() => mockAxios);
+  return { default: mockAxios };
+});
+
+const TEST_DB = path.resolve('./async-validate-test-db.sqlite');
+process.env.AGENFK_DB_PATH = TEST_DB;
+if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+
+// Import AFTER the env var is set so storage lands in the test DB.
+import { app, initStorage, VERIFY_TOKEN } from '../server';
+
+afterAll(() => {
+  for (const suffix of ['', '-shm', '-wal']) {
+    const f = `${TEST_DB}${suffix}`;
+    if (fs.existsSync(f)) fs.unlinkSync(f);
+  }
+});
+
+/** Poll the run endpoint until it leaves 'running' (or timeout). */
+async function waitForRun(runId: string, timeoutMs = 15000) {
+  const start = Date.now();
+  for (;;) {
+    const res = await request(app).get(`/items/validate-runs/${runId}`).set('x-agenfk-internal', VERIFY_TOKEN!);
+    if (res.status !== 200) return res;
+    if (res.body.status !== 'running') return res;
+    if (Date.now() - start > timeoutMs) return res;
+    await new Promise(r => setTimeout(r, 100));
+  }
+}
+
+/** Create project (+ verifyCommand) and a TASK moved to the final intermediate step. */
+async function itemOnFinalStep(name: string, verifyCommand: string) {
+  const p = (await request(app).post('/projects').send({ name })).body;
+  await request(app).put(`/projects/${p.id}/verify-command`).set('x-agenfk-internal', VERIFY_TOKEN!).send({ verifyCommand });
+  const item = (await request(app).post('/items').send({ type: 'TASK', title: `${name}-item`, projectId: p.id })).body;
+  await request(app)
+    .post('/items/bulk')
+    .set('x-agenfk-internal', VERIFY_TOKEN!)
+    .send({ items: [{ id: item.id, updates: { status: 'TEST' } }] });
+  return item;
+}
+
+describe('POST /items/:id/validate — async runs', () => {
+  beforeEach(async () => { await initStorage(); });
+
+  it('returns 202 + runId immediately when a command must run', async () => {
+    if (!VERIFY_TOKEN) return;
+    const item = await itemOnFinalStep('AV1', 'sleep 1 && echo slow-ok');
+
+    const t0 = Date.now();
+    const res = await request(app)
+      .post(`/items/${item.id}/validate`)
+      .set('x-agenfk-internal', VERIFY_TOKEN)
+      .send({ async: true });
+
+    expect(res.status).toBe(202);
+    expect(res.body.runId).toBeTruthy();
+    // Immediately = well under the command's own runtime.
+    expect(Date.now() - t0).toBeLessThan(900);
+
+    // While the command sleeps, the run reports running and the item is unchanged.
+    const mid = await request(app).get(`/items/validate-runs/${res.body.runId}`).set('x-agenfk-internal', VERIFY_TOKEN);
+    expect(mid.status).toBe(200);
+    expect(['running', 'passed']).toContain(mid.body.status);
+  });
+
+  it('applies the pass side effects in the background (transition + comment + captured output)', async () => {
+    if (!VERIFY_TOKEN) return;
+    const item = await itemOnFinalStep('AV2', 'echo async-pass-output');
+
+    const res = await request(app)
+      .post(`/items/${item.id}/validate`)
+      .set('x-agenfk-internal', VERIFY_TOKEN)
+      .send({ async: true, evidence: 'async pass test' });
+    expect(res.status).toBe(202);
+
+    const done = await waitForRun(res.body.runId);
+    expect(done.body.status).toBe('passed');
+    expect(done.body.output).toContain('async-pass-output');
+    expect(done.body.itemStatus).toBe('DONE');
+
+    const after = (await request(app).get(`/items/${item.id}`)).body;
+    expect(after.status).toBe('DONE');
+    const validationComments = (after.comments || []).filter((c: any) => c.author === 'ValidateTool');
+    expect(validationComments.length).toBeGreaterThan(0);
+  });
+
+  it('applies the failure side effects in the background (rollback to coding step)', async () => {
+    if (!VERIFY_TOKEN) return;
+    const item = await itemOnFinalStep('AV3', 'echo async-fail-output && exit 3');
+
+    const res = await request(app)
+      .post(`/items/${item.id}/validate`)
+      .set('x-agenfk-internal', VERIFY_TOKEN)
+      .send({ async: true });
+    expect(res.status).toBe(202);
+
+    const done = await waitForRun(res.body.runId);
+    expect(done.body.status).toBe('failed');
+    expect(done.body.output).toContain('async-fail-output');
+
+    const after = (await request(app).get(`/items/${item.id}`)).body;
+    expect(after.status).not.toBe('DONE');
+    expect(after.status).not.toBe('TEST'); // rolled back off the final step
+  });
+
+  it('rejects a concurrent run for the same item with 409 + the active runId', async () => {
+    if (!VERIFY_TOKEN) return;
+    const item = await itemOnFinalStep('AV4', 'sleep 2 && echo done');
+
+    const first = await request(app)
+      .post(`/items/${item.id}/validate`)
+      .set('x-agenfk-internal', VERIFY_TOKEN)
+      .send({ async: true });
+    expect(first.status).toBe(202);
+
+    const second = await request(app)
+      .post(`/items/${item.id}/validate`)
+      .set('x-agenfk-internal', VERIFY_TOKEN)
+      .send({ async: true });
+    expect(second.status).toBe(409);
+    expect(second.body.runId).toBe(first.body.runId);
+
+    await waitForRun(first.body.runId);
+  });
+
+  it('stays synchronous when no command would run (intermediate step, async flag ignored)', async () => {
+    if (!VERIFY_TOKEN) return;
+    const p = (await request(app).post('/projects').send({ name: 'AV5' })).body;
+    const item = (await request(app).post('/items').send({ type: 'TASK', title: 'AV5-item', projectId: p.id })).body;
+    await request(app).put(`/items/${item.id}`).send({ status: 'IN_PROGRESS' });
+
+    const res = await request(app)
+      .post(`/items/${item.id}/validate`)
+      .set('x-agenfk-internal', VERIFY_TOKEN)
+      .send({ async: true });
+
+    expect(res.status).toBe(200);
+    expect(res.body.runId).toBeUndefined();
+    expect(res.body.status).toBe('REVIEW');
+  });
+
+  it('returns 404 for an unknown runId', async () => {
+    if (!VERIFY_TOKEN) return;
+    const res = await request(app)
+      .get('/items/validate-runs/00000000-0000-0000-0000-000000000000')
+      .set('x-agenfk-internal', VERIFY_TOKEN);
+    expect(res.status).toBe(404);
+  });
+
+  it('sync behaviour unchanged when async is not requested', async () => {
+    if (!VERIFY_TOKEN) return;
+    const item = await itemOnFinalStep('AV6', 'echo sync-still-works');
+
+    const res = await request(app)
+      .post(`/items/${item.id}/validate`)
+      .set('x-agenfk-internal', VERIFY_TOKEN)
+      .send({});
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('DONE');
+    expect(res.body.output).toContain('sync-still-works');
+  });
+});


### PR DESCRIPTION
## Problem

`agenfk verify` held one HTTP POST open while the server ran the project's verifyCommand. The CLI/MCP axios cap was 5 minutes — long commands dropped the connection **client-side while the server finished anyway**, so agents misread slow success as failure and could double-transition items.

## What

**Server** (`packages/server/src/server.ts`)
- `POST /items/:id/validate` with `async: true` answers **202 + runId** as soon as a command must execute; the command runs in the background through the exact same pass/fail side-effect path (comments, transition, parent sync, hub events).
- `GET /items/validate-runs/:runId` — live status + streaming output (capped at 1MB live; full output in the log file). Completed runs pruned after 1h.
- **One active run per item**: concurrent validates (async *or* sync, incl. legacy `/review` and `/test`) get 409 + the active runId; the reservation happens in the same tick as the guard (no TOCTOU).
- **Hard runtime cap** on the spawned command (`AGENFK_VERIFY_MAX_MS`, default 60min) so a hung command can't lock the item's verify verb forever.
- **Stale-snapshot protection**: after a long run, the item is re-read — mid-run comments are merged, and if the item changed step during the run the transition is refused (409 + explanatory comment) instead of clobbering a rollback.
- All no-command paths (anchor advance, sibling propagation, intermediate steps) stay synchronous.

**CLI** (`packages/cli`)
- `agenfk verify` posts async and follows the run via new `verifyRun.ts` — incremental output, short per-poll timeouts, **no overall deadline**, transient-error tolerance, and a distinct "lost contact — the run may still be in progress" message. 409 → follows the active run. Definitive 404 (server restarted) surfaces the server's guidance immediately.
- POST keeps the old 5-min ceiling purely as upgrade-window compat (an old server ignores `async` and blocks synchronously).

**MCP** (`packages/server/src/index.ts`)
- `validate_progress` / `review_changes` / `test_changes` use the same async+follow path (`validateViaApi`).

## Tests
- `async-validate.test.ts` (8): 202 immediacy, background pass/fail side effects, async+sync 409 guards, sync fast-paths preserved, 404.
- `verify-run.test.ts` (9): follow-loop semantics incl. fatal-404 short-circuit; wiring contracts.
- Old 5-minute-timeout contract tests re-pinned to the async contract.
- Full suite: 161 files / 1761 tests green.

Adversarially reviewed (11 findings; blocker + all majors fixed).

JIRA: CGLAB-10