### PR TITLE
feat(hub-ui): light/dark theme toggle

### DIFF
--- a/packages/hub-ui/index.html
+++ b/packages/hub-ui/index.html
@@ -5,6 +5,31 @@
     <link rel="icon" type="image/svg+xml" href="/hub-logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>AgEnFK Hub</title>
+    <!--
+      Pre-paint theme bootstrap. ThemeProvider applies the theme in a
+      useEffect, which runs after the first paint — so a user who forced dark
+      on a light-OS machine would see a white flash on every load. This
+      blocking inline script sets the same markers (class + data-theme +
+      color-scheme) from the same 'theme' key using the same precedence
+      (stored choice, else prefers-color-scheme) before the bundle runs.
+      Keep in sync with src/ThemeContext.tsx; themeBootstrap.test.ts executes
+      this snippet and asserts the precedence matches.
+    -->
+    <script>
+      try {
+        var stored = localStorage.getItem('theme');
+        var theme = stored === 'light' || stored === 'dark'
+          ? stored
+          : (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+        var root = document.documentElement;
+        root.classList.remove('light', 'dark');
+        root.classList.add(theme);
+        root.setAttribute('data-theme', theme);
+        root.style.colorScheme = theme;
+      } catch (e) {
+        /* Blocked storage or exotic engine: fall through to CSS defaults. */
+      }
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/packages/hub-ui/src/ThemeContext.tsx
+++ b/packages/hub-ui/src/ThemeContext.tsx
@@ -1,0 +1,94 @@
+import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
+
+/**
+ * Hub UI theme state.
+ *
+ * Deliberately mirrors packages/ui/src/ThemeContext.tsx (two-state light/dark,
+ * localStorage-persisted under the same 'theme' key, seeded from the OS
+ * preference) so the two independently-built Vite apps behave identically.
+ *
+ * The design tokens themselves already support this: packages/brand/tokens.css
+ * ships `.dark`/`[data-theme="dark"]` and `.light`/`[data-theme="light"]`
+ * blocks. This provider's job is only to put the right marker on <html>; the
+ * `@variant dark` line in index.css then routes hub-ui's ~132 `dark:`
+ * utilities through the same marker.
+ */
+
+type Theme = 'light' | 'dark';
+
+const STORAGE_KEY = 'theme';
+
+interface ThemeContextType {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+function prefersDark(): boolean {
+  // matchMedia is absent in some jsdom/SSR contexts — treat that as "no
+  // preference" rather than crashing the whole app on boot.
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false;
+  try {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches;
+  } catch {
+    return false;
+  }
+}
+
+function readStoredTheme(): Theme | null {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    // Anything other than the two known values is treated as absent, so a
+    // corrupt entry degrades to the OS preference instead of a broken theme.
+    return stored === 'light' || stored === 'dark' ? stored : null;
+  } catch {
+    // Private-mode / blocked storage.
+    return null;
+  }
+}
+
+function resolveInitialTheme(): Theme {
+  return readStoredTheme() ?? (prefersDark() ? 'dark' : 'light');
+}
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>(resolveInitialTheme);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    // Remove both before adding one so the two never coexist — tokens.css
+    // gives .dark and .light equal specificity, so source order would decide
+    // and the result would be effectively random.
+    root.classList.remove('light', 'dark');
+    root.classList.add(theme);
+    root.setAttribute('data-theme', theme);
+    // Drive color-scheme from the explicit choice so native form controls,
+    // scrollbars and autofill match. A static `light dark` in CSS would keep
+    // those widgets following the OS and contradict the user's selection.
+    root.style.colorScheme = theme;
+    try {
+      localStorage.setItem(STORAGE_KEY, theme);
+    } catch {
+      // Persistence is best-effort; an in-session theme still works.
+    }
+  }, [theme]);
+
+  const toggleTheme = useCallback(() => {
+    setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));
+  }, []);
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = (): ThemeContextType => {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+};

--- a/packages/hub-ui/src/components/Layout.tsx
+++ b/packages/hub-ui/src/components/Layout.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { api, MeResponse } from '../api';
 import { LayoutDashboard, Shield, LogOut, AlertTriangle, GitPullRequest } from 'lucide-react';
 import { Logo } from './Logo';
