### PR TITLE
feat(hub-ui): add light/dark theme toggle to the hub

### DIFF
--- a/packages/hub-ui/src/components/Layout.tsx
+++ b/packages/hub-ui/src/components/Layout.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { api, MeResponse } from '../api';
 import { LayoutDashboard, Shield, LogOut, AlertTriangle, GitPullRequest } from 'lucide-react';
 import { Logo } from './Logo';
+import { ThemeToggle } from './ThemeToggle';
 
 interface NavItemProps { to: string; icon: React.ReactNode; label: string }
 function NavItem({ to, icon, label }: NavItemProps) {
@@ -48,7 +49,9 @@ export function Layout({ children }: { children: React.ReactNode }) {
         {me.data?.role === 'admin' && (
           <NavItem to="/admin" icon={<Shield className="w-4 h-4" />} label="Admin" />
         )}
-        <div className="mt-auto px-2 py-2 rounded-lg border border-border-soft bg-card-glass">
+        <div className="mt-auto flex flex-col gap-2">
+          <ThemeToggle />
+          <div className="px-2 py-2 rounded-lg border border-border-soft bg-card-glass">
           <div className="text-[10px] uppercase tracking-[0.16em] text-ink-tertiary">Signed in</div>
           <div className="mt-0.5 text-[12px] font-mono text-ink truncate">{me.data?.userId ?? '—'}</div>
           <div className="mt-0.5 text-[10px] uppercase tracking-[0.14em] text-accent-text">{me.data?.role}</div>
@@ -58,6 +61,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
           >
             <LogOut className="w-3 h-3" /> Sign out
           </button>
+          </div>
         </div>
       </aside>
       <main className="flex-1 min-w-0 p-6 lg:p-8">

--- a/packages/hub-ui/src/components/ThemeToggle.tsx
+++ b/packages/hub-ui/src/components/ThemeToggle.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Moon, Sun } from 'lucide-react';
+import { useTheme } from '../hooks/useTheme';
+
+/**
+ * Sidebar-style button that toggles between light and dark themes.
+ * Shows a Moon icon when in light mode (tapping switches to dark) and
+ * a Sun icon when in dark mode (tapping switches to light).
+ */
+export function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+
+  const label = theme === 'light' ? 'Switch to dark mode' : 'Switch to light mode';
+
+  return (
+    <button
+      type="button"
+      data-testid="theme-toggle"
+      onClick={toggleTheme}
+      aria-label={label}
+      title={label}
+      className="flex items-center gap-2 px-3 py-2 rounded-lg text-[13px] font-medium text-ink-secondary border border-transparent hover:text-ink hover:bg-chip transition-colors"
+    >
+      {theme === 'light' ? (
+        <Moon className="w-4 h-4" />
+      ) : (
+        <Sun className="w-4 h-4" />
+      )}
+    </button>
+  );
+}

--- a/packages/hub-ui/src/hooks/storage.ts
+++ b/packages/hub-ui/src/hooks/storage.ts
@@ -1,0 +1,20 @@
+/**
+ * Minimal subset of the Web Storage API used by hooks that need
+ * localStorage persistence.
+ */
+export interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+/**
+ * Safely access window.localStorage, returning null in SSR or when unavailable.
+ */
+export function getLocalStorage(): StorageLike | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}

--- a/packages/hub-ui/src/hooks/useTheme.ts
+++ b/packages/hub-ui/src/hooks/useTheme.ts
@@ -1,21 +1,5 @@
 import { useEffect, useState } from 'react';
