### PR TITLE
fix(ui): support same-origin API access

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,23 @@ After installation, complete the setup:
     agenfk up
     ```
     This launches the API server on `http://localhost:3000` and the Kanban UI (typically `http://localhost:5173`).
+
+    To access the dashboard through a reverse proxy or tunnel, publish the UI
+    origin only (for example, `https://agenfk.example.com` → `localhost:5173`).
+    The dashboard uses same-origin API and WebSocket URLs, and the bundled Vite
+    preview server proxies those requests to the local API. Protect remote
+    access with authentication; the dashboard can modify workflow data.
+
+    Allow the public hostname when starting or restarting the services:
+
+    ```bash
+    AGENFK_UI_ALLOWED_HOSTS=agenfk.example.com agenfk restart
+    ```
+
+    Multiple hostnames can be supplied as a comma-separated list.
+
+    Set `VITE_API_URL` at build time only when the API is intentionally hosted
+    on a separate origin.
 3.  **Service Lifecycle**: Manage your installation with the following commands:
     *   `agenfk upgrade`: Fetch the latest release and auto-restart services.
     *   `agenfk upgrade --beta`: Opt-in to pre-release/beta versions.

--- a/packages/cli/src/test/dist-ships-ui-config.test.ts
+++ b/packages/cli/src/test/dist-ships-ui-config.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = path.resolve(__dirname, '../../../..');
+
+describe('package-dist.mjs — ships the UI runtime config', () => {
+  it('includes vite.config.ts used by vite preview', () => {
+    const packageDist = readFileSync(
+      path.join(ROOT, 'scripts', 'package-dist.mjs'),
+      'utf8',
+    );
+
+    expect(packageDist).toContain("'packages/ui/vite.config.ts'");
+  });
+});

--- a/packages/ui/src/api.ts
+++ b/packages/ui/src/api.ts
@@ -1,9 +1,8 @@
 import axios from 'axios';
 import { AgEnFKItem, ItemType, Status, Flow, RegistryFlow } from './types'; // We need to copy types or import from core if possible, but symlinking in Vite monorepo can be tricky without proper setup.
+import { API_URL } from './apiUrl';
 // For MVP, we'll duplicate the types interface or use `any`.
 // Better: configure vite to aliase @agenfk/core to the local package.
