### PR TITLE
feat(hub-ui): add light/dark theme toggle to the hub

### DIFF
--- a/packages/hub-ui/src/ThemeContext.tsx
+++ b/packages/hub-ui/src/ThemeContext.tsx
@@ -1,0 +1,44 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextType {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>(() => {
+    const savedTheme = localStorage.getItem('theme');
+    if (savedTheme === 'light' || savedTheme === 'dark') return savedTheme;
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  });
+
+  useEffect(() => {
+    const root = window.document.documentElement;
+    root.classList.remove('light', 'dark');
+    root.classList.add(theme);
+    root.setAttribute('data-theme', theme);
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme(prev => (prev === 'light' ? 'dark' : 'light'));
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+};

--- a/packages/hub-ui/src/components/Layout.tsx
+++ b/packages/hub-ui/src/components/Layout.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { api, MeResponse } from '../api';
 import { LayoutDashboard, Shield, LogOut, AlertTriangle, GitPullRequest } from 'lucide-react';
 import { Logo } from './Logo';
+import { ThemeToggle } from './ThemeToggle';
 
 interface NavItemProps { to: string; icon: React.ReactNode; label: string }
 function NavItem({ to, icon, label }: NavItemProps) {
@@ -48,7 +49,9 @@ export function Layout({ children }: { children: React.ReactNode }) {
         {me.data?.role === 'admin' && (
           <NavItem to="/admin" icon={<Shield className="w-4 h-4" />} label="Admin" />
         )}
-        <div className="mt-auto px-2 py-2 rounded-lg border border-border-soft bg-card-glass">
+        <div className="mt-auto flex flex-col gap-1">
+          <ThemeToggle />
+          <div className="px-2 py-2 rounded-lg border border-border-soft bg-card-glass">
           <div className="text-[10px] uppercase tracking-[0.16em] text-ink-tertiary">Signed in</div>
           <div className="mt-0.5 text-[12px] font-mono text-ink truncate">{me.data?.userId ?? '—'}</div>
           <div className="mt-0.5 text-[10px] uppercase tracking-[0.14em] text-accent-text">{me.data?.role}</div>
@@ -58,6 +61,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
           >
             <LogOut className="w-3 h-3" /> Sign out
           </button>
+          </div>
         </div>
       </aside>
       <main className="flex-1 min-w-0 p-6 lg:p-8">

--- a/packages/hub-ui/src/components/ThemeToggle.tsx
+++ b/packages/hub-ui/src/components/ThemeToggle.tsx
@@ -1,0 +1,22 @@
+import { Moon, Sun } from 'lucide-react';
+import { useTheme } from '../ThemeContext';
+
+/**
+ * Light/dark theme toggle button. Rendered in the hub nav sidebar (Layout).
+ * Shows a sun icon in dark mode (click to go light) and a moon icon in light
+ * mode (click to go dark), mirroring the packages/ui KanbanBoard toggle.
+ */
+export function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+  return (
+    <button
+      onClick={toggleTheme}
+      className="flex items-center gap-2 px-3 py-2 rounded-lg text-[13px] font-medium transition-colors border border-transparent text-ink-secondary hover:text-ink hover:bg-chip hover:border-border-soft"
+      title={theme === 'dark' ? 'Switch to Light Mode' : 'Switch to Dark Mode'}
+      aria-label={theme === 'dark' ? 'Switch to Light Mode' : 'Switch to Dark Mode'}
+    >
+      {theme === 'dark' ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
+      {theme === 'dark' ? 'Light mode' : 'Dark mode'}
+    </button>
+  );
+}

--- a/packages/hub-ui/src/index.css
+++ b/packages/hub-ui/src/index.css
@@ -14,7 +14,14 @@
  * hub-ui's compiled CSS — otherwise the modal renders unsized. */
 @source "../../flow-editor/src/**/*.{ts,tsx}";
 
-:root { color-scheme: light dark; }
+/* Dark mode follows the hub's manual toggle (.dark class / data-theme
+ * attribute set by ThemeContext on <html>) rather than the OS preference.
+ * This mirrors packages/ui so dark: utilities and the shared tokens stay in
+ * sync across both apps. */
+@variant dark (&:where(.dark, .dark *, [data-theme="dark"], [data-theme="dark"] *));
+
+:root { color-scheme: light; }
+.dark, .dark *, [data-theme="dark"], [data-theme="dark"] * { color-scheme: dark; }
 
 html, body, #root { height: 100%; }
 

--- a/packages/hub-ui/src/main.tsx
+++ b/packages/hub-ui/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { App } from './App';
+import { ThemeProvider } from './ThemeContext';
 import './index.css';
 
 const qc = new QueryClient({ defaultOptions: { queries: { refetchInterval: 30_000, refetchOnWindowFocus: false } } });
@@ -10,9 +11,11 @@ const qc = new QueryClient({ defaultOptions: { queries: { refetchInterval: 30_00
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <QueryClientProvider client={qc}>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
+      <ThemeProvider>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </ThemeProvider>
     </QueryClientProvider>
   </React.StrictMode>,
 );

--- a/packages/hub-ui/src/test/ThemeContext.test.tsx
+++ b/packages/hub-ui/src/test/ThemeContext.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ThemeProvider, useTheme } from '../ThemeContext';
+
+// Mock window.matchMedia (jsdom does not implement it by default).
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+const ThemeTester = () => {
+  const { theme, toggleTheme } = useTheme();
+  return (
+    <div>
+      <span>Current theme: {theme}</span>
+      <button onClick={toggleTheme}>Toggle</button>
+    </div>
+  );
+};
+
+const getRootClasses = () => window.document.documentElement.classList;
+const getRootThemeAttr = () => window.document.documentElement.getAttribute('data-theme');
+
+describe('ThemeContext', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    // Reset <html> state between tests.
+    const root = window.document.documentElement;
+    root.classList.remove('light', 'dark');
+    root.removeAttribute('data-theme');
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('provides the light theme by default when the OS prefers light', () => {
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>
+    );
+    expect(screen.getByText(/Current theme: light/i)).toBeDefined();
+  });
+
+  it('applies the .light class and data-theme="light" to <html>', () => {
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>
+    );
+    expect(getRootClasses().contains('light')).toBe(true);
+    expect(getRootThemeAttr()).toBe('light');
+  });
+
+  it('toggles from light to dark and persists to localStorage', () => {
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>
+    );
+    fireEvent.click(screen.getByText('Toggle'));
+    expect(screen.getByText(/Current theme: dark/i)).toBeDefined();
+    expect(localStorage.getItem('theme')).toBe('dark');
+  });
+
+  it('applies the .dark class and data-theme="dark" to <html> after toggle', () => {
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>
+    );
+    fireEvent.click(screen.getByText('Toggle'));
+    expect(getRootClasses().contains('dark')).toBe(true);
+    expect(getRootClasses().contains('light')).toBe(false);
+    expect(getRootThemeAttr()).toBe('dark');
+  });
+
+  it('initializes with the dark theme from localStorage', () => {
+    localStorage.setItem('theme', 'dark');
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>
+    );
+    expect(screen.getByText(/Current theme: dark/i)).toBeDefined();
+    expect(getRootClasses().contains('dark')).toBe(true);
+  });
+
+  it('toggles from dark back to light', () => {
+    localStorage.setItem('theme', 'dark');
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>
+    );
+    fireEvent.click(screen.getByText('Toggle'));
+    expect(screen.getByText(/Current theme: light/i)).toBeDefined();
+    expect(localStorage.getItem('theme')).toBe('light');
+    expect(getRootClasses().contains('light')).toBe(true);
+    expect(getRootThemeAttr()).toBe('light');
+  });
+
+  it('provides the dark theme when the OS prefers dark and no preference is stored', () => {
+    (window.matchMedia as ReturnType<typeof vi.fn>).mockImplementationOnce((query: string) => ({
+      matches: query === '(prefers-color-scheme: dark)',
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>
+    );
+    expect(screen.getByText(/Current theme: dark/i)).toBeDefined();
+    expect(getRootThemeAttr()).toBe('dark');
+  });
+
+  it('useTheme throws when used outside a ThemeProvider', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const ThrowTest = () => {
+      useTheme(); // should throw
+      return null;
+    };
+    expect(() => render(<ThrowTest />)).toThrow('useTheme must be used within a ThemeProvider');
+    consoleError.mockRestore();
+  });
+});

