### PR TITLE
feat(CGLAB-18): live Agent Runs panel — stream orchestrator↔pi transcripts per item

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2891,6 +2891,88 @@ program
     }
   });
 
+const run = program
+  .command('run')
+  .description('Record orchestrated agent-run transcripts (the live "Runs" panel source)');
+
+run
+  .command('start')
+  .description('Register a run when dispatching a worker; prints the run (capture its id)')
+  .requiredOption('--item <id>', 'AgEnFK item the run serves')
+  .requiredOption('--step <name>', 'Flow step the run serves (e.g. CREATE_UNIT_TESTS)')
+  .option('--project <id>', 'Project id')
+  .option('--actor <a>', 'orchestrator | worker | reviewer (default worker)')
+  .option('--harness <h>', 'Worker harness (default pi)')
+  .option('--model <m>', 'Worker model id (e.g. qwen3.6:27b)')
+  .option('--session <id>', 'Worker session id (pi --session-id)')
+  .option('--source <path>', 'Absolute path of the worker session JSONL (for live tailing)')
+  .action(async (o) => {
+    try {
+      const { data } = await axios.post(`${API_URL}/agent-runs`, {
+        itemId: o.item, step: o.step, projectId: o.project, actor: o.actor,
+        harness: o.harness, model: o.model, sessionId: o.session, sourcePath: o.source,
+      });
+      console.log(structuredOutput(data));
+    } catch (error: any) {
+      console.error(chalk.red('Error starting run:'), error.response?.data?.error || error.message);
+      process.exit(1);
+    }
+  });
+
+run
+  .command('event')
+  .description('Append a transcript event to a run (streamed live to the UI)')
+  .requiredOption('--run <id>', 'Run id from `run start`')
+  .requiredOption('--kind <k>', 'dispatch | think | tool | result | diff | verdict | note')
+  .option('--lane <a>', 'orchestrator | worker | reviewer')
+  .option('--tool <t>', 'Tool name (for kind=tool): read | bash | write | edit')
+  .option('--text <t>', 'Human-readable event text')
+  .option('--payload <json>', 'JSON string with structured extras')
+  .option('--tokens <n>', 'Token count for this event', (v) => parseInt(v, 10))
+  .action(async (o) => {
+    try {
+      const { data } = await axios.post(`${API_URL}/agent-runs/${o.run}/events`, {
+        kind: o.kind, lane: o.lane, tool: o.tool, text: o.text, payload: o.payload, tokens: o.tokens,
+      });
+      console.log(structuredOutput(data));
+    } catch (error: any) {
+      console.error(chalk.red('Error appending run event:'), error.response?.data?.error || error.message);
+      process.exit(1);
+    }
+  });
+
+run
+  .command('end')
+  .description('Mark a run finished with a verdict')
+  .requiredOption('--run <id>', 'Run id')
+  .option('--status <s>', 'done | failed (default done)', 'done')
+  .option('--verdict <v>', 'Orchestrator verdict, e.g. APPROVED')
+  .action(async (o) => {
+    try {
+      const { data } = await axios.patch(`${API_URL}/agent-runs/${o.run}`, {
+        status: o.status, verdict: o.verdict,
+      });
+      console.log(structuredOutput(data));
+    } catch (error: any) {
+      console.error(chalk.red('Error ending run:'), error.response?.data?.error || error.message);
+      process.exit(1);
+    }
+  });
+
+run
+  .command('list')
+  .description('List agent runs for an item')
+  .requiredOption('--item <id>', 'AgEnFK item id')
+  .action(async (o) => {
+    try {
+      const { data } = await axios.get(`${API_URL}/items/${o.item}/agent-runs`);
+      console.log(structuredOutput(data));
+    } catch (error: any) {
+      console.error(chalk.red('Error listing runs:'), error.response?.data?.error || error.message);
+      process.exit(1);
+    }
+  });
+
 program
   .command('log-test <id>')
   .description('Log a test result for an item (MCP fallback: log_test_result)')

