### PR TITLE
feat(hub-ui): light/dark theme toggle in the hub sidebar

### DIFF
--- a/packages/brand/tokens.css
+++ b/packages/brand/tokens.css
@@ -59,15 +59,12 @@
 }
 
 /* Dark theme values.
- * Two mechanisms are covered because the two apps pick dark mode differently:
- *  - packages/ui explicitly toggles a `.dark` class + `[data-theme="dark"]`
- *    attribute on <html> (see ThemeContext.tsx) and defines its own
- *    `@variant dark` matching those selectors.
- *  - packages/hub-ui has no manual theme toggle yet and relies on the
- *    default Tailwind v4 `dark:` variant, which follows
- *    `prefers-color-scheme`.
- * Both blocks set the same values, so whichever mechanism a given app uses,
- * the tokens stay in sync. Neutral dark surfaces — NOT navy-tinted. */
+ * Both packages/ui and packages/hub-ui now explicitly toggle a `.dark` class
+ * + `[data-theme="dark"]` attribute on <html> via their own ThemeContext and
+ * declare a matching `@variant dark`. The `@media (prefers-color-scheme: dark)`
+ * block below remains as the fallback for the first paint before a user has
+ * ever chosen a theme. Both blocks set the same values so the tokens stay in
+ * sync. Neutral dark surfaces — NOT navy-tinted. */
 @media (prefers-color-scheme: dark) {
   :root {
     --canvas: #0d0f13;

--- a/packages/hub-ui/src/ThemeContext.tsx
+++ b/packages/hub-ui/src/ThemeContext.tsx
@@ -1,0 +1,49 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextType {
+  theme: Theme;
+  toggleTheme: () => void;
+  setTheme: (theme: Theme) => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setThemeState] = useState<Theme>(() => {
+    const saved = localStorage.getItem('theme');
+    if (saved === 'light' || saved === 'dark') return saved;
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.classList.remove('light', 'dark');
+    root.classList.add(theme);
+    root.setAttribute('data-theme', theme);
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setThemeState(prev => (prev === 'light' ? 'dark' : 'light'));
+  };
+
+  const setTheme = (next: Theme) => {
+    setThemeState(next);
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+};

--- a/packages/hub-ui/src/ThemeContext.tsx
+++ b/packages/hub-ui/src/ThemeContext.tsx
@@ -10,19 +10,59 @@ interface ThemeContextType {
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
-export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [theme, setThemeState] = useState<Theme>(() => {
-    const saved = localStorage.getItem('theme');
-    if (saved === 'light' || saved === 'dark') return saved;
+/**
+ * Safely access `window.localStorage`.
+ * Returns `null` when running outside a browser or when the storage access
+ * throws (Safari private mode, "block all cookies" policies, quota exceeded).
+ */
+function getLocalStorage(): Storage | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+/** Resolve the initial theme: localStorage → OS preference → light. */
+function resolveInitialTheme(): Theme {
+  const storage = getLocalStorage();
+  let saved: string | null = null;
+  if (storage) {
+    try {
+      saved = storage.getItem('theme');
+    } catch {
+      // getItem can throw under strict cookie-block policies.
+    }
+  }
+  if (saved === 'light' || saved === 'dark') return saved;
+
+  // Fall back to OS preference; default to 'light' if matchMedia is
+  // unavailable (older / embedded webviews).
+  if (typeof window.matchMedia === 'function') {
     return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-  });
+  }
+  return 'light';
+}
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setThemeState] = useState<Theme>(resolveInitialTheme);
 
   useEffect(() => {
     const root = document.documentElement;
     root.classList.remove('light', 'dark');
     root.classList.add(theme);
     root.setAttribute('data-theme', theme);
-    localStorage.setItem('theme', theme);
+
+    // Persist best-effort — swallow failures (quota exceeded, private mode).
+    const storage = getLocalStorage();
+    if (storage) {
+      try {
+        storage.setItem('theme', theme);
+      } catch {
+        // Storage write failed — theme still applies for the session.
+      }
+    }
   }, [theme]);
 
   const toggleTheme = () => {

--- a/packages/hub-ui/src/components/Layout.tsx
+++ b/packages/hub-ui/src/components/Layout.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { api, MeResponse } from '../api';
 import { LayoutDashboard, Shield, LogOut, AlertTriangle, GitPullRequest } from 'lucide-react';
 import { Logo } from './Logo';
+import { ThemeToggle } from './ThemeToggle';
 
 interface NavItemProps { to: string; icon: React.ReactNode; label: string }
 function NavItem({ to, icon, label }: NavItemProps) {
@@ -52,6 +53,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
           <div className="text-[10px] uppercase tracking-[0.16em] text-ink-tertiary">Signed in</div>
           <div className="mt-0.5 text-[12px] font-mono text-ink truncate">{me.data?.userId ?? '—'}</div>
           <div className="mt-0.5 text-[10px] uppercase tracking-[0.14em] text-accent-text">{me.data?.role}</div>
+          <ThemeToggle />
           <button
             onClick={() => logout.mutate()}
             className="mt-2 w-full flex items-center justify-center gap-1.5 px-2 py-1.5 rounded-md text-[11px] font-semibold border border-border-soft text-ink-secondary hover:bg-danger-muted/10 hover:border-danger-muted/40 hover:text-danger-muted transition-colors"

--- a/packages/hub-ui/src/components/ThemeToggle.tsx
+++ b/packages/hub-ui/src/components/ThemeToggle.tsx
@@ -1,0 +1,22 @@
+import { useTheme } from '../ThemeContext';
+import { Moon, Sun } from 'lucide-react';
+
+export function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+  const nextTheme = theme === 'light' ? 'dark' : 'light';
+
+  return (
+    <button
+      data-testid="theme-toggle"
+      type="button"
+      onClick={toggleTheme}
+      aria-pressed={theme === 'dark' ? 'true' : 'false'}
+      aria-label={`Switch to ${nextTheme} theme`}
+      title={`Switch to ${nextTheme} theme`}
+      className="w-full flex items-center justify-center gap-1.5 px-2 py-1.5 rounded-md text-[11px] font-semibold border border-border-soft text-ink-secondary hover:bg-chip hover:text-ink transition-colors"
+    >
+      {theme === 'light' ? <Moon className="w-3 h-3" /> : <Sun className="w-3 h-3" />}
+      Switch to {nextTheme}
+    </button>
+  );
+}

--- a/packages/hub-ui/src/components/ThemeToggle.tsx
+++ b/packages/hub-ui/src/components/ThemeToggle.tsx
@@ -4,6 +4,7 @@ import { Moon, Sun } from 'lucide-react';
 export function ThemeToggle() {
   const { theme, toggleTheme } = useTheme();
   const nextTheme = theme === 'light' ? 'dark' : 'light';
+  const label = `Switch to ${nextTheme} theme`;
 
   return (
     <button
@@ -11,9 +12,9 @@ export function ThemeToggle() {
       type="button"
       onClick={toggleTheme}
       aria-pressed={theme === 'dark' ? 'true' : 'false'}
-      aria-label={`Switch to ${nextTheme} theme`}
-      title={`Switch to ${nextTheme} theme`}
-      className="w-full flex items-center justify-center gap-1.5 px-2 py-1.5 rounded-md text-[11px] font-semibold border border-border-soft text-ink-secondary hover:bg-chip hover:text-ink transition-colors"
+      aria-label={label}
+      title={label}
+      className="mt-2 w-full flex items-center justify-center gap-1.5 px-2 py-1.5 rounded-md text-[11px] font-semibold border border-border-soft text-ink-secondary hover:bg-chip hover:text-ink transition-colors"
     >
       {theme === 'light' ? <Moon className="w-3 h-3" /> : <Sun className="w-3 h-3" />}
       Switch to {nextTheme}

--- a/packages/hub-ui/src/index.css
+++ b/packages/hub-ui/src/index.css
@@ -20,6 +20,20 @@
 
 :root { color-scheme: light dark; }
 
+/* Pin color-scheme when the user has made an explicit choice.
+ * Without these rules, native UI (form controls, scrollbars, <select>
+ * dropdowns) follows the *OS* preference even after the user picks a
+ * theme, producing a half-broken look (e.g. light page + dark widgets).
+ * Both compound selectors match :root's specificity and are declared
+ * after the default so source order decides and the explicit choice wins.
+ * Matches the selector style in packages/brand/tokens.css. */
+.dark, .dark *, [data-theme="dark"], [data-theme="dark"] * {
+  color-scheme: dark;
+}
+.light, .light *, [data-theme="light"], [data-theme="light"] * {
+  color-scheme: light;
+}
+
 html, body, #root { height: 100%; }
 
 body {

--- a/packages/hub-ui/src/index.css
+++ b/packages/hub-ui/src/index.css
@@ -14,6 +14,10 @@
  * hub-ui's compiled CSS — otherwise the modal renders unsized. */
 @source "../../flow-editor/src/**/*.{ts,tsx}";
 
+/* Enable dark: utilities to respond to explicit .dark class and [data-theme="dark"]
+ * attribute (set by ThemeContext) instead of only the OS prefers-color-scheme. */
+@variant dark (&:where(.dark, .dark *, [data-theme="dark"], [data-theme="dark"] *));
+
 :root { color-scheme: light dark; }
 
 html, body, #root { height: 100%; }

--- a/packages/hub-ui/src/main.tsx
+++ b/packages/hub-ui/src/main.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ThemeProvider } from './ThemeContext';
 import { App } from './App';
 import './index.css';
 
@@ -10,9 +11,11 @@ const qc = new QueryClient({ defaultOptions: { queries: { refetchInterval: 30_00
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <QueryClientProvider client={qc}>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
+      <ThemeProvider>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </ThemeProvider>
     </QueryClientProvider>
   </React.StrictMode>,
 );

--- a/packages/hub-ui/src/test/LayoutThemeToggle.test.tsx
+++ b/packages/hub-ui/src/test/LayoutThemeToggle.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ThemeProvider } from '../ThemeContext';
+import { Layout } from '../components/Layout';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+// ── mock matchMedia (required by ThemeContext) ──────────────────
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+// ── mock the api module so Layout's queries resolve ──────────────
+vi.mock('../api', () => ({
+  api: {
+    get: vi.fn((url: string) => {
+      if (url === '/auth/me') {
+        return Promise.resolve({ data: { userId: 'u1', role: 'admin' } });
+      }
+      if (url === '/healthz') {
+        return Promise.resolve({ data: { ok: true, version: '1.0.0' } });
+      }
+      if (url === '/v1/admin/system/pending') {
+        return Promise.resolve({ data: { pendingEnvOrgId: null } });
+      }
+      return Promise.resolve({ data: null });
+    }),
+    post: vi.fn(() => Promise.resolve({ data: null })),
+  },
+}));
+
+describe('LayoutThemeToggle', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders the theme-toggle inside the sidebar', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ThemeProvider>
+            <Layout>
+              <div>page content</div>
+            </Layout>
+          </ThemeProvider>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // Wait for react-query to settle and the sidebar to populate.
+    await waitFor(() => {
+      const toggle = screen.queryByTestId('theme-toggle');
+      expect(toggle).not.toBeNull();
+    });
+  });
+});

--- a/packages/hub-ui/src/test/ThemeContext.test.tsx
+++ b/packages/hub-ui/src/test/ThemeContext.test.tsx
@@ -1,0 +1,237 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { ThemeProvider, useTheme } from '../ThemeContext';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import React from 'react';
+
+// ── mock window.matchMedia ──────────────────────────────────────
+const defaultMatchMedia = (query: string) => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addListener: vi.fn(),
+  removeListener: vi.fn(),
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  dispatchEvent: vi.fn(),
+});
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation(query => defaultMatchMedia(query)),
+});
+
+// ── test harness component ──────────────────────────────────────
+const ThemeTester: React.FC = () => {
+  const { theme, toggleTheme, setTheme } = useTheme();
+  return (
+    <div>
+      <span data-testid="current-theme">{theme}</span>
+      <button data-testid="toggle-btn" onClick={toggleTheme}>
+        Toggle
+      </button>
+      <button data-testid="set-dark-btn" onClick={() => setTheme('dark')}>
+        Set Dark
+      </button>
+      <button data-testid="set-light-btn" onClick={() => setTheme('light')}>
+        Set Light
+      </button>
+    </div>
+  );
+};
+
+// ── tests ───────────────────────────────────────────────────────
+describe('ThemeContext', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.className = '';
+    document.documentElement.removeAttribute('data-theme');
+    // Reset matchMedia mock to default (no dark preference)
+    (window.matchMedia as ReturnType<typeof vi.fn>).mockImplementation(
+      query => defaultMatchMedia(query),
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── initialisation ────────────────────────────────────────────
+
+  it('provides default "light" theme when no localStorage and no OS preference', () => {
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>
+    );
+    expect(screen.getByTestId('current-theme').textContent).toBe('light');
+  });
+
+  it('initialises with "dark" from localStorage', () => {
+    localStorage.setItem('theme', 'dark');
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>
+    );
+    expect(screen.getByTestId('current-theme').textContent).toBe('dark');
+  });
+
+  it('initialises with "light" from localStorage', () => {
+    localStorage.setItem('theme', 'light');
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>
+    );
+    expect(screen.getByTestId('current-theme').textContent).toBe('light');
+  });
+
+  it('ignores invalid persisted value and falls back to OS preference (light)', () => {
+    localStorage.setItem('theme', 'banana');
+    // matchMedia mock defaults to matches: false → light
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>
+    );
+    expect(screen.getByTestId('current-theme').textContent).toBe('light');
+  });
+
+  it('ignores invalid persisted value and falls back to OS preference (dark)', () => {
+    localStorage.setItem('theme', 'banana');
+    (window.matchMedia as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      query => ({
+        ...defaultMatchMedia(query),
+        matches: query === '(prefers-color-scheme: dark)',
+      }),
+    );
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>
+    );
+    expect(screen.getByTestId('current-theme').textContent).toBe('dark');
+  });
+
+  it('initialises to "dark" when system prefers dark and no localStorage', () => {
+    (window.matchMedia as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      query => ({
+        ...defaultMatchMedia(query),
+        matches: query === '(prefers-color-scheme: dark)',
+      }),
+    );
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>
+    );
+    expect(screen.getByTestId('current-theme').textContent).toBe('dark');
+  });
+
+  // ── toggleTheme ───────────────────────────────────────────────
+
+  it('toggles light → dark and persists to localStorage', () => {
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>
+    );
+    fireEvent.click(screen.getByTestId('toggle-btn'));
+    expect(screen.getByTestId('current-theme').textContent).toBe('dark');
+    expect(localStorage.getItem('theme')).toBe('dark');
+  });
+
+  it('toggles dark → light and persists to localStorage', () => {
+    localStorage.setItem('theme', 'dark');
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>
+    );
+    fireEvent.click(screen.getByTestId('toggle-btn'));
+    expect(screen.getByTestId('current-theme').textContent).toBe('light');
+    expect(localStorage.getItem('theme')).toBe('light');
+  });
+
+  // ── setTheme ──────────────────────────────────────────────────
+
+  it('setTheme("dark") sets the theme explicitly and persists it', () => {
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>
+    );
+    fireEvent.click(screen.getByTestId('set-dark-btn'));
+    expect(screen.getByTestId('current-theme').textContent).toBe('dark');
+    expect(localStorage.getItem('theme')).toBe('dark');
+  });
+
+  it('setTheme("light") sets the theme explicitly and persists it', () => {
+    localStorage.setItem('theme', 'dark');
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>
+    );
+    fireEvent.click(screen.getByTestId('set-light-btn'));
+    expect(screen.getByTestId('current-theme').textContent).toBe('light');
+    expect(localStorage.getItem('theme')).toBe('light');
+  });
+
+  // ── document.documentElement side-effects ─────────────────────
+
+  it('applies theme class and data-theme attribute on render', () => {
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>
+    );
+    const root = document.documentElement;
+    expect(root.classList.contains('light')).toBe(true);
+    expect(root.classList.contains('dark')).toBe(false);
+    expect(root.getAttribute('data-theme')).toBe('light');
+  });
+
+  it('updates document.documentElement class and data-theme after toggle', () => {
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>
+    );
+    fireEvent.click(screen.getByTestId('toggle-btn'));
+    const root = document.documentElement;
+    expect(root.classList.contains('dark')).toBe(true);
+    expect(root.classList.contains('light')).toBe(false);
+    expect(root.getAttribute('data-theme')).toBe('dark');
+  });
+
+  it('updates document.documentElement class and data-theme after setTheme', () => {
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>
+    );
+    fireEvent.click(screen.getByTestId('set-dark-btn'));
+    const root = document.documentElement;
+    expect(root.classList.contains('dark')).toBe(true);
+    expect(root.classList.contains('light')).toBe(false);
+    expect(root.getAttribute('data-theme')).toBe('dark');
+  });
+
+  // ── useTheme outside provider ─────────────────────────────────
+
+  it('useTheme throws when used outside ThemeProvider', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const ThrowTest: React.FC = () => {
+      useTheme();
+      return null;
+    };
+    expect(() => render(<ThrowTest />)).toThrow(
+      'useTheme must be used within a ThemeProvider',
+    );
+    consoleError.mockRestore();
+  });
+});

