### PR TITLE
fix(hub-ui): make mint-family chips readable in dark theme (CGLAB-39)

### DIFF
--- a/packages/hub-ui/src/pages/PrOverview.tsx
+++ b/packages/hub-ui/src/pages/PrOverview.tsx
@@ -505,7 +505,7 @@ export function PrOverviewPage() {
                         {/* stacked vertically so long dev emails keep the width */}
                         <span className="ml-auto flex flex-col items-end gap-0.5 shrink-0">
                           <span className="font-mono text-[9px] font-bold tabular-nums whitespace-nowrap rounded-full px-1.5 py-px text-accent-text bg-chip border border-border-brand">{pct.prPct}% PRs</span>
-                          <span className="font-mono text-[9px] font-bold tabular-nums whitespace-nowrap rounded-full px-1.5 py-px text-brand-dark bg-mint/40 border border-border-brand">{pct.ptsPct}% pts</span>
+                          <span className="font-mono text-[9px] font-bold tabular-nums whitespace-nowrap rounded-full px-1.5 py-px text-brand-dark dark:text-brand-light bg-mint/40 dark:bg-brand/10 border border-border-brand">{pct.ptsPct}% pts</span>
                         </span>
                       </div>
                       {axis.map((day, i) => {

--- a/packages/hub-ui/src/pages/UserDetail.tsx
+++ b/packages/hub-ui/src/pages/UserDetail.tsx
@@ -43,8 +43,8 @@ function endOfDateInput(value: string): string {
 
 const TYPE_BADGE: Record<string, string> = {
   'item.created':       'bg-chip text-accent-text border-border-brand',
-  'item.updated':       'bg-mint/40 text-brand-dark border-border-brand',
-  'item.moved':         'bg-mint/40 text-brand-dark border-border-brand',
+  'item.updated':       'bg-mint/40 dark:bg-brand/10 text-brand-dark dark:text-brand-light border-border-brand',
+  'item.moved':         'bg-mint/40 dark:bg-brand/10 text-brand-dark dark:text-brand-light border-border-brand',
   'step.transitioned':  'bg-amber-50 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 border-amber-200 dark:border-amber-800',
   'validate.invoked':   'bg-chip text-ink-secondary border-border-soft',
   'validate.passed':    'bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300 border-emerald-200 dark:border-emerald-800',
@@ -57,7 +57,7 @@ const TYPE_BADGE: Record<string, string> = {
 const DEFAULT_BADGE = 'bg-chip text-ink-secondary border-border-soft';
 
 const ITEM_TYPE_BADGE: Record<string, string> = {
-  EPIC:  'bg-mint/40 text-brand-dark border-border-brand',
+  EPIC:  'bg-mint/40 dark:bg-brand/10 text-brand-dark dark:text-brand-light border-border-brand',
   STORY: 'bg-chip text-accent-text border-border-brand',
   TASK:  'bg-chip text-ink-secondary border-border-soft',
   BUG:   'bg-rose-50 dark:bg-rose-900/30 text-rose-700 dark:text-rose-300 border-rose-200 dark:border-rose-800',


### PR DESCRIPTION
The `item.updated`/`item.moved` event chips, the EPIC badge (UserDetail) and the pts chip (PrOverview) used `bg-mint/40 text-brand-dark` — static tokens that don't theme-flip, rendering dark-teal on a murky mint wash in the hub's dark theme (user-reported with screenshot).

Fix: `dark:bg-brand/10 dark:text-brand-light` overrides — readable in dark, unchanged in light, still visually distinct from the plain teal `bg-chip text-accent-text` chips.

Swept all three UI packages: no other un-flipped `text-brand-dark` remains. hub-ui build green, tests 19 files / 122 pass.