+import { ThemeToggle } from './ThemeToggle';
 
 interface NavItemProps { to: string; icon: React.ReactNode; label: string }
 function NavItem({ to, icon, label }: NavItemProps) {
@@ -48,16 +49,19 @@ export function Layout({ children }: { children: React.ReactNode }) {
         {me.data?.role === 'admin' && (
           <NavItem to="/admin" icon={<Shield className="w-4 h-4" />} label="Admin" />
         )}
-        <div className="mt-auto px-2 py-2 rounded-lg border border-border-soft bg-card-glass">
+        <div data-testid="sidebar-footer" className="mt-auto px-2 py-2 rounded-lg border border-border-soft bg-card-glass">
           <div className="text-[10px] uppercase tracking-[0.16em] text-ink-tertiary">Signed in</div>
           <div className="mt-0.5 text-[12px] font-mono text-ink truncate">{me.data?.userId ?? '—'}</div>
           <div className="mt-0.5 text-[10px] uppercase tracking-[0.14em] text-accent-text">{me.data?.role}</div>
-          <button
-            onClick={() => logout.mutate()}
-            className="mt-2 w-full flex items-center justify-center gap-1.5 px-2 py-1.5 rounded-md text-[11px] font-semibold border border-border-soft text-ink-secondary hover:bg-danger-muted/10 hover:border-danger-muted/40 hover:text-danger-muted transition-colors"
-          >
-            <LogOut className="w-3 h-3" /> Sign out
-          </button>
+          <div className="mt-2 grid grid-cols-2 gap-1.5">
+            <ThemeToggle />
+            <button
+              onClick={() => logout.mutate()}
+              className="flex items-center justify-center gap-1.5 px-2 py-1.5 rounded-md text-[11px] font-semibold border border-border-soft text-ink-secondary hover:bg-danger-muted/10 hover:border-danger-muted/40 hover:text-danger-muted transition-colors"
+            >
+              <LogOut className="w-3 h-3" /> Sign out
+            </button>
+          </div>
         </div>
       </aside>
       <main className="flex-1 min-w-0 p-6 lg:p-8">

--- a/packages/hub-ui/src/components/Layout.tsx
+++ b/packages/hub-ui/src/components/Layout.tsx
@@ -3,7 +3,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { api, MeResponse } from '../api';
 import { LayoutDashboard, Shield, LogOut, AlertTriangle, GitPullRequest } from 'lucide-react';
 import { Logo } from './Logo';
-import { ThemeToggle } from './ThemeToggle';
+import { ThemeToggle, sidebarButtonClass } from './ThemeToggle';
 
 interface NavItemProps { to: string; icon: React.ReactNode; label: string }
 function NavItem({ to, icon, label }: NavItemProps) {
@@ -57,7 +57,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
             <ThemeToggle />
             <button
               onClick={() => logout.mutate()}
-              className="flex items-center justify-center gap-1.5 px-2 py-1.5 rounded-md text-[11px] font-semibold border border-border-soft text-ink-secondary hover:bg-danger-muted/10 hover:border-danger-muted/40 hover:text-danger-muted transition-colors"
+              className={`${sidebarButtonClass} hover:bg-danger-muted/10 hover:border-danger-muted/40 hover:text-danger-muted`}
             >
               <LogOut className="w-3 h-3" /> Sign out
             </button>

--- a/packages/hub-ui/src/components/ThemeToggle.tsx
+++ b/packages/hub-ui/src/components/ThemeToggle.tsx
@@ -1,0 +1,31 @@
+import { Moon, Sun } from 'lucide-react';
+import { useTheme } from '../ThemeContext';
+
+/**
+ * Sidebar light/dark switch.
+ *
+ * Labelling convention: the icon and the accessible name both describe the
+ * DESTINATION mode ("Switch to dark mode" while currently light), which is
+ * what users expect from a one-shot toggle. `aria-pressed` carries the actual
+ * current state for assistive tech.
+ */
+export function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+  const isDark = theme === 'dark';
+  const label = isDark ? 'Switch to light mode' : 'Switch to dark mode';
+
+  return (
+    <button
+      type="button"
+      data-testid="theme-toggle"
+      onClick={toggleTheme}
+      title={label}
+      aria-label={label}
+      aria-pressed={isDark}
+      className="flex items-center justify-center gap-1.5 px-2 py-1.5 rounded-md text-[11px] font-semibold border border-border-soft text-ink-secondary hover:bg-chip hover:border-border-brand hover:text-accent-text transition-colors"
+    >
+      {isDark ? <Sun className="w-3 h-3" /> : <Moon className="w-3 h-3" />}
+      <span>{isDark ? 'Light' : 'Dark'}</span>
+    </button>
+  );
+}

--- a/packages/hub-ui/src/components/ThemeToggle.tsx
+++ b/packages/hub-ui/src/components/ThemeToggle.tsx
@@ -2,6 +2,14 @@ import { Moon, Sun } from 'lucide-react';
 import { useTheme } from '../ThemeContext';
 
 /**
+ * Shared look for the small buttons in the sidebar footer (theme toggle and
+ * Sign out), so the two cannot drift apart visually. Callers append their own
+ * hover accent.
+ */
+export const sidebarButtonClass =
+  'flex items-center justify-center gap-1.5 px-2 py-1.5 rounded-md text-[11px] font-semibold border border-border-soft text-ink-secondary transition-colors';
+
+/**
  * Sidebar light/dark switch.
  *
  * Labelling convention: the icon and the accessible name both describe the
@@ -22,7 +30,7 @@ export function ThemeToggle() {
       title={label}
       aria-label={label}
       aria-pressed={isDark}
-      className="flex items-center justify-center gap-1.5 px-2 py-1.5 rounded-md text-[11px] font-semibold border border-border-soft text-ink-secondary hover:bg-chip hover:border-border-brand hover:text-accent-text transition-colors"
+      className={`${sidebarButtonClass} hover:bg-chip hover:border-border-brand hover:text-accent-text`}
     >
       {isDark ? <Sun className="w-3 h-3" /> : <Moon className="w-3 h-3" />}
       <span>{isDark ? 'Light' : 'Dark'}</span>

--- a/packages/hub-ui/src/index.css
+++ b/packages/hub-ui/src/index.css
@@ -14,7 +14,17 @@
  * hub-ui's compiled CSS — otherwise the modal renders unsized. */
 @source "../../flow-editor/src/**/*.{ts,tsx}";
 
-:root { color-scheme: light dark; }
+/* Route every `dark:` utility through the explicit marker that ThemeContext
+ * puts on <html>, instead of Tailwind v4's default `prefers-color-scheme`.
+ * Without this line the CSS-variable tokens in brand/tokens.css would flip on
+ * toggle while hub-ui's ~132 `dark:` utilities stayed pinned to the OS — a
+ * half-themed UI. Must stay byte-identical to the same line in
+ * packages/ui/src/index.css (asserted by darkVariantWiring.test.ts) and must
+ * sit after all @import statements, per the CSS spec. */
+@variant dark (&:where(.dark, .dark *, [data-theme="dark"], [data-theme="dark"] *));
+
+/* color-scheme is set imperatively on <html> by ThemeProvider so native
+ * controls follow the user's explicit choice rather than the OS. */
 
 html, body, #root { height: 100%; }
 

--- a/packages/hub-ui/src/main.tsx
+++ b/packages/hub-ui/src/main.tsx
@@ -3,16 +3,19 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { App } from './App';
+import { ThemeProvider } from './ThemeContext';
 import './index.css';
 
 const qc = new QueryClient({ defaultOptions: { queries: { refetchInterval: 30_000, refetchOnWindowFocus: false } } });
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <QueryClientProvider client={qc}>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
-    </QueryClientProvider>
+    <ThemeProvider>
+      <QueryClientProvider client={qc}>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </QueryClientProvider>
+    </ThemeProvider>
   </React.StrictMode>,
 );

--- a/packages/hub-ui/src/pages/AdminFlows.tsx
+++ b/packages/hub-ui/src/pages/AdminFlows.tsx
@@ -18,6 +18,7 @@ import { api } from '../api';
 import { flattenAdminFlow } from './adminFlowShape';
 import { repoOverrideOptions } from './repoOverrideOptions';
 import { availabilityRowState } from './availabilityRowState';
+import { useTheme } from '../ThemeContext';
 
 const HUB_PROJECT_TOKEN = 'org-default'; // pseudo-projectId — hub binds to org-default assignment
 
@@ -63,6 +64,9 @@ const registryClient: RegistryClient = {
 
 export function AdminFlows() {
   const qc = useQueryClient();
+  // The shared flow editor styles itself and initialises mermaid from this
+  // prop, so it must follow the hub's live theme rather than a constant.
+  const { theme } = useTheme();
   const [editorOpen, setEditorOpen] = useState(false);
   const [initialFlowId, setInitialFlowId] = useState<string | undefined>(undefined);
   const [expandedFlowId, setExpandedFlowId] = useState<string | null>(null);
@@ -187,7 +191,7 @@ export function AdminFlows() {
         initialFlowId={initialFlowId}
         flowClient={flowClient}
         registryClient={registryClient}
-        theme="light"
+        theme={theme}
       />
     </div>
   );

--- a/packages/hub-ui/src/test/ThemeContext.test.tsx
+++ b/packages/hub-ui/src/test/ThemeContext.test.tsx
@@ -13,23 +13,9 @@ import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import React from 'react';
 import { ThemeProvider, useTheme } from '../ThemeContext';
+import { mockPrefersColorScheme, resetThemeState } from './themeTestUtils';
 
-function mockPrefersDark(prefersDark: boolean) {
-  Object.defineProperty(window, 'matchMedia', {
-    writable: true,
-    configurable: true,
-    value: vi.fn().mockImplementation((query: string) => ({
-      matches: prefersDark && query === '(prefers-color-scheme: dark)',
-      media: query,
-      onchange: null,
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-    })),
-  });
-}
+const mockPrefersDark = mockPrefersColorScheme;
 
 const ThemeTester = () => {
   const { theme, toggleTheme } = useTheme();
@@ -50,10 +36,7 @@ const renderTester = () =>
 
 describe('hub-ui ThemeContext', () => {
   beforeEach(() => {
-    localStorage.clear();
-    document.documentElement.className = '';
-    document.documentElement.removeAttribute('data-theme');
-    document.documentElement.style.colorScheme = '';
+    resetThemeState();
     mockPrefersDark(false);
   });
 

--- a/packages/hub-ui/src/test/ThemeContext.test.tsx
+++ b/packages/hub-ui/src/test/ThemeContext.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * TASK 2bad809f — hub-ui ThemeContext provider.
+ *
+ * Mirrors packages/ui/src/ThemeContext.tsx behaviour (two-state light/dark,
+ * localStorage-persisted, seeded from prefers-color-scheme) so the two Vite
+ * apps cannot drift. Extra coverage here that packages/ui lacks: the DOM side
+ * effects on <html> (class + data-theme + color-scheme), which are what the
+ * 132 existing `dark:` utilities in hub-ui actually key off.
+ */
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import React from 'react';
+import { ThemeProvider, useTheme } from '../ThemeContext';
+
+function mockPrefersDark(prefersDark: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: prefersDark && query === '(prefers-color-scheme: dark)',
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+const ThemeTester = () => {
+  const { theme, toggleTheme } = useTheme();
+  return (
+    <div>
+      <span data-testid="current">{theme}</span>
+      <button onClick={toggleTheme}>Toggle</button>
+    </div>
+  );
+};
+
+const renderTester = () =>
+  render(
+    <ThemeProvider>
+      <ThemeTester />
+    </ThemeProvider>
+  );
+
+describe('hub-ui ThemeContext', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.className = '';
+    document.documentElement.removeAttribute('data-theme');
+    document.documentElement.style.colorScheme = '';
+    mockPrefersDark(false);
+  });
+
+  afterEach(cleanup);
+
+  describe('initial theme resolution', () => {
+    it('defaults to light when the OS has no dark preference', () => {
+      renderTester();
+      expect(screen.getByTestId('current').textContent).toBe('light');
+    });
+
+    it('seeds from prefers-color-scheme: dark when nothing is persisted', () => {
+      mockPrefersDark(true);
+      renderTester();
+      expect(screen.getByTestId('current').textContent).toBe('dark');
+    });
+
+    it('lets a persisted choice win over the OS preference', () => {
+      // OS says dark, user previously forced light -> light must win.
+      mockPrefersDark(true);
+      localStorage.setItem('theme', 'light');
+      renderTester();
+      expect(screen.getByTestId('current').textContent).toBe('light');
+    });
+
+    it('restores a persisted dark choice on a light OS', () => {
+      localStorage.setItem('theme', 'dark');
+      renderTester();
+      expect(screen.getByTestId('current').textContent).toBe('dark');
+    });
+
+    it('ignores a corrupt persisted value and falls back to the OS preference', () => {
+      localStorage.setItem('theme', 'banana');
+      mockPrefersDark(true);
+      renderTester();
+      expect(screen.getByTestId('current').textContent).toBe('dark');
+    });
+
+    it('survives a matchMedia-less environment without throwing', () => {
+      // Older jsdom / SSR-ish contexts expose no matchMedia at all.
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        configurable: true,
+        value: undefined,
+      });
+      expect(() => renderTester()).not.toThrow();
+      expect(screen.getByTestId('current').textContent).toBe('light');
+    });
+  });
+
+  describe('toggling', () => {
+    it('flips light -> dark and persists it', () => {
+      renderTester();
+      fireEvent.click(screen.getByText('Toggle'));
+      expect(screen.getByTestId('current').textContent).toBe('dark');
+      expect(localStorage.getItem('theme')).toBe('dark');
+    });
+
+    it('flips dark -> light and persists it', () => {
+      localStorage.setItem('theme', 'dark');
+      renderTester();
+      fireEvent.click(screen.getByText('Toggle'));
+      expect(screen.getByTestId('current').textContent).toBe('light');
+      expect(localStorage.getItem('theme')).toBe('light');
+    });
+  });
+
+  describe('DOM side effects on <html>', () => {
+    it('applies the light class and data-theme on mount', () => {
+      renderTester();
+      const root = document.documentElement;
+      expect(root.classList.contains('light')).toBe(true);
+      expect(root.classList.contains('dark')).toBe(false);
+      expect(root.getAttribute('data-theme')).toBe('light');
+    });
+
+    it('swaps the class and data-theme when toggled, never keeping both', () => {
+      renderTester();
+      fireEvent.click(screen.getByText('Toggle'));
+      const root = document.documentElement;
+      expect(root.classList.contains('dark')).toBe(true);
+      expect(root.classList.contains('light')).toBe(false);
+      expect(root.getAttribute('data-theme')).toBe('dark');
+    });
+
+    it('drives color-scheme so native controls and scrollbars match', () => {
+      // tokens.css hardcodes `color-scheme: light dark`, which leaves native
+      // widgets following the OS even after an explicit override. TASK 85c7a519.
+      renderTester();
+      expect(document.documentElement.style.colorScheme).toBe('light');
+      fireEvent.click(screen.getByText('Toggle'));
+      expect(document.documentElement.style.colorScheme).toBe('dark');
+    });
+
+    it('does not clobber unrelated classes already on <html>', () => {
+      document.documentElement.classList.add('some-vendor-class');
+      renderTester();
+      expect(document.documentElement.classList.contains('some-vendor-class')).toBe(true);
+    });
+  });
+
+  it('throws a helpful error when useTheme is used outside the provider', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const Orphan = () => {
+      useTheme();
+      return null;
+    };
+    expect(() => render(<Orphan />)).toThrow('useTheme must be used within a ThemeProvider');
+    consoleError.mockRestore();
+  });
+});

--- a/packages/hub-ui/src/test/ThemeToggle.test.tsx
+++ b/packages/hub-ui/src/test/ThemeToggle.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * TASK ad468628 — ThemeToggle button in the Layout sidebar footer.
+ *
+ * Covers the component in isolation plus its integration into Layout, since
+ * "the toggle exists" and "the toggle is actually reachable in the hub chrome"
+ * are different failures — the latter is what the user sees.
+ */
+import { render, screen, fireEvent, cleanup, within } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import { ThemeProvider } from '../ThemeContext';
+import { ThemeToggle } from '../components/ThemeToggle';
+import { Layout } from '../components/Layout';
+
+vi.mock('../api', () => ({
+  api: {
+    get: vi.fn(async (url: string) => {
+      if (url === '/auth/me') return { data: { userId: 'ada@acme.com', orgId: 'org1', role: 'viewer' } };
+      if (url === '/healthz') return { data: { ok: true, version: '1.1.14' } };
+      return { data: {} };
+    }),
+    post: vi.fn(async () => ({ data: {} })),
+  },
+}));
+
+function mockMatchMedia(prefersDark = false) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: prefersDark && query === '(prefers-color-scheme: dark)',
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+const renderToggle = () =>
+  render(
+    <ThemeProvider>
+      <ThemeToggle />
+    </ThemeProvider>
+  );
+
+const renderLayout = () => {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <ThemeProvider>
+          <Layout>
+            <div>page body</div>
+          </Layout>
+        </ThemeProvider>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+};
+
+describe('ThemeToggle', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.className = '';
+    document.documentElement.removeAttribute('data-theme');
+    mockMatchMedia(false);
+  });
+
+  afterEach(cleanup);
+
+  it('renders a real button with a stable test id', () => {
+    renderToggle();
+    const btn = screen.getByTestId('theme-toggle');
+    expect(btn.tagName).toBe('BUTTON');
+  });
+
+  it('is labelled for screen readers, not icon-only', () => {
+    renderToggle();
+    // Accessible name must exist and mention the destination mode.
+    const btn = screen.getByRole('button', { name: /dark mode/i });
+    expect(btn).toBeDefined();
+  });
+
+  it('advertises the destination mode in its title while in light mode', () => {
+    renderToggle();
+    expect(screen.getByTestId('theme-toggle').getAttribute('title')).toMatch(/dark/i);
+  });
+
+  it('advertises the destination mode in its title while in dark mode', () => {
+    localStorage.setItem('theme', 'dark');
+    renderToggle();
+    expect(screen.getByTestId('theme-toggle').getAttribute('title')).toMatch(/light/i);
+  });
+
+  it('shows the moon icon in light mode and the sun icon in dark mode', () => {
+    const { container } = renderToggle();
+    // lucide-react renders an <svg> with a class naming the icon.
+    expect(container.querySelector('svg')?.getAttribute('class')).toMatch(/moon/i);
+    fireEvent.click(screen.getByTestId('theme-toggle'));
+    expect(container.querySelector('svg')?.getAttribute('class')).toMatch(/sun/i);
+  });
+
+  it('flips the document theme when clicked', () => {
+    renderToggle();
+    fireEvent.click(screen.getByTestId('theme-toggle'));
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+    expect(localStorage.getItem('theme')).toBe('dark');
+  });
+
+  it('round-trips back to light on a second click', () => {
+    renderToggle();
+    const btn = screen.getByTestId('theme-toggle');
+    fireEvent.click(btn);
+    fireEvent.click(btn);
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+    expect(localStorage.getItem('theme')).toBe('light');
+  });
+
+  it('exposes aria-pressed reflecting whether dark is active', () => {
+    renderToggle();
+    const btn = screen.getByTestId('theme-toggle');
+    expect(btn.getAttribute('aria-pressed')).toBe('false');
+    fireEvent.click(btn);
+    expect(btn.getAttribute('aria-pressed')).toBe('true');
+  });
+});
+
+describe('Layout integration', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.className = '';
+    document.documentElement.removeAttribute('data-theme');
+    mockMatchMedia(false);
+  });
+
+  afterEach(cleanup);
+
+  it('mounts the toggle inside the sidebar footer, next to Sign out', async () => {
+    renderLayout();
+    const footer = await screen.findByTestId('sidebar-footer');
+    expect(within(footer).getByTestId('theme-toggle')).toBeDefined();
+    expect(within(footer).getByText(/sign out/i)).toBeDefined();
+  });
+
+  it('renders the toggle exactly once in the chrome', () => {
+    renderLayout();
+    expect(screen.getAllByTestId('theme-toggle')).toHaveLength(1);
+  });
+
+  it('still renders page children alongside the toggle', () => {
+    renderLayout();
+    expect(screen.getByText('page body')).toBeDefined();
+    expect(screen.getByTestId('theme-toggle')).toBeDefined();
+  });
+
+  it('toggling from within Layout updates <html>', () => {
+    renderLayout();
+    fireEvent.click(screen.getByTestId('theme-toggle'));
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+});