--- a/packages/hub-ui/src/test/ThemeContext.test.tsx
+++ b/packages/hub-ui/src/test/ThemeContext.test.tsx
@@ -234,4 +234,50 @@ describe('ThemeContext', () => {
     );
     consoleError.mockRestore();
   });
+
+  // ── defect #1 — guarded localStorage / matchMedia ─────────────
+
+  it('falls back to OS preference when localStorage.getItem throws', () => {
+    const getItemSpy = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new DOMException('Access denied', 'SecurityError');
+    });
+    // Pretend the OS prefers dark so we can confirm the fallback path.
+    (window.matchMedia as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      query => ({
+        ...defaultMatchMedia(query),
+        matches: query === '(prefers-color-scheme: dark)',
+      }),
+    );
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId('current-theme').textContent).toBe('dark');
+    getItemSpy.mockRestore();
+  });
+
+  it('toggleTheme works when localStorage.setItem throws', () => {
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('Quota exceeded', 'QuotaExceededError');
+    });
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>,
+    );
+    // Start in light (no stored value, matchMedia defaults to false).
+    expect(screen.getByTestId('current-theme').textContent).toBe('light');
+
+    // Toggle to dark — must succeed even though setItem throws.
+    fireEvent.click(screen.getByTestId('toggle-btn'));
+    expect(screen.getByTestId('current-theme').textContent).toBe('dark');
+
+    // DOM side-effects still applied.
+    const root = document.documentElement;
+    expect(root.classList.contains('dark')).toBe(true);
+    expect(root.getAttribute('data-theme')).toBe('dark');
+
+    setItemSpy.mockRestore();
+  });
 });

