### PR TITLE
Hub: hide a departed user from installation lists, upgrades and admin actions (CGLAB-31)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenfk",
-  "version": "1.1.11",
+  "version": "1.1.12-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenfk",
-      "version": "1.1.11",
+      "version": "1.1.12-beta.1",
       "license": "ISC",
       "workspaces": [
         "packages/core",
@@ -11018,11 +11018,11 @@
     },
     "packages/cli": {
       "name": "@agenfk/cli",
-      "version": "1.1.11",
+      "version": "1.1.12-beta.1",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.1.11",
-        "@agenfk/telemetry": "1.1.11",
+        "@agenfk/core": "1.1.12-beta.1",
+        "@agenfk/telemetry": "1.1.12-beta.1",
         "axios": "^1.13.5",
         "chalk": "^4.1.2",
         "commander": "^12.0.0",
@@ -11042,7 +11042,7 @@
     },
     "packages/core": {
       "name": "@agenfk/core",
-      "version": "1.1.11",
+      "version": "1.1.12-beta.1",
       "license": "ISC",
       "devDependencies": {
         "typescript": "^5.3.3"
@@ -11050,7 +11050,7 @@
     },
     "packages/create": {
       "name": "agenfk",
-      "version": "1.1.11",
+      "version": "1.1.12-beta.1",
       "license": "ISC",
       "bin": {
         "agenfk": "bin/agenfk.js"
@@ -11061,7 +11061,7 @@
     },
     "packages/flow-editor": {
       "name": "@agenfk/flow-editor",
-      "version": "1.1.11",
+      "version": "1.1.12-beta.1",
       "peerDependencies": {
         "@tanstack/react-query": "^5.90.21",
         "clsx": "^2.1.1",
@@ -11073,9 +11073,9 @@
     },
     "packages/hub": {
       "name": "@agenfk/hub",
-      "version": "1.1.11",
+      "version": "1.1.12-beta.1",
       "dependencies": {
-        "@agenfk/core": "1.1.11",
+        "@agenfk/core": "1.1.12-beta.1",
         "axios": "^1.13.5",
         "bcryptjs": "^2.4.3",
         "cookie-parser": "^1.4.7",
@@ -11099,9 +11099,9 @@
       }
     },
     "packages/hub-ui": {
-      "version": "1.1.11",
+      "version": "1.1.12-beta.1",
       "dependencies": {
-        "@agenfk/flow-editor": "1.1.11",
+        "@agenfk/flow-editor": "1.1.12-beta.1",
         "@tailwindcss/postcss": "^4.2.0",
         "@tanstack/react-query": "^5.90.21",
         "@vitejs/plugin-react": "^5.1.1",
@@ -11472,12 +11472,12 @@
     },
     "packages/server": {
       "name": "@agenfk/server",
-      "version": "1.1.11",
+      "version": "1.1.12-beta.1",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.1.11",
-        "@agenfk/storage-sqlite": "1.1.11",
-        "@agenfk/telemetry": "1.1.11",
+        "@agenfk/core": "1.1.12-beta.1",
+        "@agenfk/storage-sqlite": "1.1.12-beta.1",
+        "@agenfk/telemetry": "1.1.12-beta.1",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "axios": "^1.13.5",
         "body-parser": "^2.2.2",
@@ -11514,13 +11514,13 @@
     },
     "packages/storage-sqlite": {
       "name": "@agenfk/storage-sqlite",
-      "version": "1.1.11",
+      "version": "1.1.12-beta.1",
       "license": "ISC",
       "dependencies": {
         "uuid": "^14.0.1"
       },
       "devDependencies": {
-        "@agenfk/core": "1.1.11",
+        "@agenfk/core": "1.1.12-beta.1",
         "@types/node": "^22.0.0",
         "@types/uuid": "^9.0.8",
         "typescript": "^5.3.3"
@@ -11538,7 +11538,7 @@
     },
     "packages/telemetry": {
       "name": "@agenfk/telemetry",
-      "version": "1.1.11",
+      "version": "1.1.12-beta.1",
       "license": "ISC",
       "dependencies": {
         "posthog-node": "^4.0.0"
@@ -11549,9 +11549,9 @@
       }
     },
     "packages/ui": {
-      "version": "1.1.11",
+      "version": "1.1.12-beta.1",
       "dependencies": {
-        "@agenfk/flow-editor": "1.1.11",
+        "@agenfk/flow-editor": "1.1.12-beta.1",
         "@tailwindcss/postcss": "^4.2.0",
         "@tailwindcss/typography": "^0.5.19",
         "@tanstack/react-query": "^5.90.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "1.1.11",
+  "version": "1.1.12-beta.1",
   "description": "AgenFK Engineering Framework",
   "private": true,
   "workspaces": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/cli",
-  "version": "1.1.11",
+  "version": "1.1.12-beta.1",
   "description": "CLI for AgenFK Engineering Framework",
   "main": "dist/index.js",
   "bin": {
@@ -12,8 +12,8 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.11",
-    "@agenfk/telemetry": "1.1.11",
+    "@agenfk/core": "1.1.12-beta.1",
+    "@agenfk/telemetry": "1.1.12-beta.1",
     "axios": "^1.13.5",
     "chalk": "^4.1.2",
     "commander": "^12.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/core",
-  "version": "1.1.11",
+  "version": "1.1.12-beta.1",
   "description": "Core logic and interfaces for the AgenFK Engineering Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "1.1.11",
+  "version": "1.1.12-beta.1",
   "description": "AgenFK Agentic Engineering Framework — installer",
   "bin": {
     "agenfk": "bin/agenfk.js"

--- a/packages/flow-editor/package.json
+++ b/packages/flow-editor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agenfk/flow-editor",
   "private": true,
-  "version": "1.1.11",
+  "version": "1.1.12-beta.1",
   "type": "module",
   "main": "./src/index.ts",
   "exports": {

--- a/packages/hub-ui/package.json
+++ b/packages/hub-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hub-ui",
   "private": true,
-  "version": "1.1.11",
+  "version": "1.1.12-beta.1",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.1.11",
+    "@agenfk/flow-editor": "1.1.12-beta.1",
     "@tailwindcss/postcss": "^4.2.0",
     "mermaid": "^11.12.3",
     "@tanstack/react-query": "^5.90.21",

--- a/packages/hub-ui/src/pages/Admin.tsx
+++ b/packages/hub-ui/src/pages/Admin.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
 import { Outlet, NavLink } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { ShieldCheck, KeyRound, Users, Trash2, Copy, Check, GitBranch, ArrowUpCircle, Server, Building2, X } from 'lucide-react';
+import { ShieldCheck, KeyRound, Users, Trash2, Copy, Check, GitBranch, ArrowUpCircle, Server, Building2, X, EyeOff, Eye } from 'lucide-react';
 import { api } from '../api';
 import { fmtDate } from '../dates';
 import { canDeleteUserRow } from './canDeleteUserRow';
+import { hideTargetKey, partitionHiddenRows, canHideRow } from './hiddenPeople';
 
 export function AdminLayout() {
   const link = ({ isActive }: { isActive: boolean }) =>
@@ -518,15 +519,47 @@ interface InstallationRow {
   osUser: string | null;
   gitName: string | null;
   gitEmail: string | null;
+  hidden?: boolean;
+}
+
+interface HiddenPersonRow {
+  userKey: string;
+  hiddenByEmail: string | null;
+  createdAt: string;
 }
 
 export function AdminInstallations() {
+  const qc = useQueryClient();
+  // CGLAB-31: hidden people are excluded server-side by default; the toggle
+  // re-fetches with ?includeHidden=1 and flags them inline.
+  const [showHidden, setShowHidden] = useState(false);
   const installations = useQuery<InstallationRow[]>({
-    queryKey: ['admin-installations'],
-    queryFn: async () => (await api.get('/v1/admin/installations')).data,
+    queryKey: ['admin-installations', showHidden],
+    queryFn: async () =>
+      (await api.get(showHidden ? '/v1/admin/installations?includeHidden=1' : '/v1/admin/installations')).data,
+  });
+  const hiddenPeople = useQuery<HiddenPersonRow[]>({
+    queryKey: ['admin-hidden-users'],
+    queryFn: async () => (await api.get('/v1/admin/hidden-users')).data,
+  });
+
+  const invalidate = () => {
+    qc.invalidateQueries({ queryKey: ['admin-installations'] });
+    qc.invalidateQueries({ queryKey: ['admin-hidden-users'] });
+    qc.invalidateQueries({ queryKey: ['api-keys'] });
+  };
+  const hide = useMutation({
+    mutationFn: (userKey: string) => api.post('/v1/admin/hidden-users', { userKey }),
+    onSuccess: invalidate,
+  });
+  const unhide = useMutation({
+    mutationFn: (userKey: string) => api.delete(`/v1/admin/hidden-users/${encodeURIComponent(userKey)}`),
+    onSuccess: invalidate,
   });
 
   const rows = installations.data ?? [];
+  const { visible, hidden: hiddenRows } = partitionHiddenRows(rows);
+  const hiddenCount = hiddenPeople.data?.length ?? hiddenRows.length;
 
   return (
     <div className="space-y-6">
@@ -538,7 +571,18 @@ export function AdminInstallations() {
               Every AgEnFK install that has reported events to this hub. Use this to audit which version is running where.
             </p>
           </div>
-          <span className="text-[11px] text-slate-500">{rows.length} total</span>
+          <div className="flex items-center gap-3">
+            {hiddenCount > 0 && (
+              <button
+                onClick={() => setShowHidden(v => !v)}
+                className="inline-flex items-center gap-1 text-[11px] font-semibold text-slate-500 hover:text-slate-700 dark:hover:text-slate-300"
+              >
+                {showHidden ? <Eye className="w-3.5 h-3.5" /> : <EyeOff className="w-3.5 h-3.5" />}
+                {showHidden ? 'Hide hidden' : `Show hidden (${hiddenCount})`}
+              </button>
+            )}
+            <span className="text-[11px] text-slate-500">{showHidden ? rows.length : visible.length} total</span>
+          </div>
         </header>
         <div className="mt-3 -mx-5 overflow-x-auto">
           <table className="w-full text-sm">
@@ -549,13 +593,17 @@ export function AdminInstallations() {
                 <th className="text-left px-2 py-2">Version</th>
                 <th className="text-left px-2 py-2">Version updated</th>
                 <th className="text-right px-5 py-2">Last seen</th>
+                <th className="text-right px-5 py-2"></th>
               </tr>
             </thead>
             <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
               {rows.map(r => (
-                <tr key={r.id} className="hover:bg-slate-50 dark:hover:bg-slate-800/40 transition-colors">
+                <tr key={r.id} className={`hover:bg-slate-50 dark:hover:bg-slate-800/40 transition-colors ${r.hidden ? 'opacity-50' : ''}`}>
                   <td className="px-5 py-2.5">
                     <span className="font-mono text-[11px] text-slate-600 dark:text-slate-300">{r.id}</span>
+                    {r.hidden && (
+                      <span className="ml-2 text-[10px] font-semibold uppercase tracking-wide text-amber-600 dark:text-amber-400">hidden</span>
+                    )}
                   </td>
                   <td className="px-2 py-2.5">
                     <div className="text-xs text-slate-700 dark:text-slate-200">{r.gitName ?? r.osUser ?? <span className="text-slate-400">—</span>}</div>
@@ -572,15 +620,63 @@ export function AdminInstallations() {
                   <td className="px-5 py-2.5 text-right text-xs text-slate-500 tabular-nums">
                     {r.lastSeen ? fmtDate(r.lastSeen) : <span className="text-slate-400">—</span>}
                   </td>
+                  <td className="px-5 py-2.5 text-right">
+                    {canHideRow(r) && (
+                      <button
+                        onClick={() => {
+                          const key = hideTargetKey(r);
+                          if (!key) return;
+                          if (confirm(`Hide ${key}? Their installations disappear from pickers, their API keys are revoked, and new events are dropped. Historical data stays visible. This is reversible.`)) {
+                            hide.mutate(key);
+                          }
+                        }}
+                        disabled={hide.isPending}
+                        className="inline-flex items-center gap-1 text-[11px] font-semibold text-slate-400 hover:text-amber-600 dark:hover:text-amber-400"
+                        title="Hide this person from selection surfaces"
+                      >
+                        <EyeOff className="w-3.5 h-3.5" /> Hide
+                      </button>
+                    )}
+                  </td>
                 </tr>
               ))}
               {rows.length === 0 && (
-                <tr><td colSpan={5} className="px-5 py-6 text-center text-sm text-slate-500">No installations have reported yet.</td></tr>
+                <tr><td colSpan={6} className="px-5 py-6 text-center text-sm text-slate-500">No installations have reported yet.</td></tr>
               )}
             </tbody>
           </table>
         </div>
       </section>
+
+      {(hiddenPeople.data?.length ?? 0) > 0 && (
+        <section className={cardCls}>
+          <header>
+            <h3 className="text-sm font-semibold text-slate-800 dark:text-slate-100">Hidden people</h3>
+            <p className="mt-0.5 text-xs text-slate-500 dark:text-slate-400">
+              Hidden people no longer appear in installation pickers, their API keys are revoked, and new events from them are dropped. Historical dashboards are unaffected. Unhiding restores visibility but does not restore revoked keys.
+            </p>
+          </header>
+          <ul className="mt-3 divide-y divide-slate-100 dark:divide-slate-800">
+            {hiddenPeople.data!.map(p => (
+              <li key={p.userKey} className="flex items-center justify-between py-2">
+                <div>
+                  <div className="font-mono text-xs text-slate-700 dark:text-slate-200">{p.userKey}</div>
+                  <div className="text-[11px] text-slate-500">
+                    hidden {fmtDate(p.createdAt)}{p.hiddenByEmail ? ` by ${p.hiddenByEmail}` : ''}
+                  </div>
+                </div>
+                <button
+                  onClick={() => unhide.mutate(p.userKey)}
+                  disabled={unhide.isPending}
+                  className="inline-flex items-center gap-1 text-[11px] font-semibold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400"
+                >
+                  <Eye className="w-3.5 h-3.5" /> Unhide
+                </button>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
     </div>
   );
 }

--- a/packages/hub-ui/src/pages/hiddenPeople.ts
+++ b/packages/hub-ui/src/pages/hiddenPeople.ts
@@ -1,0 +1,49 @@
+// Pure helpers for the Admin → Installations hidden-people UI (CGLAB-31):
+// partitioning rows into visible/hidden, deriving the hide target key from
+// an installation row, and deciding which rows the table renders.
+
+export interface InstallationRowLike {
+  id: string;
+  gitEmail: string | null;
+  hidden?: boolean;
+}
+
+/**
+ * The hide action is keyed on the person's user_key (lowercased git email).
+ * Returns null when the row has no git email — such installations cannot be
+ * attributed to a person and therefore cannot be hidden from the UI.
+ */
+export function hideTargetKey(row: Pick<InstallationRowLike, 'gitEmail'>): string | null {
+  const email = row.gitEmail?.trim().toLowerCase();
+  return email ? email : null;
+}
+
+/**
+ * Rows rendered in the installations table. When showHidden is false the
+ * hidden rows are excluded (the backend already excludes them by default;
+ * this keeps the client-side toggle consistent when includeHidden=1 rows
+ * are loaded).
+ */
+export function visibleInstallationRows<T extends InstallationRowLike>(rows: T[], showHidden: boolean): T[] {
+  if (showHidden) return rows;
+  return rows.filter(r => !r.hidden);
+}
+
+/**
+ * Partition into visible vs hidden rows — drives both the table and the
+ * "N hidden" toggle label.
+ */
+export function partitionHiddenRows<T extends InstallationRowLike>(rows: T[]): { visible: T[]; hidden: T[] } {
+  const visible: T[] = [];
+  const hidden: T[] = [];
+  for (const r of rows) (r.hidden ? hidden : visible).push(r);
+  return { visible, hidden };
+}
+
+/**
+ * Whether the Hide button should be enabled for a row: only visible rows
+ * with an attributable git email can be hidden.
+ */
+export function canHideRow(row: InstallationRowLike): boolean {
+  return !row.hidden && hideTargetKey(row) !== null;
+}

--- a/packages/hub-ui/src/test/hiddenPeople.test.ts
+++ b/packages/hub-ui/src/test/hiddenPeople.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import {
+  hideTargetKey,
+  visibleInstallationRows,
+  partitionHiddenRows,
+  canHideRow,
+  type InstallationRowLike,
+} from '../pages/hiddenPeople';
+
+const rows: InstallationRowLike[] = [
+  { id: 'inst-1', gitEmail: 'active@acme.com', hidden: false },
+  { id: 'inst-2', gitEmail: 'departed@acme.com', hidden: true },
+  { id: 'inst-3', gitEmail: null, hidden: false },
+];
+
+describe('hideTargetKey', () => {
+  it('returns the lowercased trimmed git email', () => {
+    expect(hideTargetKey({ gitEmail: '  Departed@Acme.COM ' })).toBe('departed@acme.com');
+  });
+
+  it('returns null when the row has no git email (cannot attribute to a person)', () => {
+    expect(hideTargetKey({ gitEmail: null })).toBeNull();
+    expect(hideTargetKey({ gitEmail: '' })).toBeNull();
+    expect(hideTargetKey({ gitEmail: '   ' })).toBeNull();
+  });
+});
+
+describe('visibleInstallationRows', () => {
+  it('excludes hidden rows when showHidden is false', () => {
+    expect(visibleInstallationRows(rows, false).map(r => r.id)).toEqual(['inst-1', 'inst-3']);
+  });
+
+  it('returns all rows when showHidden is true', () => {
+    expect(visibleInstallationRows(rows, true).map(r => r.id)).toEqual(['inst-1', 'inst-2', 'inst-3']);
+  });
+
+  it('treats a missing hidden flag as visible', () => {
+    expect(visibleInstallationRows([{ id: 'x', gitEmail: 'a@b' }], false)).toHaveLength(1);
+  });
+});
+
+describe('partitionHiddenRows', () => {
+  it('splits rows into visible and hidden buckets', () => {
+    const { visible, hidden } = partitionHiddenRows(rows);
+    expect(visible.map(r => r.id)).toEqual(['inst-1', 'inst-3']);
+    expect(hidden.map(r => r.id)).toEqual(['inst-2']);
+  });
+
+  it('handles an empty list', () => {
+    expect(partitionHiddenRows([])).toEqual({ visible: [], hidden: [] });
+  });
+});
+
+describe('canHideRow', () => {
+  it('allows hiding a visible row with a git email', () => {
+    expect(canHideRow({ id: 'inst-1', gitEmail: 'active@acme.com', hidden: false })).toBe(true);
+  });
+
+  it('disallows hiding an already-hidden row', () => {
+    expect(canHideRow({ id: 'inst-2', gitEmail: 'departed@acme.com', hidden: true })).toBe(false);
+  });
+
+  it('disallows hiding a row with no git email', () => {
+    expect(canHideRow({ id: 'inst-3', gitEmail: null, hidden: false })).toBe(false);
+  });
+});

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/hub",
-  "version": "1.1.11",
+  "version": "1.1.12-beta.1",
   "description": "Corporate Hub for AgEnFK — fleet-wide metrics + timeline server",
   "main": "dist/server.js",
   "types": "dist/server.d.ts",
@@ -20,7 +20,7 @@
     "start": "node dist/bin.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.11",
+    "@agenfk/core": "1.1.12-beta.1",
     "axios": "^1.13.5",
     "bcryptjs": "^2.4.3",
     "cookie-parser": "^1.4.7",

--- a/packages/hub/src/db/postgres.ts
+++ b/packages/hub/src/db/postgres.ts
@@ -179,6 +179,18 @@ const SCHEMA_PG = `
     token TEXT PRIMARY KEY,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
   );
+
+  -- People hidden by an admin (CGLAB-31). See the SQLite schema for the
+  -- full rationale — selection surfaces only, historical data untouched,
+  -- reversible by row delete.
+  CREATE TABLE IF NOT EXISTS hidden_users (
+    org_id TEXT NOT NULL,
+    user_key TEXT NOT NULL,
+    hidden_by_user_id TEXT,
+    hidden_by_email TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (org_id, user_key)
+  );
 `;
 
 /**

--- a/packages/hub/src/db/sqlite.ts
+++ b/packages/hub/src/db/sqlite.ts
@@ -190,6 +190,22 @@ const SCHEMA_SQLITE = `
     token TEXT PRIMARY KEY,
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
   );
+
+  -- People hidden by an admin (CGLAB-31), keyed on events.user_key
+  -- (lowercased git email). Membership removes the person from selection
+  -- surfaces (installation lists, upgrade targeting, admin actions) and
+  -- blocks their new events at ingest. Historical data (events,
+  -- rollups_daily, dashboards) is deliberately untouched — the hide only
+  -- affects go-forward behaviour and is fully reversible by deleting the
+  -- row.
+  CREATE TABLE IF NOT EXISTS hidden_users (
+    org_id TEXT NOT NULL,
+    user_key TEXT NOT NULL,
+    hidden_by_user_id TEXT,
+    hidden_by_email TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (org_id, user_key)
+  );
 `;
 
 class SqliteAdapter implements HubDb {

--- a/packages/hub/src/routes/admin.ts
+++ b/packages/hub/src/routes/admin.ts
@@ -111,6 +111,78 @@ export function adminRouter(ctx: HubServerContext): Router {
     res.json({ revoked: result.changes });
   });
 
+  // ── Hidden people (CGLAB-31) ─────────────────────────────────────────────
+  // Person-level hide keyed on events.user_key (lowercased git email).
+  // Selection surfaces only — historical data (events, rollups, dashboards)
+  // is deliberately untouched. Fully reversible via DELETE.
+  router.get('/hidden-users', guard, async (req: Request, res: Response) => {
+    const rows = await ctx.db.all<Record<string, unknown>>(
+      `SELECT user_key, hidden_by_user_id, hidden_by_email, created_at
+         FROM hidden_users
+         WHERE org_id = ?
+         ORDER BY created_at DESC`,
+      [req.session!.orgId],
+    );
+    res.json(rows.map((r: any) => ({
+      userKey: r.user_key,
+      hiddenByUserId: r.hidden_by_user_id ?? null,
+      hiddenByEmail: r.hidden_by_email ?? null,
+      createdAt: r.created_at,
+    })));
+  });
+
+  router.post('/hidden-users', guard, async (req: Request, res: Response) => {
+    const orgId = req.session!.orgId;
+    const raw = req.body?.userKey;
+    const userKey = typeof raw === 'string' ? raw.trim().toLowerCase() : '';
+    if (!userKey) {
+      return res.status(400).json({ error: 'Body must be { userKey: string } (non-empty).' });
+    }
+
+    // Hide + revoke the person's installation api_keys atomically: if the
+    // revocation fails the hide must not persist (and vice versa), so a
+    // hidden install can never keep a live token.
+    let hiddenByEmail: string | null = null;
+    if (req.session?.userId) {
+      const u = await ctx.db.get<{ email: string }>(
+        'SELECT email FROM users WHERE id = ?',
+        [req.session.userId],
+      );
+      hiddenByEmail = u?.email ?? null;
+    }
+    let revokedApiKeys = 0;
+    await ctx.db.transaction(async () => {
+      await ctx.db.run(
+        `INSERT OR IGNORE INTO hidden_users (org_id, user_key, hidden_by_user_id, hidden_by_email)
+         VALUES (?, ?, ?, ?)`,
+        [orgId, userKey, req.session!.userId, hiddenByEmail],
+      );
+      const r = await ctx.db.run(
+        `UPDATE api_keys SET revoked_at = datetime('now')
+          WHERE org_id = ? AND revoked_at IS NULL
+            AND installation_id IN (
+              SELECT id FROM installations
+               WHERE org_id = ? AND lower(git_email) = ?
+            )`,
+        [orgId, orgId, userKey],
+      );
+      revokedApiKeys = r.changes;
+    });
+
+    res.status(201).json({ userKey, revokedApiKeys });
+  });
+
+  router.delete('/hidden-users/:userKey', guard, async (req: Request, res: Response) => {
+    const userKey = decodeURIComponent(req.params.userKey).trim().toLowerCase();
+    const r = await ctx.db.run(
+      'DELETE FROM hidden_users WHERE org_id = ? AND user_key = ?',
+      [req.session!.orgId, userKey],
+    );
+    // Note: api_key revocation is permanent — unhiding does NOT restore
+    // revoked tokens (the person must re-register their installation).
+    res.json({ userKey, unhidden: r.changes > 0 });
+  });
+
   // ── Users ────────────────────────────────────────────────────────────────
   router.get('/installations', guard, async (req: Request, res: Response) => {
     const rows = await ctx.db.all<Record<string, unknown>>(

--- a/packages/hub/src/routes/admin.ts
+++ b/packages/hub/src/routes/admin.ts
@@ -185,24 +185,37 @@ export function adminRouter(ctx: HubServerContext): Router {
 
   // ── Users ────────────────────────────────────────────────────────────────
   router.get('/installations', guard, async (req: Request, res: Response) => {
+    // CGLAB-31: installations belonging to hidden people are excluded by
+    // default (this endpoint feeds the Admin installations list, the upgrade
+    // picker and the flow-assignment installation picker). ?includeHidden=1
+    // returns them flagged with hidden:true so the UI can render a
+    // show-hidden toggle.
+    const includeHidden = req.query.includeHidden === '1' || req.query.includeHidden === 'true';
     const rows = await ctx.db.all<Record<string, unknown>>(
-      `SELECT id, agenfk_version, agenfk_version_updated_at, first_seen, last_seen, os_user, git_name, git_email
-         FROM installations
-         WHERE org_id = ?
-         ORDER BY last_seen DESC`,
+      `SELECT i.id, i.agenfk_version, i.agenfk_version_updated_at, i.first_seen, i.last_seen,
+              i.os_user, i.git_name, i.git_email,
+              CASE WHEN h.user_key IS NULL THEN 0 ELSE 1 END AS hidden
+         FROM installations i
+         LEFT JOIN hidden_users h
+           ON h.org_id = i.org_id AND h.user_key = lower(i.git_email)
+        WHERE i.org_id = ?
+        ORDER BY i.last_seen DESC`,
       [req.session!.orgId],
     );
     res.json(
-      rows.map((r: any) => ({
-        id: r.id,
-        agenfkVersion: r.agenfk_version ?? null,
-        agenfkVersionUpdatedAt: r.agenfk_version_updated_at ?? null,
-        firstSeen: r.first_seen ?? null,
-        lastSeen: r.last_seen ?? null,
-        osUser: r.os_user ?? null,
-        gitName: r.git_name ?? null,
-        gitEmail: r.git_email ?? null,
-      })),
+      rows
+        .filter((r: any) => includeHidden || !r.hidden)
+        .map((r: any) => ({
+          id: r.id,
+          agenfkVersion: r.agenfk_version ?? null,
+          agenfkVersionUpdatedAt: r.agenfk_version_updated_at ?? null,
+          firstSeen: r.first_seen ?? null,
+          lastSeen: r.last_seen ?? null,
+          osUser: r.os_user ?? null,
+          gitName: r.git_name ?? null,
+          gitEmail: r.git_email ?? null,
+          hidden: !!r.hidden,
+        })),
     );
   });
 
@@ -726,8 +739,15 @@ export function adminRouter(ctx: HubServerContext): Router {
     type Inst = { id: string; agenfk_version: string | null };
     let installations: Inst[];
     if (scope.type === 'all') {
+      // CGLAB-31: fleet-wide directives skip hidden people's installations —
+      // a departed user's machine must not receive upgrade pushes.
       installations = await ctx.db.all<Inst>(
-        'SELECT id, agenfk_version FROM installations WHERE org_id = ?',
+        `SELECT i.id, i.agenfk_version FROM installations i
+          WHERE i.org_id = ?
+            AND NOT EXISTS (
+              SELECT 1 FROM hidden_users h
+               WHERE h.org_id = i.org_id AND h.user_key = lower(i.git_email)
+            )`,
         [orgId],
       );
     } else if (scope.type === 'installation') {
@@ -750,6 +770,26 @@ export function adminRouter(ctx: HubServerContext): Router {
         const found = new Set(installations.map(i => i.id));
         const missing = ids.filter(id => !found.has(id));
         return res.status(404).json({ error: 'One or more installations not found in this org', missing });
+      }
+    }
+
+    // CGLAB-31: explicitly targeting a hidden person's installation is
+    // rejected — the admin must unhide the person first. (scope=all silently
+    // skips them above; an explicit name is a deliberate act we refuse.)
+    if (installations.length > 0) {
+      const ids = installations.map(i => i.id);
+      const placeholders = ids.map(() => '?').join(',');
+      const hiddenTargets = await ctx.db.all<{ id: string }>(
+        `SELECT i.id FROM installations i
+          JOIN hidden_users h ON h.org_id = i.org_id AND h.user_key = lower(i.git_email)
+          WHERE i.org_id = ? AND i.id IN (${placeholders})`,
+        [orgId, ...ids],
+      );
+      if (hiddenTargets.length > 0) {
+        return res.status(409).json({
+          error: 'One or more installations belong to a hidden person. Unhide them first to target their installations.',
+          hidden: hiddenTargets.map(t => t.id),
+        });
       }
     }
 

--- a/packages/hub/src/routes/events.ts
+++ b/packages/hub/src/routes/events.ts
@@ -113,7 +113,19 @@ export function eventsRouter(ctx: HubServerContext): Router {
     let ingested = 0;
     let skipped = 0;
     let rejected = 0;
+    let hiddenDropped = 0;
     const seenInstallations = new Set<string>();
+
+    // CGLAB-31: people hidden by an admin stop emitting go-forward data.
+    // Load the org's hidden user_keys once per batch; events whose user_key
+    // is hidden are dropped BEFORE the event insert AND before the
+    // installations upsert, so a hidden install cannot resurrect via the
+    // events stream. Historical rows already in the DB are untouched.
+    const hiddenRows = await ctx.db.all<{ user_key: string }>(
+      'SELECT user_key FROM hidden_users WHERE org_id = ?',
+      [orgId],
+    );
+    const hiddenUserKeys = new Set(hiddenRows.map(r => r.user_key));
 
     await ctx.db.transaction(async () => {
       for (const e of events) {
@@ -121,8 +133,9 @@ export function eventsRouter(ctx: HubServerContext): Router {
         if (e.orgId !== orgId) { rejected++; continue; }
         if (keyInstallation && e.installationId !== keyInstallation) { rejected++; continue; }
         if (e.type === 'tokens.logged') { skipped++; continue; }
-        seenInstallations.add(e.installationId);
         const userKey = userKeyFor(e.actor);
+        if (hiddenUserKeys.has(userKey)) { hiddenDropped++; continue; }
+        seenInstallations.add(e.installationId);
         const itemType = (e as any).itemType
           ?? (e.payload && typeof (e.payload as any).itemType === 'string' ? (e.payload as any).itemType : null);
         // Sanitise the git remote URL for de-duplication in the projects filter.
@@ -236,7 +249,7 @@ export function eventsRouter(ctx: HubServerContext): Router {
       }
     });
 
-    res.json({ ingested, skipped, rejected, installationId: installationFromHeader });
+    res.json({ ingested, skipped, rejected, hiddenDropped, installationId: installationFromHeader });
   });
 
   return router;

--- a/packages/hub/src/routes/orgRename.ts
+++ b/packages/hub/src/routes/orgRename.ts
@@ -17,6 +17,7 @@ export const ORG_ID_CHILD_TABLES: readonly string[] = [
   'events',
   'flow_assignments',
   'flows',
+  'hidden_users',
   'installations',
   'rollups_daily',
   'upgrade_directives',

--- a/packages/hub/src/test/admin-hidden-users.test.ts
+++ b/packages/hub/src/test/admin-hidden-users.test.ts
@@ -1,0 +1,204 @@
+// Tests for the hidden-users admin API (CGLAB-31):
+//   GET    /v1/admin/hidden-users           — list hidden people for the org
+//   POST   /v1/admin/hidden-users           — hide a person (keyed on user_key)
+//   DELETE /v1/admin/hidden-users/:userKey  — unhide (reversible)
+// Hiding revokes, in the same transaction, every api_key bound to an
+// installation whose git email matches the hidden user_key.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import supertest from 'supertest';
+import { createHubApp } from '../server';
+import { createPasswordUser } from '../auth/password';
+
+const TEST_DB = path.join(os.tmpdir(), `agenfk-hub-hidden-users-${process.pid}.sqlite`);
+const SECRET = 'a'.repeat(64);
+
+const cleanup = () => {
+  for (const suffix of ['', '-wal', '-shm']) {
+    const f = TEST_DB + suffix;
+    if (fs.existsSync(f)) fs.unlinkSync(f);
+  }
+};
+
+const loginAs = async (app: any, email: string, password: string) => {
+  const r = await supertest(app).post('/auth/login').send({ email, password });
+  return r.headers['set-cookie']?.[0] ?? '';
+};
+
+async function seedInstallation(db: any, orgId: string, id: string, gitEmail: string | null) {
+  await db.run(
+    `INSERT INTO installations (id, org_id, first_seen, last_seen, os_user, git_name, git_email)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    [id, orgId, '2026-05-01T00:00:00Z', '2026-05-06T00:00:00Z', 'user', null, gitEmail],
+  );
+}
+
+async function seedApiKey(db: any, orgId: string, tokenHash: string, installationId: string | null) {
+  await db.run(
+    `INSERT INTO api_keys (token_hash, org_id, label, installation_id) VALUES (?, ?, ?, ?)`,
+    [tokenHash, orgId, 'test-key', installationId],
+  );
+}
+
+describe('hidden-users admin API', () => {
+  let app: any;
+  let ctx: any;
+  let cookieAdmin: string;
+  let cookieView: string;
+
+  beforeEach(async () => {
+    cleanup();
+    const out = await createHubApp({
+      dbPath: TEST_DB,
+      secretKey: SECRET,
+      sessionSecret: 'test-session-secret',
+      defaultOrgId: 'org-a',
+    });
+    app = out.app;
+    ctx = out.ctx;
+    await createPasswordUser(ctx.db, 'org-a', 'admin@x', 'longenough1', 'admin');
+    await createPasswordUser(ctx.db, 'org-a', 'view@x', 'longenough1', 'viewer');
+    cookieAdmin = await loginAs(app, 'admin@x', 'longenough1');
+    cookieView = await loginAs(app, 'view@x', 'longenough1');
+  });
+
+  afterEach(async () => { await ctx.db.close(); cleanup(); });
+
+  describe('authz', () => {
+    it('rejects unauthenticated requests', async () => {
+      expect((await supertest(app).get('/v1/admin/hidden-users')).status).toBe(401);
+      expect((await supertest(app).post('/v1/admin/hidden-users').send({ userKey: 'a@x' })).status).toBe(401);
+      expect((await supertest(app).delete('/v1/admin/hidden-users/a@x')).status).toBe(401);
+    });
+
+    it('rejects non-admin sessions', async () => {
+      expect((await supertest(app).get('/v1/admin/hidden-users').set('Cookie', cookieView)).status).toBe(403);
+      expect((await supertest(app).post('/v1/admin/hidden-users').set('Cookie', cookieView).send({ userKey: 'a@x' })).status).toBe(403);
+      expect((await supertest(app).delete('/v1/admin/hidden-users/a@x').set('Cookie', cookieView)).status).toBe(403);
+    });
+  });
+
+  describe('POST /v1/admin/hidden-users', () => {
+    it('hides a person and lists them afterwards', async () => {
+      const r = await supertest(app)
+        .post('/v1/admin/hidden-users')
+        .set('Cookie', cookieAdmin)
+        .send({ userKey: 'departed@acme.com' });
+      expect(r.status).toBe(201);
+
+      const list = await supertest(app).get('/v1/admin/hidden-users').set('Cookie', cookieAdmin);
+      expect(list.status).toBe(200);
+      expect(list.body).toHaveLength(1);
+      expect(list.body[0].userKey).toBe('departed@acme.com');
+      expect(list.body[0].hiddenByEmail).toBe('admin@x');
+      expect(list.body[0].createdAt).toBeTruthy();
+    });
+
+    it('normalizes the user_key to lowercase + trim', async () => {
+      const r = await supertest(app)
+        .post('/v1/admin/hidden-users')
+        .set('Cookie', cookieAdmin)
+        .send({ userKey: '  Departed@Acme.COM ' });
+      expect(r.status).toBe(201);
+      const list = await supertest(app).get('/v1/admin/hidden-users').set('Cookie', cookieAdmin);
+      expect(list.body[0].userKey).toBe('departed@acme.com');
+    });
+
+    it('rejects a missing/invalid userKey', async () => {
+      for (const body of [{}, { userKey: '' }, { userKey: '   ' }, { userKey: 42 }]) {
+        const r = await supertest(app).post('/v1/admin/hidden-users').set('Cookie', cookieAdmin).send(body);
+        expect(r.status).toBe(400);
+      }
+    });
+
+    it('is idempotent — hiding an already-hidden person succeeds without duplicating', async () => {
+      await supertest(app).post('/v1/admin/hidden-users').set('Cookie', cookieAdmin).send({ userKey: 'departed@acme.com' });
+      const r = await supertest(app).post('/v1/admin/hidden-users').set('Cookie', cookieAdmin).send({ userKey: 'departed@acme.com' });
+      expect([200, 201]).toContain(r.status);
+      const list = await supertest(app).get('/v1/admin/hidden-users').set('Cookie', cookieAdmin);
+      expect(list.body).toHaveLength(1);
+    });
+
+    it('revokes api_keys bound to the hidden person\'s installations, in the same transaction', async () => {
+      await seedInstallation(ctx.db, 'org-a', 'inst-1', 'departed@acme.com');
+      await seedInstallation(ctx.db, 'org-a', 'inst-2', 'Departed@Acme.com'); // case-variant
+      await seedInstallation(ctx.db, 'org-a', 'inst-3', 'active@acme.com');
+      await seedApiKey(ctx.db, 'org-a', 'hash-departed-1', 'inst-1');
+      await seedApiKey(ctx.db, 'org-a', 'hash-departed-2', 'inst-2');
+      await seedApiKey(ctx.db, 'org-a', 'hash-active', 'inst-3');
+      await seedApiKey(ctx.db, 'org-a', 'hash-unbound', null);
+
+      const r = await supertest(app)
+        .post('/v1/admin/hidden-users')
+        .set('Cookie', cookieAdmin)
+        .send({ userKey: 'departed@acme.com' });
+      expect(r.status).toBe(201);
+      expect(r.body.revokedApiKeys).toBe(2);
+
+      const keys = await ctx.db.all(
+        'SELECT token_hash, revoked_at FROM api_keys ORDER BY token_hash',
+      );
+      const byHash = Object.fromEntries(keys.map((k: any) => [k.token_hash, k.revoked_at]));
+      expect(byHash['hash-departed-1']).toBeTruthy();
+      expect(byHash['hash-departed-2']).toBeTruthy();
+      expect(byHash['hash-active']).toBeNull();
+      expect(byHash['hash-unbound']).toBeNull();
+    });
+
+    it('does not revoke api_keys from another org\'s installations even with matching email', async () => {
+      await ctx.db.run('INSERT OR IGNORE INTO orgs (id, name) VALUES (?, ?)', ['org-b', 'org-b']);
+      await seedInstallation(ctx.db, 'org-b', 'inst-b', 'departed@acme.com');
+      await seedApiKey(ctx.db, 'org-b', 'hash-org-b', 'inst-b');
+
+      await supertest(app).post('/v1/admin/hidden-users').set('Cookie', cookieAdmin).send({ userKey: 'departed@acme.com' });
+
+      const key = await ctx.db.get<{ revoked_at: string | null }>(
+        'SELECT revoked_at FROM api_keys WHERE token_hash = ?', ['hash-org-b'],
+      );
+      expect(key?.revoked_at).toBeNull();
+    });
+  });
+
+  describe('DELETE /v1/admin/hidden-users/:userKey', () => {
+    it('unhides a hidden person (reversible)', async () => {
+      await supertest(app).post('/v1/admin/hidden-users').set('Cookie', cookieAdmin).send({ userKey: 'departed@acme.com' });
+      const r = await supertest(app).delete('/v1/admin/hidden-users/departed%40acme.com').set('Cookie', cookieAdmin);
+      expect(r.status).toBe(200);
+      expect(r.body.unhidden).toBe(true);
+      const list = await supertest(app).get('/v1/admin/hidden-users').set('Cookie', cookieAdmin);
+      expect(list.body).toHaveLength(0);
+    });
+
+    it('returns 404 (or unhidden:false) when the person is not hidden', async () => {
+      const r = await supertest(app).delete('/v1/admin/hidden-users/nobody%40acme.com').set('Cookie', cookieAdmin);
+      expect([404, 200]).toContain(r.status);
+      if (r.status === 200) expect(r.body.unhidden).toBe(false);
+    });
+
+    it('does not restore revoked api_keys (revocation is permanent)', async () => {
+      await seedInstallation(ctx.db, 'org-a', 'inst-1', 'departed@acme.com');
+      await seedApiKey(ctx.db, 'org-a', 'hash-departed-1', 'inst-1');
+      await supertest(app).post('/v1/admin/hidden-users').set('Cookie', cookieAdmin).send({ userKey: 'departed@acme.com' });
+      await supertest(app).delete('/v1/admin/hidden-users/departed%40acme.com').set('Cookie', cookieAdmin);
+      const key = await ctx.db.get<{ revoked_at: string | null }>(
+        'SELECT revoked_at FROM api_keys WHERE token_hash = ?', ['hash-departed-1'],
+      );
+      expect(key?.revoked_at).toBeTruthy();
+    });
+  });
+
+  describe('GET /v1/admin/hidden-users', () => {
+    it('returns hidden people scoped to the caller org only', async () => {
+      await ctx.db.run('INSERT OR IGNORE INTO orgs (id, name) VALUES (?, ?)', ['org-b', 'org-b']);
+      await ctx.db.run(`INSERT INTO hidden_users (org_id, user_key) VALUES (?, ?)`, ['org-b', 'other@acme.com']);
+      await supertest(app).post('/v1/admin/hidden-users').set('Cookie', cookieAdmin).send({ userKey: 'mine@acme.com' });
+
+      const list = await supertest(app).get('/v1/admin/hidden-users').set('Cookie', cookieAdmin);
+      expect(list.body).toHaveLength(1);
+      expect(list.body[0].userKey).toBe('mine@acme.com');
+    });
+  });
+});

--- a/packages/hub/src/test/events-hidden-users.test.ts
+++ b/packages/hub/src/test/events-hidden-users.test.ts
@@ -1,0 +1,148 @@
+// Tests for CGLAB-31 ingest behaviour: events from hidden people (keyed on
+// user_key = lowercased git email) are dropped BEFORE the installations
+// upsert, so a hidden install cannot resurrect via the events stream.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import supertest from 'supertest';
+import { createHubApp } from '../server';
+import { issueApiKey } from '../auth/apiKey';
+
+const TEST_DB = path.join(os.tmpdir(), `agenfk-hub-events-hidden-${process.pid}.sqlite`);
+const cleanup = () => {
+  for (const suffix of ['', '-wal', '-shm']) {
+    const f = TEST_DB + suffix;
+    if (fs.existsSync(f)) fs.unlinkSync(f);
+  }
+};
+
+const sampleEvent = (overrides: Partial<any> = {}) => ({
+  eventId: 'e-' + Math.random().toString(36).slice(2),
+  installationId: 'inst-1',
+  orgId: 'org',
+  occurredAt: '2026-05-03T10:00:00Z',
+  actor: { osUser: 'alice', gitName: 'Alice', gitEmail: 'alice@example.com' },
+  type: 'item.created',
+  projectId: 'p1',
+  itemId: 'i1',
+  payload: { title: 'demo' },
+  ...overrides,
+});
+
+describe('hub /v1/events — hidden users dropped at ingest (CGLAB-31)', () => {
+  let app: any;
+  let ctx: any;
+  let token: string;
+
+  beforeEach(async () => {
+    cleanup();
+    const out = await createHubApp({ dbPath: TEST_DB, secretKey: '0'.repeat(64), sessionSecret: 'sess', defaultOrgId: 'org' });
+    app = out.app;
+    ctx = out.ctx;
+    token = await issueApiKey(ctx.db, 'org', 'test');
+  });
+
+  afterEach(async () => { await ctx.db.close(); cleanup(); });
+
+  const hide = (userKey: string) =>
+    ctx.db.run('INSERT INTO hidden_users (org_id, user_key) VALUES (?, ?)', ['org', userKey]);
+
+  it('drops events from a hidden person and does NOT store them', async () => {
+    await hide('alice@example.com');
+    const r = await supertest(app).post('/v1/events')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ events: [sampleEvent({ eventId: 'e1' })] });
+    expect(r.status).toBe(200);
+    expect(r.body.ingested).toBe(0);
+    const c = await ctx.db.get<{ c: number }>('SELECT COUNT(*) AS c FROM events');
+    expect(c!.c).toBe(0);
+  });
+
+  it('does NOT upsert the hidden person\'s installation (hidden install cannot resurrect)', async () => {
+    await hide('alice@example.com');
+    await supertest(app).post('/v1/events')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ events: [sampleEvent({ eventId: 'e1' })] });
+    const inst = await ctx.db.get('SELECT id FROM installations WHERE id = ?', ['inst-1']);
+    expect(inst).toBeUndefined();
+  });
+
+  it('does not touch last_seen of a pre-existing hidden installation', async () => {
+    await ctx.db.run(
+      `INSERT INTO installations (id, org_id, first_seen, last_seen, os_user, git_email)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      ['inst-1', 'org', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', 'alice', 'alice@example.com'],
+    );
+    await hide('alice@example.com');
+    await supertest(app).post('/v1/events')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ events: [sampleEvent({ eventId: 'e1' })] });
+    const inst = await ctx.db.get<{ last_seen: string }>('SELECT last_seen FROM installations WHERE id = ?', ['inst-1']);
+    expect(inst!.last_seen).toBe('2026-01-01T00:00:00Z');
+  });
+
+  it('still ingests events from non-hidden people in the same batch', async () => {
+    await hide('alice@example.com');
+    const r = await supertest(app).post('/v1/events')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        events: [
+          sampleEvent({ eventId: 'e-hidden', actor: { osUser: 'alice', gitName: 'A', gitEmail: 'alice@example.com' } }),
+          sampleEvent({ eventId: 'e-visible', installationId: 'inst-2', actor: { osUser: 'bob', gitName: 'B', gitEmail: 'bob@example.com' } }),
+        ],
+      });
+    expect(r.status).toBe(200);
+    expect(r.body.ingested).toBe(1);
+    const rows = await ctx.db.all<{ event_id: string }>('SELECT event_id FROM events');
+    expect(rows.map(x => x.event_id)).toEqual(['e-visible']);
+    // Visible person's installation upserted; hidden one's is not.
+    expect(await ctx.db.get('SELECT id FROM installations WHERE id = ?', ['inst-2'])).toBeTruthy();
+    expect(await ctx.db.get('SELECT id FROM installations WHERE id = ?', ['inst-1'])).toBeUndefined();
+  });
+
+  it('matches the hidden user_key case-insensitively (event git email in any case)', async () => {
+    await hide('alice@example.com');
+    const r = await supertest(app).post('/v1/events')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ events: [sampleEvent({ eventId: 'e1', actor: { osUser: 'alice', gitName: 'A', gitEmail: 'Alice@Example.COM' } })] });
+    expect(r.body.ingested).toBe(0);
+    const c = await ctx.db.get<{ c: number }>('SELECT COUNT(*) AS c FROM events');
+    expect(c!.c).toBe(0);
+  });
+
+  it('reports dropped events in the response so operators can see the filter working', async () => {
+    await hide('alice@example.com');
+    const r = await supertest(app).post('/v1/events')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        events: [
+          sampleEvent({ eventId: 'e1' }),
+          sampleEvent({ eventId: 'e2' }),
+          sampleEvent({ eventId: 'e3', installationId: 'inst-2', actor: { osUser: 'bob', gitName: 'B', gitEmail: 'bob@example.com' } }),
+        ],
+      });
+    expect(r.status).toBe(200);
+    expect(r.body.ingested).toBe(1);
+    expect(r.body.hiddenDropped ?? r.body.dropped ?? 0).toBe(2);
+  });
+
+  it('unhiding restores ingest (reversible)', async () => {
+    await hide('alice@example.com');
+    await ctx.db.run('DELETE FROM hidden_users WHERE org_id = ? AND user_key = ?', ['org', 'alice@example.com']);
+    const r = await supertest(app).post('/v1/events')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ events: [sampleEvent({ eventId: 'e1' })] });
+    expect(r.body.ingested).toBe(1);
+  });
+
+  it('hidden in another org does not affect this org\'s ingest', async () => {
+    await ctx.db.run('INSERT OR IGNORE INTO orgs (id, name) VALUES (?, ?)', ['org-b', 'org-b']);
+    await ctx.db.run('INSERT INTO hidden_users (org_id, user_key) VALUES (?, ?)', ['org-b', 'alice@example.com']);
+    const r = await supertest(app).post('/v1/events')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ events: [sampleEvent({ eventId: 'e1' })] });
+    expect(r.body.ingested).toBe(1);
+  });
+});

--- a/packages/hub/src/test/fleet-hidden-users.test.ts
+++ b/packages/hub/src/test/fleet-hidden-users.test.ts
@@ -1,0 +1,157 @@
+// Tests for CGLAB-31 fleet exclusions: hidden people disappear from the
+// admin installations list (unless explicitly requested) and from upgrade
+// targeting (scope=all skips them; explicitly naming one is rejected).
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import supertest from 'supertest';
+import { createHubApp } from '../server';
+import { createPasswordUser } from '../auth/password';
+
+const TEST_DB = path.join(os.tmpdir(), `agenfk-hub-fleet-hidden-${process.pid}.sqlite`);
+const SECRET = 'a'.repeat(64);
+const cleanup = () => {
+  for (const suffix of ['', '-wal', '-shm']) {
+    const f = TEST_DB + suffix;
+    if (fs.existsSync(f)) fs.unlinkSync(f);
+  }
+};
+
+const loginAs = async (app: any, email: string, password: string) => {
+  const r = await supertest(app).post('/auth/login').send({ email, password });
+  return r.headers['set-cookie']?.[0] ?? '';
+};
+
+async function seedInstallation(db: any, orgId: string, id: string, gitEmail: string | null, version = '0.3.0') {
+  await db.run(
+    `INSERT INTO installations (id, org_id, first_seen, last_seen, os_user, git_name, git_email, agenfk_version)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    [id, orgId, '2026-05-01T00:00:00Z', '2026-05-06T00:00:00Z', 'user', null, gitEmail, version],
+  );
+}
+
+const hide = (db: any, orgId: string, userKey: string) =>
+  db.run('INSERT INTO hidden_users (org_id, user_key) VALUES (?, ?)', [orgId, userKey]);
+
+describe('fleet exclusions for hidden people (CGLAB-31)', () => {
+  let app: any;
+  let ctx: any;
+  let cookieAdmin: string;
+
+  beforeEach(async () => {
+    cleanup();
+    const out = await createHubApp({
+      dbPath: TEST_DB,
+      secretKey: SECRET,
+      sessionSecret: 'test-session-secret',
+      defaultOrgId: 'org-a',
+      releaseExists: async (v: string) => v === '0.4.0',
+    });
+    app = out.app;
+    ctx = out.ctx;
+    await createPasswordUser(ctx.db, 'org-a', 'admin@x', 'longenough1', 'admin');
+    cookieAdmin = await loginAs(app, 'admin@x', 'longenough1');
+  });
+
+  afterEach(async () => { await ctx.db.close(); cleanup(); });
+
+  describe('GET /v1/admin/installations', () => {
+    it('excludes installations of hidden people by default', async () => {
+      await seedInstallation(ctx.db, 'org-a', 'inst-visible', 'active@acme.com');
+      await seedInstallation(ctx.db, 'org-a', 'inst-hidden', 'departed@acme.com');
+      await hide(ctx.db, 'org-a', 'departed@acme.com');
+
+      const r = await supertest(app).get('/v1/admin/installations').set('Cookie', cookieAdmin);
+      expect(r.status).toBe(200);
+      expect(r.body.map((i: any) => i.id)).toEqual(['inst-visible']);
+    });
+
+    it('matches hidden people case-insensitively on git email', async () => {
+      await seedInstallation(ctx.db, 'org-a', 'inst-hidden', 'Departed@Acme.COM');
+      await hide(ctx.db, 'org-a', 'departed@acme.com');
+
+      const r = await supertest(app).get('/v1/admin/installations').set('Cookie', cookieAdmin);
+      expect(r.body.map((i: any) => i.id)).toEqual([]);
+    });
+
+    it('?includeHidden=1 returns hidden installations flagged with hidden:true', async () => {
+      await seedInstallation(ctx.db, 'org-a', 'inst-visible', 'active@acme.com');
+      await seedInstallation(ctx.db, 'org-a', 'inst-hidden', 'departed@acme.com');
+      await hide(ctx.db, 'org-a', 'departed@acme.com');
+
+      const r = await supertest(app).get('/v1/admin/installations?includeHidden=1').set('Cookie', cookieAdmin);
+      expect(r.status).toBe(200);
+      expect(r.body).toHaveLength(2);
+      const byId = Object.fromEntries(r.body.map((i: any) => [i.id, i]));
+      expect(byId['inst-visible'].hidden ?? false).toBe(false);
+      expect(byId['inst-hidden'].hidden).toBe(true);
+    });
+
+    it('unhide restores the installation to the default list', async () => {
+      await seedInstallation(ctx.db, 'org-a', 'inst-hidden', 'departed@acme.com');
+      await hide(ctx.db, 'org-a', 'departed@acme.com');
+      await ctx.db.run('DELETE FROM hidden_users WHERE org_id = ? AND user_key = ?', ['org-a', 'departed@acme.com']);
+
+      const r = await supertest(app).get('/v1/admin/installations').set('Cookie', cookieAdmin);
+      expect(r.body.map((i: any) => i.id)).toEqual(['inst-hidden']);
+    });
+  });
+
+  describe('POST /v1/admin/upgrade — targeting', () => {
+    it('scope=all skips hidden people\'s installations', async () => {
+      await seedInstallation(ctx.db, 'org-a', 'inst-visible', 'active@acme.com');
+      await seedInstallation(ctx.db, 'org-a', 'inst-hidden', 'departed@acme.com');
+      await hide(ctx.db, 'org-a', 'departed@acme.com');
+
+      const r = await supertest(app).post('/v1/admin/upgrade')
+        .set('Cookie', cookieAdmin)
+        .send({ targetVersion: '0.4.0', scope: { type: 'all' } });
+      expect(r.status).toBe(201);
+
+      const targets = await ctx.db.all<{ installation_id: string }>(
+        'SELECT installation_id FROM upgrade_directive_targets',
+      );
+      expect(targets.map(t => t.installation_id)).toEqual(['inst-visible']);
+    });
+
+    it('scope=installation naming a hidden person\'s install is rejected (409)', async () => {
+      await seedInstallation(ctx.db, 'org-a', 'inst-hidden', 'departed@acme.com');
+      await hide(ctx.db, 'org-a', 'departed@acme.com');
+
+      const r = await supertest(app).post('/v1/admin/upgrade')
+        .set('Cookie', cookieAdmin)
+        .send({ targetVersion: '0.4.0', scope: { type: 'installation', installationId: 'inst-hidden' } });
+      expect(r.status).toBe(409);
+      expect(r.body.error).toMatch(/hidden/i);
+
+      const directives = await ctx.db.all('SELECT id FROM upgrade_directives');
+      expect(directives).toHaveLength(0);
+    });
+
+    it('scope=installations including a hidden person\'s install is rejected (409)', async () => {
+      await seedInstallation(ctx.db, 'org-a', 'inst-visible', 'active@acme.com');
+      await seedInstallation(ctx.db, 'org-a', 'inst-hidden', 'departed@acme.com');
+      await hide(ctx.db, 'org-a', 'departed@acme.com');
+
+      const r = await supertest(app).post('/v1/admin/upgrade')
+        .set('Cookie', cookieAdmin)
+        .send({ targetVersion: '0.4.0', scope: { type: 'installations', installationIds: ['inst-visible', 'inst-hidden'] } });
+      expect(r.status).toBe(409);
+      expect(r.body.error).toMatch(/hidden/i);
+
+      const directives = await ctx.db.all('SELECT id FROM upgrade_directives');
+      expect(directives).toHaveLength(0);
+    });
+
+    it('scope=installation on a visible install still works', async () => {
+      await seedInstallation(ctx.db, 'org-a', 'inst-visible', 'active@acme.com');
+
+      const r = await supertest(app).post('/v1/admin/upgrade')
+        .set('Cookie', cookieAdmin)
+        .send({ targetVersion: '0.4.0', scope: { type: 'installation', installationId: 'inst-visible' } });
+      expect(r.status).toBe(201);
+    });
+  });
+});

--- a/packages/hub/src/test/hidden-users-db.test.ts
+++ b/packages/hub/src/test/hidden-users-db.test.ts
@@ -1,0 +1,118 @@
+// Tests for the hidden_users table (CGLAB-31): schema bootstrap on both
+// backends (SQLite + pg-mem), basic hide/unhide/list semantics at the SQL
+// level, and org-rename registration so hidden rows follow an org rename.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import type { HubDb } from '../db/types';
+import { openSqliteDb } from '../db/sqlite';
+import { openPgMemDb } from '../db/postgres';
+
+const TEST_DB = path.join(os.tmpdir(), `agenfk-hidden-users-db-${process.pid}.sqlite`);
+const cleanup = () => {
+  for (const suffix of ['', '-wal', '-shm']) {
+    const f = TEST_DB + suffix;
+    if (fs.existsSync(f)) fs.unlinkSync(f);
+  }
+};
+
+function backendSuite(name: string, open: () => Promise<HubDb>, introspect: (db: HubDb) => Promise<string[]>) {
+  describe(`hidden_users table (${name})`, () => {
+    let db: HubDb;
+
+    beforeEach(async () => {
+      cleanup();
+      db = await open();
+    });
+
+    afterEach(async () => {
+      try { await db.close(); } catch { /* already closed */ }
+      cleanup();
+    });
+
+    it('bootstrap creates the hidden_users table', async () => {
+      const names = await introspect(db);
+      expect(names).toContain('hidden_users');
+    });
+
+    it('stores a hidden person keyed on (org_id, user_key)', async () => {
+      await db.run(
+        `INSERT INTO hidden_users (org_id, user_key, hidden_by_user_id, hidden_by_email)
+         VALUES (?, ?, ?, ?)`,
+        ['org', 'departed@acme.com', 'u-admin', 'admin@acme.com'],
+      );
+      const row = await db.get<{ org_id: string; user_key: string; hidden_by_email: string; created_at: unknown }>(
+        'SELECT org_id, user_key, hidden_by_email, created_at FROM hidden_users WHERE org_id = ? AND user_key = ?',
+        ['org', 'departed@acme.com'],
+      );
+      expect(row?.org_id).toBe('org');
+      expect(row?.user_key).toBe('departed@acme.com');
+      expect(row?.hidden_by_email).toBe('admin@acme.com');
+      expect(row?.created_at).toBeTruthy();
+    });
+
+    it('enforces the (org_id, user_key) primary key — same person can be hidden in two orgs but not twice in one', async () => {
+      await db.run(
+        `INSERT INTO hidden_users (org_id, user_key) VALUES (?, ?)`,
+        ['org', 'departed@acme.com'],
+      );
+      // Same user_key in a different org is fine.
+      await db.run(
+        `INSERT INTO hidden_users (org_id, user_key) VALUES (?, ?)`,
+        ['other-org', 'departed@acme.com'],
+      );
+      // Duplicate in the same org must throw.
+      await expect(
+        db.run(`INSERT INTO hidden_users (org_id, user_key) VALUES (?, ?)`, ['org', 'departed@acme.com']),
+      ).rejects.toThrow();
+    });
+
+    it('delete reverses the hide (unhide)', async () => {
+      await db.run(`INSERT INTO hidden_users (org_id, user_key) VALUES (?, ?)`, ['org', 'departed@acme.com']);
+      const r = await db.run('DELETE FROM hidden_users WHERE org_id = ? AND user_key = ?', ['org', 'departed@acme.com']);
+      expect(r.changes).toBe(1);
+      expect(await db.get('SELECT user_key FROM hidden_users WHERE org_id = ?', ['org'])).toBeUndefined();
+    });
+
+    it('list query returns all hidden people for an org', async () => {
+      await db.run(`INSERT INTO hidden_users (org_id, user_key) VALUES (?, ?)`, ['org', 'a@acme.com']);
+      await db.run(`INSERT INTO hidden_users (org_id, user_key) VALUES (?, ?)`, ['org', 'b@acme.com']);
+      await db.run(`INSERT INTO hidden_users (org_id, user_key) VALUES (?, ?)`, ['other', 'c@acme.com']);
+      const rows = await db.all<{ user_key: string }>(
+        'SELECT user_key FROM hidden_users WHERE org_id = ? ORDER BY user_key',
+        ['org'],
+      );
+      expect(rows.map(r => r.user_key)).toEqual(['a@acme.com', 'b@acme.com']);
+    });
+  });
+}
+
+backendSuite(
+  'sqlite',
+  () => openSqliteDb(TEST_DB),
+  async (db) => {
+    const rows = await db.all<{ name: string }>("SELECT name FROM sqlite_master WHERE type='table'");
+    return rows.map(r => r.name);
+  },
+);
+
+backendSuite(
+  'postgres',
+  () => openPgMemDb(),
+  async (db) => {
+    const rows = await db.all<{ table_name: string }>(
+      "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'",
+    );
+    return rows.map(r => r.table_name);
+  },
+);
+
+describe('hidden_users org-rename registration', () => {
+  it('ORG_ID_CHILD_TABLES includes hidden_users so rows follow an org rename', async () => {
+    const mod = await import('../routes/orgRename');
+    const tables = (mod as any).ORG_ID_CHILD_TABLES as string[];
+    expect(tables).toContain('hidden_users');
+  });
+});

--- a/packages/hub/src/test/hub-pg-parity.test.ts
+++ b/packages/hub/src/test/hub-pg-parity.test.ts
@@ -154,6 +154,23 @@ describe('PG parity: admin endpoints', () => {
     expect(await fx.db.get('SELECT id FROM installations WHERE id = ?', ['inst-1'])).toBeUndefined();
     expect(await fx.db.get('SELECT id FROM installations WHERE id = ?', ['inst-2'])).toBeTruthy();
   });
+
+  it('fleet exclusions: installations list hides + scope=all skips hidden on PG (CGLAB-31)', async () => {
+    for (const [id, email] of [['inst-vis', 'active@acme.com'], ['inst-hid', 'departed@acme.com']] as const) {
+      await fx.db.run(
+        `INSERT INTO installations (id, org_id, first_seen, last_seen, os_user, git_email, agenfk_version)
+         VALUES (?, ?, now(), now(), 'u', ?, '0.3.0')`,
+        [id, 'org', email],
+      );
+    }
+    await fx.db.run('INSERT INTO hidden_users (org_id, user_key) VALUES (?, ?)', ['org', 'departed@acme.com']);
+
+    const def = await supertest(fx.app).get('/v1/admin/installations').set('Cookie', fx.cookie);
+    expect(def.body.map((i: any) => i.id)).toEqual(['inst-vis']);
+    const incl = await supertest(fx.app).get('/v1/admin/installations?includeHidden=1').set('Cookie', fx.cookie);
+    expect(incl.body).toHaveLength(2);
+    expect(incl.body.find((i: any) => i.id === 'inst-hid').hidden).toBe(true);
+  });
 });
 
 describe('PG parity: connect (device + invite)', () => {

--- a/packages/hub/src/test/hub-pg-parity.test.ts
+++ b/packages/hub/src/test/hub-pg-parity.test.ts
@@ -106,6 +106,37 @@ describe('PG parity: admin endpoints', () => {
       .send({ email: 'new@x', password: 'longenough1', role: 'viewer' });
     expect(dup.status).toBe(409);
   });
+
+  it('hidden-users: hide lists, revokes installation api_keys, unhide reverses (CGLAB-31)', async () => {
+    await fx.db.run(
+      `INSERT INTO installations (id, org_id, first_seen, last_seen, os_user, git_email)
+       VALUES (?, ?, now(), now(), ?, ?)`,
+      ['inst-gone', 'org', 'gone', 'departed@acme.com'],
+    );
+    await fx.db.run(
+      `INSERT INTO api_keys (token_hash, org_id, label, installation_id) VALUES (?, ?, ?, ?)`,
+      ['hash-gone', 'org', 'k', 'inst-gone'],
+    );
+
+    const hide = await supertest(fx.app).post('/v1/admin/hidden-users').set('Cookie', fx.cookie)
+      .send({ userKey: 'Departed@Acme.com' });
+    expect(hide.status).toBe(201);
+    expect(hide.body.userKey).toBe('departed@acme.com');
+    expect(hide.body.revokedApiKeys).toBe(1);
+
+    const list = await supertest(fx.app).get('/v1/admin/hidden-users').set('Cookie', fx.cookie);
+    expect(list.body.map((u: any) => u.userKey)).toEqual(['departed@acme.com']);
+
+    const key = await fx.db.get<{ revoked_at: string | null }>(
+      'SELECT revoked_at FROM api_keys WHERE token_hash = ?', ['hash-gone'],
+    );
+    expect(key?.revoked_at).toBeTruthy();
+
+    const unhide = await supertest(fx.app).delete('/v1/admin/hidden-users/departed%40acme.com').set('Cookie', fx.cookie);
+    expect(unhide.body.unhidden).toBe(true);
+    const after = await supertest(fx.app).get('/v1/admin/hidden-users').set('Cookie', fx.cookie);
+    expect(after.body).toHaveLength(0);
+  });
 });
 
 describe('PG parity: connect (device + invite)', () => {

--- a/packages/hub/src/test/hub-pg-parity.test.ts
+++ b/packages/hub/src/test/hub-pg-parity.test.ts
@@ -137,6 +137,23 @@ describe('PG parity: admin endpoints', () => {
     const after = await supertest(fx.app).get('/v1/admin/hidden-users').set('Cookie', fx.cookie);
     expect(after.body).toHaveLength(0);
   });
+
+  it('events ingest drops hidden people before the installations upsert on PG (CGLAB-31)', async () => {
+    await fx.db.run('INSERT INTO hidden_users (org_id, user_key) VALUES (?, ?)', ['org', 'alice@acme.com']);
+    const r = await supertest(fx.app).post('/v1/events')
+      .set('Authorization', `Bearer ${fx.token}`)
+      .send({ events: [
+        sample({ eventId: 'h1', actor: { osUser: 'alice', gitName: 'A', gitEmail: 'Alice@Acme.com' } }),
+        sample({ eventId: 'v1', installationId: 'inst-2', actor: { osUser: 'bob', gitName: 'B', gitEmail: 'bob@acme.com' } }),
+      ] });
+    expect(r.status).toBe(200);
+    expect(r.body.ingested).toBe(1);
+    expect(r.body.hiddenDropped).toBe(1);
+    const evts = await fx.db.all<{ event_id: string }>('SELECT event_id FROM events');
+    expect(evts.map(e => e.event_id)).toEqual(['v1']);
+    expect(await fx.db.get('SELECT id FROM installations WHERE id = ?', ['inst-1'])).toBeUndefined();
+    expect(await fx.db.get('SELECT id FROM installations WHERE id = ?', ['inst-2'])).toBeTruthy();
+  });
 });
 
 describe('PG parity: connect (device + invite)', () => {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/server",
-  "version": "1.1.11",
+  "version": "1.1.12-beta.1",
   "description": "MCP Server for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -12,9 +12,9 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.11",
-    "@agenfk/storage-sqlite": "1.1.11",
-    "@agenfk/telemetry": "1.1.11",
+    "@agenfk/core": "1.1.12-beta.1",
+    "@agenfk/storage-sqlite": "1.1.12-beta.1",
+    "@agenfk/telemetry": "1.1.12-beta.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "axios": "^1.13.5",
     "body-parser": "^2.2.2",

--- a/packages/storage-sqlite/package.json
+++ b/packages/storage-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/storage-sqlite",
-  "version": "1.1.11",
+  "version": "1.1.12-beta.1",
   "description": "SQLite storage implementation for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -11,7 +11,7 @@
     "uuid": "^14.0.1"
   },
   "devDependencies": {
-    "@agenfk/core": "1.1.11",
+    "@agenfk/core": "1.1.12-beta.1",
     "@types/node": "^22.0.0",
     "@types/uuid": "^9.0.8",
     "typescript": "^5.3.3"

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/telemetry",
-  "version": "1.1.11",
+  "version": "1.1.12-beta.1",
   "description": "Anonymous telemetry client for AgenFK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.1.11",
+  "version": "1.1.12-beta.1",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -12,7 +12,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.1.11",
+    "@agenfk/flow-editor": "1.1.12-beta.1",
     "@tailwindcss/postcss": "^4.2.0",
     "@tailwindcss/typography": "^0.5.19",
     "@tanstack/react-query": "^5.90.21",


### PR DESCRIPTION
## Summary

Admins can now hide a person (keyed on `events.user_key` = lowercased git email) so they stop appearing as a selectable option in installation lists, upgrade targeting and admin actions.

**Historical data is explicitly out of scope and stays visible**: Org dashboard, Developers list, per-user drilldown, activity timeline, PR Overview and rollups_daily are untouched — nothing deleted or recomputed, and the hide is fully reversible.

## Changes

- **hub/db**: `hidden_users` table (PK `org_id`+`user_key`, hidden_by audit fields) on SQLite + Postgres; registered in `ORG_ID_CHILD_TABLES` for org-rename.
- **hub/admin**: `GET/POST/DELETE /v1/admin/hidden-users` — hiding revokes the person's installation api_keys in the **same transaction**; unhide is reversible (revocation is permanent by design).
- **hub/events**: ingest drops hidden people's events **before** the installations upsert, so a hidden install cannot resurrect; response gains `hiddenDropped` count.
- **hub/fleet**: `GET /v1/admin/installations` excludes hidden by default (`?includeHidden=1` flags them); upgrade `scope=all` skips hidden installs; explicitly naming one → 409.
- **hub-ui**: Admin → Installations — show-hidden toggle, per-row Hide (confirm dialog), hidden-people panel with Unhide. Upgrades/Flows installation pickers auto-exclude hidden people via the revoked api_keys filter.

## Verification

TDD throughout (red → green per task). Full suites green:
- hub backend: **486 tests / 49 files** (incl. pg-mem dual-backend parity)
- hub-ui: **118 tests / 18 files** + clean vite build

JIRA: [CGLAB-31](https://cg-lab.atlassian.net/browse/CGLAB-31)