--- a/packages/hub-ui/src/test/ThemeToggle.test.tsx
+++ b/packages/hub-ui/src/test/ThemeToggle.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ThemeProvider } from '../ThemeContext';
+import { ThemeToggle } from '../components/ThemeToggle';
+
+// Mock window.matchMedia (jsdom does not implement it by default).
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+function renderInProvider() {
+  return render(
+    <ThemeProvider>
+      <ThemeToggle />
+    </ThemeProvider>
+  );
+}
+
+describe('ThemeToggle', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    const root = window.document.documentElement;
+    root.classList.remove('light', 'dark');
+    root.removeAttribute('data-theme');
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('shows the moon icon in light mode prompting to switch to dark', () => {
+    renderInProvider();
+    expect(screen.getByTitle('Switch to Dark Mode')).toBeDefined();
+    // The moon icon is rendered with an svg; assert via the aria-hidden svg count.
+    expect(document.querySelector('svg')).not.toBeNull();
+  });
+
+  it('toggles to dark mode on click and updates title/icon', () => {
+    renderInProvider();
+    const button = screen.getByRole('button');
+    fireEvent.click(button);
+    expect(screen.getByTitle('Switch to Light Mode')).toBeDefined();
+    expect(window.document.documentElement.getAttribute('data-theme')).toBe('dark');
+    expect(localStorage.getItem('theme')).toBe('dark');
+  });
+
+  it('toggles back to light mode on a second click', () => {
+    renderInProvider();
+    const button = screen.getByRole('button');
+    fireEvent.click(button);
+    fireEvent.click(button);
+    expect(screen.getByTitle('Switch to Dark Mode')).toBeDefined();
+    expect(window.document.documentElement.getAttribute('data-theme')).toBe('light');
+  });
+
+  it('initializes in dark mode when the persisted theme is dark', () => {
+    localStorage.setItem('theme', 'dark');
+    renderInProvider();
+    expect(screen.getByTitle('Switch to Light Mode')).toBeDefined();
+    expect(window.document.documentElement.getAttribute('data-theme')).toBe('dark');
+  });
+});