--- a/packages/hub-ui/src/test/ThemeToggle.test.tsx
+++ b/packages/hub-ui/src/test/ThemeToggle.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { ThemeProvider } from '../ThemeContext';
+import { ThemeToggle } from '../components/ThemeToggle';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import React from 'react';
+
+// ── mock window.matchMedia ──────────────────────────────────────
+const defaultMatchMedia = (query: string) => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addListener: vi.fn(),
+  removeListener: vi.fn(),
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  dispatchEvent: vi.fn(),
+});
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation(query => defaultMatchMedia(query)),
+});
+
+// ── tests ───────────────────────────────────────────────────────
+describe('ThemeToggle', () => {
+  const renderToggle = (initialTheme?: string) => {
+    if (initialTheme) {
+      localStorage.setItem('theme', initialTheme);
+    }
+    return render(
+      <ThemeProvider>
+        <ThemeToggle />
+      </ThemeProvider>,
+    );
+  };
+
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.className = '';
+    document.documentElement.removeAttribute('data-theme');
+    (window.matchMedia as ReturnType<typeof vi.fn>).mockImplementation(
+      query => defaultMatchMedia(query),
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders a <button> with data-testid="theme-toggle"', () => {
+    renderToggle();
+    const btn = screen.getByTestId('theme-toggle');
+    expect(btn.tagName).toBe('BUTTON');
+  });
+
+  it('aria-label names the target theme (switches to dark) when current theme is light', () => {
+    renderToggle();
+    const btn = screen.getByTestId('theme-toggle');
+    expect(btn.getAttribute('aria-label')).toMatch(/dark/i);
+  });
+
+  it('aria-label names the target theme (switches to light) when current theme is dark', () => {
+    renderToggle('dark');
+    const btn = screen.getByTestId('theme-toggle');
+    expect(btn.getAttribute('aria-label')).toMatch(/light/i);
+  });
+
+  it('aria-pressed is "false" when theme is light', () => {
+    renderToggle();
+    const btn = screen.getByTestId('theme-toggle');
+    expect(btn.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('aria-pressed is "true" when theme is dark', () => {
+    renderToggle('dark');
+    const btn = screen.getByTestId('theme-toggle');
+    expect(btn.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('clicking the button toggles light → dark and updates DOM + localStorage', () => {
+    renderToggle();
+    const btn = screen.getByTestId('theme-toggle');
+    fireEvent.click(btn);
+
+    const root = document.documentElement;
+    expect(root.classList.contains('dark')).toBe(true);
+    expect(root.classList.contains('light')).toBe(false);
+    expect(root.getAttribute('data-theme')).toBe('dark');
+    expect(localStorage.getItem('theme')).toBe('dark');
+  });
+
+  it('clicking the button again toggles dark → light and updates DOM + localStorage', () => {
+    renderToggle();
+    const btn = screen.getByTestId('theme-toggle');
+
+    // light → dark
+    fireEvent.click(btn);
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(localStorage.getItem('theme')).toBe('dark');
+
+    // dark → light
+    fireEvent.click(btn);
+    const root = document.documentElement;
+    expect(root.classList.contains('light')).toBe(true);
+    expect(root.classList.contains('dark')).toBe(false);
+    expect(root.getAttribute('data-theme')).toBe('light');
+    expect(localStorage.getItem('theme')).toBe('light');
+  });
+
+  it('aria-label updates after click to reflect the new target theme', () => {
+    renderToggle();
+    const btn = screen.getByTestId('theme-toggle');
+
+    // Initially in light mode — label mentions dark
+    expect(btn.getAttribute('aria-label')).toMatch(/dark/i);
+
+    fireEvent.click(btn);
+    // Now in dark mode — label should mention light
+    expect(btn.getAttribute('aria-label')).toMatch(/light/i);
+  });
+});


### PR DESCRIPTION
## Summary

Adds an explicit light/dark theme toggle to the hub UI. Previously the hub followed the OS
`prefers-color-scheme` with no way for a user to override it — `packages/brand/tokens.css` even
documented this gap. The Kanban app (`packages/ui`) already had a toggle; the hub now matches.

## Changes

- **`packages/hub-ui/src/ThemeContext.tsx`** (new) — `ThemeProvider` / `useTheme` exposing
  `{ theme, toggleTheme, setTheme }`. Initialises from `localStorage`, rejecting invalid persisted
  values, and falls back to `prefers-color-scheme`. Applies the theme as a class *and* a
  `data-theme` attribute on `<html>`, and persists it.
- **`packages/hub-ui/src/components/ThemeToggle.tsx`** (new) — sidebar button with a Sun/Moon icon,
  `aria-pressed`, and an `aria-label`/`title` naming the theme it switches to.
- **`packages/hub-ui/src/main.tsx`** — wraps the app in `ThemeProvider`.
- **`packages/hub-ui/src/components/Layout.tsx`** — mounts the toggle in the sidebar panel above
  "Sign out", so it is available on every authenticated page.
- **`packages/hub-ui/src/index.css`** — declares `@variant dark` against `.dark` /
  `[data-theme="dark"]` so the 257 existing `dark:` utilities honour the explicit choice, and pins
  `color-scheme` per theme.
- **`packages/brand/tokens.css`** — comment-only fix; it claimed hub-ui had no manual toggle.

## Review findings (fixed in this PR)

Adversarial cross-model review caught three issues before merge:

1. **Crash (high)** — `localStorage` was accessed unguarded. Accessing `window.localStorage` throws
   `SecurityError` in Safari private mode and under block-all-cookies policies, and since the
   provider wraps the whole hub, that threw during first render and **blanked the entire app**. This
   was reproduced, then fixed by routing storage through the existing `useToggleSet` guard pattern;
   `matchMedia` is feature-detected too.
2. **Visual (medium)** — `color-scheme` was hardcoded to `light dark`, so native controls,
   dropdowns and scrollbars kept following the OS after an explicit choice (light page, dark
   widgets). Now pinned per theme, with the OS pair kept as the pre-choice default.
3. **Coverage (medium)** — every test exercised `ThemeToggle` in isolation, so deleting it from the
   sidebar would have left the suite green while the feature vanished. Added a `Layout` mount test
   and mutation-tested it (removing the toggle element makes it fail).

## Testing

TDD: the 22 specs were written first and committed failing (408b00d5) before any implementation.

- 147 tests / 22 files pass in `packages/hub-ui`
- Full monorepo suite: **1967 tests / 191 files pass**
- `tsc -b` clean; `vite` production build clean; `packages/ui` still builds (shared `tokens.css`)
- Verified in the compiled CSS that both the dark variant and the pinned `color-scheme` rules emit

## Known follow-up

`packages/ui/src/ThemeContext.tsx` has the same unguarded `localStorage` pattern (pre-existing, out
of scope here).