### PR TITLE
feat(hub-ui): add light/dark theme toggle

### DIFF
--- a/packages/hub-ui/src/ThemeContext.tsx
+++ b/packages/hub-ui/src/ThemeContext.tsx
@@ -1,0 +1,47 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextType {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>(() => {
+    const savedTheme = localStorage.getItem('theme');
+    if (savedTheme === 'light' || savedTheme === 'dark') return savedTheme;
+    if (typeof window.matchMedia === 'function' && window.matchMedia('(prefers-color-scheme: dark)').matches) return 'dark';
+    return 'light';
+  });
+
+  useEffect(() => {
+    const root = window.document.documentElement;
+    root.classList.remove('light', 'dark');
+    root.classList.add(theme);
+    root.setAttribute('data-theme', theme);
+    localStorage.setItem('theme', theme);
+    console.log('Current theme:', theme, 'applied to <html> via class and data-theme');
+  }, [theme]);
+
+  const toggleTheme = () => {
+    console.log('Toggling theme from:', theme);
+    setTheme(prev => (prev === 'light' ? 'dark' : 'light'));
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+};

--- a/packages/hub-ui/src/components/Layout.tsx
+++ b/packages/hub-ui/src/components/Layout.tsx
@@ -1,8 +1,9 @@
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { api, MeResponse } from '../api';
-import { LayoutDashboard, Shield, LogOut, AlertTriangle, GitPullRequest } from 'lucide-react';
+import { LayoutDashboard, Shield, LogOut, AlertTriangle, GitPullRequest, Sun, Moon } from 'lucide-react';
 import { Logo } from './Logo';
+import { useTheme } from '../ThemeContext';
 
 interface NavItemProps { to: string; icon: React.ReactNode; label: string }
 function NavItem({ to, icon, label }: NavItemProps) {
@@ -33,6 +34,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
     queryFn: async () => (await api.get('/healthz')).data,
     staleTime: 5 * 60_000,
   });
