### PR TITLE
Add theme toggle (light/dark) to hub UI

### DIFF
--- a/packages/hub-ui/src/ThemeContext.tsx
+++ b/packages/hub-ui/src/ThemeContext.tsx
@@ -1,0 +1,46 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextType {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const STORAGE_KEY = 'hub-theme';
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>(() => {
+    const savedTheme = localStorage.getItem(STORAGE_KEY);
+    if (savedTheme === 'light' || savedTheme === 'dark') return savedTheme;
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  });
+
+  useEffect(() => {
+    const root = window.document.documentElement;
+    root.classList.remove('light', 'dark');
+    root.classList.add(theme);
+    root.setAttribute('data-theme', theme);
+    localStorage.setItem(STORAGE_KEY, theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme(prev => (prev === 'light' ? 'dark' : 'light'));
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+};

--- a/packages/hub-ui/src/components/Layout.tsx
+++ b/packages/hub-ui/src/components/Layout.tsx
@@ -1,8 +1,9 @@
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { api, MeResponse } from '../api';
-import { LayoutDashboard, Shield, LogOut, AlertTriangle, GitPullRequest } from 'lucide-react';
+import { LayoutDashboard, Shield, LogOut, AlertTriangle, GitPullRequest, Sun, Moon } from 'lucide-react';
 import { Logo } from './Logo';
+import { useTheme } from '../ThemeContext';
 
 interface NavItemProps { to: string; icon: React.ReactNode; label: string }
 function NavItem({ to, icon, label }: NavItemProps) {
@@ -27,6 +28,7 @@ interface HealthResponse { ok: boolean; version: string }
 
 export function Layout({ children }: { children: React.ReactNode }) {
   const nav = useNavigate();
+  const { theme, toggleTheme } = useTheme();
   const me = useQuery<MeResponse>({ queryKey: ['me'], queryFn: async () => (await api.get('/auth/me')).data });
   const health = useQuery<HealthResponse>({
     queryKey: ['hub-healthz'],
@@ -53,8 +55,16 @@ export function Layout({ children }: { children: React.ReactNode }) {
           <div className="mt-0.5 text-[12px] font-mono text-ink truncate">{me.data?.userId ?? '—'}</div>
           <div className="mt-0.5 text-[10px] uppercase tracking-[0.14em] text-accent-text">{me.data?.role}</div>
           <button
+            onClick={toggleTheme}
+            title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+            className="mt-2 w-full flex items-center justify-center gap-1.5 px-2 py-1.5 rounded-md text-[11px] font-semibold border border-border-soft text-ink-secondary hover:bg-chip hover:border-border-brand hover:text-accent-text transition-colors"
+          >
+            {theme === 'dark' ? <Sun className="w-3 h-3" /> : <Moon className="w-3 h-3" />}
+            {theme === 'dark' ? 'Light mode' : 'Dark mode'}
+          </button>
+          <button
             onClick={() => logout.mutate()}
-            className="mt-2 w-full flex items-center justify-center gap-1.5 px-2 py-1.5 rounded-md text-[11px] font-semibold border border-border-soft text-ink-secondary hover:bg-danger-muted/10 hover:border-danger-muted/40 hover:text-danger-muted transition-colors"
+            className="mt-1.5 w-full flex items-center justify-center gap-1.5 px-2 py-1.5 rounded-md text-[11px] font-semibold border border-border-soft text-ink-secondary hover:bg-danger-muted/10 hover:border-danger-muted/40 hover:text-danger-muted transition-colors"
           >
             <LogOut className="w-3 h-3" /> Sign out
           </button>

--- a/packages/hub-ui/src/main.tsx
+++ b/packages/hub-ui/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { App } from './App';
+import { ThemeProvider } from './ThemeContext';
 import './index.css';
 
 const qc = new QueryClient({ defaultOptions: { queries: { refetchInterval: 30_000, refetchOnWindowFocus: false } } });
@@ -10,9 +11,11 @@ const qc = new QueryClient({ defaultOptions: { queries: { refetchInterval: 30_00
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <QueryClientProvider client={qc}>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
+      <ThemeProvider>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </ThemeProvider>
     </QueryClientProvider>
   </React.StrictMode>,
 );

--- a/packages/hub-ui/src/test/LayoutThemeToggle.test.tsx
+++ b/packages/hub-ui/src/test/LayoutThemeToggle.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { Layout } from '../components/Layout';
+import { ThemeProvider } from '../ThemeContext';
+import { api } from '../api';
+
+vi.mock('../api', () => ({
+  api: {
+    get: vi.fn((url: string) => {
+      if (url === '/auth/me') return Promise.resolve({ data: { userId: 'u1', orgId: 'o1', role: 'admin' } });
+      if (url === '/healthz') return Promise.resolve({ data: { ok: true, version: '1.2.3' } });
+      if (url === '/v1/admin/system/pending') return Promise.resolve({ data: { pendingEnvOrgId: null } });
+      return Promise.resolve({ data: {} });
+    }),
+    post: vi.fn(() => Promise.resolve({ data: {} })),
+  },
+}));
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+function renderLayout() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <ThemeProvider>
+        <MemoryRouter>
+          <Layout><div>content</div></Layout>
+        </MemoryRouter>
+      </ThemeProvider>
+    </QueryClientProvider>
+  );
+}
+
+describe('Layout theme toggle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    document.documentElement.classList.remove('light', 'dark');
+  });
+
+  afterEach(() => cleanup());
+
+  it('renders a theme toggle button in the sidebar', async () => {
+    renderLayout();
+    await waitFor(() => expect(api.get).toHaveBeenCalledWith('/auth/me'));
+    expect(screen.getByTitle('Switch to dark mode')).toBeDefined();
+  });
+
+  it('clicking the toggle switches to dark mode and persists it', async () => {
+    renderLayout();
+    await waitFor(() => expect(api.get).toHaveBeenCalledWith('/auth/me'));
+
+    fireEvent.click(screen.getByTitle('Switch to dark mode'));
+
+    await waitFor(() => expect(document.documentElement.classList.contains('dark')).toBe(true));
+    expect(screen.getByTitle('Switch to light mode')).toBeDefined();
+    expect(localStorage.getItem('hub-theme')).toBe('dark');
+  });
+});

--- a/packages/hub-ui/src/test/ThemeContext.test.tsx
+++ b/packages/hub-ui/src/test/ThemeContext.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { render, screen, fireEvent, cleanup, act } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ThemeProvider, useTheme } from '../ThemeContext';
+
+function matchMediaMock(matches: boolean) {
+  return vi.fn().mockImplementation((query: string) => ({
+    matches,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
+
+function Probe() {
+  const { theme, toggleTheme } = useTheme();
+  return (
+    <div>
+      <span data-testid="theme-value">{theme}</span>
+      <button onClick={toggleTheme}>toggle</button>
+    </div>
+  );
+}
+
+describe('hub-ui ThemeContext', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove('light', 'dark');
+    document.documentElement.removeAttribute('data-theme');
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: matchMediaMock(false),
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('defaults to the light theme when no preference is stored and the OS prefers light', () => {
+    render(<ThemeProvider><Probe /></ThemeProvider>);
+    expect(screen.getByTestId('theme-value').textContent).toBe('light');
+    expect(document.documentElement.classList.contains('light')).toBe(true);
+  });
+
+  it('defaults to dark when the OS prefers a dark color scheme', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: matchMediaMock(true),
+    });
+    render(<ThemeProvider><Probe /></ThemeProvider>);
+    expect(screen.getByTestId('theme-value').textContent).toBe('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('reads a previously persisted theme from localStorage over the OS preference', () => {
+    localStorage.setItem('hub-theme', 'dark');
+    render(<ThemeProvider><Probe /></ThemeProvider>);
+    expect(screen.getByTestId('theme-value').textContent).toBe('dark');
+  });
+
+  it('toggleTheme flips the theme, updates the <html> class/attribute, and persists to localStorage', () => {
+    render(<ThemeProvider><Probe /></ThemeProvider>);
+    expect(screen.getByTestId('theme-value').textContent).toBe('light');
+
+    act(() => { fireEvent.click(screen.getByText('toggle')); });
+
+    expect(screen.getByTestId('theme-value').textContent).toBe('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(document.documentElement.classList.contains('light')).toBe(false);
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+    expect(localStorage.getItem('hub-theme')).toBe('dark');
+
+    act(() => { fireEvent.click(screen.getByText('toggle')); });
+    expect(screen.getByTestId('theme-value').textContent).toBe('light');
+    expect(localStorage.getItem('hub-theme')).toBe('light');
+  });
+
+  it('useTheme throws when used outside of a ThemeProvider', () => {
+    function Bare() { useTheme(); return null; }
+    expect(() => render(<Bare />)).toThrow(/useTheme must be used within a ThemeProvider/);
+  });
+});


### PR DESCRIPTION
Adds a light/dark theme toggle to the AgEnFK hub (packages/hub-ui) sidebar, next to Sign out.

## Changes
- New `ThemeContext.tsx`: ThemeProvider/useTheme, persists to localStorage key `hub-theme`, defaults from OS `prefers-color-scheme`, toggles `.dark`/`.light` class + `data-theme` attribute on `<html>`.
- `main.tsx`: wraps the app in `ThemeProvider`.
- `Layout.tsx`: adds a Sun/Moon toggle button in the sidebar, visible on every authenticated hub page.

## Testing
- New tests: `ThemeContext.test.tsx` (5 tests), `LayoutThemeToggle.test.tsx` (2 tests) — written RED-first per TDD flow, now green.
- Full `packages/hub-ui` suite: 21 files / 129 tests passing.
- Full monorepo suite: 190 files / 1949 tests passing.
- `npm run build` succeeds in `packages/hub-ui`.

No breaking changes — purely additive.