### PR TITLE
Add light/dark theme toggle to hub-ui

### DIFF
--- a/packages/hub-ui/src/ThemeContext.tsx
+++ b/packages/hub-ui/src/ThemeContext.tsx
@@ -1,0 +1,44 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextType {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>(() => {
+    const savedTheme = localStorage.getItem('theme');
+    if (savedTheme === 'light' || savedTheme === 'dark') return savedTheme;
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  });
+
+  useEffect(() => {
+    const root = window.document.documentElement;
+    root.classList.remove('light', 'dark');
+    root.classList.add(theme);
+    root.setAttribute('data-theme', theme);
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+};

--- a/packages/hub-ui/src/components/Layout.tsx
+++ b/packages/hub-ui/src/components/Layout.tsx
@@ -1,8 +1,9 @@
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { api, MeResponse } from '../api';
-import { LayoutDashboard, Shield, LogOut, AlertTriangle, GitPullRequest } from 'lucide-react';
+import { LayoutDashboard, Shield, LogOut, AlertTriangle, GitPullRequest, Sun, Moon } from 'lucide-react';
 import { Logo } from './Logo';
+import { useTheme } from '../ThemeContext';
 
 interface NavItemProps { to: string; icon: React.ReactNode; label: string }
 function NavItem({ to, icon, label }: NavItemProps) {
@@ -27,6 +28,7 @@ interface HealthResponse { ok: boolean; version: string }
 
 export function Layout({ children }: { children: React.ReactNode }) {
   const nav = useNavigate();
+  const { theme, toggleTheme } = useTheme();
   const me = useQuery<MeResponse>({ queryKey: ['me'], queryFn: async () => (await api.get('/auth/me')).data });
   const health = useQuery<HealthResponse>({
     queryKey: ['hub-healthz'],
@@ -49,7 +51,17 @@ export function Layout({ children }: { children: React.ReactNode }) {
           <NavItem to="/admin" icon={<Shield className="w-4 h-4" />} label="Admin" />
         )}
         <div className="mt-auto px-2 py-2 rounded-lg border border-border-soft bg-card-glass">
-          <div className="text-[10px] uppercase tracking-[0.16em] text-ink-tertiary">Signed in</div>
+          <div className="flex items-center justify-between">
+            <div className="text-[10px] uppercase tracking-[0.16em] text-ink-tertiary">Signed in</div>
+            <button
+              onClick={toggleTheme}
+              title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+              aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+              className="p-1 rounded-md text-ink-tertiary hover:text-accent-text hover:bg-chip transition-colors"
+            >
+              {theme === 'dark' ? <Sun className="w-3.5 h-3.5" /> : <Moon className="w-3.5 h-3.5" />}
+            </button>
+          </div>
           <div className="mt-0.5 text-[12px] font-mono text-ink truncate">{me.data?.userId ?? '—'}</div>
           <div className="mt-0.5 text-[10px] uppercase tracking-[0.14em] text-accent-text">{me.data?.role}</div>
           <button

--- a/packages/hub-ui/src/main.tsx
+++ b/packages/hub-ui/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { App } from './App';
+import { ThemeProvider } from './ThemeContext';
 import './index.css';
 
 const qc = new QueryClient({ defaultOptions: { queries: { refetchInterval: 30_000, refetchOnWindowFocus: false } } });
@@ -11,7 +12,9 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <QueryClientProvider client={qc}>
       <BrowserRouter>
-        <App />
+        <ThemeProvider>
+          <App />
+        </ThemeProvider>
       </BrowserRouter>
     </QueryClientProvider>
   </React.StrictMode>,

--- a/packages/hub-ui/src/test/ThemeContext.test.tsx
+++ b/packages/hub-ui/src/test/ThemeContext.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ThemeProvider, useTheme } from '../ThemeContext';
+
+// Mock window.matchMedia (jsdom does not implement it).
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+const ThemeTester = () => {
+  const { theme, toggleTheme } = useTheme();
+  return (
+    <div>
+      <span>Current theme: {theme}</span>
+      <button onClick={toggleTheme}>Toggle</button>
+    </div>
+  );
+};
+
+describe('hub-ui ThemeContext', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove('light', 'dark');
+    document.documentElement.removeAttribute('data-theme');
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('defaults to light when no localStorage and no dark OS preference', () => {
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>,
+    );
+    expect(screen.getByText(/Current theme: light/i)).toBeDefined();
+  });
+
+  it('toggles from light to dark and persists to localStorage', () => {
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>,
+    );
+    fireEvent.click(screen.getByText('Toggle'));
+    expect(screen.getByText(/Current theme: dark/i)).toBeDefined();
+    expect(localStorage.getItem('theme')).toBe('dark');
+  });
+
+  it('initializes from localStorage when set to dark', () => {
+    localStorage.setItem('theme', 'dark');
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>,
+    );
+    expect(screen.getByText(/Current theme: dark/i)).toBeDefined();
+  });
+
+  it('respects prefers-color-scheme: dark when no localStorage value', () => {
+    (window.matchMedia as ReturnType<typeof vi.fn>).mockImplementationOnce((query: string) => ({
+      matches: query === '(prefers-color-scheme: dark)',
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>,
+    );
+    expect(screen.getByText(/Current theme: dark/i)).toBeDefined();
+  });
+
+  it('applies .dark class and data-theme="dark" to <html> when dark', () => {
+    localStorage.setItem('theme', 'dark');
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>,
+    );
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+  });
+
+  it('applies .light class and data-theme="light" to <html> when light', () => {
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>,
+    );
+    expect(document.documentElement.classList.contains('light')).toBe(true);
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+  });
+
+  it('toggles from dark back to light', () => {
+    localStorage.setItem('theme', 'dark');
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>,
+    );
+    fireEvent.click(screen.getByText('Toggle'));
+    expect(screen.getByText(/Current theme: light/i)).toBeDefined();
+    expect(localStorage.getItem('theme')).toBe('light');
+    expect(document.documentElement.classList.contains('light')).toBe(true);
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+
+  it('useTheme throws when used outside ThemeProvider', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const ThrowTest = () => {
+      useTheme();
+      return null;
+    };
+    expect(() => render(<ThrowTest />)).toThrow('useTheme must be used within a ThemeProvider');
+    consoleError.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a light/dark theme toggle to the hub-ui sidebar, mirroring the established pattern from packages/ui.

## Changes

- **packages/hub-ui/src/ThemeContext.tsx** (new): `ThemeProvider` + `useTheme` hook. Initializes from localStorage, falls back to `prefers-color-scheme`, defaults to light. Applies both `.light`/`.dark` class AND `data-theme` attribute to `<html>` (matches the dual selectors in `packages/brand/tokens.css`).
- **packages/hub-ui/src/main.tsx**: Wrapped `<App />` in `<ThemeProvider>`.
- **packages/hub-ui/src/components/Layout.tsx**: Added Sun/Moon toggle button in the sidebar 'Signed in' card header, with `title` + `aria-label` for accessibility.
- **packages/hub-ui/src/test/ThemeContext.test.tsx** (new): 8 tests covering default, both toggle directions, localStorage init, media-query fallback, DOM class application (light + dark), and `useTheme` throwing outside provider.

## Verification

- All 8 unit tests pass (vitest)
- `tsc -b` clean
- Full hub-ui production build (vite) succeeds

## Notes

- No breaking changes; additive only.
- Uses existing design tokens from `packages/brand/tokens.css` — no new CSS variables introduced.
- Theme persists across sessions via localStorage.