### PR DESCRIPTION
## Summary

Adds a light/dark theme toggle to the AgEnFK Hub UI (`packages/hub-ui`), following the existing pattern already in `packages/ui`.

### Changes
- **`ThemeContext.tsx`** (new) — `ThemeProvider` + `useTheme` hook: applies `.dark`/`.light` class and `data-theme` attribute to `<html>`, persists the choice to `localStorage`, falls back to the OS `prefers-color-scheme` on first visit.
- **`ThemeToggle.tsx`** (new) — Sun/Moon toggle button wired to the context (shows `Light mode`/`Dark mode` with the matching icon), with `aria-label`/`title` for accessibility.
- **`Layout.tsx`** — Mounted the toggle in the nav sidebar (bottom group above the sign-out card), available on every authed hub page.
- **`main.tsx`** — Wrapped `<App/>` in `ThemeProvider` (inside `QueryClientProvider`).
- **`index.css`** — Added `@variant dark` so all existing `dark:` utilities and the shared `brand/tokens.css` variables follow the manual toggle instead of just the OS preference; `color-scheme` follows the applied theme for native controls.

### Tests
- `ThemeContext.test.tsx` (8 tests) and `ThemeToggle.test.tsx` (4 tests) added.

### Verification
- Full monorepo test suite: 1954 tests passing.
- Full `npm run build`: succeeds.