--- a/packages/core/src/interfaces.ts
+++ b/packages/core/src/interfaces.ts
@@ -10,6 +10,9 @@ import {
   IngestionState,
   Pr,
   PrSizing,
+  AgentRun,
+  RunEvent,
+  AgentRunQuery,
 } from './types';
 
 export interface PluginConfig {
@@ -66,6 +69,15 @@ export interface StorageProvider extends AgEnFKPlugin {
   queryTokenEvents(query: TokenEventQuery): Promise<TokenEvent[]>;
   getIngestionState(sourcePath: string): Promise<IngestionState | null>;
   setIngestionState(state: IngestionState): Promise<void>;
+
+  // Observability — agent runs (orchestrated worker transcripts per item)
+  createAgentRun(run: AgentRun): Promise<AgentRun>;
+  updateAgentRun(id: string, updates: Partial<AgentRun>): Promise<AgentRun>;
+  getAgentRun(id: string): Promise<AgentRun | null>;
+  listAgentRuns(query: AgentRunQuery): Promise<AgentRun[]>;
+  getAgentRunBySession(sessionId: string): Promise<AgentRun | null>;
+  appendRunEvent(event: RunEvent): Promise<void>;
+  listRunEvents(runId: string): Promise<RunEvent[]>;
 
   // Observability — PR sizing (agent-declared)
   insertPr(pr: Pr): Promise<Pr>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -64,6 +64,49 @@ export interface IngestionState {
   lastRunAt: string;
 }
 
+// ── Agent Runs: orchestrated worker transcripts per item ────────────────────
+
+export type RunActor = 'orchestrator' | 'worker' | 'reviewer';
+export type RunStatus = 'running' | 'done' | 'failed';
+
+export interface AgentRun {
+  id: string;
+  itemId: string;
+  projectId?: string;
+  step: string;                 // flow step the run served (e.g. CREATE_UNIT_TESTS)
+  actor: RunActor;              // primary lane for the run
+  harness: string;              // e.g. "pi", "claude-code"
+  model: string;                // e.g. "qwen3.6:27b"
+  sessionId?: string;           // worker session id (pi --session-id)
+  sourcePath?: string;          // absolute path of the worker session JSONL (for tailing)
+  status: RunStatus;
+  verdict?: string;             // orchestrator verdict on the hand-off
+  startedAt: string;            // ISO
+  endedAt?: string;             // ISO
+}
+
+export type RunEventKind = 'dispatch' | 'think' | 'tool' | 'result' | 'diff' | 'verdict' | 'note';
+
+export interface RunEvent {
+  id: string;
+  runId: string;
+  seq: number;                  // monotonic order within the run
+  ts: string;                   // ISO
+  lane: RunActor;
+  kind: RunEventKind;
+  tool?: string;                // for kind==='tool': read|bash|write|edit…
+  text?: string;                // human-readable text
+  payload?: string;             // JSON blob for structured extras (args, diff, etc.)
+  tokens?: number;              // optional per-event token count
+}
+
+export interface AgentRunQuery {
+  itemId?: string;
+  projectId?: string;
+  status?: RunStatus;
+  limit?: number;
+}
+
 // ── Observability: PR sizing (agent-declared, server-shadowed) ──────────────
 
 export interface PrSizing {

--- a/packages/server/src/agent-runs/pi-parser.ts
+++ b/packages/server/src/agent-runs/pi-parser.ts
@@ -68,8 +68,11 @@ export function parsePiSessionJsonl(text: string): ParsedRunEvent[] {
     const msg = obj.message;
 
     if (msg.role === 'assistant') {
-      const totalTokens =
-        msg.usage && Number.isFinite(msg.usage.totalTokens) ? msg.usage.totalTokens : undefined;
+      // Prefer the turn's incremental output tokens; pi's `totalTokens` is the
+      // cumulative context size and would massively overcount if summed.
+      const turnTokens =
+        msg.usage && Number.isFinite(msg.usage.output) ? msg.usage.output
+          : (msg.usage && Number.isFinite(msg.usage.totalTokens) ? msg.usage.totalTokens : undefined);
       let tokenAttached = false;
       const blocks = Array.isArray(msg.content) ? msg.content : [];
       for (const b of blocks) {
@@ -87,7 +90,7 @@ export function parsePiSessionJsonl(text: string): ParsedRunEvent[] {
           };
         }
         if (ev) {
-          if (totalTokens !== undefined && !tokenAttached) { ev.tokens = totalTokens; tokenAttached = true; }
+          if (turnTokens !== undefined && !tokenAttached) { ev.tokens = turnTokens; tokenAttached = true; }
           events.push(ev);
         }
       }

--- a/packages/server/src/agent-runs/pi-parser.ts
+++ b/packages/server/src/agent-runs/pi-parser.ts
@@ -1,0 +1,105 @@
+/**
+ * Parse a pi.dev session JSONL transcript into agent-run transcript events.
+ *
+ * pi appends one JSON object per line to ~/.pi/agent/sessions/<project>/<id>.jsonl.
+ * Relevant shapes:
+ *   { type: 'session', ... }                              — ignored
+ *   { type: 'model_change', provider, modelId }           — ignored
+ *   { type: 'message', message: { role: 'assistant',
+ *       content: [ { type:'thinking', thinking },
+ *                  { type:'text', text },
+ *                  { type:'toolCall', name, arguments } ],
+ *       usage: { totalTokens } } }
+ *   { type: 'message', message: { role: 'toolResult',
+ *       toolName, isError, content: [ { type:'text', text } ] } }
+ *
+ * Pure & deterministic: the same append-only file always yields the same event
+ * sequence, so a whole-file re-parse + count-based slice is idempotent.
+ */
+
+export type ParsedLane = 'orchestrator' | 'worker' | 'reviewer';
+export type ParsedKind = 'dispatch' | 'think' | 'tool' | 'result' | 'diff' | 'verdict' | 'note';
+
+export interface ParsedRunEvent {
+  lane: ParsedLane;
+  kind: ParsedKind;
+  tool?: string;
+  text?: string;
+  payload?: string;
+  tokens?: number;
+}
+
+const MAX_TEXT = 600;
+
+function truncate(s: string): string {
+  const t = s.replace(/\s+$/g, '');
+  return t.length > MAX_TEXT ? t.slice(0, MAX_TEXT) + '…' : t;
+}
+
+/** One-line human summary of a tool call from its arguments. */
+function summarizeTool(name: string, args: any): string {
+  if (!args || typeof args !== 'object') return name;
+  if (typeof args.command === 'string') return args.command;          // bash
+  if (typeof args.path === 'string') return args.path;                // read/write/edit
+  if (typeof args.filePath === 'string') return args.filePath;
+  if (typeof args.pattern === 'string') return args.pattern;          // grep/glob
+  const keys = Object.keys(args);
+  return keys.length ? `${keys[0]}=${String(args[keys[0]]).slice(0, 120)}` : name;
+}
+
+function collectText(content: any): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  return content
+    .filter((b) => b && b.type === 'text' && typeof b.text === 'string')
+    .map((b) => b.text)
+    .join('\n');
+}
+
+export function parsePiSessionJsonl(text: string): ParsedRunEvent[] {
+  const events: ParsedRunEvent[] = [];
+  const lines = text.split('\n');
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let obj: any;
+    try { obj = JSON.parse(trimmed); } catch { continue; } // skip partial/incomplete lines
+    if (!obj || obj.type !== 'message' || !obj.message) continue;
+    const msg = obj.message;
+
+    if (msg.role === 'assistant') {
+      const totalTokens =
+        msg.usage && Number.isFinite(msg.usage.totalTokens) ? msg.usage.totalTokens : undefined;
+      let tokenAttached = false;
+      const blocks = Array.isArray(msg.content) ? msg.content : [];
+      for (const b of blocks) {
+        if (!b || typeof b !== 'object') continue;
+        let ev: ParsedRunEvent | null = null;
+        if (b.type === 'thinking' && typeof b.thinking === 'string') {
+          ev = { lane: 'worker', kind: 'think', text: truncate(b.thinking) };
+        } else if (b.type === 'text' && typeof b.text === 'string' && b.text.trim()) {
+          ev = { lane: 'worker', kind: 'note', text: truncate(b.text) };
+        } else if (b.type === 'toolCall' && typeof b.name === 'string') {
+          ev = {
+            lane: 'worker', kind: 'tool', tool: b.name,
+            text: truncate(summarizeTool(b.name, b.arguments)),
+            payload: b.arguments !== undefined ? JSON.stringify(b.arguments) : undefined,
+          };
+        }
+        if (ev) {
+          if (totalTokens !== undefined && !tokenAttached) { ev.tokens = totalTokens; tokenAttached = true; }
+          events.push(ev);
+        }
+      }
+    } else if (msg.role === 'toolResult') {
+      const body = collectText(msg.content);
+      events.push({
+        lane: 'worker', kind: 'result',
+        tool: typeof msg.toolName === 'string' ? msg.toolName : undefined,
+        text: truncate(body || (msg.isError ? 'error' : 'ok')),
+        payload: JSON.stringify({ isError: !!msg.isError }),
+      });
+    }
+  }
+  return events;
+}

--- a/packages/server/src/agent-runs/tailer.ts
+++ b/packages/server/src/agent-runs/tailer.ts
@@ -1,0 +1,85 @@
+/**
+ * Run tailer — the live half of the Agent Runs feature.
+ *
+ * Polls the agent_runs whose worker session file (sourcePath) is still being
+ * written, re-parses each file, and appends+emits only events not yet seen.
+ * Whole-file re-parse + count-based slice keeps it idempotent against the
+ * append-only pi session JSONL, so no byte-offset bookkeeping is needed.
+ */
+import * as fs from 'fs';
+import { v4 as uuidv4 } from 'uuid';
+import type { StorageProvider, RunEvent } from '@agenfk/core';
+import { parsePiSessionJsonl } from './pi-parser';
+
+export interface RunEventBroadcast {
+  itemId: string;
+  runId: string;
+  event: RunEvent;
+}
+
+export interface TailDeps {
+  readFile?: (path: string) => string;   // injectable for tests
+  now?: () => string;                     // injectable for tests
+}
+
+/**
+ * One tail pass over all running runs with a source file. Returns the events
+ * newly appended this pass (also handed to `emit` as they are persisted).
+ */
+export async function tailRunsOnce(
+  storage: StorageProvider,
+  emit: (b: RunEventBroadcast) => void,
+  deps: TailDeps = {},
+): Promise<RunEvent[]> {
+  const readFile = deps.readFile ?? ((p: string) => fs.readFileSync(p, 'utf8'));
+  const now = deps.now ?? (() => new Date().toISOString());
+  const appended: RunEvent[] = [];
+
+  const runs = await storage.listAgentRuns({ status: 'running' });
+  for (const run of runs) {
+    if (!run.sourcePath) continue;
+    let text: string;
+    try { text = readFile(run.sourcePath); } catch { continue; } // file not there yet
+    const parsed = parsePiSessionJsonl(text);
+    const known = (await storage.listRunEvents(run.id)).length;
+    for (let i = known; i < parsed.length; i++) {
+      const p = parsed[i];
+      const event: RunEvent = {
+        id: uuidv4(),
+        runId: run.id,
+        seq: i,
+        ts: now(),
+        lane: p.lane,
+        kind: p.kind,
+        tool: p.tool,
+        text: p.text,
+        payload: p.payload,
+        tokens: p.tokens,
+      };
+      await storage.appendRunEvent(event);
+      emit({ itemId: run.itemId, runId: run.id, event });
+      appended.push(event);
+    }
+  }
+  return appended;
+}
+
+/**
+ * Start the tail poll loop. Returns a stop() to clear the timer.
+ * Not started at import time — the server boot path calls this so tests that
+ * import `app` never spin a timer.
+ */
+export function startRunTailer(
+  storage: StorageProvider,
+  emit: (b: RunEventBroadcast) => void,
+  intervalMs = 2000,
+): () => void {
+  let stopped = false;
+  const tick = async () => {
+    if (stopped) return;
+    try { await tailRunsOnce(storage, emit); } catch { /* keep polling */ }
+    if (!stopped) timer = setTimeout(tick, intervalMs);
+  };
+  let timer: NodeJS.Timeout = setTimeout(tick, intervalMs);
+  return () => { stopped = true; clearTimeout(timer); };
+}

--- a/packages/server/src/agent-runs/tailer.ts
+++ b/packages/server/src/agent-runs/tailer.ts
@@ -41,13 +41,22 @@ export async function tailRunsOnce(
     let text: string;
     try { text = readFile(run.sourcePath); } catch { continue; } // file not there yet
     const parsed = parsePiSessionJsonl(text);
-    const known = (await storage.listRunEvents(run.id)).length;
-    for (let i = known; i < parsed.length; i++) {
+    // Track parser progress SEPARATELY from the run's total event count — the
+    // orchestrator also appends events (dispatch/verdict/note) to the same run
+    // via REST, so slicing by total count would drop/misalign parser events.
+    // Key the offset by run id (distinct from any token-ingestion offsets).
+    const offsetKey = `agentrun:${run.id}`;
+    const state = await storage.getIngestionState(offsetKey);
+    const consumed = state ? state.lastOffset : 0;
+    for (let i = consumed; i < parsed.length; i++) {
       const p = parsed[i];
+      // Append at end: seq = current total event count, so tailer and REST
+      // writers never collide on the (run_id, seq) dedup index.
+      const seq = (await storage.listRunEvents(run.id)).length;
       const event: RunEvent = {
         id: uuidv4(),
         runId: run.id,
-        seq: i,
+        seq,
         ts: now(),
         lane: p.lane,
         kind: p.kind,
@@ -59,6 +68,9 @@ export async function tailRunsOnce(
       await storage.appendRunEvent(event);
       emit({ itemId: run.itemId, runId: run.id, event });
       appended.push(event);
+    }
+    if (parsed.length > consumed) {
+      await storage.setIngestionState({ sourcePath: offsetKey, lastOffset: parsed.length, lastRunAt: now() });
     }
   }
   return appended;

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1057,6 +1057,101 @@ app.get("/token-events", asyncHandler(async (req: any, res: any) => {
   res.json(events);
 }));
 
+// ── Agent runs (orchestrated worker transcripts per item) ──────────────────
+const RUN_ACTORS = new Set(['orchestrator', 'worker', 'reviewer']);
+const RUN_STATUSES = new Set(['running', 'done', 'failed']);
+const RUN_EVENT_KINDS = new Set(['dispatch', 'think', 'tool', 'result', 'diff', 'verdict', 'note']);
+
+// Register a run when the orchestrator dispatches a worker (establishes the
+// session↔card link that heuristic attribution cannot).
+app.post("/agent-runs", asyncHandler(async (req: any, res: any) => {
+  const { itemId, projectId, step, actor, harness, model, sessionId, sourcePath } = req.body || {};
+  if (!itemId) return res.status(400).json({ error: "itemId is required" });
+  if (!step) return res.status(400).json({ error: "step is required" });
+  if (actor && !RUN_ACTORS.has(actor)) {
+    return res.status(400).json({ error: `Invalid actor '${actor}'. Must be one of: ${[...RUN_ACTORS].join(', ')}` });
+  }
+  const run = await storage.createAgentRun({
+    id: uuidv4(),
+    itemId,
+    projectId: projectId || undefined,
+    step,
+    actor: actor || 'worker',
+    harness: harness || 'pi',
+    model: model || 'unknown',
+    sessionId: sessionId || undefined,
+    sourcePath: sourcePath || undefined,
+    status: 'running',
+    startedAt: new Date().toISOString(),
+  });
+  io.emit('run:updated', { itemId: run.itemId, runId: run.id });
+  io.emit('items_updated');
+  res.status(201).json(run);
+}));
+
+app.patch("/agent-runs/:id", asyncHandler(async (req: any, res: any) => {
+  const existing = await storage.getAgentRun(req.params.id);
+  if (!existing) return res.status(404).json({ error: "Agent run not found" });
+  const { status, verdict, endedAt, sourcePath } = req.body || {};
+  if (status && !RUN_STATUSES.has(status)) {
+    return res.status(400).json({ error: `Invalid status '${status}'. Must be one of: ${[...RUN_STATUSES].join(', ')}` });
+  }
+  const updated = await storage.updateAgentRun(req.params.id, {
+    ...(status !== undefined ? { status } : {}),
+    ...(verdict !== undefined ? { verdict } : {}),
+    ...(sourcePath !== undefined ? { sourcePath } : {}),
+    // stamp endedAt when a terminal status arrives without an explicit one
+    ...(endedAt !== undefined ? { endedAt }
+        : (status && status !== 'running' && !existing.endedAt ? { endedAt: new Date().toISOString() } : {})),
+  });
+  io.emit('run:updated', { itemId: updated.itemId, runId: updated.id });
+  res.json(updated);
+}));
+
+// Append a transcript event. Used both by the orchestrator (dispatch/verdict/note)
+// and by the session watcher (think/tool/result). Emits a payload-bearing socket
+// event so the UI can stream it live, keyed by itemId.
+app.post("/agent-runs/:id/events", asyncHandler(async (req: any, res: any) => {
+  const run = await storage.getAgentRun(req.params.id);
+  if (!run) return res.status(404).json({ error: "Agent run not found" });
+  const { lane, kind, tool, text, payload, tokens, seq } = req.body || {};
+  if (!kind || !RUN_EVENT_KINDS.has(kind)) {
+    return res.status(400).json({ error: `Invalid kind '${kind}'. Must be one of: ${[...RUN_EVENT_KINDS].join(', ')}` });
+  }
+  if (lane && !RUN_ACTORS.has(lane)) {
+    return res.status(400).json({ error: `Invalid lane '${lane}'. Must be one of: ${[...RUN_ACTORS].join(', ')}` });
+  }
+  // Caller may supply a deterministic seq (watcher re-parse dedup); else append.
+  const nextSeq = Number.isInteger(seq) ? seq : (await storage.listRunEvents(run.id)).length;
+  const event = {
+    id: uuidv4(),
+    runId: run.id,
+    seq: nextSeq,
+    ts: new Date().toISOString(),
+    lane: (lane || run.actor) as any,
+    kind,
+    tool: tool || undefined,
+    text: text || undefined,
+    payload: payload !== undefined ? (typeof payload === 'string' ? payload : JSON.stringify(payload)) : undefined,
+    tokens: Number.isFinite(tokens) ? tokens : undefined,
+  };
+  await storage.appendRunEvent(event);
+  io.emit('run:event', { itemId: run.itemId, runId: run.id, event });
+  res.status(201).json(event);
+}));
+
+app.get("/items/:id/agent-runs", asyncHandler(async (req: any, res: any) => {
+  const runs = await storage.listAgentRuns({ itemId: req.params.id });
+  res.json(runs);
+}));
+
+app.get("/agent-runs/:id/events", asyncHandler(async (req: any, res: any) => {
+  const run = await storage.getAgentRun(req.params.id);
+  if (!run) return res.status(404).json({ error: "Agent run not found" });
+  const events = await storage.listRunEvents(run.id);
+  res.json(events);
+}));
+
 const HUB_MANAGED_FLOW_MSG = "Flow is managed by your organization's Hub and cannot be modified locally";
 
 app.post("/flows", asyncHandler(async (req: any, res: any) => {

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -8,6 +8,7 @@ import { HubClient, Flusher, loadHubConfig, PENDING_ORG } from "./hub/index.js";
 import type { RecordEventInput } from "./hub/index.js";
 import { startFlowSync, type FlowSyncHandle } from "./hub/flowSync.js";
 import { refreshProjectFlowFromHub } from "./hub/flowRefresh.js";
+import { startRunTailer } from "./agent-runs/tailer.js";
 import { startUpgradeSync, replayPendingUpgradeOutcome, type UpgradeSyncHandle } from "./hub/upgradeSync.js";
 import { spawnSync } from 'child_process';
 import { v4 as uuidv4 } from "uuid";
@@ -3329,6 +3330,8 @@ if (process.env.NODE_ENV !== 'test' && !process.env.VITEST) {
           console.log(`AgEnFK API Server: requested port ${REQUESTED_PORT} was in use, bound to ${port} instead`);
         }
         console.log(`AgEnFK API Server running on ${BIND_HOST}:${port} (with WebSockets)`);
+        // Live Agent Runs: tail registered worker sessions → stream run:event.
+        startRunTailer(storage, (b) => io.emit('run:event', b));
         telemetry.capture('server_started', {
           version: getCurrentVersion(),
           storageBackend: 'sqlite',

--- a/packages/server/src/test/agent-runs-api.test.ts
+++ b/packages/server/src/test/agent-runs-api.test.ts
@@ -1,0 +1,81 @@
+/**
+ * REST surface for agent runs (CGLAB-18a). Behaviour-based: drives the real
+ * Express app + storage against a temp DB via supertest.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import request from 'supertest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { app, initStorage } from '../server';
+
+const TEST_DB = path.resolve('./agent-runs-api-test-db.sqlite');
+
+describe('agent-runs REST', () => {
+  beforeAll(async () => {
+    process.env.AGENFK_DB_PATH = TEST_DB;
+    if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+    await initStorage();
+  });
+  afterAll(() => { if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB); });
+  beforeEach(async () => { await initStorage(); });
+
+  it('registers a run and lists it for the item', async () => {
+    const create = await request(app).post('/agent-runs').send({
+      itemId: 'item-X', projectId: 'p1', step: 'CREATE_UNIT_TESTS',
+      actor: 'worker', harness: 'pi', model: 'qwen3.6:27b', sessionId: 'sess-1',
+    });
+    expect(create.status).toBe(201);
+    expect(create.body.id).toBeTruthy();
+    expect(create.body.status).toBe('running');
+
+    const list = await request(app).get('/items/item-X/agent-runs');
+    expect(list.status).toBe(200);
+    expect(list.body).toHaveLength(1);
+    expect(list.body[0].sessionId).toBe('sess-1');
+  });
+
+  it('rejects an invalid actor and a missing itemId', async () => {
+    expect((await request(app).post('/agent-runs').send({ itemId: 'i', step: 's', actor: 'nope' })).status).toBe(400);
+    expect((await request(app).post('/agent-runs').send({ step: 's' })).status).toBe(400);
+  });
+
+  it('appends events with auto-incrementing seq and lists them ordered', async () => {
+    const run = (await request(app).post('/agent-runs').send({ itemId: 'i2', step: 'IN_PROGRESS' })).body;
+    await request(app).post(`/agent-runs/${run.id}/events`).send({ lane: 'orchestrator', kind: 'dispatch', text: 'go' });
+    await request(app).post(`/agent-runs/${run.id}/events`).send({ lane: 'worker', kind: 'tool', tool: 'bash', text: 'npx vitest' });
+    const res = await request(app).post(`/agent-runs/${run.id}/events`).send({ lane: 'worker', kind: 'result', text: '3 passed' });
+    expect(res.status).toBe(201);
+
+    const events = await request(app).get(`/agent-runs/${run.id}/events`);
+    expect(events.body.map((e: any) => e.seq)).toEqual([0, 1, 2]);
+    expect(events.body.map((e: any) => e.kind)).toEqual(['dispatch', 'tool', 'result']);
+  });
+
+  it('serializes an object payload to JSON', async () => {
+    const run = (await request(app).post('/agent-runs').send({ itemId: 'i3', step: 's' })).body;
+    await request(app).post(`/agent-runs/${run.id}/events`).send({ kind: 'diff', payload: { added: 14, removed: 2 } });
+    const events = (await request(app).get(`/agent-runs/${run.id}/events`)).body;
+    expect(JSON.parse(events[0].payload)).toEqual({ added: 14, removed: 2 });
+  });
+
+  it('rejects an invalid event kind', async () => {
+    const run = (await request(app).post('/agent-runs').send({ itemId: 'i4', step: 's' })).body;
+    const res = await request(app).post(`/agent-runs/${run.id}/events`).send({ kind: 'bogus' });
+    expect(res.status).toBe(400);
+  });
+
+  it('updates status + verdict and stamps endedAt on a terminal status', async () => {
+    const run = (await request(app).post('/agent-runs').send({ itemId: 'i5', step: 's' })).body;
+    const patched = await request(app).patch(`/agent-runs/${run.id}`).send({ status: 'done', verdict: 'APPROVED' });
+    expect(patched.status).toBe(200);
+    expect(patched.body.status).toBe('done');
+    expect(patched.body.verdict).toBe('APPROVED');
+    expect(patched.body.endedAt).toBeTruthy(); // auto-stamped
+  });
+
+  it('404s for events on an unknown run', async () => {
+    expect((await request(app).get('/agent-runs/nope/events')).status).toBe(404);
+    expect((await request(app).post('/agent-runs/nope/events').send({ kind: 'note' })).status).toBe(404);
+    expect((await request(app).patch('/agent-runs/nope').send({ status: 'done' })).status).toBe(404);
+  });
+});

--- a/packages/server/src/test/agent-runs-pi-parser.test.ts
+++ b/packages/server/src/test/agent-runs-pi-parser.test.ts
@@ -1,0 +1,67 @@
+/**
+ * pi.dev session JSONL → run transcript events (CGLAB-18b). Behaviour-based:
+ * feeds a realistic pi transcript to the pure parser and asserts the events.
+ */
+import { describe, it, expect } from 'vitest';
+import { parsePiSessionJsonl } from '../agent-runs/pi-parser';
+
+const TRANSCRIPT = [
+  JSON.stringify({ type: 'session', id: 's1', cwd: '/repo' }),
+  JSON.stringify({ type: 'model_change', provider: 'qwen-cglab', modelId: 'qwen3.6:27b' }),
+  JSON.stringify({ type: 'message', message: { role: 'assistant', content: [
+    { type: 'thinking', thinking: 'I will read the test file first.' },
+    { type: 'toolCall', id: 'c1', name: 'read', arguments: { path: 'packages/ui/src/test/KanbanBoard.test.tsx' } },
+  ], usage: { totalTokens: 3018 } } }),
+  JSON.stringify({ type: 'message', message: { role: 'toolResult', toolCallId: 'c1', toolName: 'read',
+    content: [{ type: 'text', text: 'file contents here' }], isError: false } }),
+  JSON.stringify({ type: 'message', message: { role: 'assistant', content: [
+    { type: 'toolCall', id: 'c2', name: 'bash', arguments: { command: 'npx vitest run' } },
+  ], usage: { totalTokens: 1200 } } }),
+  JSON.stringify({ type: 'message', message: { role: 'toolResult', toolCallId: 'c2', toolName: 'bash',
+    content: [{ type: 'text', text: 'Tests 3 failed' }], isError: true } }),
+  JSON.stringify({ type: 'message', message: { role: 'assistant', content: [{ type: 'text', text: 'Done.' }] } }),
+  '{"type":"message","message":{"role":"assistant"', // partial/incomplete trailing line
+].join('\n');
+
+describe('parsePiSessionJsonl', () => {
+  const events = parsePiSessionJsonl(TRANSCRIPT);
+
+  it('ignores session/model_change lines and skips the partial trailing line', () => {
+    // 6 real events: think, tool(read), result, tool(bash), result, note
+    expect(events).toHaveLength(6);
+  });
+
+  it('maps assistant thinking → think and attaches the turn token count to the first event', () => {
+    expect(events[0]).toMatchObject({ lane: 'worker', kind: 'think', tokens: 3018 });
+    expect(events[0].text).toContain('read the test file');
+  });
+
+  it('maps a toolCall → tool with a one-line arg summary', () => {
+    expect(events[1]).toMatchObject({ lane: 'worker', kind: 'tool', tool: 'read' });
+    expect(events[1].text).toBe('packages/ui/src/test/KanbanBoard.test.tsx');
+    expect(events[3]).toMatchObject({ kind: 'tool', tool: 'bash', text: 'npx vitest run', tokens: 1200 });
+  });
+
+  it('maps toolResult → result carrying the error flag', () => {
+    expect(events[2]).toMatchObject({ kind: 'result', tool: 'read', text: 'file contents here' });
+    expect(JSON.parse(events[2].payload!)).toEqual({ isError: false });
+    expect(events[4]).toMatchObject({ kind: 'result', tool: 'bash', text: 'Tests 3 failed' });
+    expect(JSON.parse(events[4].payload!)).toEqual({ isError: true });
+  });
+
+  it('maps assistant plain text → note', () => {
+    expect(events[5]).toMatchObject({ lane: 'worker', kind: 'note', text: 'Done.' });
+  });
+
+  it('truncates very long text', () => {
+    const long = JSON.stringify({ type: 'message', message: { role: 'assistant',
+      content: [{ type: 'thinking', thinking: 'x'.repeat(2000) }] } });
+    const [ev] = parsePiSessionJsonl(long);
+    expect(ev.text!.length).toBeLessThan(700);
+    expect(ev.text!.endsWith('…')).toBe(true);
+  });
+
+  it('returns [] for empty input', () => {
+    expect(parsePiSessionJsonl('')).toEqual([]);
+  });
+});

--- a/packages/server/src/test/agent-runs-storage.test.ts
+++ b/packages/server/src/test/agent-runs-storage.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Storage layer for agent runs + transcript events (CGLAB-18a).
+ * Behaviour-based: exercises the real SQLiteStorageProvider against an
+ * in-memory DB — no source grepping.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { SQLiteStorageProvider } from '@agenfk/storage-sqlite';
+import type { AgentRun, RunEvent } from '@agenfk/core';
+
+function makeRun(over: Partial<AgentRun> = {}): AgentRun {
+  return {
+    id: over.id ?? 'run-1',
+    itemId: over.itemId ?? 'item-1',
+    projectId: over.projectId ?? 'proj-1',
+    step: over.step ?? 'CREATE_UNIT_TESTS',
+    actor: over.actor ?? 'worker',
+    harness: over.harness ?? 'pi',
+    model: over.model ?? 'qwen3.6:27b',
+    sessionId: over.sessionId ?? 'cglab18-tests',
+    sourcePath: over.sourcePath ?? '/tmp/session.jsonl',
+    status: over.status ?? 'running',
+    verdict: over.verdict,
+    startedAt: over.startedAt ?? '2026-07-21T10:00:00.000Z',
+    endedAt: over.endedAt,
+  };
+}
+
+describe('agent runs storage', () => {
+  let storage: SQLiteStorageProvider;
+  beforeEach(async () => {
+    storage = new SQLiteStorageProvider();
+    await storage.init({ path: ':memory:' });
+  });
+
+  it('creates and reads back a run', async () => {
+    await storage.createAgentRun(makeRun());
+    const got = await storage.getAgentRun('run-1');
+    expect(got).not.toBeNull();
+    expect(got!.itemId).toBe('item-1');
+    expect(got!.model).toBe('qwen3.6:27b');
+    expect(got!.status).toBe('running');
+    expect(got!.sessionId).toBe('cglab18-tests');
+  });
+
+  it('lists runs filtered by item and by status', async () => {
+    await storage.createAgentRun(makeRun({ id: 'run-1', itemId: 'A', status: 'done' }));
+    await storage.createAgentRun(makeRun({ id: 'run-2', itemId: 'A', status: 'running', startedAt: '2026-07-21T10:05:00.000Z' }));
+    await storage.createAgentRun(makeRun({ id: 'run-3', itemId: 'B', status: 'done' }));
+
+    const forA = await storage.listAgentRuns({ itemId: 'A' });
+    expect(forA.map(r => r.id)).toEqual(['run-1', 'run-2']); // ordered by startedAt ASC
+
+    const doneA = await storage.listAgentRuns({ itemId: 'A', status: 'done' });
+    expect(doneA.map(r => r.id)).toEqual(['run-1']);
+  });
+
+  it('updateAgentRun merges fields (status, verdict, endedAt)', async () => {
+    await storage.createAgentRun(makeRun());
+    const updated = await storage.updateAgentRun('run-1', {
+      status: 'done', verdict: 'APPROVED', endedAt: '2026-07-21T10:03:00.000Z',
+    });
+    expect(updated.status).toBe('done');
+    expect(updated.verdict).toBe('APPROVED');
+    expect(updated.model).toBe('qwen3.6:27b'); // untouched field preserved
+    const reread = await storage.getAgentRun('run-1');
+    expect(reread!.status).toBe('done');
+    expect(reread!.endedAt).toBe('2026-07-21T10:03:00.000Z');
+  });
+
+  it('getAgentRunBySession returns the most recent run for a session id', async () => {
+    await storage.createAgentRun(makeRun({ id: 'old', sessionId: 's', startedAt: '2026-07-21T09:00:00.000Z' }));
+    await storage.createAgentRun(makeRun({ id: 'new', sessionId: 's', startedAt: '2026-07-21T11:00:00.000Z' }));
+    const got = await storage.getAgentRunBySession('s');
+    expect(got!.id).toBe('new');
+  });
+
+  it('appends and lists run events ordered by seq', async () => {
+    await storage.createAgentRun(makeRun());
+    const ev = (seq: number, over: Partial<RunEvent> = {}): RunEvent => ({
+      id: `e${seq}`, runId: 'run-1', seq, ts: '2026-07-21T10:00:0' + seq + '.000Z',
+      lane: 'worker', kind: 'tool', tool: 'bash', text: 'npx vitest', ...over,
+    });
+    await storage.appendRunEvent(ev(2));
+    await storage.appendRunEvent(ev(0, { lane: 'orchestrator', kind: 'dispatch', tool: undefined, text: 'go' }));
+    await storage.appendRunEvent(ev(1, { kind: 'think', tool: undefined, text: 'planning' }));
+
+    const events = await storage.listRunEvents('run-1');
+    expect(events.map(e => e.seq)).toEqual([0, 1, 2]);
+    expect(events[0].kind).toBe('dispatch');
+    expect(events[2].tool).toBe('bash');
+  });
+
+  it('dedupes run events on (runId, seq)', async () => {
+    await storage.createAgentRun(makeRun());
+    const base: RunEvent = { id: 'e1', runId: 'run-1', seq: 0, ts: '2026-07-21T10:00:00.000Z', lane: 'worker', kind: 'note', text: 'first' };
+    await storage.appendRunEvent(base);
+    await storage.appendRunEvent({ ...base, id: 'e1-dup', text: 'second' }); // same (runId, seq)
+    const events = await storage.listRunEvents('run-1');
+    expect(events).toHaveLength(1);
+    expect(events[0].text).toBe('first'); // INSERT OR IGNORE keeps the first
+  });
+});

--- a/packages/server/src/test/agent-runs-tailer.test.ts
+++ b/packages/server/src/test/agent-runs-tailer.test.ts
@@ -78,6 +78,32 @@ describe('tailRunsOnce', () => {
     expect(emitted).toEqual([]);
   });
 
+  it('does not drop parser events when the orchestrator also appends via REST (mixed writers)', async () => {
+    const runId = await seedRun(storage);
+    // Orchestrator posts a dispatch event first (as the REST route would).
+    await storage.appendRunEvent({ id: 'd0', runId, seq: 0, ts: 't', lane: 'orchestrator', kind: 'dispatch', text: 'go' });
+
+    // Worker file has three parser events.
+    let content = [asst('read', 'a.ts', 10), asst('bash', 'npx vitest', 20), asst('bash', 'tsc -b', 30)].join('\n');
+    const deps = { readFile: () => content, now: () => 't' };
+    const first = await tailRunsOnce(storage, emit, deps);
+    expect(first).toHaveLength(3); // none dropped despite the pre-existing REST event
+
+    const events = await storage.listRunEvents(runId);
+    expect(events.map(e => e.seq)).toEqual([0, 1, 2, 3]); // contiguous, appended after dispatch
+    expect(events[0].kind).toBe('dispatch');
+    expect(events.slice(1).map(e => e.kind)).toEqual(['tool', 'tool', 'tool']);
+
+    // Re-tail unchanged → no-op.
+    expect(await tailRunsOnce(storage, emit, deps)).toHaveLength(0);
+
+    // File grows → only the new parser event is appended, after any events.
+    content += '\n' + asst('read', 'b.ts', 40);
+    const delta = await tailRunsOnce(storage, emit, deps);
+    expect(delta).toHaveLength(1);
+    expect(delta[0].seq).toBe(4);
+  });
+
   it('ignores runs that are not running', async () => {
     await seedRun(storage, { id: 'done-run', status: 'done' });
     const appended = await tailRunsOnce(storage, emit, { readFile: () => asst('bash', 'x', 1) });

--- a/packages/server/src/test/agent-runs-tailer.test.ts
+++ b/packages/server/src/test/agent-runs-tailer.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Run tailer (CGLAB-18b). Behaviour-based: real storage + injected readFile;
+ * asserts new pi events are appended & emitted once, idempotently, as the
+ * session file grows.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { SQLiteStorageProvider } from '@agenfk/storage-sqlite';
+import type { AgentRun } from '@agenfk/core';
+import { tailRunsOnce, type RunEventBroadcast } from '../agent-runs/tailer';
+
+const line = (o: any) => JSON.stringify(o);
+const asst = (tool: string, cmd: string, tokens: number) => line({
+  type: 'message', message: { role: 'assistant',
+    content: [{ type: 'toolCall', id: 't', name: tool, arguments: { command: cmd, path: cmd } }],
+    usage: { totalTokens: tokens } } });
+
+async function seedRun(storage: SQLiteStorageProvider, over: Partial<AgentRun> = {}): Promise<string> {
+  const run: AgentRun = {
+    id: 'run-1', itemId: 'item-1', step: 'IN_PROGRESS', actor: 'worker',
+    harness: 'pi', model: 'qwen3.6:27b', sessionId: 's', sourcePath: '/fake/s.jsonl',
+    status: 'running', startedAt: '2026-07-21T10:00:00.000Z', ...over,
+  };
+  await storage.createAgentRun(run);
+  return run.id;
+}
+
+describe('tailRunsOnce', () => {
+  let storage: SQLiteStorageProvider;
+  let emitted: RunEventBroadcast[];
+  const emit = (b: RunEventBroadcast) => emitted.push(b);
+  beforeEach(async () => {
+    storage = new SQLiteStorageProvider();
+    await storage.init({ path: ':memory:' });
+    emitted = [];
+  });
+
+  it('appends and emits new events, then is a no-op when nothing changed', async () => {
+    const runId = await seedRun(storage);
+    const content = [asst('bash', 'npx vitest', 100)].join('\n');
+    const deps = { readFile: () => content, now: () => '2026-07-21T10:00:01.000Z' };
+
+    const first = await tailRunsOnce(storage, emit, deps);
+    expect(first).toHaveLength(1);
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).toMatchObject({ itemId: 'item-1', runId });
+    expect(emitted[0].event).toMatchObject({ seq: 0, kind: 'tool', tool: 'bash' });
+
+    // Second pass, identical file → nothing new appended or emitted.
+    const second = await tailRunsOnce(storage, emit, deps);
+    expect(second).toHaveLength(0);
+    expect(emitted).toHaveLength(1);
+    expect(await storage.listRunEvents(runId)).toHaveLength(1);
+  });
+
+  it('emits only the delta when the session file grows', async () => {
+    const runId = await seedRun(storage);
+    let content = [asst('read', 'a.ts', 50)].join('\n');
+    const deps = { readFile: () => content, now: () => '2026-07-21T10:00:02.000Z' };
+
+    await tailRunsOnce(storage, emit, deps);
+    expect(emitted).toHaveLength(1);
+
+    content = [asst('read', 'a.ts', 50), asst('bash', 'tsc -b', 80)].join('\n');
+    const delta = await tailRunsOnce(storage, emit, deps);
+    expect(delta).toHaveLength(1);
+    expect(delta[0].seq).toBe(1);
+    expect(emitted).toHaveLength(2);
+    const events = await storage.listRunEvents(runId);
+    expect(events.map(e => e.seq)).toEqual([0, 1]);
+  });
+
+  it('skips runs with no source file and missing files without throwing', async () => {
+    await seedRun(storage, { id: 'no-src', sourcePath: undefined });
+    await seedRun(storage, { id: 'missing', sourcePath: '/does/not/exist.jsonl' });
+    const missingDeps = { readFile: (p: string) => { throw new Error('ENOENT ' + p); } };
+    const appended = await tailRunsOnce(storage, emit, missingDeps);
+    expect(appended).toEqual([]);
+    expect(emitted).toEqual([]);
+  });
+
+  it('ignores runs that are not running', async () => {
+    await seedRun(storage, { id: 'done-run', status: 'done' });
+    const appended = await tailRunsOnce(storage, emit, { readFile: () => asst('bash', 'x', 1) });
+    expect(appended).toEqual([]);
+  });
+});

--- a/packages/storage-sqlite/src/index.ts
+++ b/packages/storage-sqlite/src/index.ts
@@ -15,6 +15,9 @@ import {
   IngestionState,
   Pr,
   PrSizing,
+  AgentRun,
+  RunEvent,
+  AgentRunQuery,
 } from '@agenfk/core';
 
 // node:sqlite is a built-in module available from Node.js v22+.
@@ -133,6 +136,37 @@ export class SQLiteStorageProvider implements StorageProvider {
       );
       CREATE UNIQUE INDEX IF NOT EXISTS idx_prs_repo_number ON prs(repo, pr_number);
       CREATE INDEX IF NOT EXISTS idx_prs_item ON prs(item_id);
+      CREATE TABLE IF NOT EXISTS agent_runs (
+        id TEXT PRIMARY KEY,
+        item_id TEXT NOT NULL,
+        project_id TEXT,
+        step TEXT NOT NULL,
+        actor TEXT NOT NULL,
+        harness TEXT NOT NULL,
+        model TEXT NOT NULL,
+        session_id TEXT,
+        source_path TEXT,
+        status TEXT NOT NULL DEFAULT 'running',
+        verdict TEXT,
+        started_at TEXT NOT NULL,
+        ended_at TEXT
+      );
+      CREATE INDEX IF NOT EXISTS idx_agent_runs_item ON agent_runs(item_id);
+      CREATE INDEX IF NOT EXISTS idx_agent_runs_session ON agent_runs(session_id);
+      CREATE TABLE IF NOT EXISTS run_events (
+        id TEXT PRIMARY KEY,
+        run_id TEXT NOT NULL,
+        seq INTEGER NOT NULL,
+        ts TEXT NOT NULL,
+        lane TEXT NOT NULL,
+        kind TEXT NOT NULL,
+        tool TEXT,
+        text TEXT,
+        payload TEXT,
+        tokens INTEGER
+      );
+      CREATE INDEX IF NOT EXISTS idx_run_events_run ON run_events(run_id, seq);
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_run_events_dedup ON run_events(run_id, seq);
     `);
     this.migrateFlowsTable();
   }
@@ -473,6 +507,140 @@ export class SQLiteStorageProvider implements StorageProvider {
       projectId: r.project_id ?? undefined,
       sourcePath: r.source_path,
       sourceOffset: r.source_offset,
+    }));
+  }
+
+  // ── Observability: agent runs + transcript events ──────────────────────────
+
+  private mapAgentRunRow(r: any): AgentRun {
+    return {
+      id: r.id,
+      itemId: r.item_id,
+      projectId: r.project_id ?? undefined,
+      step: r.step,
+      actor: r.actor,
+      harness: r.harness,
+      model: r.model,
+      sessionId: r.session_id ?? undefined,
+      sourcePath: r.source_path ?? undefined,
+      status: r.status,
+      verdict: r.verdict ?? undefined,
+      startedAt: r.started_at,
+      endedAt: r.ended_at ?? undefined,
+    };
+  }
+
+  async createAgentRun(run: AgentRun): Promise<AgentRun> {
+    this.database.prepare(
+      `INSERT INTO agent_runs
+        (id, item_id, project_id, step, actor, harness, model,
+         session_id, source_path, status, verdict, started_at, ended_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      run.id,
+      run.itemId,
+      run.projectId ?? null,
+      run.step,
+      run.actor,
+      run.harness,
+      run.model,
+      run.sessionId ?? null,
+      run.sourcePath ?? null,
+      run.status,
+      run.verdict ?? null,
+      run.startedAt,
+      run.endedAt ?? null,
+    );
+    return run;
+  }
+
+  async updateAgentRun(id: string, updates: Partial<AgentRun>): Promise<AgentRun> {
+    const existing = await this.getAgentRun(id);
+    if (!existing) throw new Error(`Agent run not found: ${id}`);
+    const merged = { ...existing, ...updates };
+    this.database.prepare(
+      `UPDATE agent_runs SET
+         item_id = ?, project_id = ?, step = ?, actor = ?, harness = ?, model = ?,
+         session_id = ?, source_path = ?, status = ?, verdict = ?, started_at = ?, ended_at = ?
+       WHERE id = ?`
+    ).run(
+      merged.itemId,
+      merged.projectId ?? null,
+      merged.step,
+      merged.actor,
+      merged.harness,
+      merged.model,
+      merged.sessionId ?? null,
+      merged.sourcePath ?? null,
+      merged.status,
+      merged.verdict ?? null,
+      merged.startedAt,
+      merged.endedAt ?? null,
+      id,
+    );
+    return merged;
+  }
+
+  async getAgentRun(id: string): Promise<AgentRun | null> {
+    const row = this.database.prepare('SELECT * FROM agent_runs WHERE id = ?').get(id) as any;
+    return row ? this.mapAgentRunRow(row) : null;
+  }
+
+  async getAgentRunBySession(sessionId: string): Promise<AgentRun | null> {
+    const row = this.database.prepare(
+      'SELECT * FROM agent_runs WHERE session_id = ? ORDER BY started_at DESC LIMIT 1'
+    ).get(sessionId) as any;
+    return row ? this.mapAgentRunRow(row) : null;
+  }
+
+  async listAgentRuns(query: AgentRunQuery): Promise<AgentRun[]> {
+    const where: string[] = [];
+    const params: any[] = [];
+    if (query.itemId !== undefined) { where.push('item_id = ?'); params.push(query.itemId); }
+    if (query.projectId !== undefined) { where.push('project_id = ?'); params.push(query.projectId); }
+    if (query.status !== undefined) { where.push('status = ?'); params.push(query.status); }
+    let sql = 'SELECT * FROM agent_runs';
+    if (where.length) sql += ' WHERE ' + where.join(' AND ');
+    sql += ' ORDER BY started_at ASC';
+    if (query.limit !== undefined) { sql += ' LIMIT ?'; params.push(query.limit); }
+    const rows = this.database.prepare(sql).all(...params) as any[];
+    return rows.map((r) => this.mapAgentRunRow(r));
+  }
+
+  async appendRunEvent(event: RunEvent): Promise<void> {
+    this.database.prepare(
+      `INSERT OR IGNORE INTO run_events
+        (id, run_id, seq, ts, lane, kind, tool, text, payload, tokens)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      event.id,
+      event.runId,
+      event.seq,
+      event.ts,
+      event.lane,
+      event.kind,
+      event.tool ?? null,
+      event.text ?? null,
+      event.payload ?? null,
+      event.tokens ?? null,
+    );
+  }
+
+  async listRunEvents(runId: string): Promise<RunEvent[]> {
+    const rows = this.database.prepare(
+      'SELECT * FROM run_events WHERE run_id = ? ORDER BY seq ASC'
+    ).all(runId) as any[];
+    return rows.map((r) => ({
+      id: r.id,
+      runId: r.run_id,
+      seq: r.seq,
+      ts: r.ts,
+      lane: r.lane,
+      kind: r.kind,
+      tool: r.tool ?? undefined,
+      text: r.text ?? undefined,
+      payload: r.payload ?? undefined,
+      tokens: r.tokens ?? undefined,
     }));
   }
 

--- a/packages/ui/src/api.ts
+++ b/packages/ui/src/api.ts
@@ -14,6 +14,24 @@ export const api = {
       throw e;
     }
   },
+  listAgentRuns: async (itemId: string) => {
+    try {
+      const { data } = await axios.get(`${API_URL}/items/${itemId}/agent-runs`);
+      return data;
+    } catch (e) {
+      console.error(`API Error listing agent runs for ${itemId}:`, e);
+      throw e;
+    }
+  },
+  listRunEvents: async (runId: string) => {
+    try {
+      const { data } = await axios.get(`${API_URL}/agent-runs/${runId}/events`);
+      return data;
+    } catch (e) {
+      console.error(`API Error listing run events for ${runId}:`, e);
+      throw e;
+    }
+  },
   createProject: async (project: { name: string; description?: string }) => {
     try {
       const { data } = await axios.post(`${API_URL}/projects`, project);

--- a/packages/ui/src/components/CardDetailModal.tsx
+++ b/packages/ui/src/components/CardDetailModal.tsx
@@ -9,7 +9,10 @@ import { clsx } from 'clsx';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
+import { useQuery } from '@tanstack/react-query';
 import { stripAnsi, calculateCost, formatCost, calculateCycleTimeMs, formatDuration } from '../utils';
+import { api } from '../api';
+import { RunsPanel, type AgentRun } from './RunsPanel';
 
 interface CardDetailModalProps {
   item: AgEnFKItem;
@@ -20,12 +23,21 @@ interface CardDetailModalProps {
   onAddItem: (title: string, type: ItemType, status?: Status, description?: string) => Promise<void>;
   onDeleteItem: (id: string) => Promise<void>;
   onUpdateItem?: (id: string, updates: Partial<AgEnFKItem>) => Promise<void>;
+  projectName?: string;
+  flowName?: string;
 }
 
-type TabType = 'overview' | 'plan' | 'subitems' | 'history' | 'tests' | 'reviews' | 'usage';
+type TabType = 'overview' | 'plan' | 'subitems' | 'history' | 'tests' | 'reviews' | 'usage' | 'runs';
 
-export const CardDetailModal: React.FC<CardDetailModalProps> = ({ item, allItems, pricesData, onClose, onSelectItem, onAddItem, onDeleteItem, onUpdateItem }) => {
+export const CardDetailModal: React.FC<CardDetailModalProps> = ({ item, allItems, pricesData, onClose, onSelectItem, onAddItem, onDeleteItem, onUpdateItem, projectName, flowName }) => {
   const isNew = !item.id;
+  // Agent runs drive the conditional "Runs" tab — only shown when orchestration
+  // actually recorded runs for this item.
+  const { data: agentRuns = [] } = useQuery<AgentRun[]>({
+    queryKey: ['agent-runs', item.id],
+    queryFn: () => api.listAgentRuns(item.id),
+    enabled: !!item.id,
+  });
   const [activeTab, setActiveTab] = React.useState<TabType>('overview');
   const [newSubitemTitle, setNewSubitemTitle] = React.useState('');
   const [isSubmitting, setIsSubmitting] = React.useState(false);
@@ -91,6 +103,7 @@ export const CardDetailModal: React.FC<CardDetailModalProps> = ({ item, allItems
     { id: 'tests', label: 'Test Results', icon: <FlaskConical size={14} />, badge: item.tests?.length, hidden: isNew },
     { id: 'reviews', label: 'Reviews', icon: <ShieldCheck size={14} />, hidden: true },
     { id: 'usage', label: 'Usage', icon: <Zap size={14} />, hidden: isNew || !item.tokenUsage?.length },
+    { id: 'runs', label: 'Runs', icon: <Zap size={14} />, badge: agentRuns.length, hidden: isNew || !agentRuns.length },
   ].filter(t => !t.hidden);
 
   // Auto-switch tab if current is hidden (e.g. after item change)
@@ -193,9 +206,10 @@ export const CardDetailModal: React.FC<CardDetailModalProps> = ({ item, allItems
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 dark:bg-black/70 backdrop-blur-sm">
-      <div className="bg-white dark:bg-slate-900 rounded-2xl shadow-2xl w-full max-w-4xl max-h-[90vh] overflow-hidden flex flex-col animate-in fade-in zoom-in duration-200 border border-slate-200 dark:border-slate-800">
+      <div className="bg-white dark:bg-slate-900 rounded-2xl shadow-2xl w-full max-w-6xl h-[calc(100vh-2rem)] overflow-hidden flex flex-col animate-in fade-in zoom-in duration-200 border border-slate-200 dark:border-slate-800">
         {/* Modal Header */}
-        <div className="px-6 py-4 border-b border-slate-100 dark:border-slate-800 flex items-center justify-between bg-slate-50/50 dark:bg-slate-800/50 relative z-20 shrink-0">
+        <div className="px-6 py-4 border-b border-slate-100 dark:border-slate-800 bg-slate-50/50 dark:bg-slate-800/50 relative z-20 shrink-0">
+          <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
             {parentItem && (
               <button 
@@ -231,6 +245,16 @@ export const CardDetailModal: React.FC<CardDetailModalProps> = ({ item, allItems
                   <option key={t} value={t}>{t}</option>
                 ))}
               </select>
+            )}
+            {!isNew && (
+              <span className={clsx(
+                "text-xs font-bold px-2.5 py-1 rounded-md border uppercase tracking-wider",
+                String(item.status).toUpperCase().includes('DONE')
+                  ? "bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-300 border-emerald-100 dark:border-emerald-800"
+                  : "bg-indigo-50 dark:bg-indigo-900/20 text-indigo-700 dark:text-indigo-300 border-indigo-100 dark:border-indigo-800"
+              )} title="Workflow status">
+                {item.status}
+              </span>
             )}
             {!isNew && (
               <div className="flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-slate-100 dark:bg-slate-800/50 border border-slate-200 dark:border-slate-700/50 group">
@@ -281,6 +305,15 @@ export const CardDetailModal: React.FC<CardDetailModalProps> = ({ item, allItems
               <X size={20} />
             </button>
           </div>
+          </div>
+          {!isNew && (
+            <div className="mt-2 font-mono text-[11px] text-slate-400 dark:text-slate-500 flex flex-wrap items-center gap-x-2 gap-y-1">
+              <span>{item.type}</span>
+              {projectName && <><span className="opacity-40">·</span><span>{projectName}</span></>}
+              {flowName && <><span className="opacity-40">·</span><span>{flowName}</span></>}
+              {item.branchName && <><span className="opacity-40">·</span><span className="truncate max-w-[280px]" title={item.branchName}>{item.branchName}</span></>}
+            </div>
+          )}
         </div>
 
         {/* Tab Navigation */}
@@ -291,12 +324,11 @@ export const CardDetailModal: React.FC<CardDetailModalProps> = ({ item, allItems
               onClick={() => setActiveTab(tab.id as TabType)}
               className={clsx(
                 "flex items-center gap-2 px-4 py-3 text-sm font-medium border-b-2 transition-all whitespace-nowrap outline-none",
-                activeTab === tab.id 
-                  ? "border-indigo-600 text-indigo-600 dark:border-indigo-400 dark:text-indigo-400" 
+                activeTab === tab.id
+                  ? "border-indigo-600 text-indigo-600 dark:border-indigo-400 dark:text-indigo-400"
                   : "border-transparent text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200"
               )}
             >
-              {tab.icon}
               {tab.label}
               {tab.badge !== undefined && (
                 <span className={clsx(
@@ -743,6 +775,11 @@ export const CardDetailModal: React.FC<CardDetailModalProps> = ({ item, allItems
                   </tbody>
                 </table>
               </div>
+            </div>
+          )}
+          {activeTab === 'runs' && (
+            <div className="h-full min-h-0 animate-in slide-in-from-bottom-2 duration-300">
+              <RunsPanel itemId={item.id} />
             </div>
           )}
         </div>

--- a/packages/ui/src/components/KanbanBoard.tsx
+++ b/packages/ui/src/components/KanbanBoard.tsx
@@ -1646,10 +1646,12 @@ export const KanbanBoard: React.FC = () => {
       </main>
 
       {selectedItem && (
-        <CardDetailModal 
-          item={selectedItem} 
+        <CardDetailModal
+          item={selectedItem}
           allItems={items || []}
           pricesData={pricesData}
+          projectName={activeProject?.name}
+          flowName={activeFlow?.name}
           onClose={() => setSelectedItem(null)} 
           onSelectItem={setSelectedItem}
           /* v8 ignore start */

--- a/packages/ui/src/components/RunsPanel.tsx
+++ b/packages/ui/src/components/RunsPanel.tsx
@@ -1,0 +1,172 @@
+import React from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { io } from 'socket.io-client';
+import { api } from '../api';
+import { API_URL } from '../apiUrl';
+
+export interface AgentRun {
+  id: string;
+  itemId: string;
+  step: string;
+  actor: 'orchestrator' | 'worker' | 'reviewer';
+  harness: string;
+  model: string;
+  sessionId?: string;
+  status: 'running' | 'done' | 'failed';
+  verdict?: string;
+  startedAt: string;
+  endedAt?: string;
+}
+
+export interface RunEvent {
+  id: string;
+  runId: string;
+  seq: number;
+  ts: string;
+  lane: 'orchestrator' | 'worker' | 'reviewer';
+  kind: 'dispatch' | 'think' | 'tool' | 'result' | 'diff' | 'verdict' | 'note';
+  tool?: string;
+  text?: string;
+  payload?: string;
+  tokens?: number;
+}
+
+const LANE = {
+  orchestrator: { label: 'orchestrator', ini: 'C', avatar: 'bg-indigo-500', tag: 'text-indigo-600 dark:text-indigo-300' },
+  worker: { label: 'pi · worker', ini: 'π', avatar: 'bg-amber-500', tag: 'text-amber-600 dark:text-amber-300' },
+  reviewer: { label: 'reviewer', ini: 'R', avatar: 'bg-teal-500', tag: 'text-teal-600 dark:text-teal-300' },
+} as const;
+
+function fmtTokens(n?: number): string {
+  return typeof n === 'number' ? n.toLocaleString('en-US') : '';
+}
+
+export const RunsPanel: React.FC<{ itemId: string }> = ({ itemId }) => {
+  const queryClient = useQueryClient();
+  const [selectedRunId, setSelectedRunId] = React.useState<string | null>(null);
+  const logRef = React.useRef<HTMLDivElement>(null);
+
+  const { data: runs = [] } = useQuery<AgentRun[]>({
+    queryKey: ['agent-runs', itemId],
+    queryFn: () => api.listAgentRuns(itemId),
+  });
+
+  // Default selection: the most recent run (list is ordered oldest→newest).
+  React.useEffect(() => {
+    if (!selectedRunId && runs.length) setSelectedRunId(runs[runs.length - 1].id);
+  }, [runs, selectedRunId]);
+
+  const { data: events = [] } = useQuery<RunEvent[]>({
+    queryKey: ['run-events', selectedRunId],
+    queryFn: () => api.listRunEvents(selectedRunId as string),
+    enabled: !!selectedRunId,
+  });
+
+  // Live: append streamed events into the cache; refresh the run list on updates.
+  React.useEffect(() => {
+    const socket = io(API_URL || undefined);
+    socket.on('run:event', (b: { itemId: string; runId: string; event: RunEvent }) => {
+      if (b.itemId !== itemId) return;
+      queryClient.setQueryData<RunEvent[]>(['run-events', b.runId], (old = []) =>
+        old.some(e => e.seq === b.event.seq) ? old : [...old, b.event].sort((a, z) => a.seq - z.seq),
+      );
+      queryClient.invalidateQueries({ queryKey: ['agent-runs', itemId] });
+    });
+    socket.on('run:updated', (b: { itemId: string }) => {
+      if (b.itemId === itemId) queryClient.invalidateQueries({ queryKey: ['agent-runs', itemId] });
+    });
+    return () => { socket.disconnect(); };
+  }, [itemId, queryClient]);
+
+  // Autoscroll the transcript as events arrive.
+  React.useEffect(() => {
+    if (logRef.current) logRef.current.scrollTop = logRef.current.scrollHeight;
+  }, [events.length]);
+
+  if (!runs.length) {
+    return <div className="text-sm text-slate-400 dark:text-slate-500 py-8 text-center">No agent runs recorded for this item.</div>;
+  }
+
+  const selected = runs.find(r => r.id === selectedRunId) || null;
+
+  return (
+    <div className="flex gap-4 h-full min-h-0" data-testid="runs-panel">
+      {/* Run list */}
+      <div className="w-56 shrink-0 space-y-2 overflow-y-auto">
+        {runs.map(run => {
+          const lane = LANE[run.actor];
+          const isSel = run.id === selectedRunId;
+          return (
+            <button
+              key={run.id}
+              onClick={() => setSelectedRunId(run.id)}
+              className={
+                'w-full text-left rounded-lg border p-2.5 transition-colors ' +
+                (isSel
+                  ? 'border-indigo-500 bg-indigo-50 dark:bg-indigo-900/20'
+                  : 'border-slate-200 dark:border-slate-700 hover:border-indigo-400')
+              }
+            >
+              <div className="flex items-center gap-2">
+                <span className={
+                  'w-2 h-2 rounded-full shrink-0 ' +
+                  (run.status === 'running' ? 'bg-indigo-500 animate-pulse' : run.status === 'failed' ? 'bg-red-500' : 'bg-emerald-500')
+                } />
+                <span className="font-mono text-xs font-bold text-slate-700 dark:text-slate-200 truncate">{run.step}</span>
+              </div>
+              <div className={'mt-1 font-mono text-[10px] ' + lane.tag}>{lane.ini} {lane.label}</div>
+              <div className="mt-0.5 font-mono text-[10px] text-slate-400 dark:text-slate-500 truncate">{run.model}</div>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Transcript */}
+      <div className="flex-1 min-w-0 flex flex-col border border-slate-200 dark:border-slate-700 rounded-lg overflow-hidden">
+        <div className="flex items-center justify-between gap-2 px-3 py-2 border-b border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/50">
+          <span className="font-mono text-xs font-bold text-slate-700 dark:text-slate-200 truncate">
+            {selected ? selected.step : ''} {selected?.sessionId && <span className="text-slate-400 dark:text-slate-500">· {selected.sessionId}</span>}
+          </span>
+          {selected && (
+            <span className={
+              'font-mono text-[10px] font-bold px-2 py-0.5 rounded-full shrink-0 ' +
+              (selected.status === 'running'
+                ? 'text-indigo-600 dark:text-indigo-300 bg-indigo-100 dark:bg-indigo-900/30'
+                : 'text-emerald-600 dark:text-emerald-300 bg-emerald-100 dark:bg-emerald-900/30')
+            }>
+              {selected.status === 'running' ? '● LIVE' : ('● ' + (selected.verdict || selected.status.toUpperCase()))}
+            </span>
+          )}
+        </div>
+        <div ref={logRef} className="flex-1 overflow-y-auto p-3 space-y-3" data-testid="runs-transcript">
+          {events.map(ev => {
+            const lane = LANE[ev.lane] || LANE.worker;
+            return (
+              <div key={ev.id} className="flex gap-2.5">
+                <div className="flex flex-col items-center shrink-0 w-8">
+                  <span className={'w-6 h-6 rounded-md grid place-items-center font-mono text-xs font-bold text-white ' + lane.avatar}>{lane.ini}</span>
+                </div>
+                <div className="min-w-0 flex-1">
+                  <span className={
+                    'font-mono text-[9px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded ' +
+                    'bg-slate-100 dark:bg-slate-800 ' + lane.tag
+                  }>{ev.kind}{ev.tool ? ' · ' + ev.tool : ''}</span>
+                  {ev.kind === 'tool' && ev.text && (
+                    <pre className="mt-1 font-mono text-[11px] bg-slate-50 dark:bg-slate-800/60 border border-slate-200 dark:border-slate-700 rounded px-2 py-1 overflow-x-auto whitespace-pre-wrap break-words text-slate-700 dark:text-slate-200">{ev.text}</pre>
+                  )}
+                  {ev.kind !== 'tool' && ev.text && (
+                    <div className={'mt-1 text-[13px] break-words ' + (ev.kind === 'think' ? 'italic text-slate-500 dark:text-slate-400' : 'text-slate-700 dark:text-slate-200')}>{ev.text}</div>
+                  )}
+                  {typeof ev.tokens === 'number' && (
+                    <span className="inline-block mt-1 font-mono text-[10px] text-slate-400 dark:text-slate-500">{fmtTokens(ev.tokens)} tok</span>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+          {!events.length && <div className="text-xs text-slate-400 dark:text-slate-500 py-6 text-center">No events yet.</div>}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/ui/src/test/CardDetailModal.test.tsx
+++ b/packages/ui/src/test/CardDetailModal.test.tsx
@@ -34,6 +34,8 @@ vi.mock('../api', () => ({
     getItem: vi.fn(() => Promise.resolve({})),
     updateItem: vi.fn(() => Promise.resolve({})),
     listItems: vi.fn(() => Promise.resolve([])),
+    listAgentRuns: vi.fn(() => Promise.resolve([])),
+    listRunEvents: vi.fn(() => Promise.resolve([])),
   }
 }));
 

--- a/packages/ui/src/test/RunsPanel.test.tsx
+++ b/packages/ui/src/test/RunsPanel.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * RunsPanel (CGLAB-18c). Behaviour-based: mocked api + socket, asserts the run
+ * list, default selection of the latest run, transcript rendering, live pill,
+ * and the empty state.
+ */
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { RunsPanel } from '../components/RunsPanel';
+import { api } from '../api';
+
+vi.mock('socket.io-client', () => ({
+  io: vi.fn(() => ({ on: vi.fn(), off: vi.fn(), emit: vi.fn(), disconnect: vi.fn() })),
+}));
+
+vi.mock('../api', () => ({
+  api: { listAgentRuns: vi.fn(), listRunEvents: vi.fn() },
+}));
+
+function renderPanel(itemId = 'i1') {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={qc}>
+      <RunsPanel itemId={itemId} />
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(() => { cleanup(); vi.clearAllMocks(); });
+
+describe('RunsPanel', () => {
+  it('shows an empty state when there are no runs', async () => {
+    vi.mocked(api.listAgentRuns).mockResolvedValue([]);
+    renderPanel();
+    await waitFor(() => expect(screen.getByText(/no agent runs recorded/i)).toBeDefined());
+  });
+
+  it('lists runs, defaults to the latest, and renders its transcript', async () => {
+    vi.mocked(api.listAgentRuns).mockResolvedValue([
+      { id: 'r1', itemId: 'i1', step: 'CREATE_UNIT_TESTS', actor: 'worker', harness: 'pi', model: 'qwen3.6:27b', status: 'done', verdict: 'APPROVED', startedAt: '2026-07-21T10:00:00.000Z' },
+      { id: 'r2', itemId: 'i1', step: 'IN_PROGRESS', actor: 'worker', harness: 'pi', model: 'qwen3.6:27b', status: 'running', startedAt: '2026-07-21T10:05:00.000Z' },
+    ] as any);
+    vi.mocked(api.listRunEvents).mockImplementation((runId: string) =>
+      Promise.resolve(runId === 'r2' ? [
+        { id: 'e1', runId: 'r2', seq: 0, ts: 't', lane: 'orchestrator', kind: 'dispatch', text: 'implement it' },
+        { id: 'e2', runId: 'r2', seq: 1, ts: 't', lane: 'worker', kind: 'tool', tool: 'bash', text: 'npx vitest' },
+      ] as any : []),
+    );
+
+    renderPanel();
+
+    // Both runs listed (the selected run's step also appears in the transcript header)
+    await waitFor(() => expect(screen.getByText('CREATE_UNIT_TESTS')).toBeDefined());
+    expect(screen.getAllByText('IN_PROGRESS').length).toBeGreaterThanOrEqual(1);
+
+    // Latest run (r2, running) selected by default → its events render
+    await waitFor(() => expect(screen.getByText('npx vitest')).toBeDefined());
+    expect(screen.getByText('implement it')).toBeDefined();
+
+    // Running run shows the LIVE pill
+    expect(screen.getByText(/live/i)).toBeDefined();
+
+    // listRunEvents was queried for the latest run
+    expect(api.listRunEvents).toHaveBeenCalledWith('r2');
+  });
+});


### PR DESCRIPTION
## What

Adds a live **Agent Runs** panel to the Kanban card detail modal that streams the orchestrator↔pi.dev-worker transcript for an item over Socket.io, plus a set of card-detail modal improvements. JIRA: CGLAB-18.

## Slices

- **18a — backend**: `agent_runs` + `run_events` tables + `StorageProvider` methods; REST to register/update/append-event/list, emitting a payload-bearing `run:event` / `run:updated` over Socket.io keyed by itemId; `agenfk run start|event|end|list` CLI. Establishes the explicit **session↔card link** that heuristic attribution lacked.
- **18b — stream**: pure pi.dev session-JSONL parser (thinking/text/toolCall/toolResult → events with incremental token attribution); idempotent run **tailer** wired into server boot (tracks parser progress separately from REST-appended events).
- **18c — UI**: `RunsPanel` (run list + two-lane transcript, own socket, live append + autoscroll); `CardDetailModal` full-viewport fixed height, wider, header status badge, no tab icons, subtitle (type·project·flow·branch), and a **conditional Runs tab** (only when the item has runs).

## Verification

- Root suite **1729 passed / 0 failed**; UI suite green except 3 documented pre-existing failures; all packages `tsc`-clean.
- Cross-model adversarial review performed; a real mixed-writer bug in the tailer (dropped parser events when the orchestrator also posted via REST) was fixed with a regression test, plus incremental-token fix.
- 25 dedicated agent-runs tests (storage, REST, parser, tailer) + RunsPanel UI tests.

Built end-to-end through the AgEnFK TDD flow (STORY CGLAB-18 + 3 tasks, all DONE).