### PR TITLE
fix(flows): make flow editing work on both the local UI and the Hub (CGLAB-36)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -72,6 +72,7 @@ enforced by the server. Each workflow tool name in this skill maps to a CLI comm
 | `get_item(id)` | `agenfk get <id> --json` |
 | `create_item(projectId, type, title)` | `agenfk create <TYPE> "<title>" --project <id> [-d/--description <desc>] [-p/--parent <id>]` |
 | `update_item(id, {status})` | `agenfk update <id> [--status <name>][--title <t>][--description <d>][--type <T>]` (status is backward/rollback only) |
+| `update_item(id, {parentId})` | `agenfk update <id> --parent <parentId>` — re-parent; `--parent none` detaches to top level. Parent must be in the same project and cannot be the item itself or a descendant. |
 | `validate_progress(id, evidence, command?)` | `agenfk verify <id> --evidence "<text>" ["<command>"]` |
 | `add_comment(id, text)` | `agenfk comment <id> "<text>" [--author <name>]` |
 | `add_context(id, path)` | `agenfk add-context <id> --path <path> [--description <text>][--content <text>]` |

--- a/clauderules/CLAUDE.md
+++ b/clauderules/CLAUDE.md
@@ -90,6 +90,7 @@ This is the full workflow surface. Each row notes the equivalent MCP tool (avail
 | Get an item | `agenfk get <id> --json` | `get_item` |
 | Create an item | `agenfk create <TYPE> "<title>" --project <id> [-d/--description <desc>] [-p/--parent <id>]` | `create_item` |
 | Update / roll back status | `agenfk update <id> [--status <name>][--title <t>][--description <d>][--type <T>]` (status is backward/rollback only) | `update_item` |
+| Re-parent an item | `agenfk update <id> --parent <parentId>` — move it under another item; `--parent none` detaches it to top level. The parent must be in the same project, and cannot be the item itself or one of its descendants. | `update_item` (`parentId`) |
 | Advance a step (forward) | `agenfk verify <id> --evidence "<text>" ["<command>"]` | `validate_progress` |
 | Add a comment | `agenfk comment <id> "<text>" [--author <name>]` | `add_comment` |
 | Attach context | `agenfk add-context <id> --path <path> [--description <text>][--content <text>]` | `add_context` |

--- a/codexrules/AGENTS.md
+++ b/codexrules/AGENTS.md
@@ -99,6 +99,7 @@ This is the full workflow surface. In Codex, call the **`mcp__agenfk__*` tool** 
 | Get an item | `agenfk get <id> --json` | `get_item` |
 | Create an item | `agenfk create <TYPE> "<title>" --project <id> [-d/--description <desc>] [-p/--parent <id>]` | `create_item` |
 | Update / roll back status | `agenfk update <id> [--status <name>][--title <t>][--description <d>][--type <T>]` (status is backward/rollback only) | `update_item` |
+| Re-parent an item | `agenfk update <id> --parent <parentId>` — move it under another item; `--parent none` detaches it to top level. The parent must be in the same project, and cannot be the item itself or one of its descendants. | `update_item` (`parentId`) |
 | Advance a step (forward) | `agenfk verify <id> --evidence "<text>" ["<command>"]` | `validate_progress` |
 | Add a comment | `agenfk comment <id> "<text>" [--author <name>]` | `add_comment` |
 | Attach context | `agenfk add-context <id> --path <path> [--description <text>][--content <text>]` | `add_context` |

--- a/cursorrules/agenfk.mdc
+++ b/cursorrules/agenfk.mdc
@@ -98,6 +98,7 @@ This is the full workflow surface. Each row notes the equivalent MCP tool (avail
 | Get an item | `agenfk get <id> --json` | `get_item` |
 | Create an item | `agenfk create <TYPE> "<title>" --project <id> [-d/--description <desc>] [-p/--parent <id>]` | `create_item` |
 | Update / roll back status | `agenfk update <id> [--status <name>][--title <t>][--description <d>][--type <T>]` (status is backward/rollback only) | `update_item` |
+| Re-parent an item | `agenfk update <id> --parent <parentId>` — move it under another item; `--parent none` detaches it to top level. The parent must be in the same project, and cannot be the item itself or one of its descendants. | `update_item` (`parentId`) |
 | Advance a step (forward) | `agenfk verify <id> --evidence "<text>" ["<command>"]` | `validate_progress` |
 | Add a comment | `agenfk comment <id> "<text>" [--author <name>]` | `add_comment` |
 | Attach context | `agenfk add-context <id> --path <path> [--description <text>][--content <text>]` | `add_context` |

--- a/geminirules/GEMINI.md
+++ b/geminirules/GEMINI.md
@@ -94,6 +94,7 @@ This is the full workflow surface. Each row notes the equivalent MCP tool (avail
 | Get an item | `agenfk get <id> --json` | `get_item` |
 | Create an item | `agenfk create <TYPE> "<title>" --project <id> [-d/--description <desc>] [-p/--parent <id>]` | `create_item` |
 | Update / roll back status | `agenfk update <id> [--status <name>][--title <t>][--description <d>][--type <T>]` (status is backward/rollback only) | `update_item` |
+| Re-parent an item | `agenfk update <id> --parent <parentId>` — move it under another item; `--parent none` detaches it to top level. The parent must be in the same project, and cannot be the item itself or one of its descendants. | `update_item` (`parentId`) |
 | Advance a step (forward) | `agenfk verify <id> --evidence "<text>" ["<command>"]` | `validate_progress` |
 | Add a comment | `agenfk comment <id> "<text>" [--author <name>]` | `add_comment` |
 | Attach context | `agenfk add-context <id> --path <path> [--description <text>][--content <text>]` | `add_context` |

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1467,11 +1467,19 @@ program
         if (detachWords.includes(String(options.parent).toLowerCase())) {
           updates.parentId = null;
         } else {
-          // Accept a short parent id too, same as the item id above.
+          // Accept a short parent id too, same as the item id above. Scope the
+          // candidates to the item's own project: a prefix that is unique where
+          // the user is working would otherwise be called ambiguous because of
+          // an unrelated project they cannot see.
           let parentId = options.parent;
           if (parentId.length < 36) {
             const { data: allItems } = await axios.get(`${API_URL}/items`);
-            const found = allItems.filter((i: any) => i.id.startsWith(parentId));
+            let candidates = allItems;
+            const { data: target } = await axios.get(`${API_URL}/items/${targetId}`).catch(() => ({ data: null }));
+            if (target?.projectId) {
+              candidates = allItems.filter((i: any) => i.projectId === target.projectId);
+            }
+            const found = candidates.filter((i: any) => i.id.startsWith(parentId));
             if (found.length === 0) {
               console.error(chalk.red(`Parent item starting with ${parentId} not found.`));
               return;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1437,6 +1437,7 @@ program
   .option('-t, --title <title>', 'New title')
   .option('-d, --description <desc>', 'New description')
   .option('--type <type>', 'New type (EPIC, STORY, TASK, BUG)')
+  .option('--parent <parentId>', "Re-parent under another item; pass 'none' to detach to top level")
   .action(async (id, options) => {
     try {
       // Handle short ID
@@ -1461,8 +1462,39 @@ program
       if (options.description) updates.description = options.description;
       if (options.type) updates.type = options.type.toUpperCase();
 
+      if (options.parent !== undefined) {
+        const detachWords = ['none', 'null', 'root', ''];
+        if (detachWords.includes(String(options.parent).toLowerCase())) {
+          updates.parentId = null;
+        } else {
+          // Accept a short parent id too, same as the item id above.
+          let parentId = options.parent;
+          if (parentId.length < 36) {
+            const { data: allItems } = await axios.get(`${API_URL}/items`);
+            const found = allItems.filter((i: any) => i.id.startsWith(parentId));
+            if (found.length === 0) {
+              console.error(chalk.red(`Parent item starting with ${parentId} not found.`));
+              return;
+            }
+            if (found.length > 1) {
+              console.error(chalk.red(`Ambiguous parent ID ${parentId}, matches multiple items.`));
+              return;
+            }
+            parentId = found[0].id;
+          }
+          updates.parentId = parentId;
+        }
+      }
+
       const { data: updated } = await axios.put(`${API_URL}/items/${targetId}`, updates);
       console.log(chalk.green(`Updated item: ${updated.title} [${updated.type}] (${updated.status})`));
+      if (options.parent !== undefined) {
+        console.log(
+          updated.parentId
+            ? chalk.blue(`  Parent: ${updated.parentId}`)
+            : chalk.blue('  Parent: none (top level)')
+        );
+      }
     } catch (error: any) {
       console.error(chalk.red('Error updating item:'), error.response?.data?.error || error.message);
     }

--- a/packages/cli/src/test/update-parent-option.test.ts
+++ b/packages/cli/src/test/update-parent-option.test.ts
@@ -1,0 +1,197 @@
+/**
+ * `agenfk update <id> --parent` — re-parenting from the CLI.
+ *
+ * `agenfk create` has always taken -p/--parent, but `update` had no equivalent,
+ * so once an item existed its place in the tree was fixed from the CLI. This
+ * surfaced while grouping two BUGs under a STORY: neither could be made a child,
+ * so the link had to live in prose and the PR sizing shadow-check disagreed with
+ * the declared counts.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockExistsSync, mockReadFileSync } = vi.hoisted(() => ({
+  mockExistsSync: vi.fn(),
+  mockReadFileSync: vi.fn(),
+}));
+
+vi.mock('@agenfk/telemetry', () => ({
+  TelemetryClient: vi.fn(function (this: any) {
+    this.capture = vi.fn();
+    this.shutdown = vi.fn().mockResolvedValue(undefined);
+    this.isEnabled = true;
+    this.id = 'test-install-id';
+  }),
+  getInstallationId: vi.fn().mockReturnValue('test-install-id'),
+  isTelemetryEnabled: vi.fn().mockReturnValue(true),
+  getApiUrl: vi.fn().mockReturnValue('http://localhost:3000'),
+  readServerPort: vi.fn().mockReturnValue(null),
+  DEFAULT_API_PORT: 3000,
+}));
+
+vi.mock('fs', () => ({
+  existsSync: mockExistsSync,
+  readFileSync: mockReadFileSync,
+  writeFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  default: {
+    existsSync: mockExistsSync,
+    readFileSync: mockReadFileSync,
+    writeFileSync: vi.fn(),
+    mkdirSync: vi.fn(),
+  },
+}));
+
+vi.mock('axios');
+vi.mock('child_process', () => ({
+  execSync: vi.fn(),
+  spawn: vi.fn(),
+  spawnSync: vi.fn(),
+  default: { execSync: vi.fn(), spawn: vi.fn(), spawnSync: vi.fn() },
+}));
+vi.mock('figlet', () => ({
+  default: { textSync: vi.fn().mockReturnValue('AgEnFK') },
+}));
+vi.mock('inquirer', () => ({ default: { prompt: vi.fn() } }));
+
+import { program } from '../index';
+import axios from 'axios';
+
+const mockedAxios = vi.mocked(axios, true);
+const API = 'http://localhost:3000';
+
+// Full-length ids so the short-id resolution path is skipped unless a test
+// deliberately exercises it.
+const ITEM = '11111111-1111-1111-1111-111111111111';
+const PARENT = '22222222-2222-2222-2222-222222222222';
+
+function resetCommanderOptions(cmd: any) {
+  const options = (cmd as any).options || [];
+  options.forEach((opt: any) => cmd.setOptionValue(opt.attributeName(), undefined));
+  (cmd.commands || []).forEach(resetCommanderOptions);
+}
+
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockExistsSync.mockReturnValue(false);
+  mockReadFileSync.mockReturnValue('{}');
+  program.commands.forEach(resetCommanderOptions);
+  program.setOptionValue('toon', undefined);
+  logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  vi.spyOn(process, 'exit').mockImplementation((() => undefined) as any);
+});
+
+describe('agenfk update <id> --parent', () => {
+  it('exposes a --parent option on update', () => {
+    const update = program.commands.find(c => c.name() === 'update');
+    expect(update).toBeDefined();
+    const flags = (update as any).options.map((o: any) => o.long);
+    expect(flags).toContain('--parent');
+  });
+
+  it('PUTs the parentId', async () => {
+    mockedAxios.put.mockResolvedValue({ data: { id: ITEM, title: 'T', type: 'BUG', status: 'TODO', parentId: PARENT } });
+
+    await program.parseAsync(['node', 'agenfk', 'update', ITEM, '--parent', PARENT]);
+
+    expect(mockedAxios.put).toHaveBeenCalledWith(
+      `${API}/items/${ITEM}`,
+      expect.objectContaining({ parentId: PARENT }),
+    );
+  });
+
+  it("sends null for --parent none, to detach to top level", async () => {
+    mockedAxios.put.mockResolvedValue({ data: { id: ITEM, title: 'T', type: 'BUG', status: 'TODO', parentId: null } });
+
+    await program.parseAsync(['node', 'agenfk', 'update', ITEM, '--parent', 'none']);
+
+    expect(mockedAxios.put).toHaveBeenCalledWith(
+      `${API}/items/${ITEM}`,
+      expect.objectContaining({ parentId: null }),
+    );
+  });
+
+  it('treats "null" and "root" as detach too', async () => {
+    mockedAxios.put.mockResolvedValue({ data: { id: ITEM, title: 'T', type: 'BUG', status: 'TODO', parentId: null } });
+
+    await program.parseAsync(['node', 'agenfk', 'update', ITEM, '--parent', 'null']);
+    expect(mockedAxios.put).toHaveBeenLastCalledWith(`${API}/items/${ITEM}`, expect.objectContaining({ parentId: null }));
+
+    await program.parseAsync(['node', 'agenfk', 'update', ITEM, '--parent', 'root']);
+    expect(mockedAxios.put).toHaveBeenLastCalledWith(`${API}/items/${ITEM}`, expect.objectContaining({ parentId: null }));
+  });
+
+  it('does not send parentId at all when --parent is omitted', async () => {
+    mockedAxios.put.mockResolvedValue({ data: { id: ITEM, title: 'New', type: 'BUG', status: 'TODO' } });
+
+    await program.parseAsync(['node', 'agenfk', 'update', ITEM, '--title', 'New']);
+
+    const body = mockedAxios.put.mock.calls[0][1] as any;
+    expect(body).not.toHaveProperty('parentId');
+  });
+
+  it('resolves a short parent id', async () => {
+    mockedAxios.get.mockResolvedValue({ data: [{ id: PARENT, title: 'Parent' }] });
+    mockedAxios.put.mockResolvedValue({ data: { id: ITEM, title: 'T', type: 'BUG', status: 'TODO', parentId: PARENT } });
+
+    await program.parseAsync(['node', 'agenfk', 'update', ITEM, '--parent', '22222222']);
+
+    expect(mockedAxios.put).toHaveBeenCalledWith(
+      `${API}/items/${ITEM}`,
+      expect.objectContaining({ parentId: PARENT }),
+    );
+  });
+
+  it('refuses an ambiguous short parent id without sending anything', async () => {
+    mockedAxios.get.mockResolvedValue({ data: [{ id: PARENT }, { id: '22222222-dead-beef-0000-000000000000' }] });
+
+    await program.parseAsync(['node', 'agenfk', 'update', ITEM, '--parent', '2222']);
+
+    expect(mockedAxios.put).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Ambiguous parent ID'));
+  });
+
+  it('refuses an unknown short parent id without sending anything', async () => {
+    mockedAxios.get.mockResolvedValue({ data: [] });
+
+    await program.parseAsync(['node', 'agenfk', 'update', ITEM, '--parent', 'nope']);
+
+    expect(mockedAxios.put).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('not found'));
+  });
+
+  it("surfaces the server's refusal reason", async () => {
+    mockedAxios.put.mockRejectedValue({
+      response: { data: { error: 'Cannot re-parent an item under one of its own descendants — that would create a cycle.' } },
+    });
+
+    await program.parseAsync(['node', 'agenfk', 'update', ITEM, '--parent', PARENT]);
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining('cycle'),
+    );
+  });
+
+  it('reports the resulting parent', async () => {
+    mockedAxios.put.mockResolvedValue({ data: { id: ITEM, title: 'T', type: 'BUG', status: 'TODO', parentId: PARENT } });
+
+    await program.parseAsync(['node', 'agenfk', 'update', ITEM, '--parent', PARENT]);
+
+    const printed = logSpy.mock.calls.flat().join('\n');
+    expect(printed).toContain(PARENT);
+  });
+
+  it('reports detachment in words rather than printing an empty parent', async () => {
+    mockedAxios.put.mockResolvedValue({ data: { id: ITEM, title: 'T', type: 'BUG', status: 'TODO', parentId: null } });
+
+    await program.parseAsync(['node', 'agenfk', 'update', ITEM, '--parent', 'none']);
+
+    const printed = logSpy.mock.calls.flat().join('\n');
+    expect(printed).toMatch(/top level/i);
+  });
+});

--- a/packages/cli/src/test/update-parent-option.test.ts
+++ b/packages/cli/src/test/update-parent-option.test.ts
@@ -194,4 +194,47 @@ describe('agenfk update <id> --parent', () => {
     const printed = logSpy.mock.calls.flat().join('\n');
     expect(printed).toMatch(/top level/i);
   });
+
+  // A prefix unique inside the user's project must not be called ambiguous just
+  // because an unrelated project they cannot see shares it.
+  it('scopes short-parent-id matching to the item\'s own project', async () => {
+    mockedAxios.get.mockImplementation((url: string) => {
+      if (url.endsWith(`/items/${ITEM}`)) {
+        return Promise.resolve({ data: { id: ITEM, projectId: 'proj-a' } });
+      }
+      return Promise.resolve({
+        data: [
+          { id: PARENT, projectId: 'proj-a' },
+          { id: '22222222-dead-beef-0000-000000000000', projectId: 'proj-b' },
+        ],
+      });
+    });
+    mockedAxios.put.mockResolvedValue({ data: { id: ITEM, title: 'T', type: 'BUG', status: 'TODO', parentId: PARENT } });
+
+    await program.parseAsync(['node', 'agenfk', 'update', ITEM, '--parent', '2222']);
+
+    expect(mockedAxios.put).toHaveBeenCalledWith(
+      `${API}/items/${ITEM}`,
+      expect.objectContaining({ parentId: PARENT }),
+    );
+  });
+
+  it('still reports ambiguity when the collision is inside the same project', async () => {
+    mockedAxios.get.mockImplementation((url: string) => {
+      if (url.endsWith(`/items/${ITEM}`)) {
+        return Promise.resolve({ data: { id: ITEM, projectId: 'proj-a' } });
+      }
+      return Promise.resolve({
+        data: [
+          { id: PARENT, projectId: 'proj-a' },
+          { id: '22222222-dead-beef-0000-000000000000', projectId: 'proj-a' },
+        ],
+      });
+    });
+
+    await program.parseAsync(['node', 'agenfk', 'update', ITEM, '--parent', '2222']);
+
+    expect(mockedAxios.put).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Ambiguous parent ID'));
+  });
 });

--- a/packages/flow-editor/src/FlowEditorModal.tsx
+++ b/packages/flow-editor/src/FlowEditorModal.tsx
@@ -328,8 +328,15 @@ const EditorPanel: React.FC<EditorPanelProps> = ({
   // change exists to kill. Per-step messages render inside the step column, but
   // only for non-anchor steps (anchors expose no name field), and a flow-level
   // issue has no column at all. Surface anything that would otherwise be silent.
+  // A step column renders its own issue only when it has an editable name field
+  // (anchors don't) and isn't already showing the reserved-name message.
+  const stepShowsOwnIssue = (index: number): boolean => {
+    const step = steps[index];
+    if (!step || step.isAnchor) return false;
+    return !RESERVED_NAMES.has((step.name ?? '').toUpperCase());
+  };
   const silentIssues = definitionIssues.filter(
-    issue => issue.stepIndex === undefined || steps[issue.stepIndex]?.isAnchor,
+    issue => issue.stepIndex === undefined || !stepShowsOwnIssue(issue.stepIndex),
   );
 
   const isActive = flow?.id !== undefined && flow.id === activeFlowId;
@@ -487,7 +494,7 @@ const EditorPanel: React.FC<EditorPanelProps> = ({
               const hasReservedName = !isAnchor && RESERVED_NAMES.has(stepNameUpper);
               // A reserved name has its own dedicated message below, so only
               // show the shape issue when that isn't already being reported.
-              const shapeIssue = hasReservedName ? undefined : stepIssue(definitionIssues, index);
+              const shapeIssue = stepShowsOwnIssue(index) ? stepIssue(definitionIssues, index) : undefined;
               const stepColor = step.color ?? '#6366f1';
               const anchorColor = isDoneAnchor ? '#10b981' : '#94a3b8';
 
@@ -1066,8 +1073,14 @@ const FlowEditorModalInner: React.FC<Props> = (props) => {
     : flows.find(f => f.id === selectedFlowId) ?? null;
 
   // If this is a legacy-props invocation the passed `flow` wins as initial selection
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
   useEffect(() => {
     if (!isOpen) return;
+    // The component never unmounts (the wrapper mounts it and it self-returns
+    // null when closed), so a stale delete failure would otherwise still be on
+    // screen the next time the modal is opened.
+    setDeleteError(null);
     if (isLegacy && (props as LegacyProps).flow?.id) {
       setSelectedFlowId((props as LegacyProps).flow!.id);
       setIsNewFlow(false);
@@ -1084,7 +1097,6 @@ const FlowEditorModalInner: React.FC<Props> = (props) => {
   // The delete path had the same defect as save (BUG 269eeec8 (a)): no onError
   // and no rendering, so a refusal — e.g. the local server's 409 on a
   // hub-managed flow — vanished and the row simply stayed put.
-  const [deleteError, setDeleteError] = useState<string | null>(null);
   const deleteMutation = useMutation({
     mutationFn: (id: string) => flowClient.deleteFlow(id),
     onError: (e: unknown) => {
@@ -1383,7 +1395,7 @@ const FlowEditorModalInner: React.FC<Props> = (props) => {
                       {/* Delete button */}
                       <button
                         data-testid={`delete-flow-btn-${flow.id}`}
-                        disabled={isActive}
+                        disabled={isActive || isRowHubManaged}
                         onClick={e => {
                           e.stopPropagation();
                           if (!isActive && !isRowHubManaged) setConfirmDeleteId(flow.id);

--- a/packages/flow-editor/src/FlowEditorModal.tsx
+++ b/packages/flow-editor/src/FlowEditorModal.tsx
@@ -2,6 +2,8 @@ import React, { useState, useRef, useEffect, useCallback, createContext, useCont
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import mermaid from 'mermaid';
 import type { Flow, FlowStep, RegistryFlow, FlowClient, RegistryClient } from './types';
+import { extractApiError } from './apiError';
+import { flowDefinitionIssues, stepIssue, withStepIds } from './flowDefinition';
 
 // ── Host injection ─────────────────────────────────────────────────────────
 // The editor accepts its data layer (server REST + community registry) and
@@ -99,6 +101,12 @@ interface FlowEditorModalProps {
   // the hub (Org Flows picker) — the client may only author + publish. Defaults
   // to true (standalone installs and the hub admin, where it means set-default).
   canSelectFlow?: boolean;
+  // When true, a flow with source='hub' is presented as owned elsewhere and is
+  // not editable here. Set by the local agenfk UI, whose server answers any
+  // mutation of a hub-sourced flow with 409 (BUG 269eeec8 (b)) — offering Save
+  // was offering a guaranteed failure. The hub admin leaves this false: over
+  // there, hub-sourced flows are exactly the ones you are meant to edit.
+  hubManagedReadOnly?: boolean;
 }
 
 // Keep legacy Props alias so KanbanBoard can pass open= until it's updated
@@ -141,11 +149,12 @@ interface EditorPanelProps {
   onClone?: () => void;
   onUseDefault?: () => void;    // only provided for the builtin default flow row
   canSelectFlow: boolean;       // false → hide "Use this Flow" (selection is hub-owned)
+  isHubManaged: boolean;        // true → owned by the org Hub, not editable here
 }
 
 const EditorPanel: React.FC<EditorPanelProps> = ({
   flow,
-  isReadOnly,
+  isReadOnly: isBuiltinReadOnly,
   projectId,
   activeFlowId,
   onSaved,
@@ -153,7 +162,13 @@ const EditorPanel: React.FC<EditorPanelProps> = ({
   onClone,
   onUseDefault,
   canSelectFlow,
+  isHubManaged,
 }) => {
+  // Two independent reasons this panel can't be edited: it's the built-in
+  // default flow, or (BUG 269eeec8 (b)) it's owned by the org Hub and this host
+  // can only read it. They render different badges but lock the same controls.
+  const isReadOnly = isBuiltinReadOnly || isHubManaged;
+
   const queryClient = useQueryClient();
   const flowClient = useFlowClient();
   const registryClient = useRegistryClient();
@@ -252,7 +267,10 @@ const EditorPanel: React.FC<EditorPanelProps> = ({
       const payload: Partial<Flow> = {
         name,
         description,
-        steps: steps.map((s, i) => ({ ...s, order: i })),
+        // order is authoritative from array position; ids are backfilled so a
+        // flow loaded without them (MCP create_flow never sent ids) still
+        // satisfies the Hub's id rule.
+        steps: withStepIds(steps, generateUUID).map((s, i) => ({ ...s, order: i })),
       };
       if (flow?.id) {
         return flowClient.updateFlow(flow.id, payload);
@@ -276,7 +294,10 @@ const EditorPanel: React.FC<EditorPanelProps> = ({
       const payload: Partial<Flow> = {
         name,
         description,
-        steps: steps.map((s, i) => ({ ...s, order: i })),
+        // order is authoritative from array position; ids are backfilled so a
+        // flow loaded without them (MCP create_flow never sent ids) still
+        // satisfies the Hub's id rule.
+        steps: withStepIds(steps, generateUUID).map((s, i) => ({ ...s, order: i })),
       };
       const created = await flowClient.createFlow(payload);
       await flowClient.setProjectFlow(projectId, created.id);
@@ -292,11 +313,24 @@ const EditorPanel: React.FC<EditorPanelProps> = ({
   });
 
   const isBusy = saveMutation.isPending || useFlowMutation.isPending;
-  const errorMsg =
-    (saveMutation.error as Error | null)?.message ??
-    (useFlowMutation.error as Error | null)?.message ??
-    null;
-  const isSaveDisabled = isBusy || !name.trim() || reservedNameError;
+  // BUG 269eeec8 (a): read the server's `{ error }` body, not Error.message —
+  // the latter is only ever "Request failed with status code N".
+  const failure = saveMutation.error ?? useFlowMutation.error ?? null;
+  const errorMsg = failure ? extractApiError(failure, 'Failed to save flow.') : null;
+
+  // BUG 269eeec8 (c): mirror the Hub's definition contract so a payload it would
+  // reject never leaves the browser, and the reason is pinned to its step.
+  const definitionIssues = flowDefinitionIssues(name, steps);
+  const isSaveDisabled = isBusy || reservedNameError || definitionIssues.length > 0;
+
+  // Every reason Save is blocked MUST be visible somewhere, or the user is left
+  // with a dead button and no way to fix it — the exact failure mode this whole
+  // change exists to kill. Per-step messages render inside the step column, but
+  // only for non-anchor steps (anchors expose no name field), and a flow-level
+  // issue has no column at all. Surface anything that would otherwise be silent.
+  const silentIssues = definitionIssues.filter(
+    issue => issue.stepIndex === undefined || steps[issue.stepIndex]?.isAnchor,
+  );
 
   const isActive = flow?.id !== undefined && flow.id === activeFlowId;
 
@@ -313,17 +347,50 @@ const EditorPanel: React.FC<EditorPanelProps> = ({
       setPublishResult({ url: data.url, kind: data.kind ?? 'pr' });
       setPublishError(null);
     },
-    onError: (e: Error) => {
-      setPublishError(e.message || 'Failed to publish.');
+    onError: (e: unknown) => {
+      setPublishError(extractApiError(e, 'Failed to publish.'));
     },
   });
+
+  // Rendered by BOTH footers — the read-only footer also offers Publish now, and
+  // a button whose outcome renders somewhere else is a silent failure.
+  const publishFeedback = (
+    <>
+      {publishResult && (
+        <a
+          data-testid="publish-success-link"
+          href={publishResult.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-1 text-xs text-emerald-700 dark:text-emerald-400 font-semibold hover:underline"
+        >
+          <ExternalLink size={12} />
+          {publishResult.kind === 'pr' ? 'PR opened — view on GitHub' : 'Already published — view on registry'}
+        </a>
+      )}
+      {publishError && (
+        <p data-testid="publish-error" className="text-xs text-red-600 dark:text-red-400 flex items-center gap-1">
+          <AlertCircle size={11} />
+          {publishError}
+        </p>
+      )}
+    </>
+  );
 
   return (
     <div className="flex flex-col h-full" data-testid="editor-panel">
       {/* Right panel header — inline-editable flow name */}
       <div className="px-6 pt-5 pb-3 shrink-0">
         <div className="flex items-center gap-2 mb-1.5">
-          {isReadOnly ? (
+          {isHubManaged ? (
+            <span
+              data-testid="hub-managed-badge"
+              title="This flow is managed by your organization's Hub. Edit it in the Hub admin, or clone it to author a local copy."
+              className="text-xs font-semibold uppercase tracking-wide px-2 py-0.5 rounded-full bg-sky-100 dark:bg-sky-900/40 text-sky-700 dark:text-sky-300"
+            >
+              Managed by Hub
+            </span>
+          ) : isBuiltinReadOnly ? (
             <span className="text-xs font-semibold uppercase tracking-wide px-2 py-0.5 rounded-full bg-slate-200 dark:bg-slate-700 text-slate-500 dark:text-slate-400">
               Default (read-only)
             </span>
@@ -341,7 +408,11 @@ const EditorPanel: React.FC<EditorPanelProps> = ({
           )}
         </div>
         {isReadOnly ? (
-          <h3 className="text-xl font-bold text-slate-800 dark:text-slate-100">Default Flow</h3>
+          // Don't hardcode "Default Flow" — this branch now also renders
+          // hub-managed flows, which have their own names.
+          <h3 data-testid="flow-name-heading" className="text-xl font-bold text-slate-800 dark:text-slate-100">
+            {isHubManaged ? name || flow?.name : 'Default Flow'}
+          </h3>
         ) : (
           <input
             data-testid="flow-name-input"
@@ -414,6 +485,9 @@ const EditorPanel: React.FC<EditorPanelProps> = ({
               const isStepLocked = isReadOnly || isAnchor;
               const stepNameUpper = step.name.toUpperCase();
               const hasReservedName = !isAnchor && RESERVED_NAMES.has(stepNameUpper);
+              // A reserved name has its own dedicated message below, so only
+              // show the shape issue when that isn't already being reported.
+              const shapeIssue = hasReservedName ? undefined : stepIssue(definitionIssues, index);
               const stepColor = step.color ?? '#6366f1';
               const anchorColor = isDoneAnchor ? '#10b981' : '#94a3b8';
 
@@ -572,6 +646,11 @@ const EditorPanel: React.FC<EditorPanelProps> = ({
                                 : 'border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-800 dark:text-slate-100 focus:ring-indigo-500'
                             )}
                           />
+                          {shapeIssue && (
+                            <p data-testid={`step-name-error-${index}`} className="text-xs text-red-600 dark:text-red-400 mt-0.5">
+                              {shapeIssue.message}
+                            </p>
+                          )}
                           {hasReservedName && (
                             <p data-testid={`step-reserved-error-${index}`} className="text-xs text-red-600 dark:text-red-400 mt-0.5">
                               Reserved name
@@ -616,6 +695,17 @@ const EditorPanel: React.FC<EditorPanelProps> = ({
             })}
           </div>
           {/* Reserved name global error */}
+          {silentIssues.length > 0 && (
+            <ul data-testid="flow-definition-issues" className="text-sm text-red-600 dark:text-red-400 mt-1 list-disc pl-5">
+              {silentIssues.map((issue, i) => (
+                <li key={i}>
+                  {issue.stepIndex === undefined
+                    ? issue.message
+                    : `${steps[issue.stepIndex]?.label || steps[issue.stepIndex]?.name || `Step ${issue.stepIndex + 1}`}: ${issue.message}`}
+                </li>
+              ))}
+            </ul>
+          )}
           {reservedNameError && (
             <p data-testid="reserved-name-error" className="text-sm text-red-600 dark:text-red-400 mt-1">
               One or more step names use a reserved name (TODO, DONE, BLOCKED, PAUSED, IDEAS, ARCHIVED, TRASHED).
@@ -633,7 +723,23 @@ const EditorPanel: React.FC<EditorPanelProps> = ({
 
       {/* Footer — sticky bottom */}
       {isReadOnly ? (
-        <div className="px-6 py-4 border-t border-slate-200 dark:border-slate-700 shrink-0 flex items-center gap-3 flex-wrap">
+        <div className="px-6 py-4 border-t border-slate-200 dark:border-slate-700 shrink-0 flex flex-col gap-3">
+         <div className="flex items-center gap-3 flex-wrap">
+          {/* A hub-managed flow used to render the editable footer, which carried
+              Publish. Keep it reachable here rather than silently dropping the
+              capability along with Save. */}
+          {isHubManaged && flow?.id && (
+            <button
+              data-testid="publish-flow-btn"
+              type="button"
+              disabled={publishMutation.isPending}
+              onClick={() => { setPublishResult(null); setPublishError(null); publishMutation.mutate(); }}
+              className="flex items-center gap-1.5 px-4 py-2 rounded-xl text-sm font-semibold border border-violet-300 dark:border-violet-700 text-violet-700 dark:text-violet-300 hover:bg-violet-50 dark:hover:bg-violet-900/20 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              {publishMutation.isPending ? <Loader2 size={15} className="animate-spin" /> : <Upload size={15} />}
+              {publishMutation.isPending ? 'Publishing…' : 'Publish'}
+            </button>
+          )}
           {onUseDefault && canSelectFlow && (
             <button
               data-testid="use-default-flow-btn"
@@ -664,6 +770,8 @@ const EditorPanel: React.FC<EditorPanelProps> = ({
           >
             Close
           </button>
+         </div>
+         {publishFeedback}
         </div>
       ) : (
         <div className="px-6 py-4 border-t border-slate-200 dark:border-slate-700 shrink-0 flex flex-col gap-3">
@@ -707,24 +815,7 @@ const EditorPanel: React.FC<EditorPanelProps> = ({
             </div>
           </div>
 
-          {publishResult && (
-            <a
-              data-testid="publish-success-link"
-              href={publishResult.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center gap-1 text-xs text-emerald-700 dark:text-emerald-400 font-semibold hover:underline"
-            >
-              <ExternalLink size={12} />
-              {publishResult.kind === 'pr' ? 'PR opened — view on GitHub' : 'Already published — view on registry'}
-            </a>
-          )}
-          {publishError && (
-            <p data-testid="publish-error" className="text-xs text-red-600 dark:text-red-400 flex items-center gap-1">
-              <AlertCircle size={11} />
-              {publishError}
-            </p>
-          )}
+          {publishFeedback}
         </div>
       )}
     </div>
@@ -906,6 +997,9 @@ const FlowEditorModalInner: React.FC<Props> = (props) => {
     : (props as FlowEditorModalProps).initialFlowId;
   // Selection actions default on; hosts opt out (hub-connected clients).
   const canSelectFlow = isLegacy ? true : ((props as FlowEditorModalProps).canSelectFlow ?? true);
+  // Defaults false so the hub admin — which must edit hub-sourced flows — keeps
+  // working without opting out; only the local agenfk UI sets it.
+  const hubManagedReadOnly = isLegacy ? false : ((props as FlowEditorModalProps).hubManagedReadOnly ?? false);
 
   const queryClient = useQueryClient();
   const flowClient = useFlowClient();
@@ -987,9 +1081,18 @@ const FlowEditorModalInner: React.FC<Props> = (props) => {
   }, [isOpen]);
 
   // ── Delete mutation ────────────────────────────────────────────────────────
+  // The delete path had the same defect as save (BUG 269eeec8 (a)): no onError
+  // and no rendering, so a refusal — e.g. the local server's 409 on a
+  // hub-managed flow — vanished and the row simply stayed put.
+  const [deleteError, setDeleteError] = useState<string | null>(null);
   const deleteMutation = useMutation({
     mutationFn: (id: string) => flowClient.deleteFlow(id),
+    onError: (e: unknown) => {
+      setDeleteError(extractApiError(e, 'Failed to delete flow.'));
+      setConfirmDeleteId(null);
+    },
     onSuccess: (_, deletedId) => {
+      setDeleteError(null);
       queryClient.invalidateQueries({ queryKey: ['flows'] });
       queryClient.invalidateQueries({ queryKey: ['flow', projectId] });
       if (selectedFlowId === deletedId) {
@@ -1038,6 +1141,12 @@ const FlowEditorModalInner: React.FC<Props> = (props) => {
 
   const isReadOnly = selectedFlowId === BUILTIN_ID && !clonedFlow;
   const isEditingClone = clonedFlow !== null;
+  // A hub-owned flow, viewed from a host that may only read it. Hoisted because
+  // the footer actions below need it too: without a Clone action the panel would
+  // be a dead end, and the badge tooltip explicitly tells the user to clone.
+  const isHubManagedSelected =
+    hubManagedReadOnly && selectedFlow?.source === 'hub' && !isEditingClone;
+
 
   const handleClone = (source: Flow, sourceName: string) => {
     const copy = cloneFlow(source, `Copy of ${sourceName}`);
@@ -1201,10 +1310,19 @@ const FlowEditorModalInner: React.FC<Props> = (props) => {
               </div>
             </div>
 
+            {deleteError && (
+              <p data-testid="flow-delete-error" className="text-xs text-red-600 dark:text-red-400 px-3 py-2">
+                {deleteError}
+              </p>
+            )}
+
             {flows.map(flow => {
               const isActive = flow.id === effectiveActiveFlowId;
               const isSelected = selectedFlowId === flow.id && !isNewFlow && !isEditingClone;
               const isPendingDelete = confirmDeleteId === flow.id;
+              // Hosts that can only read hub flows must not offer a delete the
+              // server answers with 409.
+              const isRowHubManaged = hubManagedReadOnly && flow.source === 'hub';
 
               return (
                 <div
@@ -1268,12 +1386,16 @@ const FlowEditorModalInner: React.FC<Props> = (props) => {
                         disabled={isActive}
                         onClick={e => {
                           e.stopPropagation();
-                          if (!isActive) setConfirmDeleteId(flow.id);
+                          if (!isActive && !isRowHubManaged) setConfirmDeleteId(flow.id);
                         }}
-                        title={isActive ? 'Cannot delete active flow' : 'Delete flow'}
+                        title={
+                          isRowHubManaged
+                            ? "Managed by your organization's Hub — delete it there"
+                            : isActive ? 'Cannot delete active flow' : 'Delete flow'
+                        }
                         className={clsx(
                           'shrink-0 p-1 rounded transition-colors',
-                          isActive
+                          isActive || isRowHubManaged
                             ? 'text-slate-300 dark:text-slate-600 cursor-not-allowed'
                             : 'text-slate-300 hover:text-red-500 dark:text-slate-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20'
                         )}
@@ -1332,17 +1454,22 @@ const FlowEditorModalInner: React.FC<Props> = (props) => {
               key={isEditingClone ? '__clone__' : isNewFlow ? '__new__' : selectedFlowId}
               flow={selectedFlow}
               isReadOnly={isReadOnly}
+              isHubManaged={isHubManagedSelected}
               projectId={projectId}
               activeFlowId={effectiveActiveFlowId}
               onSaved={handleFlowSaved}
               onClose={onClose}
               onClone={
-                isReadOnly && builtinFlow
-                  ? () => handleClone(builtinFlow, builtinFlow.name ?? 'Default Flow')
-                  : undefined
+                isHubManagedSelected && selectedFlow
+                  ? () => handleClone(selectedFlow, selectedFlow.name)
+                  : isReadOnly && builtinFlow
+                    ? () => handleClone(builtinFlow, builtinFlow.name ?? 'Default Flow')
+                    : undefined
               }
               onUseDefault={
-                isReadOnly
+                // Only the builtin default flow — on a hub flow this would set
+                // the DEFAULT flow, which is not what the button says.
+                isReadOnly && !isHubManagedSelected
                   ? () => useDefaultFlowMutation.mutate()
                   : undefined
               }

--- a/packages/flow-editor/src/apiError.ts
+++ b/packages/flow-editor/src/apiError.ts
@@ -1,0 +1,58 @@
+/**
+ * Pull the human-readable reason out of a failed API call.
+ *
+ * BUG 269eeec8 (a): the editor rendered `(error as Error).message`, which for an
+ * axios rejection is the useless "Request failed with status code 400". Every
+ * REST surface in this repo answers a refusal with `{ error: "<reason>" }` — the
+ * local server's hub-managed guard, the Hub's flow-definition validator — and
+ * that body is the only text that tells the user what to fix. Discarding it made
+ * two separate defects look like the same unexplained failure.
+ *
+ * Lives in the shared package because the editor runs against two different
+ * axios instances (packages/ui and packages/hub-ui); a fix in either caller
+ * would leave the other blind.
+ */
+
+/** Narrow an unknown thrown value to something with a `response.data`. */
+function responseData(e: unknown): unknown {
+  if (!e || typeof e !== 'object') return undefined;
+  const response = (e as { response?: unknown }).response;
+  if (!response || typeof response !== 'object') return undefined;
+  return (response as { data?: unknown }).data;
+}
+
+/** Longest reason worth putting in a one-line error paragraph. */
+const MAX_REASON_LENGTH = 300;
+
+function nonBlank(value: unknown): string | null {
+  if (typeof value !== 'string' || !value.trim()) return null;
+  // A proxy or gateway answering with an HTML error page would otherwise dump
+  // the whole document into the error line — worse than the generic message.
+  if (/^\s*<(?:!doctype|html|head|body)\b/i.test(value)) return null;
+  return value.length > MAX_REASON_LENGTH ? `${value.slice(0, MAX_REASON_LENGTH)}…` : value;
+}
+
+/**
+ * @param e        the thrown value (axios error, Error, or anything at all)
+ * @param fallback used only when nothing usable can be recovered
+ */
+export function extractApiError(e: unknown, fallback = 'Something went wrong.'): string {
+  const data = responseData(e);
+
+  // Server-supplied reason, in preference order.
+  const fromBody =
+    nonBlank(data) ??
+    (data && typeof data === 'object'
+      ? nonBlank((data as { error?: unknown }).error) ?? nonBlank((data as { message?: unknown }).message)
+      : null);
+  if (fromBody) return fromBody;
+
+  // No usable body — fall back to the transport/JS error text, which at least
+  // distinguishes a network failure from a rejected request.
+  if (e && typeof e === 'object') {
+    const message = nonBlank((e as { message?: unknown }).message);
+    if (message) return message;
+  }
+
+  return fallback;
+}

--- a/packages/flow-editor/src/flowDefinition.ts
+++ b/packages/flow-editor/src/flowDefinition.ts
@@ -1,0 +1,72 @@
+/**
+ * Client-side mirror of the Hub's flow-definition contract.
+ *
+ * BUG 269eeec8 (c): the Hub validates definition shape
+ * (packages/hub/src/routes/admin.ts `validateDefinition` — every step needs a
+ * non-empty id, a non-empty name, and a numeric order) while the local agenfk
+ * server validated nothing. `makeBlankStep()` seeds a new step with `name: ''`,
+ * so adding a step and saving before naming it produced a bare 400 from the Hub
+ * and a silently-corrupt flow locally. An empty step name is a broken workflow
+ * status either way: nothing can transition an item to "".
+ *
+ * Checking here means Save is blocked with a reason pinned to the offending
+ * step, before any request goes out. Keep in step with the Hub's validator and
+ * with the local server's `flowStepsError` (packages/server/src/server.ts) — the
+ * cases in flowDefinition.test.ts are the contract.
+ */
+import type { FlowStep } from './types';
+
+export interface FlowDefinitionIssue {
+  /** Index into the steps array, or undefined for a flow-level problem. */
+  stepIndex?: number;
+  message: string;
+}
+
+/**
+ * Every reason this definition would be rejected, in document order
+ * (flow-level first, then per-step). Empty array means it will be accepted.
+ */
+export function flowDefinitionIssues(name: string, steps: FlowStep[]): FlowDefinitionIssue[] {
+  const issues: FlowDefinitionIssue[] = [];
+
+  if (!name.trim()) {
+    issues.push({ message: 'Flow name is required.' });
+  }
+  if (!Array.isArray(steps) || steps.length === 0) {
+    issues.push({ message: 'A flow needs at least one step.' });
+    return issues;
+  }
+
+  // Only gate on what the user must fix themselves. Two of the Hub's rules are
+  // deliberately NOT enforced here, because blocking on them would strand the
+  // user in front of a field the editor does not expose:
+  //  - step `id`: MCP create_flow never sent ids (its zod schema omits the key),
+  //    so flows already in users' databases have steps — anchors included —
+  //    without one. The server now backfills ids on write, and withStepIds()
+  //    below fills them into the payload, so a missing id is not the user's
+  //    problem to solve.
+  //  - step `order`: the save payload rewrites order to the array index, so any
+  //    bad value in loaded data is repaired by the request itself.
+  steps.forEach((step, stepIndex) => {
+    if (typeof step?.name !== 'string' || !step.name.trim()) {
+      issues.push({ stepIndex, message: 'Step name is required.' });
+    }
+  });
+
+  return issues;
+}
+
+/**
+ * Fill in ids the loaded flow was missing, so the payload satisfies the Hub's
+ * id rule without ever asking the user for a value the UI cannot edit. The
+ * local server backfills too; doing it here also covers hub-ui, whose backend
+ * rejects rather than generates.
+ */
+export function withStepIds(steps: FlowStep[], generateId: () => string): FlowStep[] {
+  return steps.map(s => (typeof s?.id === 'string' && s.id ? s : { ...s, id: generateId() }));
+}
+
+/** The issue attached to a given step, if any — for rendering inline. */
+export function stepIssue(issues: FlowDefinitionIssue[], stepIndex: number): FlowDefinitionIssue | undefined {
+  return issues.find(i => i.stepIndex === stepIndex);
+}

--- a/packages/flow-editor/src/test/apiError.test.ts
+++ b/packages/flow-editor/src/test/apiError.test.ts
@@ -1,0 +1,77 @@
+/**
+ * BUG 269eeec8 defect (a) — the flow editor showed only "Request failed with
+ * status code N" because it read `Error.message` off the axios error instead of
+ * the server's response body. Every REST surface in this repo answers a refusal
+ * with `{ error: "<reason>" }`, so that body is the only thing that tells the
+ * user what to fix. The editor is shared by packages/ui and packages/hub-ui with
+ * two different axios instances, so the extraction lives here rather than in
+ * either caller.
+ */
+import { describe, it, expect } from 'vitest';
+import { extractApiError } from '../apiError';
+
+/** Shape axios produces: the useful text is in response.data, not in message. */
+const axiosLike = (status: number, data: unknown) => ({
+  isAxiosError: true,
+  message: `Request failed with status code ${status}`,
+  response: { status, data },
+});
+
+describe('extractApiError', () => {
+  it("prefers the server's `error` field over the generic axios message", () => {
+    const e = axiosLike(409, { error: "Flow is managed by your organization's Hub and cannot be modified locally" });
+    expect(extractApiError(e)).toBe("Flow is managed by your organization's Hub and cannot be modified locally");
+  });
+
+  it('surfaces a validation reason so the user knows which field is wrong', () => {
+    expect(extractApiError(axiosLike(400, { error: 'each step requires a name' }))).toBe('each step requires a name');
+  });
+
+  it('falls back to `message` when the body uses that key instead', () => {
+    expect(extractApiError(axiosLike(500, { message: 'boom' }))).toBe('boom');
+  });
+
+  it('uses a plain string body as-is', () => {
+    expect(extractApiError(axiosLike(502, 'upstream exploded'))).toBe('upstream exploded');
+  });
+
+  it('keeps the axios message when the body carries no usable reason', () => {
+    expect(extractApiError(axiosLike(400, {}))).toBe('Request failed with status code 400');
+  });
+
+  it('keeps the axios message when there is no response at all (network error)', () => {
+    expect(extractApiError({ isAxiosError: true, message: 'Network Error' })).toBe('Network Error');
+  });
+
+  // A proxy/gateway 502 answers with an HTML document, not a reason. Dumping the
+  // page source into a one-line error paragraph is worse than the generic text.
+  it('ignores an HTML error page body', () => {
+    const html = '<!DOCTYPE html><html><body><h1>502 Bad Gateway</h1></body></html>';
+    expect(extractApiError(axiosLike(502, html))).toBe('Request failed with status code 502');
+  });
+
+  it('truncates an over-long reason instead of rendering a wall of text', () => {
+    const long = 'x'.repeat(1000);
+    const out = extractApiError(axiosLike(400, { error: long }));
+    expect(out.length).toBeLessThan(long.length);
+    expect(out.endsWith('…')).toBe(true);
+  });
+
+  it('handles a non-axios Error', () => {
+    expect(extractApiError(new Error('Flow must be saved before publishing.')))
+      .toBe('Flow must be saved before publishing.');
+  });
+
+  it('returns the supplied fallback for a thrown non-error value', () => {
+    expect(extractApiError(undefined, 'Failed to save flow.')).toBe('Failed to save flow.');
+    expect(extractApiError(null, 'Failed to save flow.')).toBe('Failed to save flow.');
+  });
+
+  // A blank reason is no reason: it must behave exactly like an absent one
+  // (above), falling through to the axios message rather than being rendered as
+  // an empty red line. The fallback is reserved for having no text at all.
+  it('treats a whitespace-only reason as absent and keeps the axios message', () => {
+    expect(extractApiError(axiosLike(400, { error: '   ' }), 'Failed to save flow.'))
+      .toBe('Request failed with status code 400');
+  });
+});

--- a/packages/flow-editor/src/test/flowDefinition.test.ts
+++ b/packages/flow-editor/src/test/flowDefinition.test.ts
@@ -1,0 +1,124 @@
+/**
+ * BUG 269eeec8 defect (c) — the Hub validates flow-definition shape
+ * (packages/hub/src/routes/admin.ts validateDefinition) while the local agenfk
+ * server validated nothing, so the same editor could author a flow the local
+ * server persisted happily and the Hub rejected with a bare 400. This mirrors
+ * the Hub's contract client-side so Save is blocked with a field-level reason
+ * before any request goes out.
+ *
+ * These assertions ARE the contract: if the Hub's validator gains a rule, it
+ * gains a case here too, or the editor silently drifts back out of sync.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { flowDefinitionIssues, withStepIds } from '../flowDefinition';
+import type { FlowStep } from '../types';
+
+const step = (over: Partial<FlowStep> = {}): FlowStep => ({
+  id: 's1',
+  name: 'work',
+  label: 'Work',
+  order: 1,
+  exitCriteria: '',
+  ...over,
+});
+
+const validSteps = (): FlowStep[] => [
+  step({ id: 's0', name: 'TODO', label: 'To Do', order: 0, isAnchor: true }),
+  step({ id: 's1', name: 'work', label: 'Work', order: 1 }),
+  step({ id: 's2', name: 'DONE', label: 'Done', order: 2, isAnchor: true }),
+];
+
+describe('flowDefinitionIssues', () => {
+  it('reports nothing for a well-formed definition', () => {
+    expect(flowDefinitionIssues('My Flow', validSteps())).toEqual([]);
+  });
+
+  it('rejects a blank flow name', () => {
+    const issues = flowDefinitionIssues('   ', validSteps());
+    expect(issues).toHaveLength(1);
+    expect(issues[0].stepIndex).toBeUndefined();
+    expect(issues[0].message).toMatch(/name/i);
+  });
+
+  it('rejects an empty step list', () => {
+    expect(flowDefinitionIssues('My Flow', [])).toHaveLength(1);
+  });
+
+  // The defect that actually fired: makeBlankStep() seeds `name: ''`, so adding
+  // a step and saving before typing a name 400s the whole save at the Hub.
+  it('pins the blank step name to the offending step index', () => {
+    const steps = validSteps();
+    steps.splice(2, 0, step({ id: 'new', name: '', label: '', order: 2 }));
+    const issues = flowDefinitionIssues('My Flow', steps);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].stepIndex).toBe(2);
+    expect(issues[0].message).toMatch(/name/i);
+  });
+
+  it('treats a whitespace-only step name as blank', () => {
+    const steps = validSteps();
+    steps[1] = step({ id: 's1', name: '  ', label: 'Work', order: 1 });
+    expect(flowDefinitionIssues('My Flow', steps)[0].stepIndex).toBe(1);
+  });
+
+  it('reports every blank step, not just the first', () => {
+    const steps = validSteps();
+    steps.splice(1, 0, step({ id: 'n1', name: '', order: 1 }));
+    steps.splice(3, 0, step({ id: 'n2', name: '', order: 3 }));
+    const issues = flowDefinitionIssues('My Flow', steps);
+    expect(issues.map(i => i.stepIndex)).toEqual([1, 3]);
+  });
+
+  // Deliberately NOT gated: MCP create_flow never sent step ids (its schema
+  // omitted the key), so flows already in users' databases have steps — anchors
+  // included — without one. Blocking Save would strand the user in front of a
+  // field the editor does not expose, with anchors offering no input at all.
+  it('does NOT block on a missing step id — it is backfilled, not user-fixable', () => {
+    const steps = validSteps();
+    steps[1] = step({ id: '', name: 'work', order: 1 });
+    expect(flowDefinitionIssues('My Flow', steps)).toEqual([]);
+  });
+
+  // Also not gated: the save payload rewrites order to the array index, so a
+  // bad value in loaded data is repaired by the request itself.
+  it('does NOT block on a non-numeric step order — the payload rewrites it', () => {
+    const steps = validSteps();
+    steps[1] = { ...step({ id: 's1', name: 'work' }), order: undefined as unknown as number };
+    expect(flowDefinitionIssues('My Flow', steps)).toEqual([]);
+  });
+
+  it('accumulates a flow-level and a step-level issue together', () => {
+    const steps = validSteps();
+    steps[1] = step({ id: 's1', name: '', order: 1 });
+    const issues = flowDefinitionIssues('', steps);
+    expect(issues).toHaveLength(2);
+    expect(issues.some(i => i.stepIndex === undefined)).toBe(true);
+    expect(issues.some(i => i.stepIndex === 1)).toBe(true);
+  });
+});
+
+describe('withStepIds', () => {
+  let n = 0;
+  const gen = () => `generated-${++n}`;
+  beforeEach(() => { n = 0; });
+
+  it('fills in ids for steps that lack them and leaves existing ids alone', () => {
+    const steps = [step({ id: 'keep', name: 'a', order: 0 }), step({ id: '', name: 'b', order: 1 })];
+    const out = withStepIds(steps, gen);
+    expect(out[0].id).toBe('keep');
+    expect(out[1].id).toBe('generated-1');
+  });
+
+  it('does not mutate the input array or its steps', () => {
+    const steps = [step({ id: '', name: 'a', order: 0 })];
+    const out = withStepIds(steps, gen);
+    expect(steps[0].id).toBe('');
+    expect(out[0]).not.toBe(steps[0]);
+  });
+
+  it('preserves every other field while filling the id', () => {
+    const steps = [step({ id: '', name: 'a', label: 'A', order: 3, exitCriteria: 'done when X' })];
+    const [out] = withStepIds(steps, gen);
+    expect(out).toMatchObject({ name: 'a', label: 'A', order: 3, exitCriteria: 'done when X' });
+  });
+});

--- a/packages/hub/src/db/postgres.ts
+++ b/packages/hub/src/db/postgres.ts
@@ -58,6 +58,9 @@ const SCHEMA_PG = `
   CREATE INDEX IF NOT EXISTS idx_events_org_time ON events(org_id, occurred_at);
   CREATE INDEX IF NOT EXISTS idx_events_user_time ON events(org_id, user_key, occurred_at);
   CREATE INDEX IF NOT EXISTS idx_events_type_time ON events(org_id, type, occurred_at);
+  -- BUG ab9b39d3: the Admin -> Flows assignment listing looks up the latest
+  -- remote_url per project; without this it seq-scans the whole events table.
+  CREATE INDEX IF NOT EXISTS idx_events_org_project_time ON events(org_id, project_id, occurred_at);
 
   CREATE TABLE IF NOT EXISTS rollups_daily (
     org_id TEXT NOT NULL,

--- a/packages/hub/src/db/postgres.ts
+++ b/packages/hub/src/db/postgres.ts
@@ -58,9 +58,6 @@ const SCHEMA_PG = `
   CREATE INDEX IF NOT EXISTS idx_events_org_time ON events(org_id, occurred_at);
   CREATE INDEX IF NOT EXISTS idx_events_user_time ON events(org_id, user_key, occurred_at);
   CREATE INDEX IF NOT EXISTS idx_events_type_time ON events(org_id, type, occurred_at);
-  -- BUG ab9b39d3: the Admin -> Flows assignment listing looks up the latest
-  -- remote_url per project; without this it seq-scans the whole events table.
-  CREATE INDEX IF NOT EXISTS idx_events_org_project_time ON events(org_id, project_id, occurred_at);
 
   CREATE TABLE IF NOT EXISTS rollups_daily (
     org_id TEXT NOT NULL,
@@ -318,6 +315,20 @@ async function bootstrap(adapter: HubDb): Promise<void> {
   await adapter.exec("CREATE INDEX IF NOT EXISTS idx_events_item_type_time ON events(org_id, item_type, occurred_at)");
   await adapter.exec("CREATE INDEX IF NOT EXISTS idx_events_external_id ON events(org_id, external_id)");
   await adapter.exec("CREATE INDEX IF NOT EXISTS idx_rollups_org_day_user ON rollups_daily(org_id, day, user_key)");
+
+  // BUG ab9b39d3: backs the Admin -> Flows lookup of the latest remote_url per
+  // project. CONCURRENTLY, and deliberately NOT inside SCHEMA_PG: that batch is
+  // one multi-statement simple query, so Postgres wraps it in an implicit
+  // transaction, and a plain CREATE INDEX there would hold a SHARE lock on the
+  // events ingestion table — blocking every insert — until the whole batch
+  // commits. Each standalone exec() is its own implicit transaction, where
+  // CONCURRENTLY is legal. A failed concurrent build leaves an INVALID index
+  // that is simply rebuilt on the next boot, so don't fail boot over it.
+  try {
+    await adapter.exec("CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_events_org_project_time ON events(org_id, project_id, occurred_at)");
+  } catch (e) {
+    console.warn('[hub] idx_events_org_project_time build skipped:', (e as Error)?.message);
+  }
 
   // Canonicalise events.remote_url so the projects filter in the hub UI
   // doesn't show duplicates for repos expressed as ssh / https / with-or-

--- a/packages/hub/src/db/sqlite.ts
+++ b/packages/hub/src/db/sqlite.ts
@@ -58,6 +58,9 @@ const SCHEMA_SQLITE = `
   CREATE INDEX IF NOT EXISTS idx_events_org_time ON events(org_id, occurred_at);
   CREATE INDEX IF NOT EXISTS idx_events_user_time ON events(org_id, user_key, occurred_at);
   CREATE INDEX IF NOT EXISTS idx_events_type_time ON events(org_id, type, occurred_at);
+  -- BUG ab9b39d3: the Admin -> Flows assignment listing looks up the latest
+  -- remote_url per project; without this it seq-scans the whole events table.
+  CREATE INDEX IF NOT EXISTS idx_events_org_project_time ON events(org_id, project_id, occurred_at);
 
   CREATE TABLE IF NOT EXISTS rollups_daily (
     org_id TEXT NOT NULL,

--- a/packages/hub/src/routes/admin.ts
+++ b/packages/hub/src/routes/admin.ts
@@ -486,17 +486,28 @@ export function adminRouter(ctx: HubServerContext): Router {
       // to a single unbounded query streaming every matching event row into
       // Node, which is what a naive de-correlation would do on the ingestion
       // table. idx_events_org_project_time backs the lookup.
-      for (const projectId of projectTargetIds) {
-        const row = await ctx.db.get<{ remote_url: string | null }>(
-          `SELECT remote_url
-           FROM events
-           WHERE org_id = ? AND project_id = ? AND remote_url IS NOT NULL
-           ORDER BY occurred_at DESC
-           LIMIT 1`,
-          [req.session!.orgId, projectId],
-        );
-        remoteByProjectId.set(projectId, row?.remote_url ?? null);
-      }
+      // Run them concurrently: project-scoped assignment targetIds are not
+      // validated on write, so an admin can accumulate a lot of them and a
+      // sequential loop would add one round-trip each to every page load.
+      // Safe here ONLY because this route opens no transaction — PgAdapter pins
+      // a single client for the duration of transaction(), so parallel queries
+      // inside one would interleave statements on that client. Don't copy this
+      // shape into a transactional path.
+      const remotes = await Promise.all(
+        projectTargetIds.map(projectId =>
+          ctx.db
+            .get<{ remote_url: string | null }>(
+              `SELECT remote_url
+               FROM events
+               WHERE org_id = ? AND project_id = ? AND remote_url IS NOT NULL
+               ORDER BY occurred_at DESC
+               LIMIT 1`,
+              [req.session!.orgId, projectId],
+            )
+            .then(row => [projectId, row?.remote_url ?? null] as const),
+        ),
+      );
+      for (const [projectId, remoteUrl] of remotes) remoteByProjectId.set(projectId, remoteUrl);
     }
 
     res.json(rows.map(r => ({

--- a/packages/hub/src/routes/admin.ts
+++ b/packages/hub/src/routes/admin.ts
@@ -471,18 +471,32 @@ export function adminRouter(ctx: HubServerContext): Router {
       .map(r => r.target_id);
     const remoteByProjectId = new Map<string, string | null>();
     if (projectTargetIds.length > 0) {
-      const placeholders = projectTargetIds.map(() => '?').join(',');
-      const remoteRows = await ctx.db.all<{ project_id: string; remote_url: string | null }>(
-        `SELECT e.project_id,
-           (SELECT remote_url FROM events e2
-            WHERE e2.org_id = e.org_id AND e2.project_id = e.project_id AND e2.remote_url IS NOT NULL
-            ORDER BY e2.occurred_at DESC LIMIT 1) AS remote_url
-         FROM events e
-         WHERE e.org_id = ? AND e.project_id IN (${placeholders})
-         GROUP BY e.project_id`,
-        [req.session!.orgId, ...projectTargetIds],
-      );
-      for (const rr of remoteRows) remoteByProjectId.set(rr.project_id, rr.remote_url ?? null);
+      // BUG ab9b39d3: this used a GROUP BY with a correlated subquery in the
+      // SELECT list, correlated on `e.org_id`. Postgres rejects an ungrouped
+      // outer column inside a subquery ("subquery uses ungrouped column
+      // e.org_id from outer query") while SQLite silently allows the bare
+      // column — so the route 500'd on every real deployment with the SQLite
+      // tests green. Correlating on the grouped `project_id` instead is legal
+      // in real Postgres but unsupported by pg-mem, which backs the parity
+      // suite, and DISTINCT ON is Postgres-only.
+      //
+      // So: one bounded LIMIT 1 lookup per assigned project. That is a small
+      // fixed number of queries (one per project-scoped assignment, which an
+      // admin configures by hand) each returning at most one row — as opposed
+      // to a single unbounded query streaming every matching event row into
+      // Node, which is what a naive de-correlation would do on the ingestion
+      // table. idx_events_org_project_time backs the lookup.
+      for (const projectId of projectTargetIds) {
+        const row = await ctx.db.get<{ remote_url: string | null }>(
+          `SELECT remote_url
+           FROM events
+           WHERE org_id = ? AND project_id = ? AND remote_url IS NOT NULL
+           ORDER BY occurred_at DESC
+           LIMIT 1`,
+          [req.session!.orgId, projectId],
+        );
+        remoteByProjectId.set(projectId, row?.remote_url ?? null);
+      }
     }
 
     res.json(rows.map(r => ({

--- a/packages/hub/src/test/hub-pg-parity.test.ts
+++ b/packages/hub/src/test/hub-pg-parity.test.ts
@@ -461,3 +461,64 @@ describe('PG parity: flows available + selection', () => {
     expect(active.body.scope).toBe('project');
   });
 });
+
+// BUG ab9b39d3 — GET /v1/admin/flow-assignments 500s on Postgres. The
+// remote-URL enrichment for project-scoped rows puts a correlated subquery in
+// the SELECT list of a GROUP BY query and correlates it on `e.org_id`, which is
+// neither grouped nor aggregated. SQLite allows the bare column, Postgres
+// rejects the statement outright ("subquery uses ungrouped column e.org_id from
+// outer query"), so the Admin -> Flows page is broken on every real deployment.
+// admin-flow-assignments-scopes.test.ts covers this route on SQLite only, which
+// is exactly why it shipped. The enrichment branch only runs when at least one
+// PROJECT-scoped assignment exists, so the fixture must create one.
+describe('PG parity: flow assignments listing (BUG ab9b39d3)', () => {
+  let fx: Fixture;
+  beforeEach(async () => { fx = await bootHubOnPg(); });
+  afterEach(async () => { try { await fx.db.close(); } catch { /* */ } });
+
+  const def = (name: string) => ({
+    name, description: '',
+    steps: [
+      { id: 's0', name: 'todo', label: 'Todo', order: 0, isAnchor: true },
+      { id: 's1', name: 'work', label: 'Work', order: 1 },
+      { id: 's2', name: 'done', label: 'Done', order: 2, isAnchor: true },
+    ],
+  });
+
+  it('GET /flow-assignments returns project-scoped rows enriched with remote_url on Postgres', async () => {
+    await supertest(fx.app).post('/v1/events')
+      .set('Authorization', `Bearer ${fx.token}`)
+      .send({ events: [
+        sample({ eventId: 'fa-old', projectId: 'proj-pg', remoteUrl: 'git@x:stale.git', occurredAt: '2026-05-01T10:00:00Z' }),
+        sample({ eventId: 'fa-new', projectId: 'proj-pg', remoteUrl: 'git@x:web.git', occurredAt: '2026-05-03T10:00:00Z' }),
+      ] });
+
+    const f = (await supertest(fx.app).post('/v1/admin/flows')
+      .set('Cookie', fx.cookie).send({ definition: def('PgAssign') })).body;
+
+    const assign = await supertest(fx.app).put('/v1/admin/flow-assignments')
+      .set('Cookie', fx.cookie).send({ scope: 'project', targetId: 'proj-pg', flowId: f.id });
+    expect(assign.status).toBe(200);
+
+    const list = await supertest(fx.app).get('/v1/admin/flow-assignments').set('Cookie', fx.cookie);
+    expect(list.status).toBe(200);
+
+    const row = list.body.find((r: any) => r.scope === 'project' && r.targetId === 'proj-pg');
+    expect(row).toBeTruthy();
+    // Most-recent event wins — the enrichment picks remote_url ordered by occurred_at DESC.
+    expect(row.remoteUrl).toBe('git@x:web.git');
+  });
+
+  it('GET /flow-assignments still lists org-scoped rows when no project assignment exists', async () => {
+    const f = (await supertest(fx.app).post('/v1/admin/flows')
+      .set('Cookie', fx.cookie).send({ definition: def('PgOrgOnly') })).body;
+    await supertest(fx.app).put('/v1/admin/flow-assignments')
+      .set('Cookie', fx.cookie).send({ scope: 'org', flowId: f.id });
+
+    const list = await supertest(fx.app).get('/v1/admin/flow-assignments').set('Cookie', fx.cookie);
+    expect(list.status).toBe(200);
+    const row = list.body.find((r: any) => r.scope === 'org');
+    expect(row.flowId).toBe(f.id);
+    expect(row.remoteUrl).toBeNull();
+  });
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -549,10 +549,11 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             description: { type: "string", description: "Optional description." },
             steps: {
               type: "array",
-              description: "Ordered list of steps. Each step: { name, label?, exitCriteria?, order, isSpecial?, isAnchor? }.",
+              description: "Ordered list of steps. Each step: { id?, name, label?, exitCriteria?, order, isSpecial?, isAnchor? }. Omit id and the server generates one; pass back the id you read to keep it stable across updates.",
               items: {
                 type: "object",
                 properties: {
+                  id: { type: "string" },
                   name: { type: "string" },
                   label: { type: "string" },
                   exitCriteria: { type: "string" },
@@ -1032,6 +1033,9 @@ async function callToolHandler(request: any): Promise<any> {
           name: z.string(),
           description: z.string().optional(),
           steps: z.array(z.object({
+            // Accept an id so it round-trips: zod strips unknown keys, so
+            // without this an update regenerated every step id on every call.
+            id: z.string().optional(),
             name: z.string(),
             label: z.string().optional(),
             exitCriteria: z.string().optional(),
@@ -1055,6 +1059,9 @@ async function callToolHandler(request: any): Promise<any> {
           name: z.string().optional(),
           description: z.string().optional(),
           steps: z.array(z.object({
+            // Accept an id so it round-trips: zod strips unknown keys, so
+            // without this an update regenerated every step id on every call.
+            id: z.string().optional(),
             name: z.string(),
             label: z.string().optional(),
             exitCriteria: z.string().optional(),

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -151,6 +151,9 @@ const UpdateItemSchema = z.object({
   description: z.string().optional(),
   status: z.string().optional(),
   type: z.enum(["EPIC", "STORY", "TASK", "BUG"]).optional(),
+  // null detaches to top level; the REST route validates existence, project
+  // match and cycles.
+  parentId: z.string().nullable().optional(),
   implementationPlan: z.string().optional(),
 });
 
@@ -268,7 +271,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: "update_item",
-        description: "Update an existing item's status, title, or description. IMPORTANT: Cannot set status to DONE directly — use test_changes. For custom flows, call get_flow(projectId) for valid step names.",
+        description: "Update an existing item's status, title, description, or parent. IMPORTANT: Cannot set status to DONE directly — use test_changes. For custom flows, call get_flow(projectId) for valid step names. Pass parentId to re-parent (null detaches to top level); the parent must be in the same project and cannot be the item itself or one of its descendants.",
         inputSchema: {
           type: "object",
           properties: {
@@ -277,6 +280,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             description: { type: "string" },
             status: { type: "string", description: "Step name from the project's active flow. Call get_flow(projectId) for valid step names." },
             type: { type: "string", enum: ["EPIC", "STORY", "TASK", "BUG"] },
+            parentId: { type: ["string", "null"], description: "Re-parent the item under this id; null detaches it to top level." },
             implementationPlan: { type: "string" },
           },
           required: ["id"],

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1288,9 +1288,64 @@ app.get("/agent-runs/:id/events", asyncHandler(async (req: any, res: any) => {
 
 const HUB_MANAGED_FLOW_MSG = "Flow is managed by your organization's Hub and cannot be modified locally";
 
+/**
+ * BUG 269eeec8 (c): bring local flow writes into line with the shape contract
+ * the Hub enforces (packages/hub/src/routes/admin.ts validateDefinition), so a
+ * flow authored locally can always be published without an opaque 400.
+ *
+ * Deliberately NARROWER than the Hub's validator on two points, because the
+ * local server has always accepted these and callers (MCP create_flow, the CLI)
+ * depend on them:
+ *  - `steps: []` is allowed — creating an empty flow and populating it later is
+ *    a supported local flow. It only becomes un-publishable, not invalid.
+ *  - a missing step `id` is generated rather than rejected (see normalizeSteps).
+ *
+ * What it does reject is an empty step name, which is the actual defect: it is
+ * unusable as a workflow status, since nothing can transition an item to "".
+ * Mirrored client-side in packages/flow-editor/src/flowDefinition.ts.
+ *
+ * @returns an error message, or null when the step list is acceptable.
+ */
+function flowStepsError(steps: any): string | null {
+  if (!Array.isArray(steps)) return "steps must be an array";
+  for (const s of steps) {
+    if (!s || typeof s !== 'object') return "each step must be an object";
+    if (typeof s.name !== 'string' || !s.name.trim()) return "each step requires a name";
+    if (typeof s.order !== 'number' || Number.isNaN(s.order)) return "each step requires a numeric order";
+  }
+  return null;
+}
+
+/**
+ * Fill in step ids the caller omitted. The Hub requires every step to carry a
+ * non-empty id, so generating here means anything the local server persists is
+ * publishable — without breaking the callers that never sent ids.
+ */
+function normalizeSteps(steps: any): any {
+  if (!Array.isArray(steps)) return steps;
+  const seen = new Set<string>();
+  return steps.map((s: any) => {
+    if (!s || typeof s !== 'object') return s;
+    // Missing OR duplicated ids both get a fresh one: two steps sharing an id
+    // collide on React's key={step.id} in the flow editor, which silently drops
+    // a column from the UI.
+    const id = typeof s.id === 'string' ? s.id : '';
+    if (!id || seen.has(id)) {
+      const fresh = uuidv4();
+      seen.add(fresh);
+      return { ...s, id: fresh };
+    }
+    seen.add(id);
+    return { ...s };
+  });
+}
+
 app.post("/flows", asyncHandler(async (req: any, res: any) => {
   const { name, description, version, steps } = req.body;
   if (!name) return res.status(400).json({ error: "name is required" });
+
+  const stepsError = flowStepsError(steps);
+  if (stepsError) return res.status(400).json({ error: stepsError });
 
   // Always force `source = 'local'` on REST-driven creation. The reconciler
   // writes hub-managed rows directly via storage.createFlow(); this route is
@@ -1300,7 +1355,7 @@ app.post("/flows", asyncHandler(async (req: any, res: any) => {
     name,
     description: description || "",
     version: version || "1.0.0",
-    steps: steps || [],
+    steps: normalizeSteps(steps || []),
     createdAt: new Date(),
     updatedAt: new Date(),
     source: 'local',
@@ -1325,11 +1380,17 @@ app.put("/flows/:id", asyncHandler(async (req: any, res: any) => {
   }
   try {
     const { name, description, version, steps } = req.body;
+    // Only validate steps when the caller is actually replacing them — a
+    // rename-only PUT must keep working.
+    if (steps !== undefined) {
+      const stepsError = flowStepsError(steps);
+      if (stepsError) return res.status(400).json({ error: stepsError });
+    }
     const updates: Partial<Flow> = {};
     if (name !== undefined) updates.name = name;
     if (description !== undefined) updates.description = description;
     if (version !== undefined) updates.version = version;
-    if (steps !== undefined) updates.steps = steps;
+    if (steps !== undefined) updates.steps = normalizeSteps(steps);
 
     const updated = await storage.updateFlow(req.params.id, updates);
     io.emit('flow:updated', { flowId: updated.id });
@@ -1442,8 +1503,13 @@ app.post("/registry/flows/install", asyncHandler(async (req: any, res: any) => {
       .filter((s: any) => !s.isAnchor && s.name?.toUpperCase() !== 'TODO' && s.name?.toUpperCase() !== 'DONE')
       .map((s: any, i: number) => ({
         id: uuidv4(),
-        name: s.name ?? `step-${i}`,
-        label: s.label ?? s.name ?? `Step ${i + 1}`,
+        // `??` does not catch '' — a community flow with "name": "" would
+        // install an empty-named step, the exact value flowStepsError exists to
+        // reject, while bypassing it (this path calls storage.createFlow direct).
+        name: (typeof s.name === 'string' && s.name.trim()) ? s.name : `step-${i}`,
+        label: (typeof s.label === 'string' && s.label.trim())
+          ? s.label
+          : ((typeof s.name === 'string' && s.name.trim()) ? s.name : `Step ${i + 1}`),
         order: i + 1,
         exitCriteria: s.exitCriteria ?? '',
         isSpecial: s.isSpecial ?? false,

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -356,6 +356,59 @@ const trashRecursively = async (id: string): Promise<boolean> => {
   return true;
 };
 
+/**
+ * Validate a proposed parent before it is written. All three write paths share
+ * this: POST /items, PUT /items/:id and POST /items/bulk each used to apply
+ * `parentId` straight to storage with no checks, so a dangling parent, a
+ * cross-project parent, or a cycle were reachable from any REST/MCP caller.
+ *
+ * @param itemId    the item being parented, or null at create time (a brand-new
+ *                  id can have no descendants, so no cycle is possible)
+ * @param projectId the item's project — the parent must be in the same one
+ * @param parentId  the proposed value, straight off the request body
+ * @returns an error message, or null when the assignment is acceptable
+ */
+async function validateParentAssignment(
+  itemId: string | null,
+  projectId: string,
+  parentId: unknown,
+): Promise<string | null> {
+  if (parentId === undefined || parentId === null || parentId === '') return null;
+  if (typeof parentId !== 'string') {
+    // Otherwise this reaches the sqlite bind and throws, surfacing as a 500.
+    return "parentId must be a string, or null to detach the item to top level.";
+  }
+  if (itemId !== null && parentId === itemId) {
+    return "An item cannot be its own parent.";
+  }
+  const parent = await storage.getItem(parentId);
+  if (!parent) {
+    return `Parent item '${parentId}' not found.`;
+  }
+  if (parent.projectId !== projectId) {
+    return "Parent must belong to the same project as the item.";
+  }
+  if (itemId === null) return null;
+
+  // Walk up from the proposed parent: meeting this item means the proposed
+  // parent is one of its descendants. The parent chain has out-degree 1, so the
+  // walk visits every reachable ancestor once before any repeat — the `seen`
+  // break therefore cannot skip an ancestor, it only stops the walk on data that
+  // already contains a cycle.
+  const seen = new Set<string>([parentId]);
+  let cursor: string | undefined = parent.parentId;
+  while (cursor) {
+    if (cursor === itemId) {
+      return "Cannot re-parent an item under one of its own descendants — that would create a cycle.";
+    }
+    if (seen.has(cursor)) break;
+    seen.add(cursor);
+    const ancestor: any = await storage.getItem(cursor);
+    cursor = ancestor?.parentId;
+  }
+  return null;
+}
+
 const syncParentStatus = async (parentId: string) => {
   const parent = await storage.getItem(parentId);
   if (!parent) return;
@@ -1834,6 +1887,11 @@ app.post("/items", asyncHandler(async (req: any, res: any) => {
     return res.status(400).json({ error: "ProjectId is required" });
   }
 
+  // A brand-new id can have no descendants, so pass itemId=null: existence and
+  // project-match still apply, the cycle walk is skipped as impossible.
+  const createParentError = await validateParentAssignment(null, projectId, parentId);
+  if (createParentError) return res.status(400).json({ error: createParentError });
+
   const newItem: AgEnFKItem = {
     id: uuidv4(),
     projectId,
@@ -1883,6 +1941,9 @@ app.post("/items/bulk", asyncHandler(async (req: any, res: any) => {
 
   const isInternalVerify = req.headers['x-agenfk-internal'] === VERIFY_TOKEN;
   const results = [];
+  // Rejected entries are reported back rather than silently dropped — the route
+  // already `continue`s past unknown ids, which hides mistakes.
+  const skipped: Array<{ id: string; error: string }> = [];
   const parentIdsToSync = new Set<string>();
   const projectIds = new Set<string>();
 
@@ -1906,11 +1967,19 @@ app.post("/items/bulk", asyncHandler(async (req: any, res: any) => {
       continue;
     }
 
+    // Same guard as PUT /items/:id — this route is an update despite the POST
+    // verb, so without it every state that guard forbids stays reachable here.
+    const bulkParentError = await validateParentAssignment(id, currentItem.projectId, parentId);
+    if (bulkParentError) {
+      skipped.push({ id, error: bulkParentError });
+      continue;
+    }
+
     const updates: any = {};
     if (title !== undefined) updates.title = title;
     if (description !== undefined) updates.description = description;
     if (status !== undefined) updates.status = status;
-    if (parentId !== undefined) updates.parentId = parentId;
+    if (parentId !== undefined) updates.parentId = parentId === '' ? null : parentId;
     if (context !== undefined) updates.context = context;
     if (implementationPlan !== undefined) updates.implementationPlan = implementationPlan;
     if (reviews !== undefined) updates.reviews = reviews;
@@ -1924,6 +1993,12 @@ app.post("/items/bulk", asyncHandler(async (req: any, res: any) => {
 
       if (updated.parentId) {
         parentIdsToSync.add(updated.parentId);
+      }
+      // A re-parent changes the child set of the old parent too, so it needs
+      // re-deriving as well — otherwise it keeps a status computed from a child
+      // it no longer has.
+      if (currentItem.parentId && currentItem.parentId !== updated.parentId) {
+        parentIdsToSync.add(currentItem.parentId);
       }
 
       if (updated.status === Status.DONE && currentItem.status !== Status.DONE) {
@@ -1947,7 +2022,8 @@ app.post("/items/bulk", asyncHandler(async (req: any, res: any) => {
     await syncParentStatus(parentId);
   }
 
-  res.json({ results });
+  // `skipped` is additive — existing callers read `results` only.
+  res.json(skipped.length > 0 ? { results, skipped } : { results });
 }));
 
 app.put("/items/:id", asyncHandler(async (req: any, res: any) => {
@@ -2010,39 +2086,8 @@ app.put("/items/:id", asyncHandler(async (req: any, res: any) => {
     }
   }
 
-  // Validate a re-parent. This route has always applied `parentId` straight to
-  // storage with no checks, so a dangling parent, a cross-project parent, or a
-  // cycle were all reachable by any REST/MCP caller. The cycle matters most:
-  // syncParentStatus() walks upward via parent.parentId with no visited-set, so
-  // once a cycle exists any status propagation reaching it recurses unboundedly.
-  if (parentId !== undefined && parentId !== null && parentId !== '') {
-    if (parentId === req.params.id) {
-      return res.status(400).json({ error: "An item cannot be its own parent." });
-    }
-    const parent = await storage.getItem(parentId);
-    if (!parent) {
-      return res.status(400).json({ error: `Parent item '${parentId}' not found.` });
-    }
-    if (parent.projectId !== currentItem.projectId) {
-      return res.status(400).json({ error: "Parent must belong to the same project as the item." });
-    }
-    // Walk up from the proposed parent: if we meet this item, the new parent is
-    // one of its descendants. The `seen` set also stops the walk dead on data
-    // that already contains a cycle, rather than looping here.
-    const seen = new Set<string>([parentId]);
-    let cursor: string | undefined = parent.parentId;
-    while (cursor) {
-      if (cursor === req.params.id) {
-        return res.status(400).json({
-          error: "Cannot re-parent an item under one of its own descendants — that would create a cycle.",
-        });
-      }
-      if (seen.has(cursor)) break;
-      seen.add(cursor);
-      const ancestor: any = await storage.getItem(cursor);
-      cursor = ancestor?.parentId;
-    }
-  }
+  const parentError = await validateParentAssignment(req.params.id, currentItem.projectId, parentId);
+  if (parentError) return res.status(400).json({ error: parentError });
 
   const updates: any = {};
   if (title !== undefined) updates.title = title;
@@ -2071,6 +2116,13 @@ app.put("/items/:id", asyncHandler(async (req: any, res: any) => {
 
     if (updated.parentId) {
       await syncParentStatus(updated.parentId);
+    }
+    // A re-parent changes the child set of BOTH parents. Without this the old
+    // parent keeps a status derived from a child it no longer has — e.g. it sat
+    // at IN_PROGRESS only because of the child that just moved away, and should
+    // now roll up to DONE.
+    if (currentItem.parentId && currentItem.parentId !== updated.parentId) {
+      await syncParentStatus(currentItem.parentId);
     }
 
     if (status !== undefined && status !== currentItem.status) {

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -2010,12 +2010,47 @@ app.put("/items/:id", asyncHandler(async (req: any, res: any) => {
     }
   }
 
+  // Validate a re-parent. This route has always applied `parentId` straight to
+  // storage with no checks, so a dangling parent, a cross-project parent, or a
+  // cycle were all reachable by any REST/MCP caller. The cycle matters most:
+  // syncParentStatus() walks upward via parent.parentId with no visited-set, so
+  // once a cycle exists any status propagation reaching it recurses unboundedly.
+  if (parentId !== undefined && parentId !== null && parentId !== '') {
+    if (parentId === req.params.id) {
+      return res.status(400).json({ error: "An item cannot be its own parent." });
+    }
+    const parent = await storage.getItem(parentId);
+    if (!parent) {
+      return res.status(400).json({ error: `Parent item '${parentId}' not found.` });
+    }
+    if (parent.projectId !== currentItem.projectId) {
+      return res.status(400).json({ error: "Parent must belong to the same project as the item." });
+    }
+    // Walk up from the proposed parent: if we meet this item, the new parent is
+    // one of its descendants. The `seen` set also stops the walk dead on data
+    // that already contains a cycle, rather than looping here.
+    const seen = new Set<string>([parentId]);
+    let cursor: string | undefined = parent.parentId;
+    while (cursor) {
+      if (cursor === req.params.id) {
+        return res.status(400).json({
+          error: "Cannot re-parent an item under one of its own descendants — that would create a cycle.",
+        });
+      }
+      if (seen.has(cursor)) break;
+      seen.add(cursor);
+      const ancestor: any = await storage.getItem(cursor);
+      cursor = ancestor?.parentId;
+    }
+  }
+
   const updates: any = {};
   if (title !== undefined) updates.title = title;
   if (description !== undefined) updates.description = description;
   if (status !== undefined) updates.status = status;
   if (type !== undefined) updates.type = type;
-  if (parentId !== undefined) updates.parentId = parentId;
+  // Normalize the detach forms ('' / null) to undefined-in-storage semantics.
+  if (parentId !== undefined) updates.parentId = parentId === '' ? null : parentId;
   if (context !== undefined) updates.context = context;
   if (implementationPlan !== undefined) updates.implementationPlan = implementationPlan;
   if (reviews !== undefined) updates.reviews = reviews;

--- a/packages/server/src/test/flow-step-validation.test.ts
+++ b/packages/server/src/test/flow-step-validation.test.ts
@@ -1,0 +1,169 @@
+/**
+ * BUG 269eeec8 defect (c) — contract parity between the local server and the Hub.
+ *
+ * The Hub validates flow-definition shape (packages/hub/src/routes/admin.ts
+ * validateDefinition: every step needs a non-empty id, a non-empty name, and a
+ * numeric order). The local server validated none of it, so a flow authored
+ * locally could be persisted with an empty step name and then fail to publish to
+ * the Hub with an opaque 400. Worse, an empty step name is a broken workflow
+ * status in its own right — nothing can transition an item to "".
+ *
+ * These tests hold the local server to the same contract.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import request from 'supertest';
+import { app, initStorage } from '../server';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const TEST_DB = path.resolve('./flow-step-validation-test-db.sqlite');
+
+describe('local flow step-shape validation', () => {
+  beforeAll(async () => {
+    process.env.AGENFK_DB_PATH = TEST_DB;
+    if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+    await initStorage();
+  });
+
+  afterAll(() => {
+    if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+  });
+
+  beforeEach(async () => {
+    if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+    await initStorage();
+  });
+
+  const baseSteps = () => [
+    { id: 's1', name: 'TODO', label: 'TODO', order: 0, isAnchor: true },
+    { id: 's2', name: 'WORK', label: 'Work', order: 1 },
+    { id: 's3', name: 'DONE', label: 'Done', order: 2, isAnchor: true },
+  ];
+
+  const createFlow = async () => {
+    const r = await request(app).post('/flows').send({ name: 'LF', steps: baseSteps() });
+    expect(r.status).toBe(201);
+    return r.body;
+  };
+
+  it('POST /flows rejects a step with an empty name', async () => {
+    const steps = baseSteps();
+    steps[1] = { ...steps[1], name: '' };
+    const r = await request(app).post('/flows').send({ name: 'Bad', steps });
+    expect(r.status).toBe(400);
+    expect(r.body.error).toMatch(/name/i);
+  });
+
+  it('POST /flows rejects a whitespace-only step name', async () => {
+    const steps = baseSteps();
+    steps[1] = { ...steps[1], name: '   ' };
+    const r = await request(app).post('/flows').send({ name: 'Bad', steps });
+    expect(r.status).toBe(400);
+  });
+
+  // Callers (MCP create_flow, the CLI) have always been allowed to omit step
+  // ids, so generate them rather than rejecting: the Hub requires a non-empty
+  // id, and generating is what makes a locally-authored flow publishable.
+  it('POST /flows generates an id for a step that omits one', async () => {
+    const steps = baseSteps().map(({ id: _id, ...rest }) => rest);
+    const r = await request(app).post('/flows').send({ name: 'NoIds', steps });
+    expect(r.status).toBe(201);
+    const ids = r.body.steps.map((s: any) => s.id);
+    expect(ids.every((id: unknown) => typeof id === 'string' && id.length > 0)).toBe(true);
+    expect(new Set(ids).size).toBe(3);
+  });
+
+  it('POST /flows generates an id for a step whose id is blank', async () => {
+    const steps = baseSteps();
+    steps[1] = { ...steps[1], id: '' };
+    const r = await request(app).post('/flows').send({ name: 'BlankId', steps });
+    expect(r.status).toBe(201);
+    expect(r.body.steps[1].id).toBeTruthy();
+  });
+
+  it('PUT /flows/:id generates an id for a step that omits one', async () => {
+    const flow = await createFlow();
+    const steps = baseSteps().map(({ id: _id, ...rest }) => rest);
+    const r = await request(app).put(`/flows/${flow.id}`).send({ name: 'LF', steps });
+    expect(r.status).toBe(200);
+    expect(r.body.steps.every((s: any) => typeof s.id === 'string' && s.id.length > 0)).toBe(true);
+  });
+
+  it('POST /flows rejects a non-numeric step order', async () => {
+    const steps = baseSteps();
+    steps[1] = { ...steps[1], order: 'second' as unknown as number };
+    const r = await request(app).post('/flows').send({ name: 'Bad', steps });
+    expect(r.status).toBe(400);
+    expect(r.body.error).toMatch(/order/i);
+  });
+
+  // Long-standing local behaviour: create an empty flow, populate it later.
+  // The Hub refuses an empty definition, so such a flow is un-publishable until
+  // it has steps — but it is not invalid locally, and callers rely on this.
+  it('POST /flows still accepts an empty steps array', async () => {
+    const r = await request(app).post('/flows').send({ name: 'Draft', steps: [] });
+    expect(r.status).toBe(201);
+    expect(r.body.steps).toEqual([]);
+  });
+
+  it('POST /flows rejects a non-array steps value', async () => {
+    const r = await request(app).post('/flows').send({ name: 'Bad', steps: 'nope' });
+    expect(r.status).toBe(400);
+    expect(r.body.error).toMatch(/array/i);
+  });
+
+  it('PUT /flows/:id rejects a step with an empty name', async () => {
+    const flow = await createFlow();
+    const steps = baseSteps();
+    steps[1] = { ...steps[1], name: '' };
+    const r = await request(app).put(`/flows/${flow.id}`).send({ name: 'LF', steps });
+    expect(r.status).toBe(400);
+    expect(r.body.error).toMatch(/name/i);
+  });
+
+  it('PUT /flows/:id does not persist a rejected step list', async () => {
+    const flow = await createFlow();
+    const steps = baseSteps();
+    steps[1] = { ...steps[1], name: '' };
+    await request(app).put(`/flows/${flow.id}`).send({ name: 'LF', steps });
+
+    const after = await request(app).get(`/flows/${flow.id}`);
+    expect(after.status).toBe(200);
+    expect(after.body.steps.map((s: any) => s.name)).toEqual(['TODO', 'WORK', 'DONE']);
+  });
+
+  it('PUT /flows/:id still accepts a valid step list', async () => {
+    const flow = await createFlow();
+    const steps = baseSteps();
+    steps[1] = { ...steps[1], name: 'REFACTOR', label: 'Refactor' };
+    const r = await request(app).put(`/flows/${flow.id}`).send({ name: 'LF', steps });
+    expect(r.status).toBe(200);
+    expect(r.body.steps.map((s: any) => s.name)).toEqual(['TODO', 'REFACTOR', 'DONE']);
+  });
+
+  it('PUT /flows/:id leaves steps untouched when the body omits them', async () => {
+    const flow = await createFlow();
+    const r = await request(app).put(`/flows/${flow.id}`).send({ name: 'Renamed' });
+    expect(r.status).toBe(200);
+    expect(r.body.name).toBe('Renamed');
+    expect(r.body.steps.map((s: any) => s.name)).toEqual(['TODO', 'WORK', 'DONE']);
+  });
+
+  // Review finding: two steps sharing an id collide on React's key={step.id} in
+  // the flow editor, silently dropping a column.
+  it('PUT /flows/:id replaces duplicate step ids with fresh ones', async () => {
+    const flow = await createFlow();
+    const steps = baseSteps().map(s => ({ ...s, id: 'same' }));
+    const r = await request(app).put(`/flows/${flow.id}`).send({ name: 'LF', steps });
+    expect(r.status).toBe(200);
+    const ids = r.body.steps.map((s: any) => s.id);
+    expect(new Set(ids).size).toBe(3);
+  });
+
+  it('PUT /flows/:id keeps caller-supplied ids that are already unique', async () => {
+    const flow = await createFlow();
+    const r = await request(app).put(`/flows/${flow.id}`).send({ name: 'LF', steps: baseSteps() });
+    expect(r.status).toBe(200);
+    expect(r.body.steps.map((s: any) => s.id)).toEqual(['s1', 's2', 's3']);
+  });
+});

--- a/packages/server/src/test/item-reparent.test.ts
+++ b/packages/server/src/test/item-reparent.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Re-parenting an existing item, and the validation that was missing.
+ *
+ * `PUT /items/:id` has always destructured `parentId` and applied it straight to
+ * storage with no checks whatsoever. That makes three bad states reachable by any
+ * REST or MCP caller today:
+ *   - a parent id that does not exist, orphaning the item behind a dangling link;
+ *   - a parent in a different project, so the item shows under a tree it is not
+ *     part of;
+ *   - a cycle (self-parenting, or parenting to one's own descendant).
+ *
+ * The cycle case is not cosmetic: syncParentStatus() walks upward via
+ * parent.parentId with no visited-set, so once a cycle exists any status
+ * propagation that reaches it can recurse unboundedly. These tests pin the
+ * guards and the happy path the CLI needs.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import request from 'supertest';
+import { app, initStorage } from '../server';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const TEST_DB = path.resolve('./item-reparent-test-db.sqlite');
+
+describe('item re-parenting', () => {
+  let projectId: string;
+  let otherProjectId: string;
+
+  beforeAll(async () => {
+    process.env.AGENFK_DB_PATH = TEST_DB;
+    if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+    await initStorage();
+  });
+
+  afterAll(() => {
+    if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+  });
+
+  const makeProject = async (name: string) => {
+    const r = await request(app).post('/projects').send({ name });
+    expect(r.status).toBe(201);
+    return r.body.id;
+  };
+
+  const makeItem = async (type: string, title: string, opts: { projectId?: string; parentId?: string } = {}) => {
+    const r = await request(app).post('/items').send({
+      type,
+      title,
+      projectId: opts.projectId ?? projectId,
+      ...(opts.parentId ? { parentId: opts.parentId } : {}),
+    });
+    expect(r.status).toBe(201);
+    return r.body;
+  };
+
+  beforeEach(async () => {
+    if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+    await initStorage();
+    projectId = await makeProject('reparent-proj');
+    otherProjectId = await makeProject('other-proj');
+  });
+
+  // ── Happy path ────────────────────────────────────────────────────────────
+  it('attaches a previously top-level item to a parent', async () => {
+    const story = await makeItem('STORY', 'Parent story');
+    const bug = await makeItem('BUG', 'Loose bug');
+    expect(bug.parentId ?? null).toBeNull();
+
+    const r = await request(app).put(`/items/${bug.id}`).send({ parentId: story.id });
+    expect(r.status).toBe(200);
+    expect(r.body.parentId).toBe(story.id);
+
+    const children = await request(app).get(`/items?parentId=${story.id}`);
+    expect(children.body.map((c: any) => c.id)).toContain(bug.id);
+  });
+
+  it('moves an item from one parent to another', async () => {
+    const a = await makeItem('STORY', 'Story A');
+    const b = await makeItem('STORY', 'Story B');
+    const task = await makeItem('TASK', 'Task', { parentId: a.id });
+
+    const r = await request(app).put(`/items/${task.id}`).send({ parentId: b.id });
+    expect(r.status).toBe(200);
+    expect(r.body.parentId).toBe(b.id);
+
+    const oldChildren = await request(app).get(`/items?parentId=${a.id}`);
+    expect(oldChildren.body.map((c: any) => c.id)).not.toContain(task.id);
+  });
+
+  it('detaches an item to top level when parentId is null', async () => {
+    const story = await makeItem('STORY', 'Story');
+    const task = await makeItem('TASK', 'Task', { parentId: story.id });
+
+    const r = await request(app).put(`/items/${task.id}`).send({ parentId: null });
+    expect(r.status).toBe(200);
+    expect(r.body.parentId ?? null).toBeNull();
+  });
+
+  it('leaves the parent alone when parentId is omitted', async () => {
+    const story = await makeItem('STORY', 'Story');
+    const task = await makeItem('TASK', 'Task', { parentId: story.id });
+
+    const r = await request(app).put(`/items/${task.id}`).send({ title: 'Renamed' });
+    expect(r.status).toBe(200);
+    expect(r.body.title).toBe('Renamed');
+    expect(r.body.parentId).toBe(story.id);
+  });
+
+  // ── Validation ────────────────────────────────────────────────────────────
+  it('rejects a parent id that does not exist', async () => {
+    const task = await makeItem('TASK', 'Task');
+
+    const r = await request(app).put(`/items/${task.id}`).send({ parentId: 'no-such-item' });
+    expect(r.status).toBe(400);
+    expect(r.body.error).toMatch(/parent/i);
+
+    const after = await request(app).get(`/items/${task.id}`);
+    expect(after.body.parentId ?? null).toBeNull();
+  });
+
+  it('rejects a parent in a different project', async () => {
+    const foreign = await makeItem('STORY', 'Foreign story', { projectId: otherProjectId });
+    const task = await makeItem('TASK', 'Task');
+
+    const r = await request(app).put(`/items/${task.id}`).send({ parentId: foreign.id });
+    expect(r.status).toBe(400);
+    expect(r.body.error).toMatch(/project/i);
+  });
+
+  it('rejects self-parenting', async () => {
+    const task = await makeItem('TASK', 'Task');
+
+    const r = await request(app).put(`/items/${task.id}`).send({ parentId: task.id });
+    expect(r.status).toBe(400);
+    expect(r.body.error).toMatch(/own parent/i);
+  });
+
+  // The one that would otherwise recurse until the process dies.
+  it('rejects parenting to a direct child (a 2-cycle)', async () => {
+    const epic = await makeItem('EPIC', 'Epic');
+    const story = await makeItem('STORY', 'Story', { parentId: epic.id });
+
+    const r = await request(app).put(`/items/${epic.id}`).send({ parentId: story.id });
+    expect(r.status).toBe(400);
+    expect(r.body.error).toMatch(/descendant|cycle/i);
+  });
+
+  it('rejects parenting to a deeper descendant', async () => {
+    const epic = await makeItem('EPIC', 'Epic');
+    const story = await makeItem('STORY', 'Story', { parentId: epic.id });
+    const task = await makeItem('TASK', 'Task', { parentId: story.id });
+
+    const r = await request(app).put(`/items/${epic.id}`).send({ parentId: task.id });
+    expect(r.status).toBe(400);
+    expect(r.body.error).toMatch(/descendant|cycle/i);
+
+    const after = await request(app).get(`/items/${epic.id}`);
+    expect(after.body.parentId ?? null).toBeNull();
+  });
+
+  it('still allows a sibling subtree to be re-parented under another branch', async () => {
+    const epic = await makeItem('EPIC', 'Epic');
+    const storyA = await makeItem('STORY', 'Story A', { parentId: epic.id });
+    const storyB = await makeItem('STORY', 'Story B', { parentId: epic.id });
+    const task = await makeItem('TASK', 'Task', { parentId: storyA.id });
+
+    // storyB is not a descendant of task, so this is legal.
+    const r = await request(app).put(`/items/${task.id}`).send({ parentId: storyB.id });
+    expect(r.status).toBe(200);
+    expect(r.body.parentId).toBe(storyB.id);
+  });
+});

--- a/packages/server/src/test/item-reparent.test.ts
+++ b/packages/server/src/test/item-reparent.test.ts
@@ -9,10 +9,12 @@
  *     part of;
  *   - a cycle (self-parenting, or parenting to one's own descendant).
  *
- * The cycle case is not cosmetic: syncParentStatus() walks upward via
- * parent.parentId with no visited-set, so once a cycle exists any status
- * propagation that reaches it can recurse unboundedly. These tests pin the
- * guards and the happy path the CLI needs.
+ * The cycle case is about tree integrity rather than a crash: syncParentStatus()
+ * recurses upward with no visited-set, but the recursion is gated on the derived
+ * status actually changing and that derivation is monotonic toward DONE, so a
+ * cycle converges after a hop or two instead of spinning. A cycle still corrupts
+ * every consumer that walks the tree, which is reason enough to refuse it.
+ * These tests pin the guards and the happy path the CLI needs.
  */
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import request from 'supertest';
@@ -168,5 +170,173 @@ describe('item re-parenting', () => {
     const r = await request(app).put(`/items/${task.id}`).send({ parentId: storyB.id });
     expect(r.status).toBe(200);
     expect(r.body.parentId).toBe(storyB.id);
+  });
+
+  // ── Status roll-up on both sides ──────────────────────────────────────────
+  // A re-parent changes the child set of the OLD parent too. Only syncing the
+  // new one leaves the old parent asserting a status derived from a child it no
+  // longer has.
+  it("re-syncs the old parent's status after a child moves away", async () => {
+    const oldParent = await makeItem('STORY', 'Old parent');
+    const newParent = await makeItem('STORY', 'New parent');
+    const ahead = await makeItem('TASK', 'Ahead', { parentId: oldParent.id });
+    const laggard = await makeItem('TASK', 'Laggard', { parentId: oldParent.id });
+
+    // Children at REVIEW + IN_PROGRESS roll the parent up to IN_PROGRESS.
+    await request(app).put(`/items/${ahead.id}`).send({ status: 'IN_PROGRESS' });
+    await request(app).put(`/items/${ahead.id}`).send({ status: 'REVIEW' });
+    await request(app).put(`/items/${laggard.id}`).send({ status: 'IN_PROGRESS' });
+
+    const before = await request(app).get(`/items/${oldParent.id}`);
+    expect(before.body.status).toBe('IN_PROGRESS');
+
+    // Move the laggard out. The old parent's only remaining child is at REVIEW,
+    // so it should roll up to REVIEW — it will only do so if the OLD parent is
+    // re-synced, which is the point.
+    const moved = await request(app).put(`/items/${laggard.id}`).send({ parentId: newParent.id });
+    expect(moved.status).toBe(200);
+
+    const after = await request(app).get(`/items/${oldParent.id}`);
+    expect(after.body.status).toBe('REVIEW');
+  });
+
+  it("re-syncs the old parent when a child is detached to top level", async () => {
+    const oldParent = await makeItem('STORY', 'Old parent');
+    const child = await makeItem('TASK', 'Child', { parentId: oldParent.id });
+
+    await request(app).put(`/items/${child.id}`).send({ status: 'IN_PROGRESS' });
+    const parentNow = await request(app).get(`/items/${oldParent.id}`);
+    expect(parentNow.body.status).toBe('IN_PROGRESS');
+
+    const r = await request(app).put(`/items/${child.id}`).send({ parentId: null });
+    expect(r.status).toBe(200);
+
+    // Old parent has no children left; syncParentStatus leaves a childless
+    // parent alone, so this pins the CURRENT contract rather than inventing one.
+    const after = await request(app).get(`/items/${oldParent.id}`);
+    expect(after.body.status).toBe('IN_PROGRESS');
+  });
+
+  // ── Detach really clears storage, not just the response body ──────────────
+  it('persists the detach — re-reading the item shows no parent', async () => {
+    const story = await makeItem('STORY', 'Story');
+    const task = await makeItem('TASK', 'Task', { parentId: story.id });
+
+    await request(app).put(`/items/${task.id}`).send({ parentId: null });
+
+    const reread = await request(app).get(`/items/${task.id}`);
+    expect(reread.body.parentId ?? null).toBeNull();
+
+    const children = await request(app).get(`/items?parentId=${story.id}`);
+    expect(children.body.map((c: any) => c.id)).not.toContain(task.id);
+  });
+
+  it('persists an attach — re-reading shows the new parent', async () => {
+    const story = await makeItem('STORY', 'Story');
+    const task = await makeItem('TASK', 'Task');
+
+    await request(app).put(`/items/${task.id}`).send({ parentId: story.id });
+
+    const reread = await request(app).get(`/items/${task.id}`);
+    expect(reread.body.parentId).toBe(story.id);
+  });
+
+  // ── The sibling write paths must not be a back door ───────────────────────
+  // POST /items/bulk is an UPDATE route despite the verb, and POST /items sets
+  // parentId at create time. Guarding only PUT would leave every rejected state
+  // reachable one route over.
+  describe('POST /items/bulk enforces the same parent rules', () => {
+    it('refuses a cycle and reports it instead of applying it', async () => {
+      const epic = await makeItem('EPIC', 'Epic');
+      const story = await makeItem('STORY', 'Story', { parentId: epic.id });
+
+      const r = await request(app).post('/items/bulk').send({
+        items: [{ id: epic.id, updates: { parentId: story.id } }],
+      });
+      expect(r.status).toBe(200);
+      expect(r.body.skipped?.[0]?.error).toMatch(/descendant|cycle/i);
+
+      const after = await request(app).get(`/items/${epic.id}`);
+      expect(after.body.parentId ?? null).toBeNull();
+    });
+
+    it('refuses a nonexistent parent', async () => {
+      const task = await makeItem('TASK', 'Task');
+
+      const r = await request(app).post('/items/bulk').send({
+        items: [{ id: task.id, updates: { parentId: 'nope' } }],
+      });
+      expect(r.body.skipped?.[0]?.error).toMatch(/not found/i);
+
+      const after = await request(app).get(`/items/${task.id}`);
+      expect(after.body.parentId ?? null).toBeNull();
+    });
+
+    it('refuses a cross-project parent', async () => {
+      const foreign = await makeItem('STORY', 'Foreign', { projectId: otherProjectId });
+      const task = await makeItem('TASK', 'Task');
+
+      const r = await request(app).post('/items/bulk').send({
+        items: [{ id: task.id, updates: { parentId: foreign.id } }],
+      });
+      expect(r.body.skipped?.[0]?.error).toMatch(/project/i);
+    });
+
+    it('still applies a legitimate bulk re-parent, and re-syncs the old parent', async () => {
+      const oldParent = await makeItem('STORY', 'Old');
+      const newParent = await makeItem('STORY', 'New');
+      const ahead = await makeItem('TASK', 'Ahead', { parentId: oldParent.id });
+      const laggard = await makeItem('TASK', 'Laggard', { parentId: oldParent.id });
+
+      await request(app).put(`/items/${ahead.id}`).send({ status: 'IN_PROGRESS' });
+      await request(app).put(`/items/${ahead.id}`).send({ status: 'REVIEW' });
+      await request(app).put(`/items/${laggard.id}`).send({ status: 'IN_PROGRESS' });
+
+      const r = await request(app).post('/items/bulk').send({
+        items: [{ id: laggard.id, updates: { parentId: newParent.id } }],
+      });
+      expect(r.status).toBe(200);
+      expect(r.body.results[0].parentId).toBe(newParent.id);
+
+      const after = await request(app).get(`/items/${oldParent.id}`);
+      expect(after.body.status).toBe('REVIEW');
+    });
+  });
+
+  describe('POST /items enforces parent existence and project', () => {
+    it('refuses a nonexistent parent at create time', async () => {
+      const r = await request(app).post('/items').send({
+        type: 'TASK', title: 'Orphan', projectId, parentId: 'no-such-parent',
+      });
+      expect(r.status).toBe(400);
+      expect(r.body.error).toMatch(/not found/i);
+    });
+
+    it('refuses a cross-project parent at create time', async () => {
+      const foreign = await makeItem('STORY', 'Foreign', { projectId: otherProjectId });
+
+      const r = await request(app).post('/items').send({
+        type: 'TASK', title: 'Misfiled', projectId, parentId: foreign.id,
+      });
+      expect(r.status).toBe(400);
+      expect(r.body.error).toMatch(/project/i);
+    });
+
+    it('still creates a child under a valid parent', async () => {
+      const story = await makeItem('STORY', 'Story');
+      const r = await request(app).post('/items').send({
+        type: 'TASK', title: 'Child', projectId, parentId: story.id,
+      });
+      expect(r.status).toBe(201);
+      expect(r.body.parentId).toBe(story.id);
+    });
+  });
+
+  it('rejects a non-string parentId with 400 rather than a 500 from the driver', async () => {
+    const task = await makeItem('TASK', 'Task');
+
+    const r = await request(app).put(`/items/${task.id}`).send({ parentId: { nested: true } });
+    expect(r.status).toBe(400);
+    expect(r.body.error).toMatch(/string/i);
   });
 });

--- a/packages/server/src/test/reparent-rule-docs.test.ts
+++ b/packages/server/src/test/reparent-rule-docs.test.ts
@@ -1,0 +1,38 @@
+/**
+ * The rule bundles spell out `agenfk update`'s flags verbatim, so a new flag that
+ * isn't added there is invisible to every agent that reads them — which is the
+ * whole point of the bundles. `agenfk update --parent` (re-parent an item, or
+ * detach it with `none`) must be documented everywhere the command surface is.
+ *
+ * Same shape as pr-registration-rule-docs.test.ts.
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(__dirname, '../../../..');
+
+// Every bundle that documents the `agenfk update` flag list.
+const DOCS = [
+  'clauderules/CLAUDE.md',
+  'codexrules/AGENTS.md',
+  'geminirules/GEMINI.md',
+  'cursorrules/agenfk.mdc',
+  'SKILL.md',
+];
+
+describe('re-parenting is documented in the rule bundles', () => {
+  for (const rel of DOCS) {
+    it(`${rel} documents --parent on agenfk update`, () => {
+      const src = fs.readFileSync(path.join(ROOT, rel), 'utf8');
+      expect(src).toMatch(/--parent/);
+    });
+
+    it(`${rel} explains how to detach an item to top level`, () => {
+      const src = fs.readFileSync(path.join(ROOT, rel), 'utf8');
+      // The detach form is the non-obvious half — a bare --parent with no value
+      // is not how you unparent.
+      expect(src).toMatch(/--parent\s+none/);
+    });
+  }
+});

--- a/packages/server/src/test/reparent-rule-docs.test.ts
+++ b/packages/server/src/test/reparent-rule-docs.test.ts
@@ -23,16 +23,22 @@ const DOCS = [
 
 describe('re-parenting is documented in the rule bundles', () => {
   for (const rel of DOCS) {
-    it(`${rel} documents --parent on agenfk update`, () => {
+    // Anchor on the `agenfk update` invocation, not a bare /--parent/: `agenfk
+    // create` already documents -p/--parent in these files, so an unanchored
+    // grep would stay green if the flag were only ever shown on create.
+    const updateParentLine = (src: string) =>
+      src.split('\n').find(l => /agenfk update <id>/.test(l) && /--parent/.test(l));
+
+    it(`${rel} documents --parent on agenfk update specifically`, () => {
       const src = fs.readFileSync(path.join(ROOT, rel), 'utf8');
-      expect(src).toMatch(/--parent/);
+      expect(updateParentLine(src)).toBeDefined();
     });
 
     it(`${rel} explains how to detach an item to top level`, () => {
       const src = fs.readFileSync(path.join(ROOT, rel), 'utf8');
       // The detach form is the non-obvious half — a bare --parent with no value
       // is not how you unparent.
-      expect(src).toMatch(/--parent\s+none/);
+      expect(updateParentLine(src)).toMatch(/--parent\s+none/);
     });
   }
 });

--- a/packages/ui/src/components/FlowEditorModal.tsx
+++ b/packages/ui/src/components/FlowEditorModal.tsx
@@ -67,6 +67,11 @@ export const FlowEditorModal: React.FC<FlowEditorModalProps | LegacyProps> = (pr
       flowClient={flowClient}
       registryClient={registryClient}
       canSelectFlow={!hubEnabled}
+      // BUG 269eeec8 (b): the local server answers any mutation of a
+      // source='hub' flow with 409, so the editor must present those flows as
+      // read-only here instead of offering a Save that cannot succeed. The hub
+      // admin does not pass this — there, hub flows are the editable ones.
+      hubManagedReadOnly
       theme={theme === 'dark' ? 'dark' : 'light'}
     />
   );

--- a/packages/ui/src/test/FlowEditorModal.test.tsx
+++ b/packages/ui/src/test/FlowEditorModal.test.tsx
@@ -1397,6 +1397,62 @@ describe('FlowEditorModal — save failures surface the reason (BUG 269eeec8)', 
     await waitFor(() => expect(screen.queryByTestId('flow-delete-error')).toBeNull());
   });
 
+  // Hub-connected with an org-default flow: authoring stays fully available —
+  // create, save and publish — because only ACTIVATION is owned by the Hub.
+  describe('hub-connected authoring', () => {
+    beforeEach(() => {
+      vi.mocked(api.getOrgAvailableFlows).mockResolvedValue({
+        flows: [], defaultFlowId: 'flow-hub', hubEnabled: true,
+      });
+    });
+
+    it('still offers New Flow', async () => {
+      render(
+        <FlowEditorModal isOpen={true} onClose={() => {}} projectId={PROJECT_ID} />,
+        { wrapper: wrapper(makeQueryClient()) }
+      );
+      await waitFor(() => expect(screen.getByTestId('new-flow-btn')).toBeDefined());
+    });
+
+    it('saves a newly created local flow', async () => {
+      vi.mocked(api.createFlow).mockResolvedValue({ ...SAMPLE_FLOW, id: 'created' });
+      render(
+        <FlowEditorModal isOpen={true} onClose={() => {}} projectId={PROJECT_ID} />,
+        { wrapper: wrapper(makeQueryClient()) }
+      );
+      await waitFor(() => screen.getByTestId('new-flow-btn'));
+      fireEvent.click(screen.getByTestId('new-flow-btn'));
+      await waitFor(() => screen.getByTestId('flow-name-input'));
+
+      fireEvent.change(screen.getByTestId('flow-name-input'), { target: { value: 'Local Flow' } });
+      fireEvent.change(screen.getByTestId('step-name-1'), { target: { value: 'in_progress' } });
+      fireEvent.click(screen.getByTestId('save-flow-btn'));
+
+      await waitFor(() => expect(api.createFlow).toHaveBeenCalledTimes(1));
+    });
+
+    it('saves an edit to an existing local flow', async () => {
+      vi.mocked(api.updateFlow).mockResolvedValue(SAMPLE_FLOW);
+      await openFlow('flow-item-flow-1');
+
+      fireEvent.click(screen.getByTestId('save-flow-btn'));
+
+      await waitFor(() => expect(api.updateFlow).toHaveBeenCalledTimes(1));
+    });
+
+    it('offers Publish on a local flow', async () => {
+      await openFlow('flow-item-flow-1');
+
+      expect(screen.getByTestId('publish-flow-btn')).toBeDefined();
+    });
+
+    it('does NOT offer activation — that is the Hub\'s to own', async () => {
+      await openFlow('flow-item-flow-1');
+
+      expect(screen.queryByTestId('use-flow-btn')).toBeNull();
+    });
+  });
+
   // (c) — block the payload the Hub rejects, and say which step is wrong.
   it('blocks Save on a step with no name and pins the error to that step', async () => {
     await openFlow('flow-item-flow-1');

--- a/packages/ui/src/test/FlowEditorModal.test.tsx
+++ b/packages/ui/src/test/FlowEditorModal.test.tsx
@@ -495,6 +495,11 @@ describe('FlowEditorModal', () => {
     await waitFor(() => screen.getByTestId('flow-name-input'));
 
     fireEvent.change(screen.getByTestId('flow-name-input'), { target: { value: 'New Sprint Flow' } });
+    // BUG 269eeec8 (c): new-flow mode seeds one blank step, and an unnamed step
+    // is no longer a saveable definition (the Hub rejects it, and "" is not a
+    // usable workflow status). Name it so this test still exercises what it is
+    // about — that Use this Flow creates then selects.
+    fireEvent.change(screen.getByTestId('step-name-1'), { target: { value: 'in_progress' } });
     fireEvent.click(screen.getByTestId('use-flow-btn'));
 
     await waitFor(() => expect(api.createFlow).toHaveBeenCalledTimes(1));
@@ -1194,5 +1199,251 @@ describe('FlowEditorModal — version badge', () => {
     fireEvent.click(screen.getByTestId('flow-item-flow-1'));
     await waitFor(() => screen.getByTestId('flow-version-badge'));
     expect(screen.queryByTestId('flow-version-input')).toBeNull();
+  });
+});
+
+// ── BUG 269eeec8 — flow save failures on both surfaces ──────────────────────
+// (a) the editor showed only "Request failed with status code N", discarding the
+//     server's `{ error }` body, which is the only text that says what to fix;
+// (b) Save was offered on hub-managed flows the local server always 409s;
+// (c) a blank step name was sent to a backend that rejects it (Hub 400).
+describe('FlowEditorModal — save failures surface the reason (BUG 269eeec8)', () => {
+  const HUB_FLOW: Flow = {
+    id: 'flow-hub',
+    name: 'TDD Flow',
+    description: 'Hub-managed',
+    source: 'hub',
+    hubFlowId: 'e06246da-0e3f-446e-9aa2-24fd3fdbeadc',
+    steps: [
+      { id: 'h1', name: 'TODO', label: 'To Do', order: 0, exitCriteria: '', isAnchor: true },
+      { id: 'h2', name: 'DISCOVERY', label: 'Discovery', order: 1, exitCriteria: 'Cards created' },
+      { id: 'h3', name: 'DONE', label: 'Done', order: 2, exitCriteria: '', isAnchor: true },
+    ],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+
+  /** What axios actually throws: the reason is in response.data, not in message. */
+  const axiosRejection = (status: number, serverError: string) =>
+    Object.assign(new Error(`Request failed with status code ${status}`), {
+      isAxiosError: true,
+      response: { status, data: { error: serverError } },
+    });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(api.getDefaultFlow).mockResolvedValue(DEFAULT_FLOW);
+    vi.mocked(api.getOrgAvailableFlows).mockResolvedValue({ flows: [], defaultFlowId: null, hubEnabled: false });
+    vi.mocked(api.listFlows).mockResolvedValue([SAMPLE_FLOW, HUB_FLOW]);
+  });
+
+  afterEach(() => cleanup());
+
+  const openFlow = async (testId: string) => {
+    render(
+      <FlowEditorModal isOpen={true} onClose={() => {}} projectId={PROJECT_ID} />,
+      { wrapper: wrapper(makeQueryClient()) }
+    );
+    await waitFor(() => screen.getByTestId(testId));
+    fireEvent.click(screen.getByTestId(testId));
+    // Wait on the panel, not the name input — a read-only panel has no input.
+    await waitFor(() => screen.getByTestId('editor-panel'));
+  };
+
+  // (a) — the whole reason this bug took two rounds of network-tab archaeology.
+  it("shows the server's error text, not the generic axios message", async () => {
+    vi.mocked(api.updateFlow).mockRejectedValue(axiosRejection(400, 'each step requires a name'));
+    await openFlow('flow-item-flow-1');
+
+    fireEvent.click(screen.getByTestId('save-flow-btn'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('flow-editor-error').textContent).toContain('each step requires a name');
+    });
+    expect(screen.getByTestId('flow-editor-error').textContent).not.toContain('status code 400');
+  });
+
+  it('shows the hub-managed refusal verbatim when the local server 409s', async () => {
+    vi.mocked(api.updateFlow).mockRejectedValue(
+      axiosRejection(409, "Flow is managed by your organization's Hub and cannot be modified locally")
+    );
+    await openFlow('flow-item-flow-1');
+
+    fireEvent.click(screen.getByTestId('save-flow-btn'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('flow-editor-error').textContent).toContain("managed by your organization's Hub");
+    });
+  });
+
+  // (b) — don't offer a Save the local server is guaranteed to reject.
+  it('marks a hub-managed flow as hub-owned and does not offer Save', async () => {
+    await openFlow('flow-item-flow-hub');
+
+    expect(screen.getByTestId('hub-managed-badge')).toBeDefined();
+    expect(screen.queryByTestId('save-flow-btn')).toBeNull();
+  });
+
+  it('a local flow is still editable and offers Save', async () => {
+    await openFlow('flow-item-flow-1');
+
+    expect(screen.queryByTestId('hub-managed-badge')).toBeNull();
+    expect(screen.getByTestId('save-flow-btn')).toBeDefined();
+  });
+
+  // Review findings 2/3/4: the read-only panel is now also used for hub flows,
+  // so it must not claim to be the default flow, must not be a dead end, and
+  // must not offer a delete the server refuses.
+  it('shows the hub flow its own name, not "Default Flow"', async () => {
+    await openFlow('flow-item-flow-hub');
+
+    expect(screen.getByTestId('flow-name-heading').textContent).toBe('TDD Flow');
+  });
+
+  it('offers Clone to Edit on a hub flow, as the badge tooltip promises', async () => {
+    await openFlow('flow-item-flow-hub');
+
+    expect(screen.getByTestId('clone-to-edit-btn')).toBeDefined();
+  });
+
+  it('keeps Publish reachable on a hub flow', async () => {
+    await openFlow('flow-item-flow-hub');
+
+    expect(screen.getByTestId('publish-flow-btn')).toBeDefined();
+  });
+
+  // A button whose outcome renders in a different footer is a silent failure —
+  // the exact class of bug this change exists to remove.
+  it('reports a publish failure on a hub flow, in the read-only footer', async () => {
+    vi.mocked(api.publishToRegistry).mockRejectedValue(axiosRejection(502, 'registry unreachable'));
+    await openFlow('flow-item-flow-hub');
+
+    fireEvent.click(screen.getByTestId('publish-flow-btn'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('publish-error').textContent).toContain('registry unreachable');
+    });
+  });
+
+  it('shows the publish success link on a hub flow', async () => {
+    vi.mocked(api.publishToRegistry).mockResolvedValue({ url: 'https://example.test/pr/1', kind: 'pr' });
+    await openFlow('flow-item-flow-hub');
+
+    fireEvent.click(screen.getByTestId('publish-flow-btn'));
+
+    await waitFor(() => expect(screen.getByTestId('publish-success-link')).toBeDefined());
+  });
+
+  it('does not offer "Use this Flow" as a set-default action on a hub flow', async () => {
+    await openFlow('flow-item-flow-hub');
+
+    expect(screen.queryByTestId('use-default-flow-btn')).toBeNull();
+  });
+
+  it('does not fire a delete for a hub flow the server would refuse', async () => {
+    await openFlow('flow-item-flow-hub');
+
+    fireEvent.click(screen.getByTestId('delete-flow-btn-flow-hub'));
+
+    // The confirm prompt must not even open — that is what distinguishes the
+    // gate from the old behaviour, where the prompt appeared and only the
+    // eventual request failed (silently).
+    expect(screen.queryByTestId('delete-confirm')).toBeNull();
+    expect(api.deleteFlow).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a delete refusal instead of failing silently', async () => {
+    vi.mocked(api.deleteFlow).mockRejectedValue(
+      axiosRejection(409, "Flow is managed by your organization's Hub and cannot be modified locally")
+    );
+    render(
+      <FlowEditorModal isOpen={true} onClose={() => {}} projectId={PROJECT_ID} />,
+      { wrapper: wrapper(makeQueryClient()) }
+    );
+    await waitFor(() => screen.getByTestId('flow-item-flow-1'));
+
+    fireEvent.click(screen.getByTestId('delete-flow-btn-flow-1'));
+    await waitFor(() => screen.getByTestId('delete-confirm-yes'));
+    fireEvent.click(screen.getByTestId('delete-confirm-yes'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('flow-delete-error').textContent).toContain("managed by your organization's Hub");
+    });
+  });
+
+  // (c) — block the payload the Hub rejects, and say which step is wrong.
+  it('blocks Save on a step with no name and pins the error to that step', async () => {
+    await openFlow('flow-item-flow-1');
+
+    fireEvent.click(screen.getByTestId('add-step-btn'));
+
+    await waitFor(() => {
+      expect((screen.getByTestId('save-flow-btn') as HTMLButtonElement).disabled).toBe(true);
+    });
+    // The blank step lands at index 3 (TODO, in_review, DONE, new).
+    expect(screen.getByTestId('step-name-error-3')).toBeDefined();
+    expect(api.updateFlow).not.toHaveBeenCalled();
+  });
+
+  it('re-enables Save once the new step is named', async () => {
+    await openFlow('flow-item-flow-1');
+    fireEvent.click(screen.getByTestId('add-step-btn'));
+    await waitFor(() => expect((screen.getByTestId('save-flow-btn') as HTMLButtonElement).disabled).toBe(true));
+
+    fireEvent.change(screen.getByTestId('step-name-3'), { target: { value: 'REFACTOR' } });
+
+    await waitFor(() => {
+      expect((screen.getByTestId('save-flow-btn') as HTMLButtonElement).disabled).toBe(false);
+    });
+    expect(screen.queryByTestId('step-name-error-3')).toBeNull();
+  });
+
+  // Save must never be disabled without a visible reason. Per-step messages
+  // render only for non-anchor steps (anchors expose no name field) and a
+  // flow-level issue has no column at all, so both need a surfaced explanation
+  // or the user gets a dead button and nothing to act on.
+  it('explains a blank flow name instead of just disabling Save', async () => {
+    await openFlow('flow-item-flow-1');
+
+    fireEvent.change(screen.getByTestId('flow-name-input'), { target: { value: '   ' } });
+
+    await waitFor(() => {
+      expect((screen.getByTestId('save-flow-btn') as HTMLButtonElement).disabled).toBe(true);
+    });
+    expect(screen.getByTestId('flow-definition-issues').textContent).toMatch(/name/i);
+  });
+
+  it('explains a bad ANCHOR step, which renders no editable name field', async () => {
+    // A flow persisted before the server validated step shape can arrive with a
+    // blank anchor name. The anchor column has no name input, so without this
+    // the user would see a disabled Save and no reason anywhere on screen.
+    const brokenAnchor: Flow = {
+      ...SAMPLE_FLOW,
+      id: 'flow-broken',
+      steps: [
+        { id: 'b1', name: '', label: '', order: 0, exitCriteria: '', isAnchor: true },
+        { id: 'b2', name: 'work', label: 'Work', order: 1, exitCriteria: '' },
+        { id: 'b3', name: 'DONE', label: 'Done', order: 2, exitCriteria: '', isAnchor: true },
+      ],
+    };
+    vi.mocked(api.listFlows).mockResolvedValue([brokenAnchor]);
+
+    await openFlow('flow-item-flow-broken');
+
+    expect((screen.getByTestId('save-flow-btn') as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.getByTestId('flow-definition-issues').textContent).toMatch(/name/i);
+    // The anchor has no name input, so there is no per-step message to rely on.
+    expect(screen.queryByTestId('step-name-error-0')).toBeNull();
+  });
+
+  it('does not send a save while a step name is blank', async () => {
+    vi.mocked(api.updateFlow).mockResolvedValue(SAMPLE_FLOW);
+    await openFlow('flow-item-flow-1');
+    fireEvent.click(screen.getByTestId('add-step-btn'));
+
+    fireEvent.click(screen.getByTestId('save-flow-btn'));
+
+    await waitFor(() => expect((screen.getByTestId('save-flow-btn') as HTMLButtonElement).disabled).toBe(true));
+    expect(api.updateFlow).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/test/FlowEditorModal.test.tsx
+++ b/packages/ui/src/test/FlowEditorModal.test.tsx
@@ -1371,6 +1371,32 @@ describe('FlowEditorModal — save failures surface the reason (BUG 269eeec8)', 
     });
   });
 
+  it('actually disables the delete button on a hub row, not just its styling', async () => {
+    await openFlow('flow-item-flow-hub');
+
+    expect((screen.getByTestId('delete-flow-btn-flow-hub') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('clears a stale delete error when the modal is reopened', async () => {
+    vi.mocked(api.deleteFlow).mockRejectedValue(axiosRejection(409, 'nope'));
+    const qc = makeQueryClient();
+    const { rerender } = render(
+      <FlowEditorModal isOpen={true} onClose={() => {}} projectId={PROJECT_ID} />,
+      { wrapper: wrapper(qc) }
+    );
+    await waitFor(() => screen.getByTestId('flow-item-flow-1'));
+    fireEvent.click(screen.getByTestId('delete-flow-btn-flow-1'));
+    await waitFor(() => screen.getByTestId('delete-confirm-yes'));
+    fireEvent.click(screen.getByTestId('delete-confirm-yes'));
+    await waitFor(() => screen.getByTestId('flow-delete-error'));
+
+    // The component never unmounts, so reopening must not resurrect the error.
+    rerender(<FlowEditorModal isOpen={false} onClose={() => {}} projectId={PROJECT_ID} />);
+    rerender(<FlowEditorModal isOpen={true} onClose={() => {}} projectId={PROJECT_ID} />);
+
+    await waitFor(() => expect(screen.queryByTestId('flow-delete-error')).toBeNull());
+  });
+
   // (c) — block the payload the Hub rejects, and say which step is wrong.
   it('blocks Save on a step with no name and pins the error to that step', async () => {
     await openFlow('flow-item-flow-1');

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -93,6 +93,11 @@ export interface Flow {
   steps: FlowStep[];
   createdAt: string;
   updatedAt: string;
+  // Ownership. The server sets 'hub' for flows synced from the org's Hub and
+  // refuses local mutation of them; the UI must present those as read-only
+  // (BUG 269eeec8 (b)). Absent on older payloads, so treat undefined as local.
+  source?: 'local' | 'hub' | 'community';
+  hubFlowId?: string;
 }
 
 export interface RegistryFlow {


### PR DESCRIPTION
Fixes CGLAB-36.

Four defects shared one reproduction path — open the flow editor, change a step,
Save — and three of them were undiagnosable because of the fourth.

## The defects

**(a) The server's error body was thrown away.** The shared editor rendered
`(error as Error).message`, which for an axios rejection is always "Request
failed with status code N". Every REST surface here answers a refusal with
`{ error: "<reason>" }`, and that text was never shown. This is why the same
symptom covered two unrelated causes and took two rounds of network-tab
archaeology to separate. Now extracted properly, and applied to the save,
delete **and** publish paths. HTML error pages are rejected and the reason is
length-capped so a gateway's 502 page can't fill the error line.

**(b) Save was offered on flows the local server always rejects.** A flow with
`source='hub'` gets a 409 from `PUT /flows/:id` by design. Those flows now
render read-only with a "Managed by Hub" badge, keeping Clone to Edit and
Publish reachable so the panel isn't a dead end, and the sidebar no longer
offers a delete that cannot succeed. Gated behind a new `hubManagedReadOnly`
prop set only by `packages/ui` — `packages/hub-ui` uses the same component and
must still edit hub flows, so it is unaffected.

**(c) Local and Hub disagreed on what a valid flow is.** The Hub validates step
shape; the local server validated nothing, so an empty step name got a bare 400
from the Hub. The editor now blocks Save with the reason pinned to the offending
step, and the local server enforces the same rule.

Deliberately **narrower** than the Hub on two points that existing callers
depend on:
- `steps: []` stays legal — create-then-populate is long-standing local behaviour.
- a missing step `id` is **generated**, not rejected. MCP `create_flow` never
  sent ids (its schema omitted the key), so flows already in users' databases
  have steps — anchors included — without one. Blocking would have stranded the
  user on a field the UI cannot edit, and anchors expose no input at all. The
  MCP schemas now accept `id` so it stops churning on every update.

**(d) `GET /v1/admin/flow-assignments` 500'd on Postgres.** A SELECT-list
correlated subquery correlated on `e.org_id` while `GROUP BY` listed only
`project_id`. Postgres rejects the ungrouped column; SQLite allows it — which is
exactly why the existing tests stayed green while the deployed Admin → Flows
page was broken for every org. Replaced with one bounded `LIMIT 1` lookup per
assigned project, run concurrently, plus a supporting composite index.

Also fixes the registry-install path, which used `s.name ?? …` — `??` does not
catch `''`, so a community flow with `"name": ""` installed the exact value the
new validation exists to reject, while bypassing it.

## Invariant added

Every reason Save can be blocked is now rendered, including flow-level issues
and issues on anchor steps, which expose no editable field. Both the per-step
message and the fallback list derive from one predicate so it can't drift.

## Review

Two adversarial review rounds. Round 1 caught that the client gate blocked on
step `id` (the permanent unfixable Save lock described above) and that a naive
de-correlation of the (d) query pulled unbounded rows off the ingestion table.
Round 2 caught that the new index sat in the schema batch that runs on **every**
boot — Postgres wraps that multi-statement query in an implicit transaction, so a
plain `CREATE INDEX` there would hold a SHARE lock on `events` and block all
ingestion until the batch committed. It is now a standalone `CONCURRENTLY`
statement with a warn-not-fail guard.

## Verification

| | |
|---|---|
| root `npm test` | 184 files, 1893 tests, all passing |
| `packages/ui` | 397 passing |
| `packages/hub-ui` | 118 passing |
| `npm run build` | exits 0 (all packages) |
| tests removed or renamed | **zero** vs `main`, across all six touched test files |
| ESLint | 261 problems before and after — no new ones |
| coverage branch gate | already failing on `main` (73.67%); this raises it to 73.87% |

The new `hub-pg-parity` case genuinely fails on revert — pg-mem reproduces the
Postgres rejection.

One existing UI test was **adapted, not removed**: it created a flow leaving the
seeded step unnamed, which is now deliberately invalid. Its assertions are
unchanged.

## Not in this PR

- The Postgres fix needs a **hub deploy** to reach the deployed hub — merging
  alone will not fix the Admin → Flows page.
- CI runs only `npm run build` and `npm test`, and the root vitest config
  excludes `packages/ui/src/test/**`, so the 16 UI behaviour tests added here
  will not run in CI. Captured in CGLAB-36; fixing it means adding a CI job.
- Authoring the REFACTOR step at the Hub as TDD Flow v1.0.2 — the original goal
  this bug hunt interrupted.