-
-interface StorageLike {
-  getItem(key: string): string | null;
-  setItem(key: string, value: string): void;
-}
-
-/**
- * Safely access window.localStorage, returning null in SSR or when unavailable.
- */
-function getLocalStorage(): StorageLike | null {
-  if (typeof window === 'undefined') return null;
-  try {
-    return window.localStorage;
-  } catch {
-    return null;
-  }
-}
+import { getLocalStorage, StorageLike } from './storage';
 
 /**
  * Resolve the initial theme from persisted storage, falling back to the
@@ -38,6 +22,18 @@ export function resolveInitialTheme(
 }
 
 /**
+ * Apply the theme class and data-theme attribute to the <html> element.
+ * Guarded for SSR (no-op when `document` is undefined).
+ */
+export function applyThemeToDocument(theme: 'light' | 'dark'): void {
+  if (typeof document === 'undefined') return;
+  const root = document.documentElement;
+  root.classList.remove('light', 'dark');
+  root.classList.add(theme);
+  root.setAttribute('data-theme', theme);
+}
+
+/**
  * Hook that tracks and persists the UI theme ('light' | 'dark').
  *
  * Applies the theme class and data-theme attribute to <html> on every change
@@ -57,10 +53,7 @@ export function useTheme(): { theme: 'light' | 'dark'; toggleTheme: () => void }
   });
 
   useEffect(() => {
-    const root = document.documentElement;
-    root.classList.remove('light', 'dark');
-    root.classList.add(theme);
-    root.setAttribute('data-theme', theme);
+    applyThemeToDocument(theme);
 
     const storage = getLocalStorage();
     if (storage) {

--- a/packages/hub-ui/src/hooks/useTheme.ts
+++ b/packages/hub-ui/src/hooks/useTheme.ts
@@ -1,0 +1,80 @@
+import { useEffect, useState } from 'react';
+
+interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+/**
+ * Safely access window.localStorage, returning null in SSR or when unavailable.
+ */
+function getLocalStorage(): StorageLike | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the initial theme from persisted storage, falling back to the
+ * user OS preference.  Only exact `'light'` or `'dark'` values are accepted
+ * from storage; anything else (or missing keys) falls through to
+ * `prefersDark`.
+ */
+export function resolveInitialTheme(
+  storage: StorageLike | null,
+  prefersDark: boolean,
+): 'light' | 'dark' {
+  if (!storage) return prefersDark ? 'dark' : 'light';
+  try {
+    const stored = storage.getItem('theme');
+    if (stored === 'light' || stored === 'dark') return stored;
+  } catch {
+    // storage.getItem threw — fall through to OS preference
+  }
+  return prefersDark ? 'dark' : 'light';
+}
+
+/**
+ * Hook that tracks and persists the UI theme ('light' | 'dark').
+ *
+ * Applies the theme class and data-theme attribute to <html> on every change
+ * and persists the value to localStorage.
+ */
+export function useTheme(): { theme: 'light' | 'dark'; toggleTheme: () => void } {
+  const [theme, setTheme] = useState<'light' | 'dark'>(() => {
+    let prefersDark = false;
+    if (typeof window !== 'undefined') {
+      try {
+        prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      } catch {
+        // matchMedia not available — default to false
+      }
+    }
+    return resolveInitialTheme(getLocalStorage(), prefersDark);
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.classList.remove('light', 'dark');
+    root.classList.add(theme);
+    root.setAttribute('data-theme', theme);
+
+    const storage = getLocalStorage();
+    if (storage) {
+      try {
+        storage.setItem('theme', theme);
+      } catch {
+        // Quota exceeded / private mode — drop silently
+      }
+    }
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));
+  };
+
+  return { theme, toggleTheme };
+}

--- a/packages/hub-ui/src/hooks/useToggleSet.ts
+++ b/packages/hub-ui/src/hooks/useToggleSet.ts
@@ -1,9 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-
-interface StorageLike {
-  getItem(key: string): string | null;
-  setItem(key: string, value: string): void;
-}
+import { getLocalStorage, StorageLike } from './storage';
 
 /**
  * Read a persisted Set<string> from a Storage-like object.
@@ -43,15 +39,6 @@ export function writePersistedSet(
     storage.setItem(key, JSON.stringify([...value]));
   } catch {
     // Quota exceeded / private mode — drop silently; UX is fine without persistence.
-  }
-}
-
-function getLocalStorage(): StorageLike | null {
-  if (typeof window === 'undefined') return null;
-  try {
-    return window.localStorage;
-  } catch {
-    return null;
   }
 }
 

--- a/packages/hub-ui/src/main.tsx
+++ b/packages/hub-ui/src/main.tsx
@@ -3,7 +3,20 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { App } from './App';
+import { resolveInitialTheme } from './hooks/useTheme';
 import './index.css';
+
+(function applyInitialTheme() {
+  try {
+    const theme = resolveInitialTheme(window.localStorage, window.matchMedia('(prefers-color-scheme: dark)').matches);
+    const root = document.documentElement;
+    root.classList.remove('light', 'dark');
+    root.classList.add(theme);
+    root.setAttribute('data-theme', theme);
+  } catch {
+    /* non-browser env — ignore */
+  }
+})();
 
 const qc = new QueryClient({ defaultOptions: { queries: { refetchInterval: 30_000, refetchOnWindowFocus: false } } });
 

