### PR TITLE
Add light/dark theme toggle to the hub UI

### DIFF
--- a/packages/hub-ui/src/ThemeContext.tsx
+++ b/packages/hub-ui/src/ThemeContext.tsx
@@ -1,0 +1,44 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextType {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>(() => {
+    const savedTheme = localStorage.getItem('theme');
+    if (savedTheme === 'light' || savedTheme === 'dark') return savedTheme;
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  });
+
+  useEffect(() => {
+    const root = window.document.documentElement;
+    root.classList.remove('light', 'dark');
+    root.classList.add(theme);
+    root.setAttribute('data-theme', theme);
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme(prev => (prev === 'light' ? 'dark' : 'light'));
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+};

--- a/packages/hub-ui/src/components/Layout.tsx
+++ b/packages/hub-ui/src/components/Layout.tsx
@@ -1,8 +1,9 @@
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { api, MeResponse } from '../api';
-import { LayoutDashboard, Shield, LogOut, AlertTriangle, GitPullRequest } from 'lucide-react';
+import { LayoutDashboard, Shield, LogOut, AlertTriangle, GitPullRequest, Sun, Moon } from 'lucide-react';
 import { Logo } from './Logo';
+import { useTheme } from '../ThemeContext';
 
 interface NavItemProps { to: string; icon: React.ReactNode; label: string }
 function NavItem({ to, icon, label }: NavItemProps) {
@@ -58,6 +59,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
           >
             <LogOut className="w-3 h-3" /> Sign out
           </button>
+          <ThemeToggle />
         </div>
       </aside>
       <main className="flex-1 min-w-0 p-6 lg:p-8">
@@ -101,5 +103,23 @@ function PendingEnvOrgIdBanner() {
         I've updated my deployment
       </button>
     </div>
+  );
+}
+
+function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+  return (
+    <button
+      onClick={toggleTheme}
+      aria-label="Toggle theme"
+      className="mt-2 w-full flex items-center justify-center gap-1.5 px-2 py-1.5 rounded-lg text-[11px] font-semibold border border-border-soft text-ink-secondary hover:bg-chip transition-colors"
+    >
+      {theme === 'dark' ? (
+        <Sun className="w-3 h-3" />
+      ) : (
+        <Moon className="w-3 h-3" />
+      )}
+      {theme === 'dark' ? 'Light' : 'Dark'}
+    </button>
   );
 }

--- a/packages/hub-ui/src/main.tsx
+++ b/packages/hub-ui/src/main.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ThemeProvider } from './ThemeContext';
 import { App } from './App';
 import './index.css';
 
@@ -10,9 +11,11 @@ const qc = new QueryClient({ defaultOptions: { queries: { refetchInterval: 30_00
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <QueryClientProvider client={qc}>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
+      <ThemeProvider>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </ThemeProvider>
     </QueryClientProvider>
   </React.StrictMode>,
 );

--- a/packages/hub-ui/src/test/ThemeContext.test.tsx
+++ b/packages/hub-ui/src/test/ThemeContext.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { ThemeProvider, useTheme } from '../ThemeContext';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import React, { act } from 'react';
+
+// Mock window.matchMedia
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+const ThemeTester = () => {
+  const { theme, toggleTheme } = useTheme();
+  return (
+    <div>
+      <span>Current theme: {theme}</span>
+      <button onClick={toggleTheme}>Toggle</button>
+    </div>
+  );
+};
+
+describe('ThemeContext', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('should provide default theme', () => {
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>
+    );
+    expect(screen.getByText(/Current theme: light/i)).toBeDefined();
+  });
+
+  it('should toggle theme and persist to localStorage', () => {
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>
+    );
+    const toggleBtn = screen.getByText('Toggle');
+    fireEvent.click(toggleBtn);
+    expect(screen.getByText(/Current theme: dark/i)).toBeDefined();
+    expect(localStorage.getItem('theme')).toBe('dark');
+  });
+
+  it('should initialize with dark theme from localStorage', () => {
+    localStorage.setItem('theme', 'dark');
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>
+    );
+    expect(screen.getByText(/Current theme: dark/i)).toBeDefined();
+  });
+
+  it('should provide dark theme when system prefers dark and no localStorage', () => {
+    (window.matchMedia as ReturnType<typeof vi.fn>).mockImplementationOnce((query: string) => ({
+      matches: query === '(prefers-color-scheme: dark)',
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>
+    );
+    expect(screen.getByText(/Current theme: dark/i)).toBeDefined();
+  });
+
+  it('should toggle from dark back to light and persist', () => {
+    localStorage.setItem('theme', 'dark');
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>
+    );
+    const toggleBtn = screen.getByText('Toggle');
+    fireEvent.click(toggleBtn);
+    expect(screen.getByText(/Current theme: light/i)).toBeDefined();
+    expect(localStorage.getItem('theme')).toBe('light');
+  });
+
+  it('useTheme should throw when used outside ThemeProvider', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const ThrowTest = () => {
+      useTheme(); // will throw
+      return null;
+    };
+    expect(() => render(<ThrowTest />)).toThrow('useTheme must be used within a ThemeProvider');
+    consoleError.mockRestore();
+  });
+});


### PR DESCRIPTION
Adds a manual light/dark theme toggle to the hub (packages/hub-ui), following the same pattern as the sibling `ui` package.

## Changes
- **New** `packages/hub-ui/src/ThemeContext.tsx` — `ThemeProvider`/[`useTheme`] reads the persisted `theme` from localStorage, falls back to `prefers-color-scheme`, applies the `.light`/`.dark` class + `data-theme` attribute on `<html>` (the design tokens in `packages/brand/tokens.css` already define class-based overrides), and persists the user's choice.
- **`packages/hub-ui/src/main.tsx`** — wrap the app in `ThemeProvider`.
- **`packages/hub-ui/src/components/Layout.tsx`** — add a Sun/Moon theme toggle button in the sidebar (`aria-label="Toggle theme"`).
- **New** `packages/hub-ui/src/test/ThemeContext.test.tsx` — 6 unit tests (default light, toggle + persist, localStorage init, system-prefers-dark, toggle back to light, `useTheme` throws outside provider).

## Verification
- 6/6 ThemeContext unit tests pass; full hub-ui suite 128/128 green.
- `tsc -b` clean; `vite build` succeeds.
- Driven through the AgEnFK TDD flow (DISCOVERY → CREATE_UNIT_TESTS → IN_PROGRESS → REFACTOR → REVIEW → DONE) with a pi.dev worker; adversarial cross-model review accepted with two minor non-blocking notes (unguarded localStorage read in the initializer, and the DOM class/attribute side-effect isn't directly unit-asserted — both consistent with the sibling `ui` reference implementation).