+  const { theme, toggleTheme } = useTheme();
   const logout = useMutation({
     mutationFn: () => api.post('/auth/logout'),
     onSuccess: () => { nav('/login'); window.location.reload(); },
@@ -52,6 +54,14 @@ export function Layout({ children }: { children: React.ReactNode }) {
           <div className="text-[10px] uppercase tracking-[0.16em] text-ink-tertiary">Signed in</div>
           <div className="mt-0.5 text-[12px] font-mono text-ink truncate">{me.data?.userId ?? '—'}</div>
           <div className="mt-0.5 text-[10px] uppercase tracking-[0.14em] text-accent-text">{me.data?.role}</div>
+          <button
+            onClick={toggleTheme}
+            title={theme === 'dark' ? 'Switch to Light Mode' : 'Switch to Dark Mode'}
+            className="mt-2 w-full flex items-center justify-center gap-1.5 px-2 py-1.5 rounded-md text-[11px] font-semibold border border-border-soft text-ink-secondary hover:bg-chip transition-colors"
+          >
+            {theme === 'dark' ? <Sun className="w-3 h-3" /> : <Moon className="w-3 h-3" />}
+            {theme === 'dark' ? 'Light' : 'Dark'}
+          </button>
           <button
             onClick={() => logout.mutate()}
             className="mt-2 w-full flex items-center justify-center gap-1.5 px-2 py-1.5 rounded-md text-[11px] font-semibold border border-border-soft text-ink-secondary hover:bg-danger-muted/10 hover:border-danger-muted/40 hover:text-danger-muted transition-colors"

--- a/packages/hub-ui/src/index.css
+++ b/packages/hub-ui/src/index.css
@@ -13,6 +13,7 @@
  * (w-[calc(100vw-2rem)], h-[90vh], w-64, flex-1, etc.) that need to land in
  * hub-ui's compiled CSS — otherwise the modal renders unsized. */
 @source "../../flow-editor/src/**/*.{ts,tsx}";
+@variant dark (&:where(.dark, .dark *, [data-theme="dark"], [data-theme="dark"] *));
 
 :root { color-scheme: light dark; }
 

--- a/packages/hub-ui/src/main.tsx
+++ b/packages/hub-ui/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { App } from './App';
+import { ThemeProvider } from './ThemeContext';
 import './index.css';
 
 const qc = new QueryClient({ defaultOptions: { queries: { refetchInterval: 30_000, refetchOnWindowFocus: false } } });
@@ -11,7 +12,9 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <QueryClientProvider client={qc}>
       <BrowserRouter>
-        <App />
+        <ThemeProvider>
+          <App />
+        </ThemeProvider>
       </BrowserRouter>
     </QueryClientProvider>
   </React.StrictMode>,

--- a/packages/hub-ui/src/test/LayoutThemeToggle.test.tsx
+++ b/packages/hub-ui/src/test/LayoutThemeToggle.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ThemeProvider } from '../ThemeContext';
+import { Layout } from '../components/Layout';
+
+vi.mock('../api', () => ({
+  api: {
+    get: vi.fn((url: string) => {
+      if (url === '/auth/me') {
+        return Promise.resolve({ data: { userId: 'u1', orgId: 'o1', role: 'viewer' } });
+      }
+      if (url === '/healthz') {
+        return Promise.resolve({ data: { ok: true, version: '1.0.0' } });
+      }
+      if (url === '/v1/admin/system/pending') {
+        return Promise.resolve({ data: { pendingEnvOrgId: null } });
+      }
+      return Promise.resolve({ data: {} });
+    }),
+    post: vi.fn(() => Promise.resolve({ data: {} })),
+  },
+}));
+
+function renderLayout() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <ThemeProvider>
+          <Layout>
+            <div>content</div>
+          </Layout>
+        </ThemeProvider>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+afterEach(cleanup);
+
+describe('Layout theme toggle', () => {
+  it('renders a theme toggle button', async () => {
+    renderLayout();
+    const toggleBtn = await waitFor(() =>
+      screen.getByTitle(/switch to (light|dark) mode/i)
+    );
+    expect(toggleBtn).toBeDefined();
+  });
+
+  it('toggles the button title when clicked', async () => {
+    renderLayout();
+    const toggleBtn = await waitFor(() =>
+      screen.getByTitle(/switch to (light|dark) mode/i)
+    );
+    const beforeTitle = toggleBtn.getAttribute('title');
+    fireEvent.click(toggleBtn);
+    await waitFor(() => {
+      const afterTitle = screen.getByTitle(/switch to (light|dark) mode/i).getAttribute('title');
+      expect(afterTitle).not.toBe(beforeTitle);
+    });
+  });
+});

--- a/packages/hub-ui/src/test/ThemeContext.test.tsx
+++ b/packages/hub-ui/src/test/ThemeContext.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { ThemeProvider, useTheme } from '../ThemeContext';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import React, { act } from 'react';
+
+// Mock window.matchMedia
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+const ThemeTester = () => {
+  const { theme, toggleTheme } = useTheme();
+  return (
+    <div>
+      <span>Current theme: {theme}</span>
+      <button onClick={toggleTheme}>Toggle</button>
+    </div>
+  );
+};
+
+describe('ThemeContext', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('should provide default theme', () => {
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>
+    );
+    expect(screen.getByText(/Current theme: light/i)).toBeDefined();
+  });
+
+  it('should toggle theme', () => {
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>
+    );
+    const toggleBtn = screen.getByText('Toggle');
+    fireEvent.click(toggleBtn);
+    expect(screen.getByText(/Current theme: dark/i)).toBeDefined();
+    expect(localStorage.getItem('theme')).toBe('dark');
+  });
+
+  it('should initialize with dark theme from localStorage', () => {
+    localStorage.setItem('theme', 'dark');
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>
+    );
+    expect(screen.getByText(/Current theme: dark/i)).toBeDefined();
+  });
+
+  it('should provide dark theme when system prefers dark and no localStorage', () => {
+    (window.matchMedia as ReturnType<typeof vi.fn>).mockImplementationOnce((query: string) => ({
+      matches: query === '(prefers-color-scheme: dark)',
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>
+    );
+    expect(screen.getByText(/Current theme: dark/i)).toBeDefined();
+  });
+
+  it('should toggle from dark back to light', () => {
+    localStorage.setItem('theme', 'dark');
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>
+    );
+    const toggleBtn = screen.getByText('Toggle');
+    fireEvent.click(toggleBtn);
+    expect(screen.getByText(/Current theme: light/i)).toBeDefined();
+    expect(localStorage.getItem('theme')).toBe('light');
+  });
+
+  it('useTheme should throw when used outside ThemeProvider', () => {
+    // Suppress React error boundary console output during test
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const ThrowTest = () => {
+      useTheme(); // will throw
+      return null;
+    };
+    expect(() => render(<ThrowTest />)).toThrow('useTheme must be used within a ThemeProvider');
+    consoleError.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a light/dark theme toggle to the hub UI (packages/hub-ui), mirroring the existing toggle already shipped in packages/ui.

- Port ThemeContext.tsx (ThemeProvider/useTheme) from packages/ui into packages/hub-ui — same behavior: reads localStorage['theme'], falls back to prefers-color-scheme, sets .light/.dark class + data-theme attribute on <html>.
- Wire a Sun/Moon toggle button into Layout.tsx's sidebar.
- Mount ThemeProvider at the app root in main.tsx (missing wiring caught in adversarial review — useTheme() would have thrown at runtime on every route).
- Add the missing @variant dark override to hub-ui/src/index.css so Tailwind's dark: utilities respond to the manual toggle instead of only prefers-color-scheme (verified via compiled CSS diff).

## Testing

- New tests: ThemeContext.test.tsx (6 cases, ported from packages/ui) + LayoutThemeToggle.test.tsx (2 cases).
- Full monorepo suite: 190 files / 1950 tests passing.
- npm run build succeeds for all packages.

## Process note

Built via multi-agent orchestration (Claude Sonnet 5 orchestrator + pi.dev/Qwen coding worker, TDD flow: red -> green -> refactor -> review). The orchestrator's adversarial review caught and fixed the missing ThemeProvider mount and the missing Tailwind dark-variant wiring before merge.