--- a/packages/hub-ui/src/main.tsx
+++ b/packages/hub-ui/src/main.tsx
@@ -3,16 +3,13 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { App } from './App';
-import { resolveInitialTheme } from './hooks/useTheme';
+import { applyThemeToDocument, resolveInitialTheme } from './hooks/useTheme';
 import './index.css';
 
 (function applyInitialTheme() {
   try {
     const theme = resolveInitialTheme(window.localStorage, window.matchMedia('(prefers-color-scheme: dark)').matches);
-    const root = document.documentElement;
-    root.classList.remove('light', 'dark');
-    root.classList.add(theme);
-    root.setAttribute('data-theme', theme);
+    applyThemeToDocument(theme);
   } catch {
     /* non-browser env — ignore */
   }

--- a/packages/hub-ui/src/test/themeToggle.test.tsx
+++ b/packages/hub-ui/src/test/themeToggle.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { resolveInitialTheme } from '../hooks/useTheme';
+import { ThemeToggle } from '../components/ThemeToggle';
+
+function makeStorage(entries: Record<string, string>) {
+  return {
+    getItem(key: string) {
+      return entries[key] ?? null;
+    },
+    setItem(key: string, value: string) {
+      entries[key] = value;
+    },
+  };
+}
+
+describe('resolveInitialTheme', () => {
+  it('returns "dark" when storage has theme="dark", prefersDark=false', () => {
+    expect(resolveInitialTheme(makeStorage({ theme: 'dark' }), false)).toBe('dark');
+  });
+
+  it('returns "light" when storage has theme="light", prefersDark=true', () => {
+    expect(resolveInitialTheme(makeStorage({ theme: 'light' }), true)).toBe('light');
+  });
+
+  it('returns "dark" when storage empty and prefersDark=true', () => {
+    expect(resolveInitialTheme(makeStorage({}), true)).toBe('dark');
+  });
+
+  it('returns "light" when storage empty and prefersDark=false', () => {
+    expect(resolveInitialTheme(makeStorage({}), false)).toBe('light');
+  });
+
+  it('ignores stored value "blue" (not exactly "light"/"dark"), falls back to prefersDark', () => {
+    expect(resolveInitialTheme(makeStorage({ theme: 'blue' }), true)).toBe('dark');
+    expect(resolveInitialTheme(makeStorage({ theme: 'blue' }), false)).toBe('light');
+  });
+
+  it('tolerates storage === null, falls back to prefersDark', () => {
+    expect(resolveInitialTheme(null, true)).toBe('dark');
+    expect(resolveInitialTheme(null, false)).toBe('light');
+  });
+});
+
+describe('ThemeToggle', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.className = '';
+    document.documentElement.removeAttribute('data-theme');
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: (query: string) => ({
+        matches: false,
+        media: query,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        onchange: null,
+        dispatchEvent: () => false,
+      }),
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders a button with data-testid="theme-toggle"', () => {
+    render(<ThemeToggle />);
+    expect(screen.getByTestId('theme-toggle')).toBeDefined();
+  });
+
+  it('clicking toggles to dark mode', () => {
+    render(<ThemeToggle />);
+    const btn = screen.getByTestId('theme-toggle');
+    fireEvent.click(btn);
+
+    expect(document.documentElement.className).toContain('dark');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+    expect(localStorage.getItem('theme')).toBe('dark');
+  });
+
+  it('clicking twice returns to light mode', () => {
+    render(<ThemeToggle />);
+    const btn = screen.getByTestId('theme-toggle');
+    fireEvent.click(btn);
+    fireEvent.click(btn);
+
+    expect(document.documentElement.className).toContain('light');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+    expect(localStorage.getItem('theme')).toBe('light');
+  });
+
+  it('renders dark when localStorage theme is pre-seeded to "dark"', () => {
+    localStorage.setItem('theme', 'dark');
+    render(<ThemeToggle />);
+
+    expect(document.documentElement.className).toContain('dark');
+  });
+});


### PR DESCRIPTION
## Summary

Adds a user-controllable light/dark theme toggle to the hub UI (`packages/hub-ui`), which previously followed only the OS `prefers-color-scheme`.

- **`hooks/useTheme.ts`** (new): `resolveInitialTheme()` (localStorage `theme` key, strict `'light'|'dark'` validation, OS fallback) + `useTheme()` hook applying `.light`/`.dark` class and `data-theme` attribute to `<html>`, persisting on change.
- **`hooks/storage.ts`** (new): shared `StorageLike`/`getLocalStorage` extracted from `useTheme`/`useToggleSet` (refactor step).
- **`components/ThemeToggle.tsx`** (new): sidebar button with Sun/Moon lucide icons and accessible labels.
- **`components/Layout.tsx`**: toggle rendered above the 'Signed in' card at the sidebar bottom.
- **`main.tsx`**: boot-time theme application before first render — no flash of the wrong theme.

No CSS changes needed: `packages/brand/tokens.css` already defines explicit `.light`/`.dark`/`[data-theme]` override blocks that outrank the media query.

## Verification

- TDD flow: red (10 failing tests) → green → refactor (test-integrity diff: identical test names before/after).
- Full hub-ui suite: **132/132 tests pass** (20 files).
- `tsc -b && vite build` clean.
- Adversarial cross-model review (orchestrator ≠ author) approved: no correctness/security/perf/breaking issues.

## Orchestration

Coding steps executed by pi.dev workers (`qwen3.6:27b`); orchestrated, verified, and reviewed by Kimi K3 under the AgEnFK TDD flow (story `7684494d`, task `beb72d12`).