### PR TITLE
Runs panel + project picker + hub hidden-users (CGLAB-31, CGLAB-32, CGLAB-33)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenfk",
-  "version": "1.1.11",
+  "version": "1.1.12-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenfk",
-      "version": "1.1.11",
+      "version": "1.1.12-beta.1",
       "license": "ISC",
       "workspaces": [
         "packages/core",
@@ -11018,11 +11018,11 @@
     },
     "packages/cli": {
       "name": "@agenfk/cli",
-      "version": "1.1.11",
+      "version": "1.1.12-beta.1",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.1.11",
-        "@agenfk/telemetry": "1.1.11",
+        "@agenfk/core": "1.1.12-beta.1",
+        "@agenfk/telemetry": "1.1.12-beta.1",
         "axios": "^1.13.5",
         "chalk": "^4.1.2",
         "commander": "^12.0.0",
@@ -11042,7 +11042,7 @@
     },
     "packages/core": {
       "name": "@agenfk/core",
-      "version": "1.1.11",
+      "version": "1.1.12-beta.1",
       "license": "ISC",
       "devDependencies": {
         "typescript": "^5.3.3"
@@ -11050,7 +11050,7 @@
     },
     "packages/create": {
       "name": "agenfk",
-      "version": "1.1.11",
+      "version": "1.1.12-beta.1",
       "license": "ISC",
       "bin": {
         "agenfk": "bin/agenfk.js"
@@ -11061,7 +11061,7 @@
     },
     "packages/flow-editor": {
       "name": "@agenfk/flow-editor",
-      "version": "1.1.11",
+      "version": "1.1.12-beta.1",
       "peerDependencies": {
         "@tanstack/react-query": "^5.90.21",
         "clsx": "^2.1.1",
@@ -11073,9 +11073,9 @@
     },
     "packages/hub": {
       "name": "@agenfk/hub",
-      "version": "1.1.11",
+      "version": "1.1.12-beta.1",
       "dependencies": {
-        "@agenfk/core": "1.1.11",
+        "@agenfk/core": "1.1.12-beta.1",
         "axios": "^1.13.5",
         "bcryptjs": "^2.4.3",
         "cookie-parser": "^1.4.7",
@@ -11099,9 +11099,9 @@
       }
     },
     "packages/hub-ui": {
-      "version": "1.1.11",
+      "version": "1.1.12-beta.1",
       "dependencies": {
-        "@agenfk/flow-editor": "1.1.11",
+        "@agenfk/flow-editor": "1.1.12-beta.1",
         "@tailwindcss/postcss": "^4.2.0",
         "@tanstack/react-query": "^5.90.21",
         "@vitejs/plugin-react": "^5.1.1",
@@ -11472,12 +11472,12 @@
     },
     "packages/server": {
       "name": "@agenfk/server",
-      "version": "1.1.11",
+      "version": "1.1.12-beta.1",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.1.11",
-        "@agenfk/storage-sqlite": "1.1.11",
-        "@agenfk/telemetry": "1.1.11",
+        "@agenfk/core": "1.1.12-beta.1",
+        "@agenfk/storage-sqlite": "1.1.12-beta.1",
+        "@agenfk/telemetry": "1.1.12-beta.1",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "axios": "^1.13.5",
         "body-parser": "^2.2.2",
@@ -11514,13 +11514,13 @@
     },
     "packages/storage-sqlite": {
       "name": "@agenfk/storage-sqlite",
-      "version": "1.1.11",
+      "version": "1.1.12-beta.1",
       "license": "ISC",
       "dependencies": {
         "uuid": "^14.0.1"
       },
       "devDependencies": {
-        "@agenfk/core": "1.1.11",
+        "@agenfk/core": "1.1.12-beta.1",
         "@types/node": "^22.0.0",
         "@types/uuid": "^9.0.8",
         "typescript": "^5.3.3"
@@ -11538,7 +11538,7 @@
     },
     "packages/telemetry": {
       "name": "@agenfk/telemetry",
-      "version": "1.1.11",
+      "version": "1.1.12-beta.1",
       "license": "ISC",
       "dependencies": {
         "posthog-node": "^4.0.0"
@@ -11549,9 +11549,9 @@
       }
     },
     "packages/ui": {
-      "version": "1.1.11",
+      "version": "1.1.12-beta.1",
       "dependencies": {
-        "@agenfk/flow-editor": "1.1.11",
+        "@agenfk/flow-editor": "1.1.12-beta.1",
         "@tailwindcss/postcss": "^4.2.0",
         "@tailwindcss/typography": "^0.5.19",
         "@tanstack/react-query": "^5.90.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenfk",
-  "version": "1.1.12-beta.1",
+  "version": "1.1.12-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenfk",
-      "version": "1.1.12-beta.1",
+      "version": "1.1.12-beta.2",
       "license": "ISC",
       "workspaces": [
         "packages/core",
@@ -11018,11 +11018,11 @@
     },
     "packages/cli": {
       "name": "@agenfk/cli",
-      "version": "1.1.12-beta.1",
+      "version": "1.1.12-beta.2",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.1.12-beta.1",
-        "@agenfk/telemetry": "1.1.12-beta.1",
+        "@agenfk/core": "1.1.12-beta.2",
+        "@agenfk/telemetry": "1.1.12-beta.2",
         "axios": "^1.13.5",
         "chalk": "^4.1.2",
         "commander": "^12.0.0",
@@ -11042,7 +11042,7 @@
     },
     "packages/core": {
       "name": "@agenfk/core",
-      "version": "1.1.12-beta.1",
+      "version": "1.1.12-beta.2",
       "license": "ISC",
       "devDependencies": {
         "typescript": "^5.3.3"
@@ -11050,7 +11050,7 @@
     },
     "packages/create": {
       "name": "agenfk",
-      "version": "1.1.12-beta.1",
+      "version": "1.1.12-beta.2",
       "license": "ISC",
       "bin": {
         "agenfk": "bin/agenfk.js"
@@ -11061,7 +11061,7 @@
     },
     "packages/flow-editor": {
       "name": "@agenfk/flow-editor",
-      "version": "1.1.12-beta.1",
+      "version": "1.1.12-beta.2",
       "peerDependencies": {
         "@tanstack/react-query": "^5.90.21",
         "clsx": "^2.1.1",
@@ -11073,9 +11073,9 @@
     },
     "packages/hub": {
       "name": "@agenfk/hub",
-      "version": "1.1.12-beta.1",
+      "version": "1.1.12-beta.2",
       "dependencies": {
-        "@agenfk/core": "1.1.12-beta.1",
+        "@agenfk/core": "1.1.12-beta.2",
         "axios": "^1.13.5",
         "bcryptjs": "^2.4.3",
         "cookie-parser": "^1.4.7",
@@ -11099,9 +11099,9 @@
       }
     },
     "packages/hub-ui": {
-      "version": "1.1.12-beta.1",
+      "version": "1.1.12-beta.2",
       "dependencies": {
-        "@agenfk/flow-editor": "1.1.12-beta.1",
+        "@agenfk/flow-editor": "1.1.12-beta.2",
         "@tailwindcss/postcss": "^4.2.0",
         "@tanstack/react-query": "^5.90.21",
         "@vitejs/plugin-react": "^5.1.1",
@@ -11472,12 +11472,12 @@
     },
     "packages/server": {
       "name": "@agenfk/server",
-      "version": "1.1.12-beta.1",
+      "version": "1.1.12-beta.2",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.1.12-beta.1",
-        "@agenfk/storage-sqlite": "1.1.12-beta.1",
-        "@agenfk/telemetry": "1.1.12-beta.1",
+        "@agenfk/core": "1.1.12-beta.2",
+        "@agenfk/storage-sqlite": "1.1.12-beta.2",
+        "@agenfk/telemetry": "1.1.12-beta.2",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "axios": "^1.13.5",
         "body-parser": "^2.2.2",
@@ -11514,13 +11514,13 @@
     },
     "packages/storage-sqlite": {
       "name": "@agenfk/storage-sqlite",
-      "version": "1.1.12-beta.1",
+      "version": "1.1.12-beta.2",
       "license": "ISC",
       "dependencies": {
         "uuid": "^14.0.1"
       },
       "devDependencies": {
-        "@agenfk/core": "1.1.12-beta.1",
+        "@agenfk/core": "1.1.12-beta.2",
         "@types/node": "^22.0.0",
         "@types/uuid": "^9.0.8",
         "typescript": "^5.3.3"
@@ -11538,7 +11538,7 @@
     },
     "packages/telemetry": {
       "name": "@agenfk/telemetry",
-      "version": "1.1.12-beta.1",
+      "version": "1.1.12-beta.2",
       "license": "ISC",
       "dependencies": {
         "posthog-node": "^4.0.0"
@@ -11549,9 +11549,9 @@
       }
     },
     "packages/ui": {
-      "version": "1.1.12-beta.1",
+      "version": "1.1.12-beta.2",
       "dependencies": {
-        "@agenfk/flow-editor": "1.1.12-beta.1",
+        "@agenfk/flow-editor": "1.1.12-beta.2",
         "@tailwindcss/postcss": "^4.2.0",
         "@tailwindcss/typography": "^0.5.19",
         "@tanstack/react-query": "^5.90.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenfk",
-  "version": "1.1.12-beta.2",
+  "version": "1.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenfk",
-      "version": "1.1.12-beta.2",
+      "version": "1.1.12",
       "license": "ISC",
       "workspaces": [
         "packages/core",
@@ -11018,11 +11018,11 @@
     },
     "packages/cli": {
       "name": "@agenfk/cli",
-      "version": "1.1.12-beta.2",
+      "version": "1.1.12",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.1.12-beta.2",
-        "@agenfk/telemetry": "1.1.12-beta.2",
+        "@agenfk/core": "1.1.12",
+        "@agenfk/telemetry": "1.1.12",
         "axios": "^1.13.5",
         "chalk": "^4.1.2",
         "commander": "^12.0.0",
@@ -11042,7 +11042,7 @@
     },
     "packages/core": {
       "name": "@agenfk/core",
-      "version": "1.1.12-beta.2",
+      "version": "1.1.12",
       "license": "ISC",
       "devDependencies": {
         "typescript": "^5.3.3"
@@ -11050,7 +11050,7 @@
     },
     "packages/create": {
       "name": "agenfk",
-      "version": "1.1.12-beta.2",
+      "version": "1.1.12",
       "license": "ISC",
       "bin": {
         "agenfk": "bin/agenfk.js"
@@ -11061,7 +11061,7 @@
     },
     "packages/flow-editor": {
       "name": "@agenfk/flow-editor",
-      "version": "1.1.12-beta.2",
+      "version": "1.1.12",
       "peerDependencies": {
         "@tanstack/react-query": "^5.90.21",
         "clsx": "^2.1.1",
@@ -11073,9 +11073,9 @@
     },
     "packages/hub": {
       "name": "@agenfk/hub",
-      "version": "1.1.12-beta.2",
+      "version": "1.1.12",
       "dependencies": {
-        "@agenfk/core": "1.1.12-beta.2",
+        "@agenfk/core": "1.1.12",
         "axios": "^1.13.5",
         "bcryptjs": "^2.4.3",
         "cookie-parser": "^1.4.7",
@@ -11099,9 +11099,9 @@
       }
     },
     "packages/hub-ui": {
-      "version": "1.1.12-beta.2",
+      "version": "1.1.12",
       "dependencies": {
-        "@agenfk/flow-editor": "1.1.12-beta.2",
+        "@agenfk/flow-editor": "1.1.12",
         "@tailwindcss/postcss": "^4.2.0",
         "@tanstack/react-query": "^5.90.21",
         "@vitejs/plugin-react": "^5.1.1",
@@ -11472,12 +11472,12 @@
     },
     "packages/server": {
       "name": "@agenfk/server",
-      "version": "1.1.12-beta.2",
+      "version": "1.1.12",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.1.12-beta.2",
-        "@agenfk/storage-sqlite": "1.1.12-beta.2",
-        "@agenfk/telemetry": "1.1.12-beta.2",
+        "@agenfk/core": "1.1.12",
+        "@agenfk/storage-sqlite": "1.1.12",
+        "@agenfk/telemetry": "1.1.12",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "axios": "^1.13.5",
         "body-parser": "^2.2.2",
@@ -11514,13 +11514,13 @@
     },
     "packages/storage-sqlite": {
       "name": "@agenfk/storage-sqlite",
-      "version": "1.1.12-beta.2",
+      "version": "1.1.12",
       "license": "ISC",
       "dependencies": {
         "uuid": "^14.0.1"
       },
       "devDependencies": {
-        "@agenfk/core": "1.1.12-beta.2",
+        "@agenfk/core": "1.1.12",
         "@types/node": "^22.0.0",
         "@types/uuid": "^9.0.8",
         "typescript": "^5.3.3"
@@ -11538,7 +11538,7 @@
     },
     "packages/telemetry": {
       "name": "@agenfk/telemetry",
-      "version": "1.1.12-beta.2",
+      "version": "1.1.12",
       "license": "ISC",
       "dependencies": {
         "posthog-node": "^4.0.0"
@@ -11549,9 +11549,9 @@
       }
     },
     "packages/ui": {
-      "version": "1.1.12-beta.2",
+      "version": "1.1.12",
       "dependencies": {
-        "@agenfk/flow-editor": "1.1.12-beta.2",
+        "@agenfk/flow-editor": "1.1.12",
         "@tailwindcss/postcss": "^4.2.0",
         "@tailwindcss/typography": "^0.5.19",
         "@tanstack/react-query": "^5.90.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "1.1.12-beta.1",
+  "version": "1.1.12-beta.2",
   "description": "AgenFK Engineering Framework",
   "private": true,
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "1.1.12-beta.2",
+  "version": "1.1.12",
   "description": "AgenFK Engineering Framework",
   "private": true,
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "1.1.11",
+  "version": "1.1.12-beta.1",
   "description": "AgenFK Engineering Framework",
   "private": true,
   "workspaces": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/cli",
-  "version": "1.1.12-beta.1",
+  "version": "1.1.12-beta.2",
   "description": "CLI for AgenFK Engineering Framework",
   "main": "dist/index.js",
   "bin": {
@@ -12,8 +12,8 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.12-beta.1",
-    "@agenfk/telemetry": "1.1.12-beta.1",
+    "@agenfk/core": "1.1.12-beta.2",
+    "@agenfk/telemetry": "1.1.12-beta.2",
     "axios": "^1.13.5",
     "chalk": "^4.1.2",
     "commander": "^12.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/cli",
-  "version": "1.1.12-beta.2",
+  "version": "1.1.12",
   "description": "CLI for AgenFK Engineering Framework",
   "main": "dist/index.js",
   "bin": {
@@ -12,8 +12,8 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.12-beta.2",
-    "@agenfk/telemetry": "1.1.12-beta.2",
+    "@agenfk/core": "1.1.12",
+    "@agenfk/telemetry": "1.1.12",
     "axios": "^1.13.5",
     "chalk": "^4.1.2",
     "commander": "^12.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/cli",
-  "version": "1.1.11",
+  "version": "1.1.12-beta.1",
   "description": "CLI for AgenFK Engineering Framework",
   "main": "dist/index.js",
   "bin": {
@@ -12,8 +12,8 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.11",
-    "@agenfk/telemetry": "1.1.11",
+    "@agenfk/core": "1.1.12-beta.1",
+    "@agenfk/telemetry": "1.1.12-beta.1",
     "axios": "^1.13.5",
     "chalk": "^4.1.2",
     "commander": "^12.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/core",
-  "version": "1.1.12-beta.1",
+  "version": "1.1.12-beta.2",
   "description": "Core logic and interfaces for the AgenFK Engineering Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/core",
-  "version": "1.1.12-beta.2",
+  "version": "1.1.12",
   "description": "Core logic and interfaces for the AgenFK Engineering Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/core",
-  "version": "1.1.11",
+  "version": "1.1.12-beta.1",
   "description": "Core logic and interfaces for the AgenFK Engineering Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "1.1.12-beta.1",
+  "version": "1.1.12-beta.2",
   "description": "AgenFK Agentic Engineering Framework — installer",
   "bin": {
     "agenfk": "bin/agenfk.js"

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "1.1.11",
+  "version": "1.1.12-beta.1",
   "description": "AgenFK Agentic Engineering Framework — installer",
   "bin": {
     "agenfk": "bin/agenfk.js"

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "1.1.12-beta.2",
+  "version": "1.1.12",
   "description": "AgenFK Agentic Engineering Framework — installer",
   "bin": {
     "agenfk": "bin/agenfk.js"

--- a/packages/flow-editor/package.json
+++ b/packages/flow-editor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agenfk/flow-editor",
   "private": true,
-  "version": "1.1.12-beta.1",
+  "version": "1.1.12-beta.2",
   "type": "module",
   "main": "./src/index.ts",
   "exports": {

--- a/packages/flow-editor/package.json
+++ b/packages/flow-editor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agenfk/flow-editor",
   "private": true,
-  "version": "1.1.11",
+  "version": "1.1.12-beta.1",
   "type": "module",
   "main": "./src/index.ts",
   "exports": {

--- a/packages/flow-editor/package.json
+++ b/packages/flow-editor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agenfk/flow-editor",
   "private": true,
-  "version": "1.1.12-beta.2",
+  "version": "1.1.12",
   "type": "module",
   "main": "./src/index.ts",
   "exports": {

--- a/packages/hub-ui/package.json
+++ b/packages/hub-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hub-ui",
   "private": true,
-  "version": "1.1.12-beta.2",
+  "version": "1.1.12",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.1.12-beta.2",
+    "@agenfk/flow-editor": "1.1.12",
     "@tailwindcss/postcss": "^4.2.0",
     "mermaid": "^11.12.3",
     "@tanstack/react-query": "^5.90.21",

--- a/packages/hub-ui/package.json
+++ b/packages/hub-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hub-ui",
   "private": true,
-  "version": "1.1.11",
+  "version": "1.1.12-beta.1",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.1.11",
+    "@agenfk/flow-editor": "1.1.12-beta.1",
     "@tailwindcss/postcss": "^4.2.0",
     "mermaid": "^11.12.3",
     "@tanstack/react-query": "^5.90.21",

--- a/packages/hub-ui/package.json
+++ b/packages/hub-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hub-ui",
   "private": true,
-  "version": "1.1.12-beta.1",
+  "version": "1.1.12-beta.2",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.1.12-beta.1",
+    "@agenfk/flow-editor": "1.1.12-beta.2",
     "@tailwindcss/postcss": "^4.2.0",
     "mermaid": "^11.12.3",
     "@tanstack/react-query": "^5.90.21",

--- a/packages/hub-ui/src/pages/Admin.tsx
+++ b/packages/hub-ui/src/pages/Admin.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
 import { Outlet, NavLink } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { ShieldCheck, KeyRound, Users, Trash2, Copy, Check, GitBranch, ArrowUpCircle, Server, Building2, X } from 'lucide-react';
+import { ShieldCheck, KeyRound, Users, Trash2, Copy, Check, GitBranch, ArrowUpCircle, Server, Building2, X, EyeOff, Eye } from 'lucide-react';
 import { api } from '../api';
 import { fmtDate } from '../dates';
 import { canDeleteUserRow } from './canDeleteUserRow';
+import { hideTargetKey, partitionHiddenRows, canHideRow } from './hiddenPeople';
 
 export function AdminLayout() {
   const link = ({ isActive }: { isActive: boolean }) =>
@@ -518,15 +519,47 @@ interface InstallationRow {
   osUser: string | null;
   gitName: string | null;
   gitEmail: string | null;
+  hidden?: boolean;
+}
+
+interface HiddenPersonRow {
+  userKey: string;
+  hiddenByEmail: string | null;
+  createdAt: string;
 }
 
 export function AdminInstallations() {
+  const qc = useQueryClient();
+  // CGLAB-31: hidden people are excluded server-side by default; the toggle
+  // re-fetches with ?includeHidden=1 and flags them inline.
+  const [showHidden, setShowHidden] = useState(false);
   const installations = useQuery<InstallationRow[]>({
-    queryKey: ['admin-installations'],
-    queryFn: async () => (await api.get('/v1/admin/installations')).data,
+    queryKey: ['admin-installations', showHidden],
+    queryFn: async () =>
+      (await api.get(showHidden ? '/v1/admin/installations?includeHidden=1' : '/v1/admin/installations')).data,
+  });
+  const hiddenPeople = useQuery<HiddenPersonRow[]>({
+    queryKey: ['admin-hidden-users'],
+    queryFn: async () => (await api.get('/v1/admin/hidden-users')).data,
+  });
+
+  const invalidate = () => {
+    qc.invalidateQueries({ queryKey: ['admin-installations'] });
+    qc.invalidateQueries({ queryKey: ['admin-hidden-users'] });
+    qc.invalidateQueries({ queryKey: ['api-keys'] });
+  };
+  const hide = useMutation({
+    mutationFn: (userKey: string) => api.post('/v1/admin/hidden-users', { userKey }),
+    onSuccess: invalidate,
+  });
+  const unhide = useMutation({
+    mutationFn: (userKey: string) => api.delete(`/v1/admin/hidden-users/${encodeURIComponent(userKey)}`),
+    onSuccess: invalidate,
   });
 
   const rows = installations.data ?? [];
+  const { visible, hidden: hiddenRows } = partitionHiddenRows(rows);
+  const hiddenCount = hiddenPeople.data?.length ?? hiddenRows.length;
 
   return (
     <div className="space-y-6">
@@ -538,7 +571,18 @@ export function AdminInstallations() {
               Every AgEnFK install that has reported events to this hub. Use this to audit which version is running where.
             </p>
           </div>
-          <span className="text-[11px] text-slate-500">{rows.length} total</span>
+          <div className="flex items-center gap-3">
+            {hiddenCount > 0 && (
+              <button
+                onClick={() => setShowHidden(v => !v)}
+                className="inline-flex items-center gap-1 text-[11px] font-semibold text-slate-500 hover:text-slate-700 dark:hover:text-slate-300"
+              >
+                {showHidden ? <Eye className="w-3.5 h-3.5" /> : <EyeOff className="w-3.5 h-3.5" />}
+                {showHidden ? 'Hide hidden' : `Show hidden (${hiddenCount})`}
+              </button>
+            )}
+            <span className="text-[11px] text-slate-500">{showHidden ? rows.length : visible.length} total</span>
+          </div>
         </header>
         <div className="mt-3 -mx-5 overflow-x-auto">
           <table className="w-full text-sm">
@@ -549,13 +593,17 @@ export function AdminInstallations() {
                 <th className="text-left px-2 py-2">Version</th>
                 <th className="text-left px-2 py-2">Version updated</th>
                 <th className="text-right px-5 py-2">Last seen</th>
+                <th className="text-right px-5 py-2"></th>
               </tr>
             </thead>
             <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
               {rows.map(r => (
-                <tr key={r.id} className="hover:bg-slate-50 dark:hover:bg-slate-800/40 transition-colors">
+                <tr key={r.id} className={`hover:bg-slate-50 dark:hover:bg-slate-800/40 transition-colors ${r.hidden ? 'opacity-50' : ''}`}>
                   <td className="px-5 py-2.5">
                     <span className="font-mono text-[11px] text-slate-600 dark:text-slate-300">{r.id}</span>
+                    {r.hidden && (
+                      <span className="ml-2 text-[10px] font-semibold uppercase tracking-wide text-amber-600 dark:text-amber-400">hidden</span>
+                    )}
                   </td>
                   <td className="px-2 py-2.5">
                     <div className="text-xs text-slate-700 dark:text-slate-200">{r.gitName ?? r.osUser ?? <span className="text-slate-400">—</span>}</div>
@@ -572,15 +620,63 @@ export function AdminInstallations() {
                   <td className="px-5 py-2.5 text-right text-xs text-slate-500 tabular-nums">
                     {r.lastSeen ? fmtDate(r.lastSeen) : <span className="text-slate-400">—</span>}
                   </td>
+                  <td className="px-5 py-2.5 text-right">
+                    {canHideRow(r) && (
+                      <button
+                        onClick={() => {
+                          const key = hideTargetKey(r);
+                          if (!key) return;
+                          if (confirm(`Hide ${key}? Their installations disappear from pickers, their API keys are revoked, and new events are dropped. Historical data stays visible. This is reversible.`)) {
+                            hide.mutate(key);
+                          }
+                        }}
+                        disabled={hide.isPending}
+                        className="inline-flex items-center gap-1 text-[11px] font-semibold text-slate-400 hover:text-amber-600 dark:hover:text-amber-400"
+                        title="Hide this person from selection surfaces"
+                      >
+                        <EyeOff className="w-3.5 h-3.5" /> Hide
+                      </button>
+                    )}
+                  </td>
                 </tr>
               ))}
               {rows.length === 0 && (
-                <tr><td colSpan={5} className="px-5 py-6 text-center text-sm text-slate-500">No installations have reported yet.</td></tr>
+                <tr><td colSpan={6} className="px-5 py-6 text-center text-sm text-slate-500">No installations have reported yet.</td></tr>
               )}
             </tbody>
           </table>
         </div>
       </section>
+
+      {(hiddenPeople.data?.length ?? 0) > 0 && (
+        <section className={cardCls}>
+          <header>
+            <h3 className="text-sm font-semibold text-slate-800 dark:text-slate-100">Hidden people</h3>
+            <p className="mt-0.5 text-xs text-slate-500 dark:text-slate-400">
+              Hidden people no longer appear in installation pickers, their API keys are revoked, and new events from them are dropped. Historical dashboards are unaffected. Unhiding restores visibility but does not restore revoked keys.
+            </p>
+          </header>
+          <ul className="mt-3 divide-y divide-slate-100 dark:divide-slate-800">
+            {hiddenPeople.data!.map(p => (
+              <li key={p.userKey} className="flex items-center justify-between py-2">
+                <div>
+                  <div className="font-mono text-xs text-slate-700 dark:text-slate-200">{p.userKey}</div>
+                  <div className="text-[11px] text-slate-500">
+                    hidden {fmtDate(p.createdAt)}{p.hiddenByEmail ? ` by ${p.hiddenByEmail}` : ''}
+                  </div>
+                </div>
+                <button
+                  onClick={() => unhide.mutate(p.userKey)}
+                  disabled={unhide.isPending}
+                  className="inline-flex items-center gap-1 text-[11px] font-semibold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400"
+                >
+                  <Eye className="w-3.5 h-3.5" /> Unhide
+                </button>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
     </div>
   );
 }

--- a/packages/hub-ui/src/pages/hiddenPeople.ts
+++ b/packages/hub-ui/src/pages/hiddenPeople.ts
@@ -1,0 +1,49 @@
+// Pure helpers for the Admin → Installations hidden-people UI (CGLAB-31):
+// partitioning rows into visible/hidden, deriving the hide target key from
+// an installation row, and deciding which rows the table renders.
+
+export interface InstallationRowLike {
+  id: string;
+  gitEmail: string | null;
+  hidden?: boolean;
+}
+
+/**
+ * The hide action is keyed on the person's user_key (lowercased git email).
+ * Returns null when the row has no git email — such installations cannot be
+ * attributed to a person and therefore cannot be hidden from the UI.
+ */
+export function hideTargetKey(row: Pick<InstallationRowLike, 'gitEmail'>): string | null {
+  const email = row.gitEmail?.trim().toLowerCase();
+  return email ? email : null;
+}
+
+/**
+ * Rows rendered in the installations table. When showHidden is false the
+ * hidden rows are excluded (the backend already excludes them by default;
+ * this keeps the client-side toggle consistent when includeHidden=1 rows
+ * are loaded).
+ */
+export function visibleInstallationRows<T extends InstallationRowLike>(rows: T[], showHidden: boolean): T[] {
+  if (showHidden) return rows;
+  return rows.filter(r => !r.hidden);
+}
+
+/**
+ * Partition into visible vs hidden rows — drives both the table and the
+ * "N hidden" toggle label.
+ */
+export function partitionHiddenRows<T extends InstallationRowLike>(rows: T[]): { visible: T[]; hidden: T[] } {
+  const visible: T[] = [];
+  const hidden: T[] = [];
+  for (const r of rows) (r.hidden ? hidden : visible).push(r);
+  return { visible, hidden };
+}
+
+/**
+ * Whether the Hide button should be enabled for a row: only visible rows
+ * with an attributable git email can be hidden.
+ */
+export function canHideRow(row: InstallationRowLike): boolean {
+  return !row.hidden && hideTargetKey(row) !== null;
+}

--- a/packages/hub-ui/src/test/hiddenPeople.test.ts
+++ b/packages/hub-ui/src/test/hiddenPeople.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import {
+  hideTargetKey,
+  visibleInstallationRows,
+  partitionHiddenRows,
+  canHideRow,
+  type InstallationRowLike,
+} from '../pages/hiddenPeople';
+
+const rows: InstallationRowLike[] = [
+  { id: 'inst-1', gitEmail: 'active@acme.com', hidden: false },
+  { id: 'inst-2', gitEmail: 'departed@acme.com', hidden: true },
+  { id: 'inst-3', gitEmail: null, hidden: false },
+];
+
+describe('hideTargetKey', () => {
+  it('returns the lowercased trimmed git email', () => {
+    expect(hideTargetKey({ gitEmail: '  Departed@Acme.COM ' })).toBe('departed@acme.com');
+  });
+
+  it('returns null when the row has no git email (cannot attribute to a person)', () => {
+    expect(hideTargetKey({ gitEmail: null })).toBeNull();
+    expect(hideTargetKey({ gitEmail: '' })).toBeNull();
+    expect(hideTargetKey({ gitEmail: '   ' })).toBeNull();
+  });
+});
+
+describe('visibleInstallationRows', () => {
+  it('excludes hidden rows when showHidden is false', () => {
+    expect(visibleInstallationRows(rows, false).map(r => r.id)).toEqual(['inst-1', 'inst-3']);
+  });
+
+  it('returns all rows when showHidden is true', () => {
+    expect(visibleInstallationRows(rows, true).map(r => r.id)).toEqual(['inst-1', 'inst-2', 'inst-3']);
+  });
+
+  it('treats a missing hidden flag as visible', () => {
+    expect(visibleInstallationRows([{ id: 'x', gitEmail: 'a@b' }], false)).toHaveLength(1);
+  });
+});
+
+describe('partitionHiddenRows', () => {
+  it('splits rows into visible and hidden buckets', () => {
+    const { visible, hidden } = partitionHiddenRows(rows);
+    expect(visible.map(r => r.id)).toEqual(['inst-1', 'inst-3']);
+    expect(hidden.map(r => r.id)).toEqual(['inst-2']);
+  });
+
+  it('handles an empty list', () => {
+    expect(partitionHiddenRows([])).toEqual({ visible: [], hidden: [] });
+  });
+});
+
+describe('canHideRow', () => {
+  it('allows hiding a visible row with a git email', () => {
+    expect(canHideRow({ id: 'inst-1', gitEmail: 'active@acme.com', hidden: false })).toBe(true);
+  });
+
+  it('disallows hiding an already-hidden row', () => {
+    expect(canHideRow({ id: 'inst-2', gitEmail: 'departed@acme.com', hidden: true })).toBe(false);
+  });
+
+  it('disallows hiding a row with no git email', () => {
+    expect(canHideRow({ id: 'inst-3', gitEmail: null, hidden: false })).toBe(false);
+  });
+});

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/hub",
-  "version": "1.1.11",
+  "version": "1.1.12-beta.1",
   "description": "Corporate Hub for AgEnFK — fleet-wide metrics + timeline server",
   "main": "dist/server.js",
   "types": "dist/server.d.ts",
@@ -20,7 +20,7 @@
     "start": "node dist/bin.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.11",
+    "@agenfk/core": "1.1.12-beta.1",
     "axios": "^1.13.5",
     "bcryptjs": "^2.4.3",
     "cookie-parser": "^1.4.7",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/hub",
-  "version": "1.1.12-beta.2",
+  "version": "1.1.12",
   "description": "Corporate Hub for AgEnFK — fleet-wide metrics + timeline server",
   "main": "dist/server.js",
   "types": "dist/server.d.ts",
@@ -20,7 +20,7 @@
     "start": "node dist/bin.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.12-beta.2",
+    "@agenfk/core": "1.1.12",
     "axios": "^1.13.5",
     "bcryptjs": "^2.4.3",
     "cookie-parser": "^1.4.7",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/hub",
-  "version": "1.1.12-beta.1",
+  "version": "1.1.12-beta.2",
   "description": "Corporate Hub for AgEnFK — fleet-wide metrics + timeline server",
   "main": "dist/server.js",
   "types": "dist/server.d.ts",
@@ -20,7 +20,7 @@
     "start": "node dist/bin.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.12-beta.1",
+    "@agenfk/core": "1.1.12-beta.2",
     "axios": "^1.13.5",
     "bcryptjs": "^2.4.3",
     "cookie-parser": "^1.4.7",

--- a/packages/hub/src/db/postgres.ts
+++ b/packages/hub/src/db/postgres.ts
@@ -179,6 +179,18 @@ const SCHEMA_PG = `
     token TEXT PRIMARY KEY,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
   );
+
+  -- People hidden by an admin (CGLAB-31). See the SQLite schema for the
+  -- full rationale — selection surfaces only, historical data untouched,
+  -- reversible by row delete.
+  CREATE TABLE IF NOT EXISTS hidden_users (
+    org_id TEXT NOT NULL,
+    user_key TEXT NOT NULL,
+    hidden_by_user_id TEXT,
+    hidden_by_email TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (org_id, user_key)
+  );
 `;
 
 /**

--- a/packages/hub/src/db/sqlite.ts
+++ b/packages/hub/src/db/sqlite.ts
@@ -190,6 +190,22 @@ const SCHEMA_SQLITE = `
     token TEXT PRIMARY KEY,
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
   );
+
+  -- People hidden by an admin (CGLAB-31), keyed on events.user_key
+  -- (lowercased git email). Membership removes the person from selection
+  -- surfaces (installation lists, upgrade targeting, admin actions) and
+  -- blocks their new events at ingest. Historical data (events,
+  -- rollups_daily, dashboards) is deliberately untouched — the hide only
+  -- affects go-forward behaviour and is fully reversible by deleting the
+  -- row.
+  CREATE TABLE IF NOT EXISTS hidden_users (
+    org_id TEXT NOT NULL,
+    user_key TEXT NOT NULL,
+    hidden_by_user_id TEXT,
+    hidden_by_email TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (org_id, user_key)
+  );
 `;
 
 class SqliteAdapter implements HubDb {

--- a/packages/hub/src/routes/admin.ts
+++ b/packages/hub/src/routes/admin.ts
@@ -111,6 +111,78 @@ export function adminRouter(ctx: HubServerContext): Router {
     res.json({ revoked: result.changes });
   });
 
+  // ── Hidden people (CGLAB-31) ─────────────────────────────────────────────
+  // Person-level hide keyed on events.user_key (lowercased git email).
+  // Selection surfaces only — historical data (events, rollups, dashboards)
+  // is deliberately untouched. Fully reversible via DELETE.
+  router.get('/hidden-users', guard, async (req: Request, res: Response) => {
+    const rows = await ctx.db.all<Record<string, unknown>>(
+      `SELECT user_key, hidden_by_user_id, hidden_by_email, created_at
+         FROM hidden_users
+         WHERE org_id = ?
+         ORDER BY created_at DESC`,
+      [req.session!.orgId],
+    );
+    res.json(rows.map((r: any) => ({
+      userKey: r.user_key,
+      hiddenByUserId: r.hidden_by_user_id ?? null,
+      hiddenByEmail: r.hidden_by_email ?? null,
+      createdAt: r.created_at,
+    })));
+  });
+
+  router.post('/hidden-users', guard, async (req: Request, res: Response) => {
+    const orgId = req.session!.orgId;
+    const raw = req.body?.userKey;
+    const userKey = typeof raw === 'string' ? raw.trim().toLowerCase() : '';
+    if (!userKey) {
+      return res.status(400).json({ error: 'Body must be { userKey: string } (non-empty).' });
+    }
+
+    // Hide + revoke the person's installation api_keys atomically: if the
+    // revocation fails the hide must not persist (and vice versa), so a
+    // hidden install can never keep a live token.
+    let hiddenByEmail: string | null = null;
+    if (req.session?.userId) {
+      const u = await ctx.db.get<{ email: string }>(
+        'SELECT email FROM users WHERE id = ?',
+        [req.session.userId],
+      );
+      hiddenByEmail = u?.email ?? null;
+    }
+    let revokedApiKeys = 0;
+    await ctx.db.transaction(async () => {
+      await ctx.db.run(
+        `INSERT OR IGNORE INTO hidden_users (org_id, user_key, hidden_by_user_id, hidden_by_email)
+         VALUES (?, ?, ?, ?)`,
+        [orgId, userKey, req.session!.userId, hiddenByEmail],
+      );
+      const r = await ctx.db.run(
+        `UPDATE api_keys SET revoked_at = datetime('now')
+          WHERE org_id = ? AND revoked_at IS NULL
+            AND installation_id IN (
+              SELECT id FROM installations
+               WHERE org_id = ? AND lower(git_email) = ?
+            )`,
+        [orgId, orgId, userKey],
+      );
+      revokedApiKeys = r.changes;
+    });
+
+    res.status(201).json({ userKey, revokedApiKeys });
+  });
+
+  router.delete('/hidden-users/:userKey', guard, async (req: Request, res: Response) => {
+    const userKey = decodeURIComponent(req.params.userKey).trim().toLowerCase();
+    const r = await ctx.db.run(
+      'DELETE FROM hidden_users WHERE org_id = ? AND user_key = ?',
+      [req.session!.orgId, userKey],
+    );
+    // Note: api_key revocation is permanent — unhiding does NOT restore
+    // revoked tokens (the person must re-register their installation).
+    res.json({ userKey, unhidden: r.changes > 0 });
+  });
+
   // ── Users ────────────────────────────────────────────────────────────────
   router.get('/installations', guard, async (req: Request, res: Response) => {
     const rows = await ctx.db.all<Record<string, unknown>>(

--- a/packages/hub/src/routes/admin.ts
+++ b/packages/hub/src/routes/admin.ts
@@ -185,24 +185,37 @@ export function adminRouter(ctx: HubServerContext): Router {
 
   // ── Users ────────────────────────────────────────────────────────────────
   router.get('/installations', guard, async (req: Request, res: Response) => {
+    // CGLAB-31: installations belonging to hidden people are excluded by
+    // default (this endpoint feeds the Admin installations list, the upgrade
+    // picker and the flow-assignment installation picker). ?includeHidden=1
+    // returns them flagged with hidden:true so the UI can render a
+    // show-hidden toggle.
+    const includeHidden = req.query.includeHidden === '1' || req.query.includeHidden === 'true';
     const rows = await ctx.db.all<Record<string, unknown>>(
-      `SELECT id, agenfk_version, agenfk_version_updated_at, first_seen, last_seen, os_user, git_name, git_email
-         FROM installations
-         WHERE org_id = ?
-         ORDER BY last_seen DESC`,
+      `SELECT i.id, i.agenfk_version, i.agenfk_version_updated_at, i.first_seen, i.last_seen,
+              i.os_user, i.git_name, i.git_email,
+              CASE WHEN h.user_key IS NULL THEN 0 ELSE 1 END AS hidden
+         FROM installations i
+         LEFT JOIN hidden_users h
+           ON h.org_id = i.org_id AND h.user_key = lower(i.git_email)
+        WHERE i.org_id = ?
+        ORDER BY i.last_seen DESC`,
       [req.session!.orgId],
     );
     res.json(
-      rows.map((r: any) => ({
-        id: r.id,
-        agenfkVersion: r.agenfk_version ?? null,
-        agenfkVersionUpdatedAt: r.agenfk_version_updated_at ?? null,
-        firstSeen: r.first_seen ?? null,
-        lastSeen: r.last_seen ?? null,
-        osUser: r.os_user ?? null,
-        gitName: r.git_name ?? null,
-        gitEmail: r.git_email ?? null,
-      })),
+      rows
+        .filter((r: any) => includeHidden || !r.hidden)
+        .map((r: any) => ({
+          id: r.id,
+          agenfkVersion: r.agenfk_version ?? null,
+          agenfkVersionUpdatedAt: r.agenfk_version_updated_at ?? null,
+          firstSeen: r.first_seen ?? null,
+          lastSeen: r.last_seen ?? null,
+          osUser: r.os_user ?? null,
+          gitName: r.git_name ?? null,
+          gitEmail: r.git_email ?? null,
+          hidden: !!r.hidden,
+        })),
     );
   });
 
@@ -726,8 +739,15 @@ export function adminRouter(ctx: HubServerContext): Router {
     type Inst = { id: string; agenfk_version: string | null };
     let installations: Inst[];
     if (scope.type === 'all') {
+      // CGLAB-31: fleet-wide directives skip hidden people's installations —
+      // a departed user's machine must not receive upgrade pushes.
       installations = await ctx.db.all<Inst>(
-        'SELECT id, agenfk_version FROM installations WHERE org_id = ?',
+        `SELECT i.id, i.agenfk_version FROM installations i
+          WHERE i.org_id = ?
+            AND NOT EXISTS (
+              SELECT 1 FROM hidden_users h
+               WHERE h.org_id = i.org_id AND h.user_key = lower(i.git_email)
+            )`,
         [orgId],
       );
     } else if (scope.type === 'installation') {
@@ -750,6 +770,26 @@ export function adminRouter(ctx: HubServerContext): Router {
         const found = new Set(installations.map(i => i.id));
         const missing = ids.filter(id => !found.has(id));
         return res.status(404).json({ error: 'One or more installations not found in this org', missing });
+      }
+    }
+
+    // CGLAB-31: explicitly targeting a hidden person's installation is
+    // rejected — the admin must unhide the person first. (scope=all silently
+    // skips them above; an explicit name is a deliberate act we refuse.)
+    if (installations.length > 0) {
+      const ids = installations.map(i => i.id);
+      const placeholders = ids.map(() => '?').join(',');
+      const hiddenTargets = await ctx.db.all<{ id: string }>(
+        `SELECT i.id FROM installations i
+          JOIN hidden_users h ON h.org_id = i.org_id AND h.user_key = lower(i.git_email)
+          WHERE i.org_id = ? AND i.id IN (${placeholders})`,
+        [orgId, ...ids],
+      );
+      if (hiddenTargets.length > 0) {
+        return res.status(409).json({
+          error: 'One or more installations belong to a hidden person. Unhide them first to target their installations.',
+          hidden: hiddenTargets.map(t => t.id),
+        });
       }
     }
 

--- a/packages/hub/src/routes/events.ts
+++ b/packages/hub/src/routes/events.ts
@@ -113,7 +113,19 @@ export function eventsRouter(ctx: HubServerContext): Router {
     let ingested = 0;
     let skipped = 0;
     let rejected = 0;
+    let hiddenDropped = 0;
     const seenInstallations = new Set<string>();
+
+    // CGLAB-31: people hidden by an admin stop emitting go-forward data.
+    // Load the org's hidden user_keys once per batch; events whose user_key
+    // is hidden are dropped BEFORE the event insert AND before the
+    // installations upsert, so a hidden install cannot resurrect via the
+    // events stream. Historical rows already in the DB are untouched.
+    const hiddenRows = await ctx.db.all<{ user_key: string }>(
+      'SELECT user_key FROM hidden_users WHERE org_id = ?',
+      [orgId],
+    );
+    const hiddenUserKeys = new Set(hiddenRows.map(r => r.user_key));
 
     await ctx.db.transaction(async () => {
       for (const e of events) {
@@ -121,8 +133,9 @@ export function eventsRouter(ctx: HubServerContext): Router {
         if (e.orgId !== orgId) { rejected++; continue; }
         if (keyInstallation && e.installationId !== keyInstallation) { rejected++; continue; }
         if (e.type === 'tokens.logged') { skipped++; continue; }
-        seenInstallations.add(e.installationId);
         const userKey = userKeyFor(e.actor);
+        if (hiddenUserKeys.has(userKey)) { hiddenDropped++; continue; }
+        seenInstallations.add(e.installationId);
         const itemType = (e as any).itemType
           ?? (e.payload && typeof (e.payload as any).itemType === 'string' ? (e.payload as any).itemType : null);
         // Sanitise the git remote URL for de-duplication in the projects filter.
@@ -236,7 +249,7 @@ export function eventsRouter(ctx: HubServerContext): Router {
       }
     });
 
-    res.json({ ingested, skipped, rejected, installationId: installationFromHeader });
+    res.json({ ingested, skipped, rejected, hiddenDropped, installationId: installationFromHeader });
   });
 
   return router;

--- a/packages/hub/src/routes/orgRename.ts
+++ b/packages/hub/src/routes/orgRename.ts
@@ -17,6 +17,7 @@ export const ORG_ID_CHILD_TABLES: readonly string[] = [
   'events',
   'flow_assignments',
   'flows',
+  'hidden_users',
   'installations',
   'rollups_daily',
   'upgrade_directives',

--- a/packages/hub/src/test/admin-hidden-users.test.ts
+++ b/packages/hub/src/test/admin-hidden-users.test.ts
@@ -1,0 +1,204 @@
+// Tests for the hidden-users admin API (CGLAB-31):
+//   GET    /v1/admin/hidden-users           — list hidden people for the org
+//   POST   /v1/admin/hidden-users           — hide a person (keyed on user_key)
+//   DELETE /v1/admin/hidden-users/:userKey  — unhide (reversible)
+// Hiding revokes, in the same transaction, every api_key bound to an
+// installation whose git email matches the hidden user_key.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import supertest from 'supertest';
+import { createHubApp } from '../server';
+import { createPasswordUser } from '../auth/password';
+
+const TEST_DB = path.join(os.tmpdir(), `agenfk-hub-hidden-users-${process.pid}.sqlite`);
+const SECRET = 'a'.repeat(64);
+
+const cleanup = () => {
+  for (const suffix of ['', '-wal', '-shm']) {
+    const f = TEST_DB + suffix;
+    if (fs.existsSync(f)) fs.unlinkSync(f);
+  }
+};
+
+const loginAs = async (app: any, email: string, password: string) => {
+  const r = await supertest(app).post('/auth/login').send({ email, password });
+  return r.headers['set-cookie']?.[0] ?? '';
+};
+
+async function seedInstallation(db: any, orgId: string, id: string, gitEmail: string | null) {
+  await db.run(
+    `INSERT INTO installations (id, org_id, first_seen, last_seen, os_user, git_name, git_email)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    [id, orgId, '2026-05-01T00:00:00Z', '2026-05-06T00:00:00Z', 'user', null, gitEmail],
+  );
+}
+
+async function seedApiKey(db: any, orgId: string, tokenHash: string, installationId: string | null) {
+  await db.run(
+    `INSERT INTO api_keys (token_hash, org_id, label, installation_id) VALUES (?, ?, ?, ?)`,
+    [tokenHash, orgId, 'test-key', installationId],
+  );
+}
+
+describe('hidden-users admin API', () => {
+  let app: any;
+  let ctx: any;
+  let cookieAdmin: string;
+  let cookieView: string;
+
+  beforeEach(async () => {
+    cleanup();
+    const out = await createHubApp({
+      dbPath: TEST_DB,
+      secretKey: SECRET,
+      sessionSecret: 'test-session-secret',
+      defaultOrgId: 'org-a',
+    });
+    app = out.app;
+    ctx = out.ctx;
+    await createPasswordUser(ctx.db, 'org-a', 'admin@x', 'longenough1', 'admin');
+    await createPasswordUser(ctx.db, 'org-a', 'view@x', 'longenough1', 'viewer');
+    cookieAdmin = await loginAs(app, 'admin@x', 'longenough1');
+    cookieView = await loginAs(app, 'view@x', 'longenough1');
+  });
+
+  afterEach(async () => { await ctx.db.close(); cleanup(); });
+
+  describe('authz', () => {
+    it('rejects unauthenticated requests', async () => {
+      expect((await supertest(app).get('/v1/admin/hidden-users')).status).toBe(401);
+      expect((await supertest(app).post('/v1/admin/hidden-users').send({ userKey: 'a@x' })).status).toBe(401);
+      expect((await supertest(app).delete('/v1/admin/hidden-users/a@x')).status).toBe(401);
+    });
+
+    it('rejects non-admin sessions', async () => {
+      expect((await supertest(app).get('/v1/admin/hidden-users').set('Cookie', cookieView)).status).toBe(403);
+      expect((await supertest(app).post('/v1/admin/hidden-users').set('Cookie', cookieView).send({ userKey: 'a@x' })).status).toBe(403);
+      expect((await supertest(app).delete('/v1/admin/hidden-users/a@x').set('Cookie', cookieView)).status).toBe(403);
+    });
+  });
+
+  describe('POST /v1/admin/hidden-users', () => {
+    it('hides a person and lists them afterwards', async () => {
+      const r = await supertest(app)
+        .post('/v1/admin/hidden-users')
+        .set('Cookie', cookieAdmin)
+        .send({ userKey: 'departed@acme.com' });
+      expect(r.status).toBe(201);
+
+      const list = await supertest(app).get('/v1/admin/hidden-users').set('Cookie', cookieAdmin);
+      expect(list.status).toBe(200);
+      expect(list.body).toHaveLength(1);
+      expect(list.body[0].userKey).toBe('departed@acme.com');
+      expect(list.body[0].hiddenByEmail).toBe('admin@x');
+      expect(list.body[0].createdAt).toBeTruthy();
+    });
+
+    it('normalizes the user_key to lowercase + trim', async () => {
+      const r = await supertest(app)
+        .post('/v1/admin/hidden-users')
+        .set('Cookie', cookieAdmin)
+        .send({ userKey: '  Departed@Acme.COM ' });
+      expect(r.status).toBe(201);
+      const list = await supertest(app).get('/v1/admin/hidden-users').set('Cookie', cookieAdmin);
+      expect(list.body[0].userKey).toBe('departed@acme.com');
+    });
+
+    it('rejects a missing/invalid userKey', async () => {
+      for (const body of [{}, { userKey: '' }, { userKey: '   ' }, { userKey: 42 }]) {
+        const r = await supertest(app).post('/v1/admin/hidden-users').set('Cookie', cookieAdmin).send(body);
+        expect(r.status).toBe(400);
+      }
+    });
+
+    it('is idempotent — hiding an already-hidden person succeeds without duplicating', async () => {
+      await supertest(app).post('/v1/admin/hidden-users').set('Cookie', cookieAdmin).send({ userKey: 'departed@acme.com' });
+      const r = await supertest(app).post('/v1/admin/hidden-users').set('Cookie', cookieAdmin).send({ userKey: 'departed@acme.com' });
+      expect([200, 201]).toContain(r.status);
+      const list = await supertest(app).get('/v1/admin/hidden-users').set('Cookie', cookieAdmin);
+      expect(list.body).toHaveLength(1);
+    });
+
+    it('revokes api_keys bound to the hidden person\'s installations, in the same transaction', async () => {
+      await seedInstallation(ctx.db, 'org-a', 'inst-1', 'departed@acme.com');
+      await seedInstallation(ctx.db, 'org-a', 'inst-2', 'Departed@Acme.com'); // case-variant
+      await seedInstallation(ctx.db, 'org-a', 'inst-3', 'active@acme.com');
+      await seedApiKey(ctx.db, 'org-a', 'hash-departed-1', 'inst-1');
+      await seedApiKey(ctx.db, 'org-a', 'hash-departed-2', 'inst-2');
+      await seedApiKey(ctx.db, 'org-a', 'hash-active', 'inst-3');
+      await seedApiKey(ctx.db, 'org-a', 'hash-unbound', null);
+
+      const r = await supertest(app)
+        .post('/v1/admin/hidden-users')
+        .set('Cookie', cookieAdmin)
+        .send({ userKey: 'departed@acme.com' });
+      expect(r.status).toBe(201);
+      expect(r.body.revokedApiKeys).toBe(2);
+
+      const keys = await ctx.db.all(
+        'SELECT token_hash, revoked_at FROM api_keys ORDER BY token_hash',
+      );
+      const byHash = Object.fromEntries(keys.map((k: any) => [k.token_hash, k.revoked_at]));
+      expect(byHash['hash-departed-1']).toBeTruthy();
+      expect(byHash['hash-departed-2']).toBeTruthy();
+      expect(byHash['hash-active']).toBeNull();
+      expect(byHash['hash-unbound']).toBeNull();
+    });
+
+    it('does not revoke api_keys from another org\'s installations even with matching email', async () => {
+      await ctx.db.run('INSERT OR IGNORE INTO orgs (id, name) VALUES (?, ?)', ['org-b', 'org-b']);
+      await seedInstallation(ctx.db, 'org-b', 'inst-b', 'departed@acme.com');
+      await seedApiKey(ctx.db, 'org-b', 'hash-org-b', 'inst-b');
+
+      await supertest(app).post('/v1/admin/hidden-users').set('Cookie', cookieAdmin).send({ userKey: 'departed@acme.com' });
+
+      const key = await ctx.db.get<{ revoked_at: string | null }>(
+        'SELECT revoked_at FROM api_keys WHERE token_hash = ?', ['hash-org-b'],
+      );
+      expect(key?.revoked_at).toBeNull();
+    });
+  });
+
+  describe('DELETE /v1/admin/hidden-users/:userKey', () => {
+    it('unhides a hidden person (reversible)', async () => {
+      await supertest(app).post('/v1/admin/hidden-users').set('Cookie', cookieAdmin).send({ userKey: 'departed@acme.com' });
+      const r = await supertest(app).delete('/v1/admin/hidden-users/departed%40acme.com').set('Cookie', cookieAdmin);
+      expect(r.status).toBe(200);
+      expect(r.body.unhidden).toBe(true);
+      const list = await supertest(app).get('/v1/admin/hidden-users').set('Cookie', cookieAdmin);
+      expect(list.body).toHaveLength(0);
+    });
+
+    it('returns 404 (or unhidden:false) when the person is not hidden', async () => {
+      const r = await supertest(app).delete('/v1/admin/hidden-users/nobody%40acme.com').set('Cookie', cookieAdmin);
+      expect([404, 200]).toContain(r.status);
+      if (r.status === 200) expect(r.body.unhidden).toBe(false);
+    });
+
+    it('does not restore revoked api_keys (revocation is permanent)', async () => {
+      await seedInstallation(ctx.db, 'org-a', 'inst-1', 'departed@acme.com');
+      await seedApiKey(ctx.db, 'org-a', 'hash-departed-1', 'inst-1');
+      await supertest(app).post('/v1/admin/hidden-users').set('Cookie', cookieAdmin).send({ userKey: 'departed@acme.com' });
+      await supertest(app).delete('/v1/admin/hidden-users/departed%40acme.com').set('Cookie', cookieAdmin);
+      const key = await ctx.db.get<{ revoked_at: string | null }>(
+        'SELECT revoked_at FROM api_keys WHERE token_hash = ?', ['hash-departed-1'],
+      );
+      expect(key?.revoked_at).toBeTruthy();
+    });
+  });
+
+  describe('GET /v1/admin/hidden-users', () => {
+    it('returns hidden people scoped to the caller org only', async () => {
+      await ctx.db.run('INSERT OR IGNORE INTO orgs (id, name) VALUES (?, ?)', ['org-b', 'org-b']);
+      await ctx.db.run(`INSERT INTO hidden_users (org_id, user_key) VALUES (?, ?)`, ['org-b', 'other@acme.com']);
+      await supertest(app).post('/v1/admin/hidden-users').set('Cookie', cookieAdmin).send({ userKey: 'mine@acme.com' });
+
+      const list = await supertest(app).get('/v1/admin/hidden-users').set('Cookie', cookieAdmin);
+      expect(list.body).toHaveLength(1);
+      expect(list.body[0].userKey).toBe('mine@acme.com');
+    });
+  });
+});

--- a/packages/hub/src/test/events-hidden-users.test.ts
+++ b/packages/hub/src/test/events-hidden-users.test.ts
@@ -1,0 +1,148 @@
+// Tests for CGLAB-31 ingest behaviour: events from hidden people (keyed on
+// user_key = lowercased git email) are dropped BEFORE the installations
+// upsert, so a hidden install cannot resurrect via the events stream.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import supertest from 'supertest';
+import { createHubApp } from '../server';
+import { issueApiKey } from '../auth/apiKey';
+
+const TEST_DB = path.join(os.tmpdir(), `agenfk-hub-events-hidden-${process.pid}.sqlite`);
+const cleanup = () => {
+  for (const suffix of ['', '-wal', '-shm']) {
+    const f = TEST_DB + suffix;
+    if (fs.existsSync(f)) fs.unlinkSync(f);
+  }
+};
+
+const sampleEvent = (overrides: Partial<any> = {}) => ({
+  eventId: 'e-' + Math.random().toString(36).slice(2),
+  installationId: 'inst-1',
+  orgId: 'org',
+  occurredAt: '2026-05-03T10:00:00Z',
+  actor: { osUser: 'alice', gitName: 'Alice', gitEmail: 'alice@example.com' },
+  type: 'item.created',
+  projectId: 'p1',
+  itemId: 'i1',
+  payload: { title: 'demo' },
+  ...overrides,
+});
+
+describe('hub /v1/events — hidden users dropped at ingest (CGLAB-31)', () => {
+  let app: any;
+  let ctx: any;
+  let token: string;
+
+  beforeEach(async () => {
+    cleanup();
+    const out = await createHubApp({ dbPath: TEST_DB, secretKey: '0'.repeat(64), sessionSecret: 'sess', defaultOrgId: 'org' });
+    app = out.app;
+    ctx = out.ctx;
+    token = await issueApiKey(ctx.db, 'org', 'test');
+  });
+
+  afterEach(async () => { await ctx.db.close(); cleanup(); });
+
+  const hide = (userKey: string) =>
+    ctx.db.run('INSERT INTO hidden_users (org_id, user_key) VALUES (?, ?)', ['org', userKey]);
+
+  it('drops events from a hidden person and does NOT store them', async () => {
+    await hide('alice@example.com');
+    const r = await supertest(app).post('/v1/events')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ events: [sampleEvent({ eventId: 'e1' })] });
+    expect(r.status).toBe(200);
+    expect(r.body.ingested).toBe(0);
+    const c = await ctx.db.get<{ c: number }>('SELECT COUNT(*) AS c FROM events');
+    expect(c!.c).toBe(0);
+  });
+
+  it('does NOT upsert the hidden person\'s installation (hidden install cannot resurrect)', async () => {
+    await hide('alice@example.com');
+    await supertest(app).post('/v1/events')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ events: [sampleEvent({ eventId: 'e1' })] });
+    const inst = await ctx.db.get('SELECT id FROM installations WHERE id = ?', ['inst-1']);
+    expect(inst).toBeUndefined();
+  });
+
+  it('does not touch last_seen of a pre-existing hidden installation', async () => {
+    await ctx.db.run(
+      `INSERT INTO installations (id, org_id, first_seen, last_seen, os_user, git_email)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      ['inst-1', 'org', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', 'alice', 'alice@example.com'],
+    );
+    await hide('alice@example.com');
+    await supertest(app).post('/v1/events')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ events: [sampleEvent({ eventId: 'e1' })] });
+    const inst = await ctx.db.get<{ last_seen: string }>('SELECT last_seen FROM installations WHERE id = ?', ['inst-1']);
+    expect(inst!.last_seen).toBe('2026-01-01T00:00:00Z');
+  });
+
+  it('still ingests events from non-hidden people in the same batch', async () => {
+    await hide('alice@example.com');
+    const r = await supertest(app).post('/v1/events')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        events: [
+          sampleEvent({ eventId: 'e-hidden', actor: { osUser: 'alice', gitName: 'A', gitEmail: 'alice@example.com' } }),
+          sampleEvent({ eventId: 'e-visible', installationId: 'inst-2', actor: { osUser: 'bob', gitName: 'B', gitEmail: 'bob@example.com' } }),
+        ],
+      });
+    expect(r.status).toBe(200);
+    expect(r.body.ingested).toBe(1);
+    const rows = await ctx.db.all<{ event_id: string }>('SELECT event_id FROM events');
+    expect(rows.map(x => x.event_id)).toEqual(['e-visible']);
+    // Visible person's installation upserted; hidden one's is not.
+    expect(await ctx.db.get('SELECT id FROM installations WHERE id = ?', ['inst-2'])).toBeTruthy();
+    expect(await ctx.db.get('SELECT id FROM installations WHERE id = ?', ['inst-1'])).toBeUndefined();
+  });
+
+  it('matches the hidden user_key case-insensitively (event git email in any case)', async () => {
+    await hide('alice@example.com');
+    const r = await supertest(app).post('/v1/events')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ events: [sampleEvent({ eventId: 'e1', actor: { osUser: 'alice', gitName: 'A', gitEmail: 'Alice@Example.COM' } })] });
+    expect(r.body.ingested).toBe(0);
+    const c = await ctx.db.get<{ c: number }>('SELECT COUNT(*) AS c FROM events');
+    expect(c!.c).toBe(0);
+  });
+
+  it('reports dropped events in the response so operators can see the filter working', async () => {
+    await hide('alice@example.com');
+    const r = await supertest(app).post('/v1/events')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        events: [
+          sampleEvent({ eventId: 'e1' }),
+          sampleEvent({ eventId: 'e2' }),
+          sampleEvent({ eventId: 'e3', installationId: 'inst-2', actor: { osUser: 'bob', gitName: 'B', gitEmail: 'bob@example.com' } }),
+        ],
+      });
+    expect(r.status).toBe(200);
+    expect(r.body.ingested).toBe(1);
+    expect(r.body.hiddenDropped ?? r.body.dropped ?? 0).toBe(2);
+  });
+
+  it('unhiding restores ingest (reversible)', async () => {
+    await hide('alice@example.com');
+    await ctx.db.run('DELETE FROM hidden_users WHERE org_id = ? AND user_key = ?', ['org', 'alice@example.com']);
+    const r = await supertest(app).post('/v1/events')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ events: [sampleEvent({ eventId: 'e1' })] });
+    expect(r.body.ingested).toBe(1);
+  });
+
+  it('hidden in another org does not affect this org\'s ingest', async () => {
+    await ctx.db.run('INSERT OR IGNORE INTO orgs (id, name) VALUES (?, ?)', ['org-b', 'org-b']);
+    await ctx.db.run('INSERT INTO hidden_users (org_id, user_key) VALUES (?, ?)', ['org-b', 'alice@example.com']);
+    const r = await supertest(app).post('/v1/events')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ events: [sampleEvent({ eventId: 'e1' })] });
+    expect(r.body.ingested).toBe(1);
+  });
+});

--- a/packages/hub/src/test/fleet-hidden-users.test.ts
+++ b/packages/hub/src/test/fleet-hidden-users.test.ts
@@ -1,0 +1,157 @@
+// Tests for CGLAB-31 fleet exclusions: hidden people disappear from the
+// admin installations list (unless explicitly requested) and from upgrade
+// targeting (scope=all skips them; explicitly naming one is rejected).
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import supertest from 'supertest';
+import { createHubApp } from '../server';
+import { createPasswordUser } from '../auth/password';
+
+const TEST_DB = path.join(os.tmpdir(), `agenfk-hub-fleet-hidden-${process.pid}.sqlite`);
+const SECRET = 'a'.repeat(64);
+const cleanup = () => {
+  for (const suffix of ['', '-wal', '-shm']) {
+    const f = TEST_DB + suffix;
+    if (fs.existsSync(f)) fs.unlinkSync(f);
+  }
+};
+
+const loginAs = async (app: any, email: string, password: string) => {
+  const r = await supertest(app).post('/auth/login').send({ email, password });
+  return r.headers['set-cookie']?.[0] ?? '';
+};
+
+async function seedInstallation(db: any, orgId: string, id: string, gitEmail: string | null, version = '0.3.0') {
+  await db.run(
+    `INSERT INTO installations (id, org_id, first_seen, last_seen, os_user, git_name, git_email, agenfk_version)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    [id, orgId, '2026-05-01T00:00:00Z', '2026-05-06T00:00:00Z', 'user', null, gitEmail, version],
+  );
+}
+
+const hide = (db: any, orgId: string, userKey: string) =>
+  db.run('INSERT INTO hidden_users (org_id, user_key) VALUES (?, ?)', [orgId, userKey]);
+
+describe('fleet exclusions for hidden people (CGLAB-31)', () => {
+  let app: any;
+  let ctx: any;
+  let cookieAdmin: string;
+
+  beforeEach(async () => {
+    cleanup();
+    const out = await createHubApp({
+      dbPath: TEST_DB,
+      secretKey: SECRET,
+      sessionSecret: 'test-session-secret',
+      defaultOrgId: 'org-a',
+      releaseExists: async (v: string) => v === '0.4.0',
+    });
+    app = out.app;
+    ctx = out.ctx;
+    await createPasswordUser(ctx.db, 'org-a', 'admin@x', 'longenough1', 'admin');
+    cookieAdmin = await loginAs(app, 'admin@x', 'longenough1');
+  });
+
+  afterEach(async () => { await ctx.db.close(); cleanup(); });
+
+  describe('GET /v1/admin/installations', () => {
+    it('excludes installations of hidden people by default', async () => {
+      await seedInstallation(ctx.db, 'org-a', 'inst-visible', 'active@acme.com');
+      await seedInstallation(ctx.db, 'org-a', 'inst-hidden', 'departed@acme.com');
+      await hide(ctx.db, 'org-a', 'departed@acme.com');
+
+      const r = await supertest(app).get('/v1/admin/installations').set('Cookie', cookieAdmin);
+      expect(r.status).toBe(200);
+      expect(r.body.map((i: any) => i.id)).toEqual(['inst-visible']);
+    });
+
+    it('matches hidden people case-insensitively on git email', async () => {
+      await seedInstallation(ctx.db, 'org-a', 'inst-hidden', 'Departed@Acme.COM');
+      await hide(ctx.db, 'org-a', 'departed@acme.com');
+
+      const r = await supertest(app).get('/v1/admin/installations').set('Cookie', cookieAdmin);
+      expect(r.body.map((i: any) => i.id)).toEqual([]);
+    });
+
+    it('?includeHidden=1 returns hidden installations flagged with hidden:true', async () => {
+      await seedInstallation(ctx.db, 'org-a', 'inst-visible', 'active@acme.com');
+      await seedInstallation(ctx.db, 'org-a', 'inst-hidden', 'departed@acme.com');
+      await hide(ctx.db, 'org-a', 'departed@acme.com');
+
+      const r = await supertest(app).get('/v1/admin/installations?includeHidden=1').set('Cookie', cookieAdmin);
+      expect(r.status).toBe(200);
+      expect(r.body).toHaveLength(2);
+      const byId = Object.fromEntries(r.body.map((i: any) => [i.id, i]));
+      expect(byId['inst-visible'].hidden ?? false).toBe(false);
+      expect(byId['inst-hidden'].hidden).toBe(true);
+    });
+
+    it('unhide restores the installation to the default list', async () => {
+      await seedInstallation(ctx.db, 'org-a', 'inst-hidden', 'departed@acme.com');
+      await hide(ctx.db, 'org-a', 'departed@acme.com');
+      await ctx.db.run('DELETE FROM hidden_users WHERE org_id = ? AND user_key = ?', ['org-a', 'departed@acme.com']);
+
+      const r = await supertest(app).get('/v1/admin/installations').set('Cookie', cookieAdmin);
+      expect(r.body.map((i: any) => i.id)).toEqual(['inst-hidden']);
+    });
+  });
+
+  describe('POST /v1/admin/upgrade — targeting', () => {
+    it('scope=all skips hidden people\'s installations', async () => {
+      await seedInstallation(ctx.db, 'org-a', 'inst-visible', 'active@acme.com');
+      await seedInstallation(ctx.db, 'org-a', 'inst-hidden', 'departed@acme.com');
+      await hide(ctx.db, 'org-a', 'departed@acme.com');
+
+      const r = await supertest(app).post('/v1/admin/upgrade')
+        .set('Cookie', cookieAdmin)
+        .send({ targetVersion: '0.4.0', scope: { type: 'all' } });
+      expect(r.status).toBe(201);
+
+      const targets = await ctx.db.all<{ installation_id: string }>(
+        'SELECT installation_id FROM upgrade_directive_targets',
+      );
+      expect(targets.map(t => t.installation_id)).toEqual(['inst-visible']);
+    });
+
+    it('scope=installation naming a hidden person\'s install is rejected (409)', async () => {
+      await seedInstallation(ctx.db, 'org-a', 'inst-hidden', 'departed@acme.com');
+      await hide(ctx.db, 'org-a', 'departed@acme.com');
+
+      const r = await supertest(app).post('/v1/admin/upgrade')
+        .set('Cookie', cookieAdmin)
+        .send({ targetVersion: '0.4.0', scope: { type: 'installation', installationId: 'inst-hidden' } });
+      expect(r.status).toBe(409);
+      expect(r.body.error).toMatch(/hidden/i);
+
+      const directives = await ctx.db.all('SELECT id FROM upgrade_directives');
+      expect(directives).toHaveLength(0);
+    });
+
+    it('scope=installations including a hidden person\'s install is rejected (409)', async () => {
+      await seedInstallation(ctx.db, 'org-a', 'inst-visible', 'active@acme.com');
+      await seedInstallation(ctx.db, 'org-a', 'inst-hidden', 'departed@acme.com');
+      await hide(ctx.db, 'org-a', 'departed@acme.com');
+
+      const r = await supertest(app).post('/v1/admin/upgrade')
+        .set('Cookie', cookieAdmin)
+        .send({ targetVersion: '0.4.0', scope: { type: 'installations', installationIds: ['inst-visible', 'inst-hidden'] } });
+      expect(r.status).toBe(409);
+      expect(r.body.error).toMatch(/hidden/i);
+
+      const directives = await ctx.db.all('SELECT id FROM upgrade_directives');
+      expect(directives).toHaveLength(0);
+    });
+
+    it('scope=installation on a visible install still works', async () => {
+      await seedInstallation(ctx.db, 'org-a', 'inst-visible', 'active@acme.com');
+
+      const r = await supertest(app).post('/v1/admin/upgrade')
+        .set('Cookie', cookieAdmin)
+        .send({ targetVersion: '0.4.0', scope: { type: 'installation', installationId: 'inst-visible' } });
+      expect(r.status).toBe(201);
+    });
+  });
+});

--- a/packages/hub/src/test/hidden-users-db.test.ts
+++ b/packages/hub/src/test/hidden-users-db.test.ts
@@ -1,0 +1,118 @@
+// Tests for the hidden_users table (CGLAB-31): schema bootstrap on both
+// backends (SQLite + pg-mem), basic hide/unhide/list semantics at the SQL
+// level, and org-rename registration so hidden rows follow an org rename.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import type { HubDb } from '../db/types';
+import { openSqliteDb } from '../db/sqlite';
+import { openPgMemDb } from '../db/postgres';
+
+const TEST_DB = path.join(os.tmpdir(), `agenfk-hidden-users-db-${process.pid}.sqlite`);
+const cleanup = () => {
+  for (const suffix of ['', '-wal', '-shm']) {
+    const f = TEST_DB + suffix;
+    if (fs.existsSync(f)) fs.unlinkSync(f);
+  }
+};
+
+function backendSuite(name: string, open: () => Promise<HubDb>, introspect: (db: HubDb) => Promise<string[]>) {
+  describe(`hidden_users table (${name})`, () => {
+    let db: HubDb;
+
+    beforeEach(async () => {
+      cleanup();
+      db = await open();
+    });
+
+    afterEach(async () => {
+      try { await db.close(); } catch { /* already closed */ }
+      cleanup();
+    });
+
+    it('bootstrap creates the hidden_users table', async () => {
+      const names = await introspect(db);
+      expect(names).toContain('hidden_users');
+    });
+
+    it('stores a hidden person keyed on (org_id, user_key)', async () => {
+      await db.run(
+        `INSERT INTO hidden_users (org_id, user_key, hidden_by_user_id, hidden_by_email)
+         VALUES (?, ?, ?, ?)`,
+        ['org', 'departed@acme.com', 'u-admin', 'admin@acme.com'],
+      );
+      const row = await db.get<{ org_id: string; user_key: string; hidden_by_email: string; created_at: unknown }>(
+        'SELECT org_id, user_key, hidden_by_email, created_at FROM hidden_users WHERE org_id = ? AND user_key = ?',
+        ['org', 'departed@acme.com'],
+      );
+      expect(row?.org_id).toBe('org');
+      expect(row?.user_key).toBe('departed@acme.com');
+      expect(row?.hidden_by_email).toBe('admin@acme.com');
+      expect(row?.created_at).toBeTruthy();
+    });
+
+    it('enforces the (org_id, user_key) primary key — same person can be hidden in two orgs but not twice in one', async () => {
+      await db.run(
+        `INSERT INTO hidden_users (org_id, user_key) VALUES (?, ?)`,
+        ['org', 'departed@acme.com'],
+      );
+      // Same user_key in a different org is fine.
+      await db.run(
+        `INSERT INTO hidden_users (org_id, user_key) VALUES (?, ?)`,
+        ['other-org', 'departed@acme.com'],
+      );
+      // Duplicate in the same org must throw.
+      await expect(
+        db.run(`INSERT INTO hidden_users (org_id, user_key) VALUES (?, ?)`, ['org', 'departed@acme.com']),
+      ).rejects.toThrow();
+    });
+
+    it('delete reverses the hide (unhide)', async () => {
+      await db.run(`INSERT INTO hidden_users (org_id, user_key) VALUES (?, ?)`, ['org', 'departed@acme.com']);
+      const r = await db.run('DELETE FROM hidden_users WHERE org_id = ? AND user_key = ?', ['org', 'departed@acme.com']);
+      expect(r.changes).toBe(1);
+      expect(await db.get('SELECT user_key FROM hidden_users WHERE org_id = ?', ['org'])).toBeUndefined();
+    });
+
+    it('list query returns all hidden people for an org', async () => {
+      await db.run(`INSERT INTO hidden_users (org_id, user_key) VALUES (?, ?)`, ['org', 'a@acme.com']);
+      await db.run(`INSERT INTO hidden_users (org_id, user_key) VALUES (?, ?)`, ['org', 'b@acme.com']);
+      await db.run(`INSERT INTO hidden_users (org_id, user_key) VALUES (?, ?)`, ['other', 'c@acme.com']);
+      const rows = await db.all<{ user_key: string }>(
+        'SELECT user_key FROM hidden_users WHERE org_id = ? ORDER BY user_key',
+        ['org'],
+      );
+      expect(rows.map(r => r.user_key)).toEqual(['a@acme.com', 'b@acme.com']);
+    });
+  });
+}
+
+backendSuite(
+  'sqlite',
+  () => openSqliteDb(TEST_DB),
+  async (db) => {
+    const rows = await db.all<{ name: string }>("SELECT name FROM sqlite_master WHERE type='table'");
+    return rows.map(r => r.name);
+  },
+);
+
+backendSuite(
+  'postgres',
+  () => openPgMemDb(),
+  async (db) => {
+    const rows = await db.all<{ table_name: string }>(
+      "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'",
+    );
+    return rows.map(r => r.table_name);
+  },
+);
+
+describe('hidden_users org-rename registration', () => {
+  it('ORG_ID_CHILD_TABLES includes hidden_users so rows follow an org rename', async () => {
+    const mod = await import('../routes/orgRename');
+    const tables = (mod as any).ORG_ID_CHILD_TABLES as string[];
+    expect(tables).toContain('hidden_users');
+  });
+});

--- a/packages/hub/src/test/hub-pg-parity.test.ts
+++ b/packages/hub/src/test/hub-pg-parity.test.ts
@@ -154,6 +154,23 @@ describe('PG parity: admin endpoints', () => {
     expect(await fx.db.get('SELECT id FROM installations WHERE id = ?', ['inst-1'])).toBeUndefined();
     expect(await fx.db.get('SELECT id FROM installations WHERE id = ?', ['inst-2'])).toBeTruthy();
   });
+
+  it('fleet exclusions: installations list hides + scope=all skips hidden on PG (CGLAB-31)', async () => {
+    for (const [id, email] of [['inst-vis', 'active@acme.com'], ['inst-hid', 'departed@acme.com']] as const) {
+      await fx.db.run(
+        `INSERT INTO installations (id, org_id, first_seen, last_seen, os_user, git_email, agenfk_version)
+         VALUES (?, ?, now(), now(), 'u', ?, '0.3.0')`,
+        [id, 'org', email],
+      );
+    }
+    await fx.db.run('INSERT INTO hidden_users (org_id, user_key) VALUES (?, ?)', ['org', 'departed@acme.com']);
+
+    const def = await supertest(fx.app).get('/v1/admin/installations').set('Cookie', fx.cookie);
+    expect(def.body.map((i: any) => i.id)).toEqual(['inst-vis']);
+    const incl = await supertest(fx.app).get('/v1/admin/installations?includeHidden=1').set('Cookie', fx.cookie);
+    expect(incl.body).toHaveLength(2);
+    expect(incl.body.find((i: any) => i.id === 'inst-hid').hidden).toBe(true);
+  });
 });
 
 describe('PG parity: connect (device + invite)', () => {

--- a/packages/hub/src/test/hub-pg-parity.test.ts
+++ b/packages/hub/src/test/hub-pg-parity.test.ts
@@ -106,6 +106,37 @@ describe('PG parity: admin endpoints', () => {
       .send({ email: 'new@x', password: 'longenough1', role: 'viewer' });
     expect(dup.status).toBe(409);
   });
+
+  it('hidden-users: hide lists, revokes installation api_keys, unhide reverses (CGLAB-31)', async () => {
+    await fx.db.run(
+      `INSERT INTO installations (id, org_id, first_seen, last_seen, os_user, git_email)
+       VALUES (?, ?, now(), now(), ?, ?)`,
+      ['inst-gone', 'org', 'gone', 'departed@acme.com'],
+    );
+    await fx.db.run(
+      `INSERT INTO api_keys (token_hash, org_id, label, installation_id) VALUES (?, ?, ?, ?)`,
+      ['hash-gone', 'org', 'k', 'inst-gone'],
+    );
+
+    const hide = await supertest(fx.app).post('/v1/admin/hidden-users').set('Cookie', fx.cookie)
+      .send({ userKey: 'Departed@Acme.com' });
+    expect(hide.status).toBe(201);
+    expect(hide.body.userKey).toBe('departed@acme.com');
+    expect(hide.body.revokedApiKeys).toBe(1);
+
+    const list = await supertest(fx.app).get('/v1/admin/hidden-users').set('Cookie', fx.cookie);
+    expect(list.body.map((u: any) => u.userKey)).toEqual(['departed@acme.com']);
+
+    const key = await fx.db.get<{ revoked_at: string | null }>(
+      'SELECT revoked_at FROM api_keys WHERE token_hash = ?', ['hash-gone'],
+    );
+    expect(key?.revoked_at).toBeTruthy();
+
+    const unhide = await supertest(fx.app).delete('/v1/admin/hidden-users/departed%40acme.com').set('Cookie', fx.cookie);
+    expect(unhide.body.unhidden).toBe(true);
+    const after = await supertest(fx.app).get('/v1/admin/hidden-users').set('Cookie', fx.cookie);
+    expect(after.body).toHaveLength(0);
+  });
 });
 
 describe('PG parity: connect (device + invite)', () => {

--- a/packages/hub/src/test/hub-pg-parity.test.ts
+++ b/packages/hub/src/test/hub-pg-parity.test.ts
@@ -137,6 +137,23 @@ describe('PG parity: admin endpoints', () => {
     const after = await supertest(fx.app).get('/v1/admin/hidden-users').set('Cookie', fx.cookie);
     expect(after.body).toHaveLength(0);
   });
+
+  it('events ingest drops hidden people before the installations upsert on PG (CGLAB-31)', async () => {
+    await fx.db.run('INSERT INTO hidden_users (org_id, user_key) VALUES (?, ?)', ['org', 'alice@acme.com']);
+    const r = await supertest(fx.app).post('/v1/events')
+      .set('Authorization', `Bearer ${fx.token}`)
+      .send({ events: [
+        sample({ eventId: 'h1', actor: { osUser: 'alice', gitName: 'A', gitEmail: 'Alice@Acme.com' } }),
+        sample({ eventId: 'v1', installationId: 'inst-2', actor: { osUser: 'bob', gitName: 'B', gitEmail: 'bob@acme.com' } }),
+      ] });
+    expect(r.status).toBe(200);
+    expect(r.body.ingested).toBe(1);
+    expect(r.body.hiddenDropped).toBe(1);
+    const evts = await fx.db.all<{ event_id: string }>('SELECT event_id FROM events');
+    expect(evts.map(e => e.event_id)).toEqual(['v1']);
+    expect(await fx.db.get('SELECT id FROM installations WHERE id = ?', ['inst-1'])).toBeUndefined();
+    expect(await fx.db.get('SELECT id FROM installations WHERE id = ?', ['inst-2'])).toBeTruthy();
+  });
 });
 
 describe('PG parity: connect (device + invite)', () => {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/server",
-  "version": "1.1.12-beta.2",
+  "version": "1.1.12",
   "description": "MCP Server for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -12,9 +12,9 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.12-beta.2",
-    "@agenfk/storage-sqlite": "1.1.12-beta.2",
-    "@agenfk/telemetry": "1.1.12-beta.2",
+    "@agenfk/core": "1.1.12",
+    "@agenfk/storage-sqlite": "1.1.12",
+    "@agenfk/telemetry": "1.1.12",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "axios": "^1.13.5",
     "body-parser": "^2.2.2",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/server",
-  "version": "1.1.11",
+  "version": "1.1.12-beta.1",
   "description": "MCP Server for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -12,9 +12,9 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.11",
-    "@agenfk/storage-sqlite": "1.1.11",
-    "@agenfk/telemetry": "1.1.11",
+    "@agenfk/core": "1.1.12-beta.1",
+    "@agenfk/storage-sqlite": "1.1.12-beta.1",
+    "@agenfk/telemetry": "1.1.12-beta.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "axios": "^1.13.5",
     "body-parser": "^2.2.2",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/server",
-  "version": "1.1.12-beta.1",
+  "version": "1.1.12-beta.2",
   "description": "MCP Server for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -12,9 +12,9 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.12-beta.1",
-    "@agenfk/storage-sqlite": "1.1.12-beta.1",
-    "@agenfk/telemetry": "1.1.12-beta.1",
+    "@agenfk/core": "1.1.12-beta.2",
+    "@agenfk/storage-sqlite": "1.1.12-beta.2",
+    "@agenfk/telemetry": "1.1.12-beta.2",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "axios": "^1.13.5",
     "body-parser": "^2.2.2",

--- a/packages/storage-sqlite/package.json
+++ b/packages/storage-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/storage-sqlite",
-  "version": "1.1.11",
+  "version": "1.1.12-beta.1",
   "description": "SQLite storage implementation for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -11,7 +11,7 @@
     "uuid": "^14.0.1"
   },
   "devDependencies": {
-    "@agenfk/core": "1.1.11",
+    "@agenfk/core": "1.1.12-beta.1",
     "@types/node": "^22.0.0",
     "@types/uuid": "^9.0.8",
     "typescript": "^5.3.3"

--- a/packages/storage-sqlite/package.json
+++ b/packages/storage-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/storage-sqlite",
-  "version": "1.1.12-beta.2",
+  "version": "1.1.12",
   "description": "SQLite storage implementation for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -11,7 +11,7 @@
     "uuid": "^14.0.1"
   },
   "devDependencies": {
-    "@agenfk/core": "1.1.12-beta.2",
+    "@agenfk/core": "1.1.12",
     "@types/node": "^22.0.0",
     "@types/uuid": "^9.0.8",
     "typescript": "^5.3.3"

--- a/packages/storage-sqlite/package.json
+++ b/packages/storage-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/storage-sqlite",
-  "version": "1.1.12-beta.1",
+  "version": "1.1.12-beta.2",
   "description": "SQLite storage implementation for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -11,7 +11,7 @@
     "uuid": "^14.0.1"
   },
   "devDependencies": {
-    "@agenfk/core": "1.1.12-beta.1",
+    "@agenfk/core": "1.1.12-beta.2",
     "@types/node": "^22.0.0",
     "@types/uuid": "^9.0.8",
     "typescript": "^5.3.3"

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/telemetry",
-  "version": "1.1.12-beta.1",
+  "version": "1.1.12-beta.2",
   "description": "Anonymous telemetry client for AgenFK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/telemetry",
-  "version": "1.1.12-beta.2",
+  "version": "1.1.12",
   "description": "Anonymous telemetry client for AgenFK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/telemetry",
-  "version": "1.1.11",
+  "version": "1.1.12-beta.1",
   "description": "Anonymous telemetry client for AgenFK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.1.11",
+  "version": "1.1.12-beta.1",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -12,7 +12,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.1.11",
+    "@agenfk/flow-editor": "1.1.12-beta.1",
     "@tailwindcss/postcss": "^4.2.0",
     "@tailwindcss/typography": "^0.5.19",
     "@tanstack/react-query": "^5.90.21",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.1.12-beta.1",
+  "version": "1.1.12-beta.2",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -12,7 +12,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.1.12-beta.1",
+    "@agenfk/flow-editor": "1.1.12-beta.2",
     "@tailwindcss/postcss": "^4.2.0",
     "@tailwindcss/typography": "^0.5.19",
     "@tanstack/react-query": "^5.90.21",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.1.12-beta.2",
+  "version": "1.1.12",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -12,7 +12,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.1.12-beta.2",
+    "@agenfk/flow-editor": "1.1.12",
     "@tailwindcss/postcss": "^4.2.0",
     "@tailwindcss/typography": "^0.5.19",
     "@tanstack/react-query": "^5.90.21",

--- a/packages/ui/src/api.ts
+++ b/packages/ui/src/api.ts
@@ -126,13 +126,8 @@ export const api = {
     }
   },
   getJiraStatus: async (): Promise<{ configured: boolean; connected: boolean; cloudId?: string; email?: string; message?: string; reason?: string }> => {
-    try {
-      const { data } = await axios.get(`${API_URL}/jira/status`);
-      return data;
-    } catch (e) {
-      console.error('API Error getting JIRA status:', e);
-      return { configured: false, connected: false };
-    }
+    const { data } = await axios.get(`${API_URL}/jira/status`);
+    return data;
   },
   disconnectJira: async (): Promise<void> => {
     try {

--- a/packages/ui/src/api.ts
+++ b/packages/ui/src/api.ts
@@ -126,8 +126,13 @@ export const api = {
     }
   },
   getJiraStatus: async (): Promise<{ configured: boolean; connected: boolean; cloudId?: string; email?: string; message?: string; reason?: string }> => {
-    const { data } = await axios.get(`${API_URL}/jira/status`);
-    return data;
+    try {
+      const { data } = await axios.get(`${API_URL}/jira/status`);
+      return data;
+    } catch (e) {
+      console.error('API Error getting JIRA status:', e);
+      return { configured: false, connected: false };
+    }
   },
   disconnectJira: async (): Promise<void> => {
     try {

--- a/packages/ui/src/components/KanbanBoard.tsx
+++ b/packages/ui/src/components/KanbanBoard.tsx
@@ -752,6 +752,10 @@ export const KanbanBoard: React.FC = () => {
     [projects, projectSearch]
   );
 
+  // Clamp an index into [0, n-1]; returns -1 when the list is empty.
+  const clampIndex = (next: number, n: number): number =>
+    n === 0 ? -1 : Math.min(Math.max(next, 0), n - 1);
+
   // Keyboard navigation in the project picker — works anywhere when the picker
   // is open (first-load screen or overlay), so you don't need to focus the
   // search box first. Skips when creating a new project so Enter stays free.
@@ -760,19 +764,34 @@ export const KanbanBoard: React.FC = () => {
     if (!pickerVisible || isCreatingProject) return;
     const cols = columnCount;
     const n = sortedFilteredProjects.length;
+
     const onKeyDown = (e: KeyboardEvent) => {
+      const caretTarget =
+        e.target instanceof HTMLInputElement &&
+        e.target.getAttribute('aria-label') === 'Search projects'
+          ? e.target
+          : null;
+
       if (e.key === 'ArrowDown') {
         e.preventDefault();
-        setHighlightedProjectIndex(prev => prev === -1 ? 0 : Math.min(prev + cols, n - 1));
+        setHighlightedProjectIndex(prev => clampIndex(prev === -1 ? 0 : prev + cols, n));
       } else if (e.key === 'ArrowUp') {
         e.preventDefault();
-        setHighlightedProjectIndex(prev => prev === -1 ? 0 : Math.max(prev - cols, 0));
+        setHighlightedProjectIndex(prev => clampIndex(prev === -1 ? 0 : prev - cols, n));
       } else if (e.key === 'ArrowRight') {
+        // Boundary-aware: let the browser move the caret when it can.
+        if (caretTarget && (caretTarget.selectionEnd ?? 0) < caretTarget.value.length) {
+          return; // caret can move right — do nothing
+        }
         e.preventDefault();
-        setHighlightedProjectIndex(prev => prev === -1 ? 0 : Math.min(prev + 1, n - 1));
+        setHighlightedProjectIndex(prev => clampIndex(prev === -1 ? 0 : prev + 1, n));
       } else if (e.key === 'ArrowLeft') {
+        // Boundary-aware: let the browser move the caret when it can.
+        if (caretTarget && (caretTarget.selectionStart ?? 0) > 0) {
+          return; // caret can move left — do nothing
+        }
         e.preventDefault();
-        setHighlightedProjectIndex(prev => prev === -1 ? 0 : Math.max(prev - 1, 0));
+        setHighlightedProjectIndex(prev => clampIndex(prev === -1 ? 0 : prev - 1, n));
       } else if (e.key === 'Enter') {
         if (highlightedProjectIndex >= 0 && highlightedProjectIndex < sortedFilteredProjects.length) {
           handleSelectProject(sortedFilteredProjects[highlightedProjectIndex].id);
@@ -782,6 +801,15 @@ export const KanbanBoard: React.FC = () => {
     document.addEventListener('keydown', onKeyDown);
     return () => document.removeEventListener('keydown', onKeyDown);
   }, [selectedProjectId, isPickerOpen, isCreatingProject, sortedFilteredProjects, highlightedProjectIndex, columnCount]);
+
+  // Scroll the highlighted option into view when the index changes
+  useEffect(() => {
+    if (highlightedProjectIndex < 0) return;
+    const project = sortedFilteredProjects[highlightedProjectIndex];
+    if (!project) return;
+    const el = document.getElementById(`project-option-${project.id}`);
+    el?.scrollIntoView?.({ block: 'nearest' });
+  }, [highlightedProjectIndex, sortedFilteredProjects]);
 
   // Auto-focus the project-picker search input when the picker opens
   const pickerHasProjects = projects != null && projects.length > 0;
@@ -1068,7 +1096,7 @@ export const KanbanBoard: React.FC = () => {
   // Project Selection Screen
 
   const projectPickerCard = (
-        <div data-testid="project-picker-panel" role="dialog" aria-modal="true" aria-label="Project picker" className="relative w-full max-w-4xl bg-white dark:bg-slate-900 rounded-2xl shadow-xl border border-slate-200 dark:border-slate-800 p-8 text-center">
+        <div data-testid="project-picker-panel" role="dialog" aria-modal="true" aria-label="Project picker" className={`relative w-full bg-white dark:bg-slate-900 rounded-2xl shadow-xl border border-slate-200 dark:border-slate-800 p-8 text-center ${isCreatingProject ? 'max-w-md' : 'max-w-4xl'}`}>
           {selectedProjectId && (
             <button
               aria-label="Close project picker"
@@ -1100,7 +1128,7 @@ export const KanbanBoard: React.FC = () => {
                 />
                 <div className="grid gap-2 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 max-h-[60vh] overflow-y-auto" role="listbox" aria-label="Projects" data-columns={columnCount}>
                   {projectSearch.trim() !== '' && sortedFilteredProjects.length === 0 ? (
-                    <p className="text-sm text-slate-400 py-4 text-center">No projects match "{projectSearch}"</p>
+                    <p className="col-span-full text-sm text-slate-400 py-4 text-center">No projects match "{projectSearch}"</p>
                   ) : (
                     sortedFilteredProjects.map((p, index) => (
                     <div
@@ -1203,7 +1231,7 @@ export const KanbanBoard: React.FC = () => {
   // First load / no project chosen yet: full-screen, not dismissable (no close button).
   if (!selectedProjectId) {
     return (
-      <div data-testid="project-picker-backdrop" className="flex h-screen w-full flex-col items-center justify-center bg-slate-50 dark:bg-slate-950 p-6">
+      <div data-testid="project-picker-backdrop" className="flex h-screen w-full flex-col items-center justify-center overflow-y-auto bg-slate-50 dark:bg-slate-950 p-6">
         <Logo size={64} className="mb-8" />
         {projectPickerCard}
       </div>
@@ -1813,7 +1841,7 @@ export const KanbanBoard: React.FC = () => {
         <div
           data-testid="project-picker-backdrop"
           onClick={(e) => { if (e.target === e.currentTarget) closePicker(); }}
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-6"
+          className="fixed inset-0 z-50 flex items-center justify-center overflow-y-auto bg-black/50 backdrop-blur-sm p-6"
         >
           {projectPickerCard}
         </div>

--- a/packages/ui/src/components/KanbanBoard.tsx
+++ b/packages/ui/src/components/KanbanBoard.tsx
@@ -246,7 +246,7 @@ const KanbanCard: React.FC<KanbanCardProps> = ({
             {item.type}
           </span>
           {(item.type === ItemType.EPIC || item.type === ItemType.STORY) && items?.some((i: AgEnFKItem) => i.parentId === item.id) && (
-            <button onClick={(e) => { e.stopPropagation(); onDrillDown(item); }} className="bg-indigo-50 dark:bg-indigo-900/30 hover:bg-indigo-100 dark:hover:bg-indigo-800 text-indigo-600 dark:text-indigo-400 px-1.5 py-0.5 rounded text-[9px] font-bold flex items-center gap-1 transition-colors">
+            <button onClick={(e) => { e.stopPropagation(); onDrillDown(item); }} className="bg-indigo-50 dark:bg-indigo-900/30 hover:bg-indigo-100 dark:hover:bg-indigo-800 text-indigo-600 dark:text-indigo-400 px-1.5 py-0.5 rounded text-[9px] font-bold flex items-center gap-1 transition-colors" aria-label={`Show ${items?.filter((i: AgEnFKItem) => i.parentId === item.id).length} child items`}>
               <Search size={9} /> {items?.filter((i: AgEnFKItem) => i.parentId === item.id).length}
             </button>
           )}
@@ -737,6 +737,7 @@ export const KanbanBoard: React.FC = () => {
         setIsPickerOpen(false);
         setIsCreatingProject(false);
         setProjectSearch('');
+        setHighlightedProjectIndex(-1);
       }
     };
     document.addEventListener('keydown', onKeyDown);
@@ -1106,7 +1107,7 @@ export const KanbanBoard: React.FC = () => {
   // Project Selection Screen
 
   const projectPickerCard = (
-        <div data-testid="project-picker-panel" role="dialog" aria-modal="true" aria-label="Project picker" className={`relative w-full bg-white dark:bg-slate-900 rounded-2xl shadow-xl border border-slate-200 dark:border-slate-800 p-8 text-center ${isCreatingProject ? 'max-w-md' : 'max-w-4xl'}`}>
+        <div data-testid="project-picker-panel" role="dialog" aria-modal="true" aria-label="Project picker" className={`relative w-full my-auto bg-white dark:bg-slate-900 rounded-2xl shadow-xl border border-slate-200 dark:border-slate-800 p-8 text-center ${isCreatingProject ? 'max-w-md' : 'max-w-4xl'}`}>
           {selectedProjectId && (
             <button
               aria-label="Close project picker"

--- a/packages/ui/src/components/KanbanBoard.tsx
+++ b/packages/ui/src/components/KanbanBoard.tsx
@@ -734,6 +734,13 @@ export const KanbanBoard: React.FC = () => {
     if (!selectedProjectId || (!isPickerOpen && !isCreatingProject)) return;
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
+        // Escape answers the innermost question first: an armed delete confirm
+        // is cancelled, and the picker stays open. Closing the whole picker
+        // would dismiss the prompt without the user ever answering it.
+        if (confirmDeleteProjectId !== null) {
+          setConfirmDeleteProjectId(null);
+          return;
+        }
         setIsPickerOpen(false);
         setIsCreatingProject(false);
         setProjectSearch('');
@@ -742,7 +749,7 @@ export const KanbanBoard: React.FC = () => {
     };
     document.addEventListener('keydown', onKeyDown);
     return () => document.removeEventListener('keydown', onKeyDown);
-  }, [selectedProjectId, isPickerOpen, isCreatingProject]);
+  }, [selectedProjectId, isPickerOpen, isCreatingProject, confirmDeleteProjectId]);
 
   // Single source of truth for the sorted+filtered project list.
   // Placed before the early-return so hook order is always stable.
@@ -769,6 +776,32 @@ export const KanbanBoard: React.FC = () => {
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.shiftKey || e.metaKey || e.altKey || e.ctrlKey || e.isComposing) {
         return;
+      }
+
+      // A delete confirmation is a modal question about one specific project.
+      // Enter must not fall through to "open the highlighted project" while it
+      // is armed — the keystroke was aimed at the confirm, and answering it by
+      // navigating elsewhere is the wrong action for a destructive prompt.
+      // Enter is deliberately inert here rather than confirming: Enter must
+      // never be the key that deletes something. Arrow keys disarm instead,
+      // since moving the highlight away abandons the question.
+      // Escape is handled here rather than in the picker-dismiss effect below,
+      // because that effect is only mounted once a project is selected — on the
+      // first-load picker there is no board to return to, so it never attaches.
+      // The confirm can be armed on that screen too, and must be cancellable.
+      if (confirmDeleteProjectId !== null) {
+        if (e.key === 'Escape') {
+          e.preventDefault();
+          setConfirmDeleteProjectId(null);
+          return;
+        }
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          return;
+        }
+        if (e.key === 'ArrowDown' || e.key === 'ArrowUp' || e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+          setConfirmDeleteProjectId(null);
+        }
       }
 
       const caretTarget =
@@ -811,7 +844,7 @@ export const KanbanBoard: React.FC = () => {
     };
     document.addEventListener('keydown', onKeyDown);
     return () => document.removeEventListener('keydown', onKeyDown);
-  }, [selectedProjectId, isPickerOpen, isCreatingProject, sortedFilteredProjects, highlightedProjectIndex, columnCount]);
+  }, [selectedProjectId, isPickerOpen, isCreatingProject, sortedFilteredProjects, highlightedProjectIndex, columnCount, confirmDeleteProjectId]);
 
   // Scroll the highlighted option into view when the index changes
   useEffect(() => {
@@ -1184,6 +1217,7 @@ export const KanbanBoard: React.FC = () => {
                             onClick={(e) => { e.stopPropagation(); setConfirmDeleteProjectId(p.id); }}
                             className="opacity-0 group-hover:opacity-100 p-1 rounded-lg text-slate-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 transition-all"
                             title="Delete project"
+                            aria-label={`Delete project ${p.name}`}
                           >
                             <Trash2 size={16} />
                           </button>

--- a/packages/ui/src/components/KanbanBoard.tsx
+++ b/packages/ui/src/components/KanbanBoard.tsx
@@ -766,6 +766,10 @@ export const KanbanBoard: React.FC = () => {
     const n = sortedFilteredProjects.length;
 
     const onKeyDown = (e: KeyboardEvent) => {
+      if (e.shiftKey || e.metaKey || e.altKey || e.ctrlKey || e.isComposing) {
+        return;
+      }
+
       const caretTarget =
         e.target instanceof HTMLInputElement &&
         e.target.getAttribute('aria-label') === 'Search projects'
@@ -783,12 +787,18 @@ export const KanbanBoard: React.FC = () => {
         if (caretTarget && (caretTarget.selectionEnd ?? 0) < caretTarget.value.length) {
           return; // caret can move right — do nothing
         }
+        if (caretTarget && caretTarget.selectionStart !== caretTarget.selectionEnd) {
+          return; // selection exists — let browser handle it
+        }
         e.preventDefault();
         setHighlightedProjectIndex(prev => clampIndex(prev === -1 ? 0 : prev + 1, n));
       } else if (e.key === 'ArrowLeft') {
         // Boundary-aware: let the browser move the caret when it can.
         if (caretTarget && (caretTarget.selectionStart ?? 0) > 0) {
           return; // caret can move left — do nothing
+        }
+        if (caretTarget && caretTarget.selectionStart !== caretTarget.selectionEnd) {
+          return; // selection exists — let browser handle it
         }
         e.preventDefault();
         setHighlightedProjectIndex(prev => clampIndex(prev === -1 ? 0 : prev - 1, n));

--- a/packages/ui/src/components/KanbanBoard.tsx
+++ b/packages/ui/src/components/KanbanBoard.tsx
@@ -404,6 +404,26 @@ export const KanbanBoard: React.FC = () => {
   const [confirmDeleteProjectId, setConfirmDeleteProjectId] = useState<string | null>(null);
   const [isPickerOpen, setIsPickerOpen] = useState(false);
 
+  // Responsive column count for the project-picker grid
+  const [columnCount, setColumnCount] = useState(1);
+  useEffect(() => {
+    if (typeof window.matchMedia === 'undefined') return;
+    const mq3 = window.matchMedia('(min-width: 1024px)');
+    const mq2 = window.matchMedia('(min-width: 640px)');
+    const update = () => {
+      if (mq3.matches) setColumnCount(3);
+      else if (mq2.matches) setColumnCount(2);
+      else setColumnCount(1);
+    };
+    update();
+    mq3.addEventListener('change', update);
+    mq2.addEventListener('change', update);
+    return () => {
+      mq3.removeEventListener('change', update);
+      mq2.removeEventListener('change', update);
+    };
+  }, []);
+
   const togglePin = () => {
     setIsPinned(prev => {
       const next = !prev;
@@ -738,13 +758,21 @@ export const KanbanBoard: React.FC = () => {
   useEffect(() => {
     const pickerVisible = selectedProjectId === null || isPickerOpen;
     if (!pickerVisible || isCreatingProject) return;
+    const cols = columnCount;
+    const n = sortedFilteredProjects.length;
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'ArrowDown') {
         e.preventDefault();
-        setHighlightedProjectIndex(prev => Math.min(prev + 1, sortedFilteredProjects.length - 1));
+        setHighlightedProjectIndex(prev => prev === -1 ? 0 : Math.min(prev + cols, n - 1));
       } else if (e.key === 'ArrowUp') {
         e.preventDefault();
-        setHighlightedProjectIndex(prev => prev > 0 ? prev - 1 : 0);
+        setHighlightedProjectIndex(prev => prev === -1 ? 0 : Math.max(prev - cols, 0));
+      } else if (e.key === 'ArrowRight') {
+        e.preventDefault();
+        setHighlightedProjectIndex(prev => prev === -1 ? 0 : Math.min(prev + 1, n - 1));
+      } else if (e.key === 'ArrowLeft') {
+        e.preventDefault();
+        setHighlightedProjectIndex(prev => prev === -1 ? 0 : Math.max(prev - 1, 0));
       } else if (e.key === 'Enter') {
         if (highlightedProjectIndex >= 0 && highlightedProjectIndex < sortedFilteredProjects.length) {
           handleSelectProject(sortedFilteredProjects[highlightedProjectIndex].id);
@@ -753,7 +781,7 @@ export const KanbanBoard: React.FC = () => {
     };
     document.addEventListener('keydown', onKeyDown);
     return () => document.removeEventListener('keydown', onKeyDown);
-  }, [selectedProjectId, isPickerOpen, isCreatingProject, sortedFilteredProjects, highlightedProjectIndex]);
+  }, [selectedProjectId, isPickerOpen, isCreatingProject, sortedFilteredProjects, highlightedProjectIndex, columnCount]);
 
   // Auto-focus the project-picker search input when the picker opens
   const pickerHasProjects = projects != null && projects.length > 0;
@@ -1040,7 +1068,7 @@ export const KanbanBoard: React.FC = () => {
   // Project Selection Screen
 
   const projectPickerCard = (
-        <div data-testid="project-picker-panel" role="dialog" aria-modal="true" aria-label="Project picker" className="relative w-full max-w-md bg-white dark:bg-slate-900 rounded-2xl shadow-xl border border-slate-200 dark:border-slate-800 p-8 text-center">
+        <div data-testid="project-picker-panel" role="dialog" aria-modal="true" aria-label="Project picker" className="relative w-full max-w-4xl bg-white dark:bg-slate-900 rounded-2xl shadow-xl border border-slate-200 dark:border-slate-800 p-8 text-center">
           {selectedProjectId && (
             <button
               aria-label="Close project picker"
@@ -1070,7 +1098,7 @@ export const KanbanBoard: React.FC = () => {
                   aria-activedescendant={highlightedProjectIndex >= 0 && highlightedProjectIndex < sortedFilteredProjects.length ? `project-option-${sortedFilteredProjects[highlightedProjectIndex].id}` : undefined}
                   className="w-full p-3 rounded-xl border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-indigo-500 mb-2"
                 />
-                <div className="grid gap-2 max-h-72 overflow-y-auto" role="listbox" aria-label="Projects">
+                <div className="grid gap-2 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 max-h-[60vh] overflow-y-auto" role="listbox" aria-label="Projects" data-columns={columnCount}>
                   {projectSearch.trim() !== '' && sortedFilteredProjects.length === 0 ? (
                     <p className="text-sm text-slate-400 py-4 text-center">No projects match "{projectSearch}"</p>
                   ) : (

--- a/packages/ui/src/components/RunsPanel.tsx
+++ b/packages/ui/src/components/RunsPanel.tsx
@@ -34,10 +34,19 @@ export interface RunEvent {
   tokens?: number;
 }
 
-// Kinds whose text is machine output (command output, test results, diffs).
-// Rendering these through ReactMarkdown corrupts them: __init__ becomes bold,
-// pipe-aligned tables get reinterpreted, and diffs lose whitespace alignment.
-const MACHINE_OUTPUT_KINDS = new Set(['tool', 'result', 'diff'] as const);
+// Which kinds carry machine output (command output, test results, diffs) and so
+// must render literally, versus prose the agent wrote, which renders as markdown.
+// Keyed on the full kind union on purpose: adding a kind to RunEvent without
+// classifying it here is a compile error, not a silent default to markdown.
+const IS_MACHINE_OUTPUT: Record<RunEvent['kind'], boolean> = {
+  tool: true,
+  result: true,
+  diff: true,
+  dispatch: false,
+  think: false,
+  note: false,
+  verdict: false,
+};
 
 const LANE = {
   orchestrator: { label: 'orchestrator', ini: 'C', avatar: 'bg-indigo-500/60', tag: 'text-indigo-600 dark:text-indigo-300' },
@@ -135,10 +144,10 @@ const TranscriptRow = React.memo(function TranscriptRow({
           'font-mono text-[9px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded ' +
           'bg-slate-100 dark:bg-slate-800 ' + lane.tag
         }>{ev.kind}{ev.tool ? ' · ' + ev.tool : ''}</span>
-        {MACHINE_OUTPUT_KINDS.has(ev.kind as 'tool' | 'result' | 'diff') && ev.text && (
+        {IS_MACHINE_OUTPUT[ev.kind] && ev.text && (
           <pre className="mt-1 font-mono text-[11px] bg-slate-50 dark:bg-slate-800/60 border border-slate-200 dark:border-slate-700 rounded px-2 py-1 overflow-x-auto whitespace-pre-wrap break-words text-slate-700 dark:text-slate-200">{stripAnsi(ev.text)}</pre>
         )}
-        {!MACHINE_OUTPUT_KINDS.has(ev.kind as 'tool' | 'result' | 'diff') && ev.text && (
+        {!IS_MACHINE_OUTPUT[ev.kind] && ev.text && (
           <div className={'mt-1 text-[13px] break-words ' + (ev.kind === 'think' ? 'italic text-slate-500 dark:text-slate-400' : 'text-slate-700 dark:text-slate-200')}>
             <div className="prose prose-slate dark:prose-invert prose-sm max-w-none">
               <ReactMarkdown remarkPlugins={[remarkGfm]} components={mdComponents}>

--- a/packages/ui/src/components/RunsPanel.tsx
+++ b/packages/ui/src/components/RunsPanel.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { io } from 'socket.io-client';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import { api } from '../api';
 import { API_URL } from '../apiUrl';
+import { stripAnsi } from '../utils';
 
 export interface AgentRun {
   id: string;
@@ -209,7 +212,13 @@ export const RunsPanel: React.FC<{ itemId: string }> = ({ itemId }) => {
                     <pre className="mt-1 font-mono text-[11px] bg-slate-50 dark:bg-slate-800/60 border border-slate-200 dark:border-slate-700 rounded px-2 py-1 overflow-x-auto whitespace-pre-wrap break-words text-slate-700 dark:text-slate-200">{ev.text}</pre>
                   )}
                   {ev.kind !== 'tool' && ev.text && (
-                    <div className={'mt-1 text-[13px] break-words ' + (ev.kind === 'think' ? 'italic text-slate-500 dark:text-slate-400' : 'text-slate-700 dark:text-slate-200')}>{ev.text}</div>
+                    <div className={'mt-1 text-[13px] break-words ' + (ev.kind === 'think' ? 'italic text-slate-500 dark:text-slate-400' : 'text-slate-700 dark:text-slate-200')}>
+                      <div className="prose prose-slate dark:prose-invert prose-sm max-w-none">
+                        <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                          {stripAnsi(ev.text)}
+                        </ReactMarkdown>
+                      </div>
+                    </div>
                   )}
                   {typeof ev.tokens === 'number' && (
                     <span className="inline-block mt-1 font-mono text-[10px] text-slate-400 dark:text-slate-500">{fmtTokens(ev.tokens)} tok</span>

--- a/packages/ui/src/components/RunsPanel.tsx
+++ b/packages/ui/src/components/RunsPanel.tsx
@@ -34,6 +34,11 @@ export interface RunEvent {
   tokens?: number;
 }
 
+// Kinds whose text is machine output (command output, test results, diffs).
+// Rendering these through ReactMarkdown corrupts them: __init__ becomes bold,
+// pipe-aligned tables get reinterpreted, and diffs lose whitespace alignment.
+const MACHINE_OUTPUT_KINDS = new Set(['tool', 'result', 'diff'] as const);
+
 const LANE = {
   orchestrator: { label: 'orchestrator', ini: 'C', avatar: 'bg-indigo-500/60', tag: 'text-indigo-600 dark:text-indigo-300' },
   worker: { label: 'pi · worker', ini: 'π', avatar: 'bg-amber-500/60', tag: 'text-amber-600 dark:text-amber-300' },
@@ -130,10 +135,10 @@ const TranscriptRow = React.memo(function TranscriptRow({
           'font-mono text-[9px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded ' +
           'bg-slate-100 dark:bg-slate-800 ' + lane.tag
         }>{ev.kind}{ev.tool ? ' · ' + ev.tool : ''}</span>
-        {ev.kind === 'tool' && ev.text && (
+        {MACHINE_OUTPUT_KINDS.has(ev.kind as 'tool' | 'result' | 'diff') && ev.text && (
           <pre className="mt-1 font-mono text-[11px] bg-slate-50 dark:bg-slate-800/60 border border-slate-200 dark:border-slate-700 rounded px-2 py-1 overflow-x-auto whitespace-pre-wrap break-words text-slate-700 dark:text-slate-200">{stripAnsi(ev.text)}</pre>
         )}
-        {ev.kind !== 'tool' && ev.text && (
+        {!MACHINE_OUTPUT_KINDS.has(ev.kind as 'tool' | 'result' | 'diff') && ev.text && (
           <div className={'mt-1 text-[13px] break-words ' + (ev.kind === 'think' ? 'italic text-slate-500 dark:text-slate-400' : 'text-slate-700 dark:text-slate-200')}>
             <div className="prose prose-slate dark:prose-invert prose-sm max-w-none">
               <ReactMarkdown remarkPlugins={[remarkGfm]} components={mdComponents}>

--- a/packages/ui/src/components/RunsPanel.tsx
+++ b/packages/ui/src/components/RunsPanel.tsx
@@ -66,6 +66,90 @@ function prettyModel(model?: string): string {
   return family.charAt(0).toUpperCase() + family.slice(1);
 }
 
+// Components override for ReactMarkdown:
+//   img → render alt text as plain text (no remote image fetch from untrusted text)
+//   a   → open in new tab, rel="noopener noreferrer" (safe links)
+const mdComponents = {
+  img: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
+    <span>{(props as any).alt || '<image>'}</span>
+  ),
+  a: (props: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a {...props} target="_blank" rel="noopener noreferrer" />
+  ),
+};
+
+// Memoised transcript row — re-renders only when this row's own content
+// changes, so the live-panel path avoids re-parsing markdown for every
+// unchanged row on each websocket tick. Every arriving event invalidates the
+// run list, and react-query's structural sharing keeps `selected` referentially
+// stable when the refetched list is deep-equal, so the memo actually holds on
+// that path (measured: 0 row re-renders across 5 refetches at 50 rows). It only
+// gives way when the run object itself changes — e.g. status running -> done —
+// which happens once per run rather than once per event.
+const TranscriptRow = React.memo(function TranscriptRow({
+  ev,
+  selected,
+  isLast,
+}: {
+  ev: RunEvent;
+  selected: AgentRun | null;
+  isLast: boolean;
+}) {
+  const lane = LANE[ev.lane as keyof typeof LANE] || LANE.worker;
+  // Identity caption: for the lane that matches this run's own actor (the agent
+  // that ran it — pi worker, or the reviewer/orchestrator), show
+  // "<harness> · <model>" from the run, omitting the separator when the model is
+  // unknown. Cross-lane events (e.g. the orchestrator's dispatch inside a worker
+  // run) show their role label instead.
+  const who = ev.lane === selected?.actor
+    ? [selected?.harness, prettyModel(selected?.model)].filter(Boolean).join(' · ')
+    : lane.label;
+
+  return (
+    // The left gutter's border-r forms a faint, continuous timeline rail; each
+    // row stretches so the rail connects across events. The last row omits the
+    // bottom padding so the rail ends at the event rather than trailing past it.
+    <div className="flex gap-3">
+      <div className="flex flex-col items-start shrink-0 w-24 pr-3 border-r border-slate-200/70 dark:border-slate-700/50">
+        <span className={'w-6 h-6 rounded-md grid place-items-center font-mono text-xs font-bold text-white ' + lane.avatar}>{lane.ini}</span>
+        <span className={'mt-1 font-mono text-[10px] leading-tight break-words ' + lane.tag}>{who}</span>
+        {(() => {
+          const { date, time } = fmtTimestamp(ev.ts);
+          if (!date) return null;
+          return (
+            <span className="mt-0.5 font-mono text-[9px] leading-tight text-slate-400 dark:text-slate-500 break-words">
+              {date}
+              <br />
+              {time}
+            </span>
+          );
+        })()}
+      </div>
+      <div className={'min-w-0 flex-1 ' + (isLast ? '' : 'pb-4')}>
+        <span className={
+          'font-mono text-[9px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded ' +
+          'bg-slate-100 dark:bg-slate-800 ' + lane.tag
+        }>{ev.kind}{ev.tool ? ' · ' + ev.tool : ''}</span>
+        {ev.kind === 'tool' && ev.text && (
+          <pre className="mt-1 font-mono text-[11px] bg-slate-50 dark:bg-slate-800/60 border border-slate-200 dark:border-slate-700 rounded px-2 py-1 overflow-x-auto whitespace-pre-wrap break-words text-slate-700 dark:text-slate-200">{stripAnsi(ev.text)}</pre>
+        )}
+        {ev.kind !== 'tool' && ev.text && (
+          <div className={'mt-1 text-[13px] break-words ' + (ev.kind === 'think' ? 'italic text-slate-500 dark:text-slate-400' : 'text-slate-700 dark:text-slate-200')}>
+            <div className="prose prose-slate dark:prose-invert prose-sm max-w-none">
+              <ReactMarkdown remarkPlugins={[remarkGfm]} components={mdComponents}>
+                {stripAnsi(ev.text)}
+              </ReactMarkdown>
+            </div>
+          </div>
+        )}
+        {typeof ev.tokens === 'number' && (
+          <span className="inline-block mt-1 font-mono text-[10px] text-slate-400 dark:text-slate-500">{fmtTokens(ev.tokens)} tok</span>
+        )}
+      </div>
+    </div>
+  );
+});
+
 export const RunsPanel: React.FC<{ itemId: string }> = ({ itemId }) => {
   const queryClient = useQueryClient();
   const [selectedRunId, setSelectedRunId] = React.useState<string | null>(null);
@@ -172,61 +256,9 @@ export const RunsPanel: React.FC<{ itemId: string }> = ({ itemId }) => {
           )}
         </div>
         <div ref={logRef} className="flex-1 overflow-y-auto p-3" data-testid="runs-transcript">
-          {events.map((ev, i) => {
-            const lane = LANE[ev.lane] || LANE.worker;
-            // Identity caption: for the lane that matches this run's own actor
-            // (the agent that ran it — pi worker, or the reviewer/orchestrator),
-            // show "<harness> · <model>" from the run (omitting the separator
-            // when the model is unknown). Cross-lane events (e.g. the
-            // orchestrator's dispatch inside a worker run) show their role label.
-            const who = ev.lane === selected?.actor
-              ? [selected?.harness, prettyModel(selected?.model)].filter(Boolean).join(' · ')
-              : lane.label;
-            const isLast = i === events.length - 1;
-            return (
-              // The left gutter's border-r forms a faint, continuous timeline
-              // rail; each row stretches so the rail connects across events. The
-              // last row omits the bottom padding so the rail ends at the event.
-              <div key={ev.id} className="flex gap-3">
-                <div className="flex flex-col items-start shrink-0 w-24 pr-3 border-r border-slate-200/70 dark:border-slate-700/50">
-                  <span className={'w-6 h-6 rounded-md grid place-items-center font-mono text-xs font-bold text-white ' + lane.avatar}>{lane.ini}</span>
-                  <span className={'mt-1 font-mono text-[10px] leading-tight break-words ' + lane.tag}>{who}</span>
-                  {(() => {
-                    const { date, time } = fmtTimestamp(ev.ts);
-                    if (!date) return null;
-                    return (
-                      <span className="mt-0.5 font-mono text-[9px] leading-tight text-slate-400 dark:text-slate-500 break-words">
-                        {date}
-                        <br />
-                        {time}
-                      </span>
-                    );
-                  })()}
-                </div>
-                <div className={'min-w-0 flex-1 ' + (isLast ? '' : 'pb-4')}>
-                  <span className={
-                    'font-mono text-[9px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded ' +
-                    'bg-slate-100 dark:bg-slate-800 ' + lane.tag
-                  }>{ev.kind}{ev.tool ? ' · ' + ev.tool : ''}</span>
-                  {ev.kind === 'tool' && ev.text && (
-                    <pre className="mt-1 font-mono text-[11px] bg-slate-50 dark:bg-slate-800/60 border border-slate-200 dark:border-slate-700 rounded px-2 py-1 overflow-x-auto whitespace-pre-wrap break-words text-slate-700 dark:text-slate-200">{ev.text}</pre>
-                  )}
-                  {ev.kind !== 'tool' && ev.text && (
-                    <div className={'mt-1 text-[13px] break-words ' + (ev.kind === 'think' ? 'italic text-slate-500 dark:text-slate-400' : 'text-slate-700 dark:text-slate-200')}>
-                      <div className="prose prose-slate dark:prose-invert prose-sm max-w-none">
-                        <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                          {stripAnsi(ev.text)}
-                        </ReactMarkdown>
-                      </div>
-                    </div>
-                  )}
-                  {typeof ev.tokens === 'number' && (
-                    <span className="inline-block mt-1 font-mono text-[10px] text-slate-400 dark:text-slate-500">{fmtTokens(ev.tokens)} tok</span>
-                  )}
-                </div>
-              </div>
-            );
-          })}
+          {events.map((ev, i) => (
+            <TranscriptRow key={ev.id} ev={ev} selected={selected} isLast={i === events.length - 1} />
+          ))}
           {!events.length && <div className="text-xs text-slate-400 dark:text-slate-500 py-6 text-center">No events yet.</div>}
         </div>
       </div>

--- a/packages/ui/src/components/RunsPanel.tsx
+++ b/packages/ui/src/components/RunsPanel.tsx
@@ -41,6 +41,16 @@ function fmtTokens(n?: number): string {
   return typeof n === 'number' ? n.toLocaleString('en-US') : '';
 }
 
+function fmtTimestamp(ts?: string): { date?: string; time?: string } {
+  if (!ts) return {};
+  const d = new Date(ts);
+  if (isNaN(d.getTime())) return {};
+  return {
+    date: d.toLocaleDateString(),
+    time: d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+  };
+}
+
 // Short, human display name for a model id: the first meaningful alphabetic
 // family token (>=3 letters, so version bits like "v1"/"27b" are skipped),
 // title-cased. "qwen3.6:27b" -> "Qwen", "claude-opus-4-8" -> "Claude",
@@ -178,6 +188,17 @@ export const RunsPanel: React.FC<{ itemId: string }> = ({ itemId }) => {
                 <div className="flex flex-col items-start shrink-0 w-24 pr-3 border-r border-slate-200/70 dark:border-slate-700/50">
                   <span className={'w-6 h-6 rounded-md grid place-items-center font-mono text-xs font-bold text-white ' + lane.avatar}>{lane.ini}</span>
                   <span className={'mt-1 font-mono text-[10px] leading-tight break-words ' + lane.tag}>{who}</span>
+                  {(() => {
+                    const { date, time } = fmtTimestamp(ev.ts);
+                    if (!date) return null;
+                    return (
+                      <span className="mt-0.5 font-mono text-[9px] leading-tight text-slate-400 dark:text-slate-500 break-words">
+                        {date}
+                        <br />
+                        {time}
+                      </span>
+                    );
+                  })()}
                 </div>
                 <div className={'min-w-0 flex-1 ' + (isLast ? '' : 'pb-4')}>
                   <span className={

--- a/packages/ui/src/components/RunsPanel.tsx
+++ b/packages/ui/src/components/RunsPanel.tsx
@@ -80,6 +80,57 @@ function prettyModel(model?: string): string {
   return family.charAt(0).toUpperCase() + family.slice(1);
 }
 
+// Markdown emphasis rewrites literal text, and these transcripts are full of
+// identifiers. "AttributeError: '__init__' missing" would render as 'init' —
+// the WRONG SYMBOL NAME, with nothing to signal the text was transformed — and
+// "2*3*4" would come out as 2<em>3</em>4.
+//
+// Intent is not recoverable: `__init__` as a literal and `__init__` as bold
+// "init" are the same bytes. So this resolves it by CONVENTION instead, applied
+// identically every time: an underscore never means emphasis, and an asterisk
+// never means emphasis mid-word. CommonMark already enforces exactly that rule
+// for `_` inside words (snake_case is safe); this extends it to `_` everywhere
+// and to `*` mid-word.
+//
+// The cost is `_italic_` and `__bold__`, which stop working. `*italic*` and
+// `**bold**` are untouched, and that is how agents actually write emphasis,
+// while identifiers are overwhelmingly underscored — so the trade favours the
+// identifiers. Code spans were never affected either way: `inlineCode` is a
+// different node type and is never visited here.
+//
+// Works off the mdast's source offsets rather than a regex over the raw text,
+// so it cannot misfire on text that merely looks like a delimiter.
+function remarkLiteralIdentifiers() {
+  const isWordChar = (c: string | undefined) => !!c && /[0-9A-Za-z]/.test(c);
+
+  return (tree: any, file: any) => {
+    const src: string = String(file.value ?? '');
+
+    const walk = (node: any) => {
+      if (!node || !Array.isArray(node.children)) return;
+      node.children.forEach(walk);
+
+      node.children = node.children.map((child: any) => {
+        if (child.type !== 'emphasis' && child.type !== 'strong') return child;
+        const start = child.position?.start?.offset;
+        const end = child.position?.end?.offset;
+        if (typeof start !== 'number' || typeof end !== 'number') return child;
+
+        const delimiter = src[start];
+        const intraWord =
+          isWordChar(src[start - 1]) && isWordChar(src[end]);
+        // Underscore emphasis is always literal; asterisk emphasis only when it
+        // sits inside a word (`2*3*4`), never when it stands alone (`**bold**`).
+        if (delimiter !== '_' && !(delimiter === '*' && intraWord)) return child;
+
+        return { type: 'text', value: src.slice(start, end), position: child.position };
+      });
+    };
+
+    walk(tree);
+  };
+}
+
 // Components override for ReactMarkdown:
 //   img → render alt text as plain text (no remote image fetch from untrusted text)
 //   a   → open in new tab, rel="noopener noreferrer" (safe links)
@@ -150,7 +201,7 @@ const TranscriptRow = React.memo(function TranscriptRow({
         {!IS_MACHINE_OUTPUT[ev.kind] && ev.text && (
           <div className={'mt-1 text-[13px] break-words ' + (ev.kind === 'think' ? 'italic text-slate-500 dark:text-slate-400' : 'text-slate-700 dark:text-slate-200')}>
             <div className="prose prose-slate dark:prose-invert prose-sm max-w-none">
-              <ReactMarkdown remarkPlugins={[remarkGfm]} components={mdComponents}>
+              <ReactMarkdown remarkPlugins={[remarkGfm, remarkLiteralIdentifiers]} components={mdComponents}>
                 {stripAnsi(ev.text)}
               </ReactMarkdown>
             </div>

--- a/packages/ui/src/test/KanbanBoard.test.tsx
+++ b/packages/ui/src/test/KanbanBoard.test.tsx
@@ -294,14 +294,14 @@ describe('KanbanBoard', () => {
     });
   });
 
-  it('should correctly reorder items even when a type filter is active', async () => {
+  it('should correctly reorder items when drilled into a parent', async () => {
       const project = { id: 'p1', name: 'P1', createdAt: new Date(), updatedAt: new Date() };
       const items = [
-        { id: 'i1', projectId: 'p1', type: ItemType.TASK, title: 'Task 1', status: Status.TODO, sortOrder: 0, createdAt: new Date('2026-01-01'), updatedAt: new Date('2026-01-01'), history: [] },
-        { id: 's1', projectId: 'p1', type: ItemType.STORY, title: 'Story 1', status: Status.TODO, sortOrder: 1, createdAt: new Date('2026-01-02'), updatedAt: new Date('2026-01-02'), history: [] },
-        { id: 'i2', projectId: 'p1', type: ItemType.TASK, title: 'Task 2', status: Status.TODO, sortOrder: 2, createdAt: new Date('2026-01-03'), updatedAt: new Date('2026-01-03'), history: [] },
+        { id: 's1', projectId: 'p1', type: ItemType.STORY, title: 'Parent Story', status: Status.TODO, sortOrder: 0, createdAt: new Date('2026-01-01'), updatedAt: new Date('2026-01-01'), history: [] },
+        { id: 'c1', projectId: 'p1', type: ItemType.TASK, title: 'Child One', status: Status.TODO, sortOrder: 10, parentId: 's1', createdAt: new Date('2026-01-02'), updatedAt: new Date('2026-01-02'), history: [] },
+        { id: 'c2', projectId: 'p1', type: ItemType.TASK, title: 'Child Two', status: Status.TODO, sortOrder: 20, parentId: 's1', createdAt: new Date('2026-01-03'), updatedAt: new Date('2026-01-03'), history: [] },
       ];
-      
+
       vi.mocked(api.listProjects).mockResolvedValue([project as any]);
       vi.mocked(api.listItems).mockResolvedValue(items as any);
       vi.mocked(api.updateItem).mockImplementation((id, updates) => Promise.resolve({ id, ...updates } as any));
@@ -309,36 +309,56 @@ describe('KanbanBoard', () => {
 
       render(<KanbanBoard />, { wrapper });
 
-      // Set filter to TASK
-      const select = await screen.findByRole('combobox');
-      fireEvent.change(select, { target: { value: ItemType.TASK } });
+      // Wait for all items to render, then drill into the parent story
+      await screen.findByText('Parent Story');
 
-      const task1Card = (await screen.findByText('Task 1')).closest('[draggable="true"]')!;
+      // Find the drill-down button inside the parent story's card.
+      // The drill button has the child count as its text.
+      const parentCard = screen.getByText('Parent Story').closest('[draggable="true"]')!;
+      const buttons = Array.from(parentCard.querySelectorAll('button'));
+      const drillBtn = buttons.find(b => b.textContent?.trim() === '2');
+      expect(drillBtn).toBeDefined();
+      fireEvent.click(drillBtn!);
+
+      // After drilling, only the children of the parent should be visible in columns.
+      // The parent title appears in the breadcrumb but NOT as a card.
+      await waitFor(() => {
+        expect(screen.getByText('Child One')).toBeDefined();
+        expect(screen.getByText('Child Two')).toBeDefined();
+        // Parent card should not be in any column
+        expect(document.querySelectorAll('#card-s1').length).toBe(0);
+      }, { timeout: 3000 });
+
+      const child1Card = (await screen.findByText('Child One')).closest('[draggable="true"]')!;
       const todoColumn = screen.getByText('TODO').closest('.flex-col')!;
 
+      // Drag Child Two onto Child One (top half → above)
       const dataTransfer = {
         setData: vi.fn(),
-        getData: vi.fn((key) => key === 'itemId' ? 'i2' : ''),
+        getData: vi.fn((key) => key === 'itemId' ? 'c2' : ''),
       };
-      fireEvent.dragStart(screen.getByText('Task 2').closest('[draggable="true"]')!, { dataTransfer });
+      fireEvent.dragStart(screen.getByText('Child Two').closest('[draggable="true"]')!, { dataTransfer });
 
-      task1Card.getBoundingClientRect = vi.fn(() => ({
+      child1Card.getBoundingClientRect = vi.fn(() => ({
         top: 100, height: 100, bottom: 200, left: 0, right: 200, width: 200, x: 0, y: 100, toJSON: () => {}
       } as DOMRect));
 
       const dragOverEvent = new CustomEvent('dragover', { bubbles: true, cancelable: true }) as any;
-      dragOverEvent.clientY = 120; 
-      fireEvent(task1Card, dragOverEvent);
+      dragOverEvent.clientY = 120;
+      fireEvent(child1Card, dragOverEvent);
 
       fireEvent.drop(todoColumn, { dataTransfer });
 
       await waitFor(() => {
-        expect(api.bulkUpdateItems).toHaveBeenCalledWith(expect.arrayContaining([
-          expect.objectContaining({ id: 'i2', updates: expect.objectContaining({ sortOrder: 0 }) }),
-          expect.objectContaining({ id: 'i1', updates: expect.objectContaining({ sortOrder: 1 }) }),
-          expect.objectContaining({ id: 's1', updates: expect.objectContaining({ sortOrder: 2 }) })
-        ]));
+        expect(api.bulkUpdateItems).toHaveBeenCalled();
       });
+
+      const callArgs = (api.bulkUpdateItems as any).mock.calls[0][0];
+
+      expect(callArgs).toEqual(expect.arrayContaining([
+        expect.objectContaining({ id: 'c2', updates: expect.objectContaining({ sortOrder: 0 }) }),
+        expect.objectContaining({ id: 'c1', updates: expect.objectContaining({ sortOrder: 1 }) }),
+      ]));
     });
   });
 
@@ -718,6 +738,10 @@ describe('KanbanBoard', () => {
   });
 
   describe('Dynamic Flow Columns', () => {
+    beforeEach(() => {
+      vi.mocked(api.getProjectFlow).mockResolvedValue(DEFAULT_FLOW_MOCK as any);
+    });
+
     it('should render columns from the active flow steps in order', async () => {
       const project = { id: 'p1', name: 'P1', createdAt: new Date(), updatedAt: new Date() };
       const customFlow = {

--- a/packages/ui/src/test/KanbanBoard.test.tsx
+++ b/packages/ui/src/test/KanbanBoard.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, cleanup, waitFor, within } from '@testing-library/react';
 import { KanbanBoard } from '../components/KanbanBoard';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from '../ThemeContext';
@@ -38,6 +38,7 @@ Object.defineProperty(window, 'matchMedia', {
 // Mock scrollTo
 if (typeof window !== 'undefined') {
   window.HTMLElement.prototype.scrollTo = vi.fn();
+  window.HTMLElement.prototype.scrollIntoView = vi.fn();
 }
 
 // Default flow used in tests — uses Status names as labels to keep column header assertions stable
@@ -99,6 +100,7 @@ describe('KanbanBoard', () => {
     vi.clearAllMocks();
     localStorage.clear();
     queryClient.clear();
+    vi.mocked(api.getProjectFlow).mockResolvedValue(DEFAULT_FLOW_MOCK as any);
   });
 
   afterEach(() => {
@@ -313,12 +315,10 @@ describe('KanbanBoard', () => {
       await screen.findByText('Parent Story');
 
       // Find the drill-down button inside the parent story's card.
-      // The drill button has the child count as its text.
-      const parentCard = screen.getByText('Parent Story').closest('[draggable="true"]')!;
-      const buttons = Array.from(parentCard.querySelectorAll('button'));
-      const drillBtn = buttons.find(b => b.textContent?.trim() === '2');
+      const parentCard = screen.getByText('Parent Story').closest('[draggable="true"]') as HTMLElement;
+      const drillBtn = within(parentCard).getByRole('button', { name: /child items/i });
       expect(drillBtn).toBeDefined();
-      fireEvent.click(drillBtn!);
+      fireEvent.click(drillBtn);
 
       // After drilling, only the children of the parent should be visible in columns.
       // The parent title appears in the breadcrumb but NOT as a card.
@@ -359,6 +359,7 @@ describe('KanbanBoard', () => {
         expect.objectContaining({ id: 'c2', updates: expect.objectContaining({ sortOrder: 0 }) }),
         expect.objectContaining({ id: 'c1', updates: expect.objectContaining({ sortOrder: 1 }) }),
       ]));
+      expect(callArgs).toHaveLength(2);
     });
   });
 
@@ -738,9 +739,6 @@ describe('KanbanBoard', () => {
   });
 
   describe('Dynamic Flow Columns', () => {
-    beforeEach(() => {
-      vi.mocked(api.getProjectFlow).mockResolvedValue(DEFAULT_FLOW_MOCK as any);
-    });
 
     it('should render columns from the active flow steps in order', async () => {
       const project = { id: 'p1', name: 'P1', createdAt: new Date(), updatedAt: new Date() };

--- a/packages/ui/src/test/ProjectPickerGrid.test.tsx
+++ b/packages/ui/src/test/ProjectPickerGrid.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, cleanup, waitFor, act } from '@testing-library/react';
 import { KanbanBoard } from '../components/KanbanBoard';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from '../ThemeContext';
@@ -349,5 +349,212 @@ describe('ProjectPickerGrid', () => {
     expect(listClasses).toContain('lg:grid-cols-3');
 
     expect(listClasses).toContain('overflow-y-auto');
+  });
+
+  // ── Group A — arrow keys must not steal the search caret ──────────────────
+
+  it('ArrowLeft with text in the search box moves the caret, not the highlight', async () => {
+    setColumns(3);
+    setup();
+    await waitFor(() => screen.getByText('a1'));
+
+    const input = screen.getByLabelText('Search projects');
+    fireEvent.change(input, { target: { value: 'a' } });
+    input.setSelectionRange(1, 1);
+
+    const result = fireEvent.keyDown(input, { key: 'ArrowLeft' });
+    // preventDefault() was NOT called (fireEvent returns false when it was)
+    expect(result).toBe(true);
+    expect(getHighlightedRow()).toBeNull();
+  });
+
+  it('ArrowRight with the caret mid-text moves the caret, not the highlight', async () => {
+    setColumns(3);
+    setup();
+    await waitFor(() => screen.getByText('a1'));
+
+    const input = screen.getByLabelText('Search projects');
+    fireEvent.change(input, { target: { value: 'a' } });
+    input.setSelectionRange(0, 0);
+
+    const result = fireEvent.keyDown(input, { key: 'ArrowRight' });
+    expect(result).toBe(true);
+    expect(getHighlightedRow()).toBeNull();
+  });
+
+  it('ArrowLeft at caret position 0 navigates the grid', async () => {
+    setColumns(3);
+    setup();
+    await waitFor(() => screen.getByText('a1'));
+
+    const input = screen.getByLabelText('Search projects');
+    fireEvent.change(input, { target: { value: 'a' } });
+    // highlight a1 (index 0), then ArrowRight to index 1 (a2), then ArrowLeft at caret 0
+    fireEvent.keyDown(document, { key: 'ArrowDown' }); // a1 (idx 0)
+    fireEvent.keyDown(document, { key: 'ArrowRight' }); // a2 (idx 1)
+
+    input.setSelectionRange(0, 0);
+    fireEvent.keyDown(input, { key: 'ArrowLeft' });
+
+    // highlight should have moved back to the first matching project (a1)
+    const row = getProjectRow('a1');
+    expect(row).not.toBeNull();
+    expect(row!.getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('ArrowRight at the end of the text navigates the grid', async () => {
+    setColumns(3);
+    setup();
+    await waitFor(() => screen.getByText('a1'));
+
+    const input = screen.getByLabelText('Search projects');
+    fireEvent.change(input, { target: { value: 'a' } });
+    input.setSelectionRange(1, 1);
+
+    fireEvent.keyDown(document, { key: 'ArrowDown' }); // a1 (idx 0)
+    fireEvent.keyDown(input, { key: 'ArrowRight' });
+
+    const row = getProjectRow('a2');
+    expect(row).not.toBeNull();
+    expect(row!.getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('ArrowDown and ArrowUp still navigate even with text in the box', async () => {
+    setColumns(3);
+    setup();
+    await waitFor(() => screen.getByText('a1'));
+
+    const input = screen.getByLabelText('Search projects');
+    fireEvent.change(input, { target: { value: 'a' } });
+
+    fireEvent.keyDown(document, { key: 'ArrowDown' }); // a1 (idx 0)
+    fireEvent.keyDown(document, { key: 'ArrowDown' }); // a4 (idx 3)
+
+    const row = getProjectRow('a4');
+    expect(row).not.toBeNull();
+    expect(row!.getAttribute('aria-selected')).toBe('true');
+  });
+
+  // ── Group B — empty and stale index states ────────────────────────────────
+
+  it('arrowing on an empty filtered list highlights nothing', async () => {
+    setColumns(3);
+    setup();
+    await waitFor(() => screen.getByText('a1'));
+
+    const input = screen.getByLabelText('Search projects');
+    fireEvent.change(input, { target: { value: 'zzzz' } });
+
+    fireEvent.keyDown(document, { key: 'ArrowDown' });
+
+    expect(getHighlightedRow()).toBeNull();
+    expect(screen.queryByText(/No projects match/)).not.toBeNull();
+  });
+
+  it('the empty-state message spans the full grid width', async () => {
+    setColumns(3);
+    setup();
+    await waitFor(() => screen.getByText('a1'));
+
+    const input = screen.getByLabelText('Search projects');
+    fireEvent.change(input, { target: { value: 'zzzz' } });
+
+    const emptyMsg = screen.getByText(/No projects match/);
+    expect(emptyMsg.className).toContain('col-span-full');
+  });
+
+  it('ArrowUp re-clamps an index left beyond the end of a shrunken list', async () => {
+    setColumns(3);
+    setup();
+    await waitFor(() => screen.getByText('a1'));
+
+    // ArrowDown x3 at 3 cols: 0 -> 3 -> 6 (a7)
+    fireEvent.keyDown(document, { key: 'ArrowDown' }); // a1 (idx 0)
+    fireEvent.keyDown(document, { key: 'ArrowDown' }); // a4 (idx 3)
+    fireEvent.keyDown(document, { key: 'ArrowDown' }); // a7 (idx 6)
+
+    const input = screen.getByLabelText('Search projects');
+    // narrow to just a1
+    fireEvent.change(input, { target: { value: 'a1' } });
+
+    // ArrowUp: 6-3 = 3, which is beyond the new list (length 1)
+    fireEvent.keyDown(document, { key: 'ArrowUp' });
+
+    // should clamp inside the new shorter list -> a1
+    const row = getProjectRow('a1');
+    expect(row).not.toBeNull();
+    expect(row!.getAttribute('aria-selected')).toBe('true');
+  });
+
+  // ── Group C — the matchMedia subscription is real ─────────────────────────
+
+  it('data-columns updates when a media query change fires', async () => {
+    // Build a matchMedia mock that records listeners and starts non-matching
+    const listeners: Array<(mq: any) => void> = [];
+    let matchesNow = false;
+
+    (window.matchMedia as any).mockImplementation((query: string) => ({
+      get matches() { return matchesNow; },
+      media: query,
+      onchange: null,
+      addEventListener(type: string, cb: (mq: any) => void) {
+        if (type === 'change') listeners.push(cb);
+      },
+      removeEventListener(type: string, cb: (mq: any) => void) {
+        if (type === 'change') {
+          const idx = listeners.indexOf(cb);
+          if (idx >= 0) listeners.splice(idx, 1);
+        }
+      },
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+
+    // Start with nothing matching -> 1 column
+    setup();
+    await waitFor(() => screen.getByText('a1'));
+
+    const listbox = screen.getByRole('listbox', { name: /projects/i });
+    expect(listbox.getAttribute('data-columns')).toBe('1');
+
+    // Flip the mock so the 1024px query now matches
+    matchesNow = true;
+    // Fire all recorded change listeners
+    await act(async () => {
+      for (const cb of listeners) {
+        cb({ matches: true } as any);
+      }
+    });
+
+    expect(listbox.getAttribute('data-columns')).toBe('3');
+  });
+
+  // ── Group D — navigation at one column ────────────────────────────────────
+
+  it('cols=1: ArrowDown moves one item at a time', async () => {
+    setColumns(1);
+    setup();
+    await waitFor(() => screen.getByText('a1'));
+
+    fireEvent.keyDown(document, { key: 'ArrowDown' }); // a1
+    fireEvent.keyDown(document, { key: 'ArrowDown' }); // a2
+
+    const row = getProjectRow('a2');
+    expect(row).not.toBeNull();
+    expect(row!.getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('cols=1: ArrowRight also moves one item', async () => {
+    setColumns(1);
+    setup();
+    await waitFor(() => screen.getByText('a1'));
+
+    fireEvent.keyDown(document, { key: 'ArrowDown' }); // a1
+    fireEvent.keyDown(document, { key: 'ArrowRight' }); // a2
+
+    const row = getProjectRow('a2');
+    expect(row).not.toBeNull();
+    expect(row!.getAttribute('aria-selected')).toBe('true');
   });
 });

--- a/packages/ui/src/test/ProjectPickerGrid.test.tsx
+++ b/packages/ui/src/test/ProjectPickerGrid.test.tsx
@@ -1,0 +1,353 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import { KanbanBoard } from '../components/KanbanBoard';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ThemeProvider } from '../ThemeContext';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { api } from '../api';
+
+// Mock socket.io-client
+vi.mock('socket.io-client', () => ({
+  io: vi.fn(() => ({
+    on: vi.fn(),
+    off: vi.fn(),
+    emit: vi.fn(),
+    disconnect: vi.fn(),
+  })),
+}));
+
+// Default flow used in tests
+const DEFAULT_FLOW_MOCK = {
+  id: 'default',
+  name: 'Default Flow',
+  projectId: '__builtin__',
+  steps: [
+    { id: 's-ideas', name: 'IDEAS', label: 'IDEAS', order: 0, isSpecial: true },
+    { id: 's-todo', name: 'TODO', label: 'TODO', order: 1 },
+    { id: 's-ip', name: 'IN_PROGRESS', label: 'IN PROGRESS', order: 2 },
+    { id: 's-review', name: 'REVIEW', label: 'REVIEW', order: 3 },
+    { id: 's-test', name: 'TEST', label: 'TEST', order: 4 },
+    { id: 's-done', name: 'DONE', label: 'DONE', order: 5 },
+    { id: 's-blocked', name: 'BLOCKED', label: 'BLOCKED', order: 6, isSpecial: true },
+    { id: 's-paused', name: 'PAUSED', label: 'PAUSED', order: 7, isSpecial: true },
+    { id: 's-archived', name: 'ARCHIVED', label: 'ARCHIVED', order: 8, isSpecial: true },
+  ],
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+// Mock window.matchMedia
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+// Mock scrollTo
+if (typeof window !== 'undefined') {
+  window.HTMLElement.prototype.scrollTo = vi.fn();
+}
+
+vi.mock('../api', () => ({
+  api: {
+    listProjects: vi.fn(() => Promise.resolve([])),
+    listItems: vi.fn(() => Promise.resolve([])),
+    getItem: vi.fn(() => Promise.resolve({})),
+    createItem: vi.fn(() => Promise.resolve({})),
+    updateItem: vi.fn(() => Promise.resolve({})),
+    deleteItem: vi.fn(() => Promise.resolve({})),
+    deleteProject: vi.fn(() => Promise.resolve({})),
+    createProject: vi.fn(() => Promise.resolve({ id: 'p-new', name: 'New' })),
+    bulkUpdateItems: vi.fn(() => Promise.resolve({})),
+    trashArchivedItems: vi.fn(() => Promise.resolve({})),
+    getJiraStatus: vi.fn(() => Promise.resolve({ configured: false, connected: false })),
+    getLatestRelease: vi.fn(() => Promise.resolve(null)),
+    getVersion: vi.fn(() => Promise.resolve({ version: '1.0.0' })),
+    getProjectFlow: vi.fn(() => Promise.resolve(DEFAULT_FLOW_MOCK)),
+    getGitHubStatus: vi.fn(() => Promise.resolve({ configured: false })),
+  }
+}));
+
+function makeProject(id: string, name: string) {
+  return { id, name, createdAt: new Date(), updatedAt: new Date() };
+}
+
+/** Walk up from a project-name text element to the row div carrying aria-selected. */
+function getProjectRow(name: string): HTMLElement | null {
+  const textEl = screen.getByText(name);
+  return (textEl as HTMLElement).closest('[aria-selected]') as HTMLElement | null;
+}
+
+/** Return the element whose aria-selected is "true", or null. */
+function getHighlightedRow(): HTMLElement | null {
+  return document.querySelector('[aria-selected="true"]') as HTMLElement | null;
+}
+
+describe('ProjectPickerGrid', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  function renderKanbanBoard() {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: 0 },
+      },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider>
+          {children}
+        </ThemeProvider>
+      </QueryClientProvider>
+    );
+    render(<KanbanBoard />, { wrapper });
+  }
+
+  function setColumns(cols: number) {
+    (window.matchMedia as any).mockImplementation((query: string) => ({
+      matches: cols === 3 ? query.includes('1024')
+             : cols === 2 ? query.includes('640')
+             : false,
+      media: query, onchange: null,
+      addListener: vi.fn(), removeListener: vi.fn(),
+      addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn(),
+    }));
+  }
+
+  const projects = [
+    makeProject('a1', 'a1'),
+    makeProject('a2', 'a2'),
+    makeProject('a3', 'a3'),
+    makeProject('a4', 'a4'),
+    makeProject('a5', 'a5'),
+    makeProject('a6', 'a6'),
+    makeProject('a7', 'a7'),
+  ];
+
+  function setup() {
+    vi.mocked(api.listProjects).mockResolvedValue(projects);
+    renderKanbanBoard();
+  }
+
+  it('data-columns is "1" with the default mock (nothing matches)', async () => {
+    setColumns(1);
+    setup();
+    await waitFor(() => screen.getByText('a1'));
+    const listbox = screen.getByRole('listbox', { name: /projects/i });
+    expect(listbox.getAttribute('data-columns')).toBe('1');
+  });
+
+  it('data-columns is "2" when the 640px query matches', async () => {
+    setColumns(2);
+    setup();
+    await waitFor(() => screen.getByText('a1'));
+    const listbox = screen.getByRole('listbox', { name: /projects/i });
+    expect(listbox.getAttribute('data-columns')).toBe('2');
+  });
+
+  it('data-columns is "3" when the 1024px query matches', async () => {
+    setColumns(3);
+    setup();
+    await waitFor(() => screen.getByText('a1'));
+    const listbox = screen.getByRole('listbox', { name: /projects/i });
+    expect(listbox.getAttribute('data-columns')).toBe('3');
+  });
+
+  it('cols=3: ArrowDown once -> a1 highlighted (from the -1 state)', async () => {
+    setColumns(3);
+    setup();
+    await waitFor(() => screen.getByText('a1'));
+
+    fireEvent.keyDown(document, { key: 'ArrowDown' });
+
+    const row = getProjectRow('a1');
+    expect(row).not.toBeNull();
+    expect(row!.getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('cols=3: ArrowUp from the -1 state highlights a1', async () => {
+    setColumns(3);
+    setup();
+    await waitFor(() => screen.getByText('a1'));
+
+    fireEvent.keyDown(document, { key: 'ArrowUp' });
+
+    const row = getProjectRow('a1');
+    expect(row).not.toBeNull();
+    expect(row!.getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('cols=3: ArrowRight from the -1 state highlights a1', async () => {
+    setColumns(3);
+    setup();
+    await waitFor(() => screen.getByText('a1'));
+
+    fireEvent.keyDown(document, { key: 'ArrowRight' });
+
+    const row = getProjectRow('a1');
+    expect(row).not.toBeNull();
+    expect(row!.getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('cols=3: ArrowLeft from the -1 state highlights a1', async () => {
+    setColumns(3);
+    setup();
+    await waitFor(() => screen.getByText('a1'));
+
+    fireEvent.keyDown(document, { key: 'ArrowLeft' });
+
+    const row = getProjectRow('a1');
+    expect(row).not.toBeNull();
+    expect(row!.getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('cols=3: ArrowDown, ArrowDown -> a4 (moved a whole row, NOT a2)', async () => {
+    setColumns(3);
+    setup();
+    await waitFor(() => screen.getByText('a1'));
+
+    fireEvent.keyDown(document, { key: 'ArrowDown' }); // a1 (idx 0)
+    fireEvent.keyDown(document, { key: 'ArrowDown' }); // a4 (idx 3)
+
+    const row = getProjectRow('a4');
+    expect(row).not.toBeNull();
+    expect(row!.getAttribute('aria-selected')).toBe('true');
+    expect(getProjectRow('a2')?.getAttribute('aria-selected')).toBe('false');
+  });
+
+  it('cols=3: ArrowDown, ArrowRight -> a2', async () => {
+    setColumns(3);
+    setup();
+    await waitFor(() => screen.getByText('a1'));
+
+    fireEvent.keyDown(document, { key: 'ArrowDown' }); // a1
+    fireEvent.keyDown(document, { key: 'ArrowRight' }); // a2
+
+    const row = getProjectRow('a2');
+    expect(row).not.toBeNull();
+    expect(row!.getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('cols=3: ArrowDown, ArrowRight, ArrowLeft -> a1', async () => {
+    setColumns(3);
+    setup();
+    await waitFor(() => screen.getByText('a1'));
+
+    fireEvent.keyDown(document, { key: 'ArrowDown' }); // a1
+    fireEvent.keyDown(document, { key: 'ArrowRight' }); // a2
+    fireEvent.keyDown(document, { key: 'ArrowLeft' });  // a1
+
+    const row = getProjectRow('a1');
+    expect(row).not.toBeNull();
+    expect(row!.getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('cols=3: ArrowLeft at index 0 clamps to a1 (stays)', async () => {
+    setColumns(3);
+    setup();
+    await waitFor(() => screen.getByText('a1'));
+
+    fireEvent.keyDown(document, { key: 'ArrowDown' }); // a1
+    fireEvent.keyDown(document, { key: 'ArrowLeft' });  // clamp a1
+
+    const row = getProjectRow('a1');
+    expect(row).not.toBeNull();
+    expect(row!.getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('cols=3: ArrowDown then ArrowUp clamps to a1 (no row above)', async () => {
+    setColumns(3);
+    setup();
+    await waitFor(() => screen.getByText('a1'));
+
+    fireEvent.keyDown(document, { key: 'ArrowDown' }); // a1
+    fireEvent.keyDown(document, { key: 'ArrowUp' });    // clamp a1
+
+    const row = getProjectRow('a1');
+    expect(row).not.toBeNull();
+    expect(row!.getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('cols=3: from a5 (index 4), ArrowDown clamps to a7 (index 6, the last item) rather than running off the end', async () => {
+    setColumns(3);
+    setup();
+    await waitFor(() => screen.getByText('a5'));
+
+    // Manually highlight a5 first
+    fireEvent.keyDown(document, { key: 'ArrowDown' }); // a1
+    fireEvent.keyDown(document, { key: 'ArrowDown' }); // a4
+    fireEvent.keyDown(document, { key: 'ArrowRight' }); // a5
+
+    fireEvent.keyDown(document, { key: 'ArrowDown' }); // should clamp to a7 (idx 6)
+
+    const row = getProjectRow('a7');
+    expect(row).not.toBeNull();
+    expect(row!.getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('cols=3: ArrowDown to a1 then Enter selects it — assert localStorage.getItem(\'agenfk_project_id\') is a1\'s id', async () => {
+    setColumns(3);
+    setup();
+    await waitFor(() => screen.getByText('a1'));
+
+    fireEvent.keyDown(document, { key: 'ArrowDown' }); // a1
+    fireEvent.keyDown(document, { key: 'Enter' });
+
+    expect(localStorage.getItem('agenfk_project_id')).toBe('a1');
+  });
+
+  it('cols=2: ArrowDown, ArrowDown -> a3 (row step of 2, proving the step follows the live column count and is not hardcoded)', async () => {
+    setColumns(2);
+    setup();
+    await waitFor(() => screen.getByText('a1'));
+
+    fireEvent.keyDown(document, { key: 'ArrowDown' }); // a1
+    fireEvent.keyDown(document, { key: 'ArrowDown' }); // a3
+
+    const row = getProjectRow('a3');
+    expect(row).not.toBeNull();
+    expect(row!.getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('the modal panel has max-w-4xl and does not have max-w-md', async () => {
+    setColumns(3);
+    setup();
+    await waitFor(() => screen.getByText('a1'));
+
+    const panel = screen.getByTestId('project-picker-panel');
+    expect(panel.className).toContain('max-w-4xl');
+    expect(panel.className).not.toContain('max-w-md');
+  });
+
+  it('the list has max-h-[60vh], grid-cols-1, sm:grid-cols-2, lg:grid-cols-3, and still has an ancestor with overflow-y-auto', async () => {
+    setColumns(3);
+    setup();
+    await waitFor(() => screen.getByText('a1'));
+
+    const listbox = screen.getByRole('listbox', { name: /projects/i });
+    const listClasses = listbox.className;
+
+    expect(listClasses).toContain('max-h-[60vh]');
+    expect(listClasses).toContain('grid-cols-1');
+    expect(listClasses).toContain('sm:grid-cols-2');
+    expect(listClasses).toContain('lg:grid-cols-3');
+
+    expect(listClasses).toContain('overflow-y-auto');
+  });
+});

--- a/packages/ui/src/test/ProjectPickerGrid.test.tsx
+++ b/packages/ui/src/test/ProjectPickerGrid.test.tsx
@@ -358,7 +358,7 @@ describe('ProjectPickerGrid', () => {
     setup();
     await waitFor(() => screen.getByText('a1'));
 
-    const input = screen.getByLabelText('Search projects');
+    const input = screen.getByLabelText('Search projects') as HTMLInputElement;
     fireEvent.change(input, { target: { value: 'a' } });
     input.setSelectionRange(1, 1);
 
@@ -373,7 +373,7 @@ describe('ProjectPickerGrid', () => {
     setup();
     await waitFor(() => screen.getByText('a1'));
 
-    const input = screen.getByLabelText('Search projects');
+    const input = screen.getByLabelText('Search projects') as HTMLInputElement;
     fireEvent.change(input, { target: { value: 'a' } });
     input.setSelectionRange(0, 0);
 
@@ -387,7 +387,7 @@ describe('ProjectPickerGrid', () => {
     setup();
     await waitFor(() => screen.getByText('a1'));
 
-    const input = screen.getByLabelText('Search projects');
+    const input = screen.getByLabelText('Search projects') as HTMLInputElement;
     fireEvent.change(input, { target: { value: 'a' } });
     // highlight a1 (index 0), then ArrowRight to index 1 (a2), then ArrowLeft at caret 0
     fireEvent.keyDown(document, { key: 'ArrowDown' }); // a1 (idx 0)
@@ -407,7 +407,7 @@ describe('ProjectPickerGrid', () => {
     setup();
     await waitFor(() => screen.getByText('a1'));
 
-    const input = screen.getByLabelText('Search projects');
+    const input = screen.getByLabelText('Search projects') as HTMLInputElement;
     fireEvent.change(input, { target: { value: 'a' } });
     input.setSelectionRange(1, 1);
 

--- a/packages/ui/src/test/ProjectPickerGrid.test.tsx
+++ b/packages/ui/src/test/ProjectPickerGrid.test.tsx
@@ -557,4 +557,71 @@ describe('ProjectPickerGrid', () => {
     expect(row).not.toBeNull();
     expect(row!.getAttribute('aria-selected')).toBe('true');
   });
+
+  // The modifier / IME guard had no coverage at all: deleting it left the suite
+  // green. It exists because Shift+Arrow (extending a selection) and IME
+  // composition keystrokes were both being swallowed as grid navigation.
+  describe('does not hijack keys that belong to the user', () => {
+    for (const modifier of ['shiftKey', 'metaKey', 'altKey', 'ctrlKey'] as const) {
+      it(`ignores ArrowDown with ${modifier}`, async () => {
+        setColumns(3);
+        setup();
+        await waitFor(() => screen.getByText('a1'));
+
+        fireEvent.keyDown(document, { key: 'ArrowDown', [modifier]: true });
+
+        expect(getProjectRow('a1')!.getAttribute('aria-selected')).toBe('false');
+      });
+    }
+
+    it('ignores ArrowDown mid-IME-composition', async () => {
+      setColumns(3);
+      setup();
+      await waitFor(() => screen.getByText('a1'));
+
+      fireEvent.keyDown(document, { key: 'ArrowDown', isComposing: true });
+
+      expect(getProjectRow('a1')!.getAttribute('aria-selected')).toBe('false');
+    });
+  });
+
+  // A delete confirmation is a question about one project. Navigation keys must
+  // not answer it, and Enter must not fall through to "open the highlighted
+  // project" while it is on screen.
+  describe('with a delete confirmation armed', () => {
+    async function armDelete() {
+      setColumns(3);
+      setup();
+      await waitFor(() => screen.getByText('a1'));
+      fireEvent.keyDown(document, { key: 'ArrowDown' }); // highlight a1
+      fireEvent.click(screen.getByLabelText('Delete project a1'));
+      await waitFor(() => screen.getByText('Delete "a1"?'));
+    }
+
+    it('Enter does not select the highlighted project', async () => {
+      await armDelete();
+
+      fireEvent.keyDown(document, { key: 'Enter' });
+
+      expect(localStorage.getItem('agenfk_project_id')).toBeNull();
+      expect(screen.getByText('Delete "a1"?')).toBeDefined();
+    });
+
+    it('an arrow key disarms the confirmation', async () => {
+      await armDelete();
+
+      fireEvent.keyDown(document, { key: 'ArrowRight' });
+
+      expect(screen.queryByText('Delete "a1"?')).toBeNull();
+    });
+
+    it('Escape cancels the confirmation and leaves the picker open', async () => {
+      await armDelete();
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      expect(screen.queryByText('Delete "a1"?')).toBeNull();
+      expect(screen.getByRole('listbox', { name: /projects/i })).toBeDefined();
+    });
+  });
 });

--- a/packages/ui/src/test/RunsPanel.test.tsx
+++ b/packages/ui/src/test/RunsPanel.test.tsx
@@ -231,8 +231,13 @@ describe('RunsPanel', () => {
     ] as any);
     renderPanel();
 
-    // Wait for the transcript to render
-    const transcript = await waitFor(() => screen.getByTestId('runs-transcript'));
+    // Wait for the CONTENT, not the container: the transcript div is present on
+    // the very first render, before the events query resolves, so awaiting the
+    // testid alone returns an empty transcript and every assertion below races.
+    await waitFor(() =>
+      expect(screen.getByTestId('runs-transcript').querySelector('strong')).not.toBeNull()
+    );
+    const transcript = screen.getByTestId('runs-transcript');
 
     // After the fix, **bold text** produces a <strong> element
     expect(transcript.querySelector('strong')).not.toBeNull();
@@ -263,7 +268,11 @@ describe('RunsPanel', () => {
     ] as any);
     renderPanel();
 
-    const transcript = await waitFor(() => screen.getByTestId('runs-transcript'));
+    // Await the content, not the container — see the note in the test above.
+    await waitFor(() =>
+      expect(screen.getByTestId('runs-transcript').querySelector('del')).not.toBeNull()
+    );
+    const transcript = screen.getByTestId('runs-transcript');
     // After the fix, ~~strikethrough~~ produces a <del> element
     expect(transcript.querySelector('del')).not.toBeNull();
     expect(transcript.querySelector('del')?.textContent).toBe('strikethrough');

--- a/packages/ui/src/test/RunsPanel.test.tsx
+++ b/packages/ui/src/test/RunsPanel.test.tsx
@@ -400,6 +400,79 @@ describe('RunsPanel', () => {
     expect(document.querySelector('img')).toBeNull();
   });
 
+  // CGLAB-33: machine-output kinds (result, diff) must render literally, not as markdown.
+
+  it('renders a diff event inside <pre> and preserves leading spaces on context lines', async () => {
+    vi.mocked(api.listAgentRuns).mockResolvedValue([
+      { id: 'r1', itemId: 'i1', step: 'IN_PROGRESS', actor: 'worker', harness: 'pi', model: 'qwen3.6:27b', status: 'done', startedAt: '2026-07-21T10:00:00.000Z' },
+    ] as any);
+    vi.mocked(api.listRunEvents).mockResolvedValue([
+      { id: 'e1', runId: 'r1', seq: 0, ts: 't', lane: 'worker', kind: 'diff', text: '--- a/file.py\n+++ b/file.py\n@@ -1 +1 @@\n- old line\n+ new line\n unchanged line' },
+    ] as any);
+    renderPanel();
+
+    await waitFor(() => expect(document.querySelector('pre')).not.toBeNull());
+    const pre = document.querySelector('pre');
+    expect(pre).not.toBeNull();
+    // Leading space on context line must survive (diff alignment)
+    expect(pre?.textContent).toContain(' unchanged line');
+    // Must NOT produce markdown artefacts like <hr> or <ul>
+    expect(screen.queryByRole('separator')).toBeNull();
+    expect(screen.getByTestId('runs-transcript').querySelector('ul')).toBeNull();
+  });
+
+  it('renders __init__ verbatim in a result event (no <strong> from double underscores)', async () => {
+    vi.mocked(api.listAgentRuns).mockResolvedValue([
+      { id: 'r1', itemId: 'i1', step: 'IN_PROGRESS', actor: 'worker', harness: 'pi', model: 'qwen3.6:27b', status: 'done', startedAt: '2026-07-21T10:00:00.000Z' },
+    ] as any);
+    vi.mocked(api.listRunEvents).mockResolvedValue([
+      { id: 'e1', runId: 'r1', seq: 0, ts: 't', lane: 'worker', kind: 'result', text: "AttributeError: '__init__' missing" },
+    ] as any);
+    renderPanel();
+
+    await waitFor(() => expect(document.querySelector('pre')).not.toBeNull());
+    const pre = document.querySelector('pre');
+    expect(pre).not.toBeNull();
+    expect(pre?.textContent).toContain('__init__');
+    // Double underscores must NOT produce a <strong>
+    expect(screen.getByTestId('runs-transcript').querySelector('strong')).toBeNull();
+  });
+
+  it('does not produce a <table> from pipe-aligned lines in a result event', async () => {
+    vi.mocked(api.listAgentRuns).mockResolvedValue([
+      { id: 'r1', itemId: 'i1', step: 'IN_PROGRESS', actor: 'worker', harness: 'pi', model: 'qwen3.6:27b', status: 'done', startedAt: '2026-07-21T10:00:00.000Z' },
+    ] as any);
+    vi.mocked(api.listRunEvents).mockResolvedValue([
+      { id: 'e1', runId: 'r1', seq: 0, ts: 't', lane: 'worker', kind: 'result', text: 'a | b | c\n--|--|--\n1 | 2 | 3' },
+    ] as any);
+    renderPanel();
+
+    await waitFor(() => expect(document.querySelector('pre')).not.toBeNull());
+    const pre = document.querySelector('pre');
+    expect(pre).not.toBeNull();
+    expect(pre?.textContent).toContain('a | b | c');
+    expect(pre?.textContent).toContain('1 | 2 | 3');
+    // Must NOT produce a GFM table
+    expect(screen.getByTestId('runs-transcript').querySelector('table')).toBeNull();
+  });
+
+  it('still renders markdown in a note event (prose path regression guard)', async () => {
+    vi.mocked(api.listAgentRuns).mockResolvedValue([
+      { id: 'r1', itemId: 'i1', step: 'IN_PROGRESS', actor: 'worker', harness: 'pi', model: 'qwen3.6:27b', status: 'done', startedAt: '2026-07-21T10:00:00.000Z' },
+    ] as any);
+    vi.mocked(api.listRunEvents).mockResolvedValue([
+      { id: 'e1', runId: 'r1', seq: 0, ts: 't', lane: 'worker', kind: 'note', text: '**prose markdown** is still rendered' },
+    ] as any);
+    renderPanel();
+
+    await waitFor(() =>
+      expect(screen.getByTestId('runs-transcript').querySelector('strong')).not.toBeNull()
+    );
+    const transcript = screen.getByTestId('runs-transcript');
+    expect(transcript.querySelector('strong')).not.toBeNull();
+    expect(transcript.querySelector('strong')?.textContent).toBe('prose markdown');
+  });
+
   // Fix 5e: links must open in a new tab with noopener/noreferrer for safety.
   it('renders markdown links with target="_blank" and rel containing noopener', async () => {
     vi.mocked(api.listAgentRuns).mockResolvedValue([

--- a/packages/ui/src/test/RunsPanel.test.tsx
+++ b/packages/ui/src/test/RunsPanel.test.tsx
@@ -221,6 +221,90 @@ describe('RunsPanel', () => {
     expect(gutter.textContent).toContain(d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }));
   });
 
+  // CGLAB-18d: non-tool events must render markdown as formatted HTML, not raw syntax.
+  it('renders markdown constructs (bold, code, list) as real DOM elements in a non-tool event', async () => {
+    vi.mocked(api.listAgentRuns).mockResolvedValue([
+      { id: 'r1', itemId: 'i1', step: 'IN_PROGRESS', actor: 'worker', harness: 'pi', model: 'qwen3.6:27b', status: 'done', startedAt: '2026-07-21T10:00:00.000Z' },
+    ] as any);
+    vi.mocked(api.listRunEvents).mockResolvedValue([
+      { id: 'e1', runId: 'r1', seq: 0, ts: 't', lane: 'worker', kind: 'note', text: '**bold text** and `inline code`\n\n- first item\n- second item' },
+    ] as any);
+    renderPanel();
+
+    // Wait for the transcript to render
+    const transcript = await waitFor(() => screen.getByTestId('runs-transcript'));
+
+    // After the fix, **bold text** produces a <strong> element
+    expect(transcript.querySelector('strong')).not.toBeNull();
+    expect(transcript.querySelector('strong')?.textContent).toBe('bold text');
+
+    // After the fix, `inline code` produces a <code> element (inside a paragraph)
+    const code = transcript.querySelector('code');
+    expect(code).not.toBeNull();
+    expect(code?.textContent).toBe('inline code');
+
+    // After the fix, list items are <li> elements (not "- item" text)
+    const lis = transcript.querySelectorAll('li');
+    expect(lis.length).toBe(2);
+    expect(lis[0].textContent).toBe('first item');
+
+    // Literal markdown syntax must NOT survive in the rendered output
+    expect(transcript.textContent).not.toContain('**');
+    expect(transcript.textContent).not.toContain('- first item');
+  });
+
+  // CGLAB-18d: remark-gfm must be wired up, not just react-markdown alone.
+  it('renders a GFM strikethrough as a <del> element', async () => {
+    vi.mocked(api.listAgentRuns).mockResolvedValue([
+      { id: 'r1', itemId: 'i1', step: 'IN_PROGRESS', actor: 'worker', harness: 'pi', model: 'qwen3.6:27b', status: 'done', startedAt: '2026-07-21T10:00:00.000Z' },
+    ] as any);
+    vi.mocked(api.listRunEvents).mockResolvedValue([
+      { id: 'e1', runId: 'r1', seq: 0, ts: 't', lane: 'worker', kind: 'note', text: '~~strikethrough~~' },
+    ] as any);
+    renderPanel();
+
+    const transcript = await waitFor(() => screen.getByTestId('runs-transcript'));
+    // After the fix, ~~strikethrough~~ produces a <del> element
+    expect(transcript.querySelector('del')).not.toBeNull();
+    expect(transcript.querySelector('del')?.textContent).toBe('strikethrough');
+  });
+
+  // CGLAB-18d: tool events must NOT render markdown — they stay literal in <pre>.
+  it('keeps markdown literal in a tool event (renders in <pre>, no formatting)', async () => {
+    vi.mocked(api.listAgentRuns).mockResolvedValue([
+      { id: 'r1', itemId: 'i1', step: 'IN_PROGRESS', actor: 'worker', harness: 'pi', model: 'qwen3.6:27b', status: 'done', startedAt: '2026-07-21T10:00:00.000Z' },
+    ] as any);
+    vi.mocked(api.listRunEvents).mockResolvedValue([
+      { id: 'e1', runId: 'r1', seq: 0, ts: 't', lane: 'worker', kind: 'tool', tool: 'bash', text: '**bold** and `code`\n- list' },
+    ] as any);
+    renderPanel();
+
+    // Wait for the <pre> to appear (tool events render text in <pre>)
+    await waitFor(() => expect(document.querySelector('pre')).not.toBeNull());
+    const pre = document.querySelector('pre');
+    expect(pre).not.toBeNull();
+    expect(pre?.textContent).toContain('**bold**');
+    expect(pre?.textContent).toContain('- list');
+
+    // No markdown-formatted elements should appear
+    expect(document.querySelector('strong')).toBeNull();
+  });
+
+  // CGLAB-18d: think events keep their italic visual distinction.
+  it('keeps italic styling on think events after markdown rendering', async () => {
+    vi.mocked(api.listAgentRuns).mockResolvedValue([
+      { id: 'r1', itemId: 'i1', step: 'IN_PROGRESS', actor: 'worker', harness: 'pi', model: 'qwen3.6:27b', status: 'done', startedAt: '2026-07-21T10:00:00.000Z' },
+    ] as any);
+    vi.mocked(api.listRunEvents).mockResolvedValue([
+      { id: 'e1', runId: 'r1', seq: 0, ts: 't', lane: 'worker', kind: 'think', text: 'reasoning here' },
+    ] as any);
+    renderPanel();
+
+    await waitFor(() => expect(screen.getByText('reasoning here')).toBeDefined());
+    const textEl = screen.getByText('reasoning here');
+    expect(textEl.closest('.italic')).not.toBeNull();
+  });
+
   it('renders nothing for the timestamp when ts is missing or unparseable', async () => {
     vi.mocked(api.listAgentRuns).mockResolvedValue([
       { id: 'r1', itemId: 'i1', step: 'IN_PROGRESS', actor: 'worker', harness: 'pi', model: 'qwen3.6:27b', status: 'done', startedAt: '2026-07-21T10:00:00.000Z' },

--- a/packages/ui/src/test/RunsPanel.test.tsx
+++ b/packages/ui/src/test/RunsPanel.test.tsx
@@ -511,6 +511,54 @@ describe('RunsPanel', () => {
     expect(transcript.querySelector('code')?.textContent).toBe('calculateTotal');
   });
 
+  // Markdown emphasis rewrites literal text, which matters because these
+  // transcripts carry identifiers. '__init__' rendering as a bold "init" shows
+  // the WRONG SYMBOL NAME with nothing signalling the text was transformed.
+  // Resolved by convention rather than by guessing intent: underscores never
+  // mean emphasis, and asterisks do not mean emphasis mid-word.
+  const proseEvent = (text: string) => {
+    vi.mocked(api.listAgentRuns).mockResolvedValue([
+      { id: 'r1', itemId: 'i1', step: 'IN_PROGRESS', actor: 'worker', harness: 'pi', model: 'qwen3.6:27b', status: 'done', startedAt: '2026-07-21T10:00:00.000Z' },
+    ] as any);
+    vi.mocked(api.listRunEvents).mockResolvedValue([
+      { id: 'e1', runId: 'r1', seq: 0, ts: 't', lane: 'worker', kind: 'note', text },
+    ] as any);
+    renderPanel();
+  };
+
+  it('keeps a dunder identifier literal instead of bolding it', async () => {
+    proseEvent("AttributeError: '__init__' missing");
+    await waitFor(() => expect(screen.getByTestId('runs-transcript').textContent).toContain('AttributeError'));
+    const t = screen.getByTestId('runs-transcript');
+    // The symbol name must survive intact — this is the whole point.
+    expect(t.textContent).toContain('__init__');
+    expect(t.querySelector('strong')).toBeNull();
+  });
+
+  it('keeps a dunder inside a path literal', async () => {
+    proseEvent('see path/to/__pycache__/x for details');
+    await waitFor(() => expect(screen.getByTestId('runs-transcript').textContent).toContain('see path'));
+    const t = screen.getByTestId('runs-transcript');
+    expect(t.textContent).toContain('__pycache__');
+    expect(t.querySelector('strong')).toBeNull();
+  });
+
+  it('does not italicise around intra-word asterisks', async () => {
+    proseEvent('2*3*4 equals 24');
+    await waitFor(() => expect(screen.getByTestId('runs-transcript').textContent).toContain('equals 24'));
+    const t = screen.getByTestId('runs-transcript');
+    expect(t.textContent).toContain('2*3*4');
+    expect(t.querySelector('em')).toBeNull();
+  });
+
+  it('still renders asterisk bold and italic, which is how agents write emphasis', async () => {
+    proseEvent('**bold here** and *italic here* both work');
+    await waitFor(() => expect(screen.getByTestId('runs-transcript').querySelector('strong')).not.toBeNull());
+    const t = screen.getByTestId('runs-transcript');
+    expect(t.querySelector('strong')?.textContent).toBe('bold here');
+    expect(t.querySelector('em')?.textContent).toBe('italic here');
+  });
+
   // Fix 5e: links must open in a new tab with noopener/noreferrer for safety.
   it('renders markdown links with target="_blank" and rel containing noopener', async () => {
     vi.mocked(api.listAgentRuns).mockResolvedValue([

--- a/packages/ui/src/test/RunsPanel.test.tsx
+++ b/packages/ui/src/test/RunsPanel.test.tsx
@@ -200,4 +200,39 @@ describe('RunsPanel', () => {
     // Selection auto-advances to the newest run → its transcript renders.
     await waitFor(() => expect(screen.getByText('impl phase')).toBeDefined());
   });
+
+  it('renders the event timestamp (date + time) under the identity caption when ts is valid', async () => {
+    vi.mocked(api.listAgentRuns).mockResolvedValue([
+      { id: 'r1', itemId: 'i1', step: 'IN_PROGRESS', actor: 'worker', harness: 'pi', model: 'qwen3.6:27b', status: 'done', startedAt: '2026-07-21T10:00:00.000Z' },
+    ] as any);
+    vi.mocked(api.listRunEvents).mockResolvedValue([
+      { id: 'e1', runId: 'r1', seq: 0, ts: '2026-07-21T10:00:00.000Z', lane: 'worker', kind: 'note', text: 'hello' },
+    ] as any);
+    renderPanel();
+    await waitFor(() => expect(screen.getByText('hello')).toBeDefined());
+    // The formatted date and time appear somewhere in the DOM (they are inside the gutter)
+    // toLocaleDateString / toLocaleTimeString output is locale-dependent, so just assert
+    // that the caption is present and the gutter content is richer than just the caption.
+    const who = screen.getByText('pi · Qwen');
+    // The timestamp is rendered as a sibling span inside the same gutter div
+    const gutterDiv = (who.parentElement as HTMLElement);
+    const timestampSpans = gutterDiv.querySelectorAll('span');
+    // There should be more than just the avatar + who caption (the timestamp span is extra)
+    // The timestamp span contains two lines (date \n time)
+    expect(timestampSpans.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('renders nothing for the timestamp when ts is missing or unparseable', async () => {
+    vi.mocked(api.listAgentRuns).mockResolvedValue([
+      { id: 'r1', itemId: 'i1', step: 'IN_PROGRESS', actor: 'worker', harness: 'pi', model: 'qwen3.6:27b', status: 'done', startedAt: '2026-07-21T10:00:00.000Z' },
+    ] as any);
+    vi.mocked(api.listRunEvents).mockResolvedValue([
+      { id: 'e1', runId: 'r1', seq: 0, ts: 'not-a-date', lane: 'worker', kind: 'note', text: 'bad ts' },
+      { id: 'e2', runId: 'r1', seq: 1, lane: 'worker', kind: 'note', text: 'missing ts' },
+    ] as any);
+    renderPanel();
+    await waitFor(() => expect(screen.getByText('bad ts')).toBeDefined());
+    // No "Invalid Date" anywhere
+    expect(screen.queryByText('Invalid Date')).toBeNull();
+  });
 });

--- a/packages/ui/src/test/RunsPanel.test.tsx
+++ b/packages/ui/src/test/RunsPanel.test.tsx
@@ -205,21 +205,20 @@ describe('RunsPanel', () => {
     vi.mocked(api.listAgentRuns).mockResolvedValue([
       { id: 'r1', itemId: 'i1', step: 'IN_PROGRESS', actor: 'worker', harness: 'pi', model: 'qwen3.6:27b', status: 'done', startedAt: '2026-07-21T10:00:00.000Z' },
     ] as any);
+    const ts = '2026-07-21T10:00:00.000Z';
     vi.mocked(api.listRunEvents).mockResolvedValue([
-      { id: 'e1', runId: 'r1', seq: 0, ts: '2026-07-21T10:00:00.000Z', lane: 'worker', kind: 'note', text: 'hello' },
+      { id: 'e1', runId: 'r1', seq: 0, ts, lane: 'worker', kind: 'note', text: 'hello' },
     ] as any);
     renderPanel();
     await waitFor(() => expect(screen.getByText('hello')).toBeDefined());
-    // The formatted date and time appear somewhere in the DOM (they are inside the gutter)
-    // toLocaleDateString / toLocaleTimeString output is locale-dependent, so just assert
-    // that the caption is present and the gutter content is richer than just the caption.
-    const who = screen.getByText('pi · Qwen');
-    // The timestamp is rendered as a sibling span inside the same gutter div
-    const gutterDiv = (who.parentElement as HTMLElement);
-    const timestampSpans = gutterDiv.querySelectorAll('span');
-    // There should be more than just the avatar + who caption (the timestamp span is extra)
-    // The timestamp span contains two lines (date \n time)
-    expect(timestampSpans.length).toBeGreaterThanOrEqual(3);
+    // Assert the rendered date and time themselves, not just that an extra span
+    // exists — a span-count check passes on any garbage the formatter emits.
+    // The exact strings are locale- and timezone-dependent, so derive the
+    // expectation the same way the component does rather than hardcoding it.
+    const d = new Date(ts);
+    const gutter = (screen.getByText('pi · Qwen').parentElement as HTMLElement);
+    expect(gutter.textContent).toContain(d.toLocaleDateString());
+    expect(gutter.textContent).toContain(d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }));
   });
 
   it('renders nothing for the timestamp when ts is missing or unparseable', async () => {
@@ -232,7 +231,17 @@ describe('RunsPanel', () => {
     ] as any);
     renderPanel();
     await waitFor(() => expect(screen.getByText('bad ts')).toBeDefined());
-    // No "Invalid Date" anywhere
-    expect(screen.queryByText('Invalid Date')).toBeNull();
+    // queryByText('Invalid Date') is NOT enough: with the guard removed the span
+    // renders "Invalid Date" twice (date + <br> + time), whose normalised
+    // textContent never equals the exact string — so that assertion passes on
+    // the very bug it exists to catch. Match the substring, and assert the
+    // timestamp span is genuinely absent rather than merely not-that-string.
+    for (const text of ['bad ts', 'missing ts']) {
+      const gutter = (screen.getByText(text).closest('.flex.gap-3') as HTMLElement)
+        .firstElementChild as HTMLElement;
+      expect(gutter.textContent).not.toMatch(/Invalid/);
+      // avatar tile + who caption only — no third (timestamp) span.
+      expect(gutter.querySelectorAll('span')).toHaveLength(2);
+    }
   });
 });

--- a/packages/ui/src/test/RunsPanel.test.tsx
+++ b/packages/ui/src/test/RunsPanel.test.tsx
@@ -337,4 +337,83 @@ describe('RunsPanel', () => {
       expect(gutter.querySelectorAll('span')).toHaveLength(2);
     }
   });
+
+  // Fix 5a: stripAnsi must be applied to non-tool event text.
+  // Mutation: changing stripAnsi(ev.text) back to ev.text would let escapes survive.
+  it('strips ANSI escapes from non-tool event text', async () => {
+    vi.mocked(api.listAgentRuns).mockResolvedValue([
+      { id: 'r1', itemId: 'i1', step: 'IN_PROGRESS', actor: 'worker', harness: 'pi', model: 'qwen3.6:27b', status: 'done', startedAt: '2026-07-21T10:00:00.000Z' },
+    ] as any);
+    vi.mocked(api.listRunEvents).mockResolvedValue([
+      { id: 'e1', runId: 'r1', seq: 0, ts: 't', lane: 'worker', kind: 'note', text: '\x1b[31mred error\x1b[0m' },
+    ] as any);
+    renderPanel();
+    await waitFor(() => expect(screen.getByText('red error')).toBeDefined());
+    // The raw escape sequence must not appear in the rendered output
+    expect(screen.queryByText(/\x1b\[31m/)).toBeNull();
+  });
+
+  // Fix 5b: stripAnsi must be applied to tool event text.
+  // Mutation: omitting stripAnsi on the tool <pre> would let escapes render as garbage glyphs.
+  it('strips ANSI escapes from tool event text', async () => {
+    vi.mocked(api.listAgentRuns).mockResolvedValue([
+      { id: 'r1', itemId: 'i1', step: 'IN_PROGRESS', actor: 'worker', harness: 'pi', model: 'qwen3.6:27b', status: 'done', startedAt: '2026-07-21T10:00:00.000Z' },
+    ] as any);
+    vi.mocked(api.listRunEvents).mockResolvedValue([
+      { id: 'e1', runId: 'r1', seq: 0, ts: 't', lane: 'worker', kind: 'tool', tool: 'bash', text: '\x1b[31mred error\x1b[0m' },
+    ] as any);
+    renderPanel();
+    await waitFor(() => expect(screen.getByText('red error')).toBeDefined());
+    // The raw escape sequence must not appear in the rendered output
+    expect(screen.queryByText(/\x1b\[31m/)).toBeNull();
+  });
+
+  // Fix 5c: the prose classes must be present on the markdown wrapper.
+  // Mutation: deleting the class string would not break any semantic test.
+  it('wraps markdown output in an element with prose and dark:prose-invert classes', async () => {
+    vi.mocked(api.listAgentRuns).mockResolvedValue([
+      { id: 'r1', itemId: 'i1', step: 'IN_PROGRESS', actor: 'worker', harness: 'pi', model: 'qwen3.6:27b', status: 'done', startedAt: '2026-07-21T10:00:00.000Z' },
+    ] as any);
+    vi.mocked(api.listRunEvents).mockResolvedValue([
+      { id: 'e1', runId: 'r1', seq: 0, ts: 't', lane: 'worker', kind: 'note', text: 'hello world' },
+    ] as any);
+    renderPanel();
+    await waitFor(() => expect(screen.getByText('hello world')).toBeDefined());
+    const prose = document.querySelector('.prose');
+    expect(prose).not.toBeNull();
+    expect(prose?.className).toContain('prose');
+    expect(prose?.className).toContain('dark:prose-invert');
+  });
+
+  // Fix 5d: markdown images must not produce real <img> elements that fetch remote URLs.
+  it('does not render <img> elements for markdown image syntax in event text', async () => {
+    vi.mocked(api.listAgentRuns).mockResolvedValue([
+      { id: 'r1', itemId: 'i1', step: 'IN_PROGRESS', actor: 'worker', harness: 'pi', model: 'qwen3.6:27b', status: 'done', startedAt: '2026-07-21T10:00:00.000Z' },
+    ] as any);
+    vi.mocked(api.listRunEvents).mockResolvedValue([
+      { id: 'e1', runId: 'r1', seq: 0, ts: 't', lane: 'worker', kind: 'note', text: '![tracking pixel](https://evil.example/track.png)' },
+    ] as any);
+    renderPanel();
+    // Wait for the alt text to appear (rendered as plain text instead of <img>)
+    await waitFor(() => expect(screen.getByText('tracking pixel')).toBeDefined());
+    // No <img> element should exist in the DOM
+    expect(document.querySelector('img')).toBeNull();
+  });
+
+  // Fix 5e: links must open in a new tab with noopener/noreferrer for safety.
+  it('renders markdown links with target="_blank" and rel containing noopener', async () => {
+    vi.mocked(api.listAgentRuns).mockResolvedValue([
+      { id: 'r1', itemId: 'i1', step: 'IN_PROGRESS', actor: 'worker', harness: 'pi', model: 'qwen3.6:27b', status: 'done', startedAt: '2026-07-21T10:00:00.000Z' },
+    ] as any);
+    vi.mocked(api.listRunEvents).mockResolvedValue([
+      { id: 'e1', runId: 'r1', seq: 0, ts: 't', lane: 'worker', kind: 'note', text: '[click me](https://example.com)' },
+    ] as any);
+    renderPanel();
+    await waitFor(() => expect(screen.getByText('click me')).toBeDefined());
+    const link = document.querySelector('a');
+    expect(link).not.toBeNull();
+    expect(link?.getAttribute('target')).toBe('_blank');
+    expect(link?.getAttribute('rel')).toContain('noopener');
+    expect(link?.getAttribute('rel')).toContain('noreferrer');
+  });
 });

--- a/packages/ui/src/test/RunsPanel.test.tsx
+++ b/packages/ui/src/test/RunsPanel.test.tsx
@@ -473,6 +473,44 @@ describe('RunsPanel', () => {
     expect(transcript.querySelector('strong')?.textContent).toBe('prose markdown');
   });
 
+  // CGLAB-33: 'verdict' and 'dispatch' are orchestrator-authored prose, not
+  // machine output, so they must keep rendering as markdown. Without these the
+  // suite stays green when both are misclassified into the machine-output set —
+  // the prose side was otherwise pinned only by 'note' and 'think'.
+  it('renders a verdict event as markdown (prose kind)', async () => {
+    vi.mocked(api.listAgentRuns).mockResolvedValue([
+      { id: 'rv', itemId: 'i1', step: 'REVIEW', actor: 'reviewer', harness: 'claude-code', model: 'claude-opus-4-8', status: 'done', verdict: 'APPROVE', startedAt: '2026-07-21T10:00:00.000Z' },
+    ] as any);
+    vi.mocked(api.listRunEvents).mockResolvedValue([
+      { id: 'e1', runId: 'rv', seq: 0, ts: 't', lane: 'reviewer', kind: 'verdict', text: '**APPROVED** — changes look solid' },
+    ] as any);
+    renderPanel();
+
+    await waitFor(() =>
+      expect(screen.getByTestId('runs-transcript').querySelector('strong')).not.toBeNull()
+    );
+    const transcript = screen.getByTestId('runs-transcript');
+    expect(transcript.querySelector('strong')?.textContent).toBe('APPROVED');
+    expect(transcript.textContent).not.toContain('**');
+  });
+
+  it('renders a dispatch event as markdown (prose kind)', async () => {
+    vi.mocked(api.listAgentRuns).mockResolvedValue([
+      { id: 'r1', itemId: 'i1', step: 'IN_PROGRESS', actor: 'worker', harness: 'pi', model: 'qwen3.6:27b', status: 'running', startedAt: '2026-07-21T10:00:00.000Z' },
+    ] as any);
+    vi.mocked(api.listRunEvents).mockResolvedValue([
+      { id: 'e1', runId: 'r1', seq: 0, ts: 't', lane: 'orchestrator', kind: 'dispatch', text: 'Please **implement** the `calculateTotal` function' },
+    ] as any);
+    renderPanel();
+
+    await waitFor(() =>
+      expect(screen.getByTestId('runs-transcript').querySelector('strong')).not.toBeNull()
+    );
+    const transcript = screen.getByTestId('runs-transcript');
+    expect(transcript.querySelector('strong')?.textContent).toBe('implement');
+    expect(transcript.querySelector('code')?.textContent).toBe('calculateTotal');
+  });
+
   // Fix 5e: links must open in a new tab with noopener/noreferrer for safety.
   it('renders markdown links with target="_blank" and rel containing noopener', async () => {
     vi.mocked(api.listAgentRuns).mockResolvedValue([

--- a/packages/ui/src/test/api.test.ts
+++ b/packages/ui/src/test/api.test.ts
@@ -90,11 +90,9 @@ describe('UI API Client', () => {
     expect(result.connected).toBe(true);
   });
 
-  it('should return disconnected jira status on error', async () => {
+  it('should propagate errors from jira status so the caller can show a loading state', async () => {
     mockedAxios.get.mockRejectedValue(new Error('network'));
-    const result = await api.getJiraStatus();
-    expect(result.configured).toBe(false);
-    expect(result.connected).toBe(false);
+    await expect(api.getJiraStatus()).rejects.toThrow('network');
   });
 
   it('should disconnect jira', async () => {


### PR DESCRIPTION
Single PR for the whole v1.1.12 line. It supersedes **#124** and **#125**, whose branches are
both ancestors of this one — everything in them is already here, verified with
`git merge-base --is-ancestor`. They are closed in favour of this PR so there is one thing to
review and one thing to merge.

Shipped and exercised as `v1.1.12-beta.1`, `-beta.2` and `-beta.3`.

**Please merge with a merge commit, not squash.** Squashing would collapse 21 commits across
three features into one blob and discard the review history; a merge commit keeps each
feature's trail intact.

---

## 1. Hub: hide a departed user (CGLAB-31) — was #124

Hides a departed user from installation lists, upgrade targeting, event ingest and admin
actions: `hidden_users` table plus migration on both SQLite and Postgres, an admin
hide/unhide API with api-key revocation, fleet-list and upgrade-targeting exclusion, ingest
drop, and the hub-ui controls and hidden-people panel.

Already deployed and running on the hub.

## 2. Multi-column project picker + run timestamps (CGLAB-32) — was #125

The picker modal was a single-column list wasting horizontal space. It is now a responsive
1/2/3-column grid (`max-w-md` → `max-w-4xl`, list cap `max-h-72` → `max-h-[60vh]`), with the
column count read at runtime from `matchMedia` rather than hardcoded.

Keyboard navigation uses grid semantics: Up/Down by a row, Left/Right by one, clamped without
wrap. Arrows are boundary-aware, so they move the search caret first and only navigate at the
ends of the text; modifier chords and IME composition are left alone.

Three adversarial review passes, each of which found something the previous one had declared
fine. The last found a HIGH the first two missed: with a delete confirmation on screen, Enter
fell through to "open the highlighted project" — the keystroke was aimed at a destructive
prompt and instead navigated away from it. Enter is now inert there (never wired to confirm a
delete), arrows disarm, Escape cancels. Also caught earlier: the branch did not build, because
`tsc -b` typechecks `src/test/**` while `tsc --noEmit` does not, and CI builds before testing.

Each transcript event also gained a date/time line under its `<harness> · <model>` caption.

## 3. Markdown-rendered run entries (CGLAB-33) — this branch

Worker turns come straight from pi's transcript and are markdown in practice, but rendered as
raw characters. Agent prose now renders as formatted markdown via `react-markdown` +
`remark-gfm` through `stripAnsi`, in the `prose`/`dark:prose-invert` wrapper this UI already
uses elsewhere.

**Only prose renders as markdown.** `RunEvent` has seven kinds and three carry machine output —
`tool`, `result`, `diff` — which render byte-exact in a `<pre>`, because reflowing them changes
their meaning: a test failure containing `__init__` would otherwise display the *wrong symbol
name*, pipe-aligned output would be eaten into a table, and a diff would lose the leading
spaces that make it readable. The classification is keyed on the full kind union, so adding a
kind without classifying it is a compile error (verified: TS2741) rather than a silent default
to markdown — which is how the bug arose in the first place.

From the adversarial review of that work:

- Transcript rows are memoised. Markdown was re-parsed for every row on every websocket event
  (~57 ms of blocking work per event at 200 rows), on exactly the live path the panel exists
  for. Measured after the fix with a render counter: 0 re-renders across five refetches.
- `stripAnsi` now also applies to tool output, the lane that actually carries ANSI.
- Event text is untrusted: markdown images no longer fetch remote URLs (a tracking pixel could
  leak a viewer's IP on tab open), and links open in a new tab with `rel="noopener noreferrer"`.

Security was verified empirically rather than assumed — hostile payloads rendered through the
component confirm `rehype-raw` is absent from react-markdown 10's pipeline so HTML is escaped,
and its default URL transform strips `javascript:`, `data:` and `vbscript:`.

### Literal identifiers survive emphasis

Prose is where identifiers live, and markdown emphasis rewrote them: `'__init__'` rendered as
a bold **init** — the wrong symbol name, with nothing signalling the text had changed — and
`2*3*4` became 2*3*4 with the middle italicised.

Intent is not recoverable (`__init__` as a literal and as bold "init" are the same bytes), so
this is resolved by convention, applied identically every time: an underscore never means
emphasis, and an asterisk never means emphasis mid-word. CommonMark already enforces that for
`_` inside words — which is why `snake_case` was always safe — and this extends it to `_`
everywhere and `*` mid-word. `**bold**` and `*italic*` still work; `_italic_` no longer does.
Code spans were never affected.

Measured beforehand rather than assumed: only those two classes actually mangle. Lone
asterisks (`glob *.ts`, `rm -rf *`) and `snake_case` were already safe.

## Verification

Full monorepo build passes. Root suite **181 files / 1854 tests**, UI suite **19 files / 374
tests**, all green.

Every guard added across CGLAB-32 and CGLAB-33 is mutation-verified — the code it covers was
removed and the test confirmed to fail. That caught several assertions that were passing
vacuously, including one that checked for `Invalid Date` in a way that could never have matched.

## Version

Bumped to **1.1.12** (from the inherited `1.1.12-beta.2`) across all 11 manifests and the
lockfile, so merging lands a clean stable version on `main` rather than a superseded
prerelease string. Cut the stable release once this merges.

## Known follow-ups, not in this PR

- Picker accessibility needs a design decision, not a patch: `role="listbox"` is a 1-D role
  driven with 2-D navigation; the answer is `role="grid"` with rows/gridcells, or dropping
  Left/Right. No ticket filed.
- 8 Tailwind-class-string assertions in `ProjectPickerGrid.test.tsx` reintroduce the
  source-inspection style CGLAB-16 removed wholesale — seven at lines 334-351 (`max-w-4xl`,
  `max-w-md`, `max-h-[60vh]`, `grid-cols-1`, `sm:grid-cols-2`, `lg:grid-cols-3`,
  `overflow-y-auto`) and one at line 463 (`col-span-full`). They assert class strings rather
  than layout, so they pass whether or not the grid actually renders in columns and break on a
  harmless refactor.

