### PR TITLE
feat: add light/dark theme toggle to hub UI

### DIFF
--- a/packages/hub-ui/src/ThemeContext.tsx
+++ b/packages/hub-ui/src/ThemeContext.tsx
@@ -1,0 +1,48 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextType {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+const STORAGE_KEY = 'hub-theme';
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>(() => {
+    try {
+      const savedTheme = localStorage.getItem(STORAGE_KEY);
+      if (savedTheme === 'light' || savedTheme === 'dark') return savedTheme;
+    } catch { /* localStorage may be unavailable in private/restricted browsing */ }
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  });
+
+  useEffect(() => {
+    const root = window.document.documentElement;
+    root.classList.remove('light', 'dark');
+    root.classList.add(theme);
+    root.setAttribute('data-theme', theme);
+    try { localStorage.setItem(STORAGE_KEY, theme); } catch { /* localStorage may be unavailable in private/restricted browsing */ }
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme(prev => (prev === 'light' ? 'dark' : 'light'));
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+};

--- a/packages/hub-ui/src/components/Layout.tsx
+++ b/packages/hub-ui/src/components/Layout.tsx
@@ -1,8 +1,9 @@
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { api, MeResponse } from '../api';
-import { LayoutDashboard, Shield, LogOut, AlertTriangle, GitPullRequest } from 'lucide-react';
+import { LayoutDashboard, Shield, LogOut, AlertTriangle, GitPullRequest, Sun, Moon } from 'lucide-react';
 import { Logo } from './Logo';
+import { useTheme } from '../ThemeContext';
 
 interface NavItemProps { to: string; icon: React.ReactNode; label: string }
 function NavItem({ to, icon, label }: NavItemProps) {
@@ -27,6 +28,7 @@ interface HealthResponse { ok: boolean; version: string }
 
 export function Layout({ children }: { children: React.ReactNode }) {
   const nav = useNavigate();
+  const { theme, toggleTheme } = useTheme();
   const me = useQuery<MeResponse>({ queryKey: ['me'], queryFn: async () => (await api.get('/auth/me')).data });
   const health = useQuery<HealthResponse>({
     queryKey: ['hub-healthz'],
@@ -48,6 +50,14 @@ export function Layout({ children }: { children: React.ReactNode }) {
         {me.data?.role === 'admin' && (
           <NavItem to="/admin" icon={<Shield className="w-4 h-4" />} label="Admin" />
         )}
+        <button
+          onClick={toggleTheme}
+          className="flex items-center justify-center gap-2 px-3 py-2 rounded-lg border border-border-soft bg-card-glass hover:bg-chip transition-colors text-ink-secondary hover:text-accent-text mb-2"
+          title={theme === 'dark' ? 'Switch to Light Mode' : 'Switch to Dark Mode'}
+        >
+          {theme === 'dark' ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
+          <span className="text-[13px] font-medium">{theme === 'dark' ? 'Light' : 'Dark'}</span>
+        </button>
         <div className="mt-auto px-2 py-2 rounded-lg border border-border-soft bg-card-glass">
           <div className="text-[10px] uppercase tracking-[0.16em] text-ink-tertiary">Signed in</div>
           <div className="mt-0.5 text-[12px] font-mono text-ink truncate">{me.data?.userId ?? '—'}</div>

--- a/packages/hub-ui/src/main.tsx
+++ b/packages/hub-ui/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { App } from './App';
+import { ThemeProvider } from './ThemeContext';
 import './index.css';
 
 const qc = new QueryClient({ defaultOptions: { queries: { refetchInterval: 30_000, refetchOnWindowFocus: false } } });
@@ -11,7 +12,9 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <QueryClientProvider client={qc}>
       <BrowserRouter>
-        <App />
+        <ThemeProvider>
+          <App />
+        </ThemeProvider>
       </BrowserRouter>
     </QueryClientProvider>
   </React.StrictMode>,

--- a/packages/hub-ui/src/test/ThemeToggle.test.tsx
+++ b/packages/hub-ui/src/test/ThemeToggle.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { ThemeProvider, useTheme } from '../ThemeContext';
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+  document.documentElement.classList.remove('light', 'dark');
+  document.documentElement.removeAttribute('data-theme');
+});
+
+/** Helper component that exposes theme state for testing */
+function TestToggle() {
+  const { theme, toggleTheme } = useTheme();
+  return (
+    <div>
+      <span data-testid="theme-value">{theme}</span>
+      <button data-testid="toggle-btn" onClick={toggleTheme}>
+        Toggle
+      </button>
+    </div>
+  );
+}
+
+describe('ThemeToggle', () => {
+  beforeEach(() => {
+    // Default: no saved theme, clean matchMedia mock
+  });
+
+  it('defaults to light when no OS preference is set and no saved theme exists', () => {
+    // matchMedia returns false for (prefers-color-scheme: dark)
+    window.matchMedia = (() => ({
+      matches: false,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    })) as any;
+
+    render(
+      <ThemeProvider>
+        <TestToggle />
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId('theme-value').textContent).toBe('light');
+    expect(document.documentElement.classList.contains('light')).toBe(true);
+    expect(localStorage.getItem('hub-theme')).toBe('light');
+  });
+
+  it('defaults to dark when OS prefers dark mode and no saved theme exists', () => {
+    window.matchMedia = (() => ({
+      matches: true,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    })) as any;
+
+    render(
+      <ThemeProvider>
+        <TestToggle />
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId('theme-value').textContent).toBe('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(localStorage.getItem('hub-theme')).toBe('dark');
+  });
+
+  it('reads saved theme from localStorage over OS preference', () => {
+    localStorage.setItem('hub-theme', 'dark');
+    window.matchMedia = (() => ({
+      matches: false, // OS says light, but saved says dark
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    })) as any;
+
+    render(
+      <ThemeProvider>
+        <TestToggle />
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId('theme-value').textContent).toBe('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('toggles from light to dark on button click', () => {
+    window.matchMedia = (() => ({
+      matches: false,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    })) as any;
+
+    render(
+      <ThemeProvider>
+        <TestToggle />
+      </ThemeProvider>,
+    );
+
+    fireEvent.click(screen.getByTestId('toggle-btn'));
+    expect(screen.getByTestId('theme-value').textContent).toBe('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(document.documentElement.classList.contains('light')).toBe(false);
+    expect(localStorage.getItem('hub-theme')).toBe('dark');
+  });
+
+  it('toggles from dark to light on button click', () => {
+    localStorage.setItem('hub-theme', 'dark');
+    window.matchMedia = (() => ({
+      matches: true,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    })) as any;
+
+    render(
+      <ThemeProvider>
+        <TestToggle />
+      </ThemeProvider>,
+    );
+
+    fireEvent.click(screen.getByTestId('toggle-btn'));
+    expect(screen.getByTestId('theme-value').textContent).toBe('light');
+    expect(document.documentElement.classList.contains('light')).toBe(true);
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+    expect(localStorage.getItem('hub-theme')).toBe('light');
+  });
+
+  it('applies data-theme attribute matching the current theme', () => {
+    window.matchMedia = (() => ({
+      matches: false,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    })) as any;
+
+    render(
+      <ThemeProvider>
+        <TestToggle />
+      </ThemeProvider>,
+    );
+
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+
+    fireEvent.click(screen.getByTestId('toggle-btn'));
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+  });
+
+  it('throws when useTheme is used outside ThemeProvider', () => {
+    // Suppress console.error for the expected uncaught error
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => render(<TestToggle />)).toThrow(
+      'useTheme must be used within a ThemeProvider',
+    );
+
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a Sun/Moon theme toggle button in the AgEnFK Hub sidebar, letting users manually switch between light and dark modes.

## Changes

- **`packages/hub-ui/src/ThemeContext.tsx`** (new) — Theme provider with localStorage persistence and OS preference detection
- **`packages/hub-ui/src/main.tsx`** — Wraps app in `<ThemeProvider>`
- **`packages/hub-ui/src/components/Layout.tsx`** — Theme toggle button in sidebar
- **`packages/hub-ui/src/test/ThemeToggle.test.tsx`** (new) — 7 tests

## Verification

- 1949 tests pass, TypeScript clean, Vite build succeeds
- localStorage wrapped in try/catch for private browsing safety