--- a/packages/hub-ui/src/test/ThemeToggle.test.tsx
+++ b/packages/hub-ui/src/test/ThemeToggle.test.tsx
@@ -15,6 +15,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { ThemeProvider } from '../ThemeContext';
 import { ThemeToggle } from '../components/ThemeToggle';
 import { Layout } from '../components/Layout';
+import { mockPrefersColorScheme, resetThemeState } from './themeTestUtils';
 
 vi.mock('../api', () => ({
   api: {
@@ -27,22 +28,7 @@ vi.mock('../api', () => ({
   },
 }));
 
-function mockMatchMedia(prefersDark = false) {
-  Object.defineProperty(window, 'matchMedia', {
-    writable: true,
-    configurable: true,
-    value: vi.fn().mockImplementation((query: string) => ({
-      matches: prefersDark && query === '(prefers-color-scheme: dark)',
-      media: query,
-      onchange: null,
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-    })),
-  });
-}
+const mockMatchMedia = mockPrefersColorScheme;
 
 const renderToggle = () =>
   render(
@@ -68,9 +54,7 @@ const renderLayout = () => {
 
 describe('ThemeToggle', () => {
   beforeEach(() => {
-    localStorage.clear();
-    document.documentElement.className = '';
-    document.documentElement.removeAttribute('data-theme');
+    resetThemeState();
     mockMatchMedia(false);
   });
 
@@ -135,9 +119,7 @@ describe('ThemeToggle', () => {
 
 describe('Layout integration', () => {
   beforeEach(() => {
-    localStorage.clear();
-    document.documentElement.className = '';
-    document.documentElement.removeAttribute('data-theme');
+    resetThemeState();
     mockMatchMedia(false);
   });
 

--- a/packages/hub-ui/src/test/darkVariantWiring.test.ts
+++ b/packages/hub-ui/src/test/darkVariantWiring.test.ts
@@ -61,3 +61,17 @@ describe('hub-ui dark variant wiring', () => {
     expect(readCss()).not.toMatch(/color-scheme:\s*light\s+dark/);
   });
 });
+
+describe('shared FlowEditorModal theme prop', () => {
+  it('feeds the live theme into FlowEditorModal instead of hardcoding light', () => {
+    // The shared @agenfk/flow-editor styles itself AND initialises mermaid from
+    // this prop (FlowEditorModal.tsx: theme === 'dark' ? 'dark' : 'default').
+    // Hardcoding "light" leaves the flow editor and its diagrams in light mode
+    // even when the rest of the hub is dark. packages/ui passes useTheme()
+    // through; hub-ui must too.
+    const src = fs.readFileSync(path.join(HUB_UI_SRC, 'pages', 'AdminFlows.tsx'), 'utf8');
+    expect(src).not.toMatch(/theme=["']light["']/);
+    expect(src).toMatch(/useTheme/);
+    expect(src).toMatch(/theme=\{/);
+  });
+});

--- a/packages/hub-ui/src/test/darkVariantWiring.test.ts
+++ b/packages/hub-ui/src/test/darkVariantWiring.test.ts
@@ -1,0 +1,63 @@
+/**
+ * TASK 85c7a519 — class-based `dark:` variant wiring for hub-ui.
+ *
+ * These are static-source assertions (same style as favicon.test.ts) rather
+ * than render tests, because what we need to guarantee lives in CSS that Vite
+ * compiles — jsdom does not run Tailwind, so a render test literally cannot
+ * observe whether `dark:` resolves against a class or a media query.
+ *
+ * Why it matters: hub-ui has ~132 `dark:` utilities. Without the `@variant`
+ * override they follow `prefers-color-scheme` and a manual toggle silently
+ * does nothing to them, even though the CSS-variable tokens do flip.
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const HUB_UI_SRC = path.resolve(__dirname, '..');
+const INDEX_CSS = path.join(HUB_UI_SRC, 'index.css');
+const UI_INDEX_CSS = path.resolve(HUB_UI_SRC, '../../ui/src/index.css');
+
+const readCss = () => fs.readFileSync(INDEX_CSS, 'utf8');
+
+describe('hub-ui dark variant wiring', () => {
+  it('declares an @variant dark override so `dark:` follows the explicit class', () => {
+    const css = readCss();
+    const variantLine = css
+      .split('\n')
+      .find((l) => l.trim().startsWith('@variant dark'));
+    expect(variantLine, 'expected an `@variant dark (...)` declaration in hub-ui/src/index.css').toBeDefined();
+  });
+
+  it('matches both the .dark class and the [data-theme="dark"] attribute', () => {
+    const css = readCss();
+    const variantLine = css.split('\n').find((l) => l.trim().startsWith('@variant dark')) ?? '';
+    expect(variantLine).toContain('.dark');
+    expect(variantLine).toContain('[data-theme="dark"]');
+    // Descendant forms matter: tokens.css sets vars on `.dark *` too.
+    expect(variantLine).toMatch(/\.dark \*/);
+  });
+
+  it('uses the identical variant definition as packages/ui so the apps cannot drift', () => {
+    const pick = (css: string) =>
+      css.split('\n').find((l) => l.trim().startsWith('@variant dark'))?.trim();
+    expect(pick(readCss())).toBe(pick(fs.readFileSync(UI_INDEX_CSS, 'utf8')));
+  });
+
+  it('keeps all @import statements ahead of @variant, per the CSS spec', () => {
+    // packages/ui/src/index.css carries a comment about @import silently
+    // breaking when preceded by other at-rules. Same trap applies here.
+    const lines = readCss().split('\n').map((l) => l.trim());
+    const lastImport = lines.reduce((acc, l, i) => (l.startsWith('@import') ? i : acc), -1);
+    const firstVariant = lines.findIndex((l) => l.startsWith('@variant'));
+    expect(lastImport).toBeGreaterThanOrEqual(0);
+    expect(firstVariant).toBeGreaterThan(lastImport);
+  });
+
+  it('no longer hardcodes `color-scheme: light dark` on :root', () => {
+    // A static `light dark` leaves native form controls and scrollbars
+    // following the OS, contradicting an explicit user choice. The provider
+    // now sets documentElement.style.colorScheme instead.
+    expect(readCss()).not.toMatch(/color-scheme:\s*light\s+dark/);
+  });
+});

--- a/packages/hub-ui/src/test/themeBootstrap.test.ts
+++ b/packages/hub-ui/src/test/themeBootstrap.test.ts
@@ -1,0 +1,92 @@
+/**
+ * TASK 85c7a519 — pre-paint theme application.
+ *
+ * The provider applies the theme in a useEffect, which runs *after* React's
+ * first paint. For a user who forced dark on a light-OS machine, the first
+ * frame therefore renders with tokens.css's light `:root` defaults and then
+ * snaps to dark — a visible white flash on every full page load.
+ *
+ * The fix is a tiny synchronous inline script in index.html that sets the
+ * marker before the bundle (and before first paint). Asserted statically
+ * because vitest never performs a real document parse of index.html.
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const INDEX_HTML = path.resolve(__dirname, '../../index.html');
+const readHtml = () => fs.readFileSync(INDEX_HTML, 'utf8');
+
+describe('hub-ui pre-paint theme bootstrap', () => {
+  it('ships a blocking inline script in <head>', () => {
+    const html = readHtml();
+    const head = html.slice(html.indexOf('<head>'), html.indexOf('</head>'));
+    // Inline (no src) and not deferred/module, so it executes immediately.
+    expect(head).toMatch(/<script>[\s\S]*<\/script>/);
+  });
+
+  it('runs before the app bundle so the marker exists on the first frame', () => {
+    const html = readHtml();
+    const inlineAt = html.indexOf('<script>');
+    const bundleAt = html.indexOf('src="/src/main.tsx"');
+    expect(inlineAt).toBeGreaterThan(-1);
+    expect(bundleAt).toBeGreaterThan(-1);
+    expect(inlineAt).toBeLessThan(bundleAt);
+  });
+
+  it('applies the same markers and storage key as ThemeContext', () => {
+    const html = readHtml();
+    const inline = html.slice(html.indexOf('<script>'), html.indexOf('</script>'));
+    expect(inline).toContain("'theme'");
+    expect(inline).toContain('data-theme');
+    expect(inline).toContain('classList');
+    expect(inline).toContain('prefers-color-scheme: dark');
+    expect(inline).toContain('colorScheme');
+  });
+
+  it('is resilient to blocked storage so a throwing localStorage cannot white-screen the hub', () => {
+    const inline = readHtml();
+    expect(inline.slice(inline.indexOf('<script>'), inline.indexOf('</script>'))).toMatch(/try\s*\{/);
+  });
+
+  it('reproduces the provider\'s precedence: stored choice wins, else OS', () => {
+    // Execute the extracted snippet against a stubbed environment and assert
+    // the resulting marker, so the two implementations cannot silently diverge.
+    const html = readHtml();
+    const inline = html.slice(html.indexOf('<script>') + '<script>'.length, html.indexOf('</script>'));
+
+    const run = (stored: string | null, prefersDark: boolean) => {
+      const root = { className: '', attrs: {} as Record<string, string>, style: {} as Record<string, string> };
+      const fakeDoc = {
+        documentElement: {
+          classList: {
+            remove: (...cs: string[]) => {
+              const kept = root.className.split(' ').filter((c) => c && !cs.includes(c));
+              root.className = kept.join(' ');
+            },
+            add: (c: string) => {
+              root.className = `${root.className} ${c}`.trim();
+            },
+          },
+          setAttribute: (k: string, v: string) => { root.attrs[k] = v; },
+          style: root.style,
+        },
+      };
+      const fakeWin = {
+        localStorage: { getItem: () => stored },
+        matchMedia: (q: string) => ({ matches: prefersDark && q === '(prefers-color-scheme: dark)' }),
+      };
+      // eslint-disable-next-line no-new-func
+      new Function('document', 'window', 'localStorage', 'matchMedia', inline)(
+        fakeDoc, fakeWin, fakeWin.localStorage, fakeWin.matchMedia,
+      );
+      return { cls: root.className, attr: root.attrs['data-theme'] };
+    };
+
+    expect(run('dark', false)).toEqual({ cls: 'dark', attr: 'dark' });
+    expect(run('light', true)).toEqual({ cls: 'light', attr: 'light' });
+    expect(run(null, true)).toEqual({ cls: 'dark', attr: 'dark' });
+    expect(run(null, false)).toEqual({ cls: 'light', attr: 'light' });
+    expect(run('banana', true)).toEqual({ cls: 'dark', attr: 'dark' });
+  });
+});

--- a/packages/hub-ui/src/test/themeTestUtils.ts
+++ b/packages/hub-ui/src/test/themeTestUtils.ts
@@ -1,0 +1,32 @@
+import { vi } from 'vitest';
+
+/**
+ * Installs a window.matchMedia stub reporting the given OS colour preference.
+ *
+ * Shared by ThemeContext.test.tsx and ThemeToggle.test.tsx — both need to
+ * drive the prefers-color-scheme seed, and jsdom ships no matchMedia at all.
+ */
+export function mockPrefersColorScheme(prefersDark: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: prefersDark && query === '(prefers-color-scheme: dark)',
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+/** Clears persisted theme state and every marker the provider writes to <html>. */
+export function resetThemeState() {
+  localStorage.clear();
+  document.documentElement.className = '';
+  document.documentElement.removeAttribute('data-theme');
+  document.documentElement.style.colorScheme = '';
+}


### PR DESCRIPTION
Adds a two-state (light/dark) theme toggle to the hub UI, matching `packages/ui` so the two Vite apps cannot drift.

## Why
`packages/hub-ui` had no way to override the OS theme. Its ~132 `dark:` utilities resolved via Tailwind v4's default `dark` variant (`prefers-color-scheme`), so the hub followed the operating system and nothing else. The design tokens in `packages/brand/tokens.css` were already toggle-ready — its own comment noted *"hub-ui has no manual theme toggle yet"*.

## What
- **`src/ThemeContext.tsx`** (new) — two-state provider, persisted under the same `theme` key as `packages/ui`, seeded from `prefers-color-scheme`. Applies `class` + `data-theme` + `color-scheme` to `<html>`. Hardened over the original: guards absent/throwing `matchMedia`, treats a corrupt stored value as absent, tolerates blocked storage.
- **`src/index.css`** — added the `@variant dark` line (byte-identical to `packages/ui`'s) so `dark:` utilities follow the explicit class; removed `:root { color-scheme: light dark }`, which pinned native controls to the OS.
- **`src/components/ThemeToggle.tsx`** (new) — Moon/Sun button in the sidebar footer beside Sign out. `title`/`aria-label` name the destination mode; `aria-pressed` carries actual state.
- **`index.html`** — blocking pre-paint bootstrap, mirroring the provider's precedence, to kill the white flash for dark-on-light-OS users.
- **`src/pages/AdminFlows.tsx`** — was hardcoding `theme="light"` on the shared `FlowEditorModal`, which also feeds `mermaid.initialize`; now threads `useTheme()`.

## Verification
- 36 new tests (13 provider, 12 toggle/Layout, 6 CSS wiring, 5 bootstrap). Full suite: **1978 passed / 192 files**, `npm run build` clean.
- Written TDD red→green; each claim **mutation-tested** (5 mutations, all caught).
- `dark:` conversion proved against compiled output: `dark:border-amber-700` emits `.dark\:border-amber-700:where(.dark,.dark *,[data-theme=dark],[data-theme=dark] *){...}` — class-gated, not a media query.
- Refactor step verified at test-**name** level: 152 → 152, identical.

## Notes for reviewers
- **Behavioural change:** OS-dark users now follow the class. First load is pixel-identical because both the provider and the bootstrap seed from `prefers-color-scheme`.
- **Known gap (not a bug):** `Login`/`Setup` render outside `Layout` so have no pre-auth toggle button. They theme correctly via CSS-variable tokens (zero `dark:` utilities). Left out of scope deliberately.
- **Follow-up:** `ThemeContext` is now duplicated between `packages/ui` and `packages/hub-ui`. Hoisting it into a shared package is a cross-package change I kept out of this PR.