-
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
 
 export const api = {
   listProjects: async () => {

--- a/packages/ui/src/apiUrl.ts
+++ b/packages/ui/src/apiUrl.ts
@@ -1,0 +1,8 @@
+const configuredApiUrl = (import.meta.env.VITE_API_URL as string | undefined)?.trim();
+
+/**
+ * Use an explicitly configured API origin when provided. Otherwise, keep
+ * requests relative so the dashboard works behind a same-origin reverse proxy.
+ */
+export const API_URL = configuredApiUrl?.replace(/\/+$/, '') ?? '';
+

--- a/packages/ui/src/components/JiraConnectionButton.tsx
+++ b/packages/ui/src/components/JiraConnectionButton.tsx
@@ -3,8 +3,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { api } from '../api';
 import { Link, Unlink, CheckCircle, AlertCircle, Loader2 } from 'lucide-react';
 import { clsx } from 'clsx';
-
-const API_URL = (import.meta.env.VITE_API_URL as string | undefined) || 'http://localhost:3000';
+import { API_URL } from '../apiUrl';
 
 export const JiraConnectionButton: React.FC = () => {
   const queryClient = useQueryClient();

--- a/packages/ui/src/components/KanbanBoard.tsx
+++ b/packages/ui/src/components/KanbanBoard.tsx
@@ -13,6 +13,7 @@ import {
   ChevronUp, ChevronDown, X, FolderInput, GitBranch
 } from 'lucide-react';
 import { io } from 'socket.io-client';
+import { API_URL } from '../apiUrl';
 import { CardDetailModal } from './CardDetailModal';
 import { CardAnimationWrapper } from '../animations/CardAnimationWrapper';
 import '../animations'; // Side-effect: registers all easter egg animations
@@ -562,7 +563,7 @@ export const KanbanBoard: React.FC = () => {
   // WebSocket setup
   /* v8 ignore start */
   useEffect(() => {
-    const socket = io((import.meta.env.VITE_API_URL as string | undefined) || 'http://localhost:3000');
+    const socket = io(API_URL || undefined);
 
     socket.on('connect', () => {
       console.log('%c[WS_CONNECT] %cConnected to AgEnFK Brain', 'color: #6366f1; font-weight: bold', 'color: inherit');

--- a/packages/ui/src/main.tsx
+++ b/packages/ui/src/main.tsx
@@ -5,6 +5,7 @@ import App from './App.tsx'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ThemeProvider } from './ThemeContext'
 import { initPosthog, capture } from './posthog'
+import { API_URL } from './apiUrl'
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -14,8 +15,6 @@ const queryClient = new QueryClient({
     },
   },
 });
-
-const API_URL = (import.meta.env.VITE_API_URL as string | undefined) || 'http://localhost:3000';
 
 async function bootstrap() {
   // Non-blocking: fetch telemetry config and init Posthog if enabled.

--- a/packages/ui/src/test/apiUrl.test.ts
+++ b/packages/ui/src/test/apiUrl.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('API URL', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('defaults to same-origin requests', async () => {
+    vi.stubEnv('VITE_API_URL', '');
+    const { API_URL } = await import('../apiUrl');
+
+    expect(API_URL).toBe('');
+  });
+
+  it('normalizes an explicitly configured API origin', async () => {
+    vi.stubEnv('VITE_API_URL', 'https://agenfk-api.example.com///');
+    const { API_URL } = await import('../apiUrl');
+
+    expect(API_URL).toBe('https://agenfk-api.example.com');
+  });
+});

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -6,11 +6,9 @@ import { homedir } from 'os'
 
 const pkg = JSON.parse(readFileSync(resolve(__dirname, 'package.json'), 'utf8'))
 
-// If VITE_API_URL is not explicitly set, fall back to the API port persisted by
-// the server at ~/.agenfk/server-port (the API auto-selects the closest free
-// port and writes it there). Default to localhost:3000 if neither is present.
-function resolveApiUrl(): string {
-  if (process.env.VITE_API_URL) return process.env.VITE_API_URL
+// The browser uses same-origin API URLs by default. During local development
+// and preview, proxy those requests to the API port persisted by the server.
+function resolveApiProxyTarget(): string {
   try {
     const port = readFileSync(resolve(homedir(), '.agenfk', 'server-port'), 'utf8').trim()
     if (port) return `http://localhost:${port}`
@@ -18,8 +16,22 @@ function resolveApiUrl(): string {
   return 'http://localhost:3000'
 }
 
-const apiUrl = resolveApiUrl()
-process.env.VITE_API_URL = apiUrl
+const apiProxyTarget = resolveApiProxyTarget()
+const allowedHosts = (process.env.AGENFK_UI_ALLOWED_HOSTS || '')
+  .split(',')
+  .map(host => host.trim())
+  .filter(Boolean)
+const proxy = {
+  '^/(api|version|db|backup|projects|flows|prs|token-events|registry|items|internal|jira|github|releases)(/|\\?|$)': {
+    target: apiProxyTarget,
+    changeOrigin: true,
+  },
+  '/socket.io': {
+    target: apiProxyTarget,
+    changeOrigin: true,
+    ws: true,
+  },
+}
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -29,8 +41,12 @@ export default defineConfig({
   },
   server: {
     port: parseInt(process.env.VITE_PORT || '5173'),
+    ...(allowedHosts.length ? { allowedHosts } : {}),
+    proxy,
   },
   preview: {
     port: parseInt(process.env.VITE_PORT || '5173'),
+    ...(allowedHosts.length ? { allowedHosts } : {}),
+    proxy,
   },
 })

--- a/scripts/package-dist.mjs
+++ b/scripts/package-dist.mjs
@@ -54,6 +54,9 @@ async function run() {
         'packages/telemetry/package.json',
         'packages/telemetry/dist/',
         'packages/ui/package.json',
+        // vite preview loads this at runtime. It contains the same-origin API
+        // and WebSocket proxy used by installed dashboards.
+        'packages/ui/vite.config.ts',
         'packages/ui/dist/',
         // flow-editor is a source-only TS package consumed by ui + hub-ui at
         // build time; its src/ must travel in the tarball so workspace resolution


### PR DESCRIPTION
## Summary

- default dashboard HTTP, OAuth, telemetry, and Socket.IO requests to the UI origin
- proxy API and WebSocket routes to the local AgenFK API during Vite development and preview
- preserve `VITE_API_URL` as an explicit separate-origin build override
- configure reverse-proxy hostnames through `AGENFK_UI_ALLOWED_HOSTS`
- ship the runtime Vite config in release archives, with regression coverage
- document authenticated reverse-proxy/tunnel deployment

## Verification

- `npm run build -w packages/ui`
- focused URL regression tests: 2 passed
- release-packaging regression test: passed
- confirmed the production bundle contains no `http://localhost:3000` API origin
- exercised the preview proxy end-to-end: `/version` returned the API version and Socket.IO polling completed its handshake
- built and inspected `agenfk-dist.tar.gz`; it contains the generic Vite runtime config and no deployment-specific hostname

## Existing baseline failures

The full UI test suite currently has 3 unrelated failures (263 tests pass), and UI lint reports pre-existing errors across the package. This change does not modify those failing areas.
