### PR TITLE
feat(hub-ui): add light/dark theme toggle to the hub

### DIFF
--- a/packages/hub-ui/src/ThemeContext.tsx
+++ b/packages/hub-ui/src/ThemeContext.tsx
@@ -1,0 +1,64 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+import type { ReactNode } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextType {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+function systemPrefersDark(): boolean {
+  return typeof window !== 'undefined'
+    && typeof window.matchMedia === 'function'
+    && window.matchMedia('(prefers-color-scheme: dark)').matches;
+}
+
+function initialTheme(): Theme {
+  if (typeof window === 'undefined') return 'light';
+  const saved = window.localStorage.getItem('theme');
+  if (saved === 'light' || saved === 'dark') return saved;
+  return systemPrefersDark() ? 'dark' : 'light';
+}
+
+/**
+ * Provides a manual light/dark theme toggle for the hub UI.
+ *
+ * The brand token layer (packages/brand/tokens.css) already defines `.dark` /
+ * `.light` classes and `[data-theme]` overrides that beat the OS
+ * `prefers-color-scheme` preference. This provider owns the choice: it writes
+ * the active class + `data-theme` attribute on `<html>` and persists the
+ * selection to `localStorage`, defaulting to the OS preference when nothing
+ * is saved.
+ */
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setTheme] = useState<Theme>(initialTheme);
+
+  useEffect(() => {
+    const root = window.document.documentElement;
+    root.classList.remove('light', 'dark');
+    root.classList.add(theme);
+    root.setAttribute('data-theme', theme);
+    window.localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme(prev => (prev === 'light' ? 'dark' : 'light'));
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme(): ThemeContextType {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+}

--- a/packages/hub-ui/src/components/Layout.tsx
+++ b/packages/hub-ui/src/components/Layout.tsx
@@ -1,8 +1,9 @@
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { api, MeResponse } from '../api';
-import { LayoutDashboard, Shield, LogOut, AlertTriangle, GitPullRequest } from 'lucide-react';
+import { LayoutDashboard, Shield, LogOut, AlertTriangle, GitPullRequest, Sun, Moon } from 'lucide-react';
 import { Logo } from './Logo';
+import { useTheme } from '../ThemeContext';
 
 interface NavItemProps { to: string; icon: React.ReactNode; label: string }
 function NavItem({ to, icon, label }: NavItemProps) {
@@ -40,8 +41,9 @@ export function Layout({ children }: { children: React.ReactNode }) {
   return (
     <div className="min-h-screen flex bg-canvas text-ink">
       <aside className="w-60 shrink-0 border-r border-border-brand bg-nav-surface backdrop-blur-sm p-4 flex flex-col gap-1">
-        <div className="px-2 pt-1 pb-5">
+        <div className="px-2 pt-1 pb-5 flex items-start justify-between gap-2">
           <Logo version={health.data?.version ?? null} />
+          <ThemeToggle />
         </div>
         <NavItem to="/" icon={<LayoutDashboard className="w-4 h-4" />} label="Org rollup" />
         <NavItem to="/prs" icon={<GitPullRequest className="w-4 h-4" />} label="PR overview" />
@@ -65,6 +67,26 @@ export function Layout({ children }: { children: React.ReactNode }) {
         {children}
       </main>
     </div>
+  );
+}
+
+/** Compact light/dark toggle for the sidebar. The brand token layer
+ * (packages/brand/tokens.css) already swaps --canvas/--surface/etc. via the
+ * `.light`/`.dark` class + `data-theme` attribute that ThemeProvider sets on
+ * <html>; this button just flips the choice. */
+function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+  const isDark = theme === 'dark';
+  return (
+    <button
+      type="button"
+      aria-label={isDark ? 'Switch to light theme' : 'Switch to dark theme'}
+      title={isDark ? 'Switch to light theme' : 'Switch to dark theme'}
+      onClick={toggleTheme}
+      className="shrink-0 mt-0.5 p-1.5 rounded-md text-ink-tertiary hover:text-ink hover:bg-chip border border-transparent hover:border-border-soft transition-colors"
+    >
+      {isDark ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
+    </button>
   );
 }
 

--- a/packages/hub-ui/src/main.tsx
+++ b/packages/hub-ui/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { App } from './App';
+import { ThemeProvider } from './ThemeContext';
 import './index.css';
 
 const qc = new QueryClient({ defaultOptions: { queries: { refetchInterval: 30_000, refetchOnWindowFocus: false } } });
@@ -10,9 +11,11 @@ const qc = new QueryClient({ defaultOptions: { queries: { refetchInterval: 30_00
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <QueryClientProvider client={qc}>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
+      <ThemeProvider>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </ThemeProvider>
     </QueryClientProvider>
   </React.StrictMode>,
 );

--- a/packages/hub-ui/src/test/LayoutThemeToggle.test.tsx
+++ b/packages/hub-ui/src/test/LayoutThemeToggle.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Layout } from '../components/Layout';
+
+// Layout relies on react-query for /auth/me, /healthz, and the admin-only
+// pending banner. Stub the api axios instance so no network is touched.
+vi.mock('../api', () => {
+  const handlers: Record<string, (url: string) => unknown> = {
+    '/auth/me': () => ({ userId: 'viewer@example.com', orgId: 'org-1', role: 'viewer' }),
+    '/healthz': () => ({ ok: true, version: '9.9.9' }),
+    '/v1/admin/system/pending': () => ({ pendingEnvOrgId: null }),
+  };
+  const get = vi.fn(async (url: string) => ({ data: (handlers[url] ?? (() => null))(url) }));
+  const post = vi.fn(async () => ({ data: {} }));
+  return { api: { get, post }, MeResponse: {} };
+});
+
+function renderLayout(child: React.ReactNode = <div>page</div>) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={['/']}>
+        <Routes>
+          <Route path="/" element={<Layout>{child}</Layout>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('Layout theme toggle', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove('light', 'dark');
+    document.documentElement.removeAttribute('data-theme');
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders a theme toggle button in the sidebar', async () => {
+    renderLayout();
+    // The button exposes its current state via aria-label so it is
+    // discoverable by assistive tech and by the test.
+    const btn = await screen.findByRole('button', { name: /switch to dark theme/i });
+    expect(btn).toBeDefined();
+  });
+
+  it('flips the theme from light to dark on click', async () => {
+    renderLayout();
+    const btn = await screen.findByRole('button', { name: /switch to dark theme/i });
+    fireEvent.click(btn);
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(localStorage.getItem('theme')).toBe('dark');
+    // After flipping to dark, the label offers switching back to light.
+    expect(screen.getByRole('button', { name: /switch to light theme/i })).toBeDefined();
+  });
+
+  it('flips back from dark to light on a second click', async () => {
+    localStorage.setItem('theme', 'dark');
+    document.documentElement.classList.add('dark');
+    renderLayout();
+    const btn = await screen.findByRole('button', { name: /switch to light theme/i });
+    fireEvent.click(btn);
+    expect(document.documentElement.classList.contains('light')).toBe(true);
+    expect(localStorage.getItem('theme')).toBe('light');
+  });
+});

--- a/packages/hub-ui/src/test/LayoutThemeToggle.test.tsx
+++ b/packages/hub-ui/src/test/LayoutThemeToggle.test.tsx
@@ -6,6 +6,7 @@ import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ThemeProvider } from '../ThemeContext';
 import { Layout } from '../components/Layout';
 
 // Layout relies on react-query for /auth/me, /healthz, and the admin-only
@@ -25,11 +26,13 @@ function renderLayout(child: React.ReactNode = <div>page</div>) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={qc}>
-      <MemoryRouter initialEntries={['/']}>
-        <Routes>
-          <Route path="/" element={<Layout>{child}</Layout>} />
-        </Routes>
-      </MemoryRouter>
+      <ThemeProvider>
+        <MemoryRouter initialEntries={['/']}>
+          <Routes>
+            <Route path="/" element={<Layout>{child}</Layout>} />
+          </Routes>
+        </MemoryRouter>
+      </ThemeProvider>
     </QueryClientProvider>,
   );
 }

--- a/packages/hub-ui/src/test/ThemeContext.test.tsx
+++ b/packages/hub-ui/src/test/ThemeContext.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { render, screen, fireEvent, cleanup, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ThemeProvider, useTheme } from '../ThemeContext';
+
+// Mock window.matchMedia (jsdom does not implement it). Defaults to a
+// light system preference; individual tests override it as needed.
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+const ThemeTester = () => {
+  const { theme, toggleTheme } = useTheme();
+  return (
+    <div>
+      <span>Current theme: {theme}</span>
+      <button onClick={toggleTheme}>Toggle</button>
+    </div>
+  );
+};
+
+describe('ThemeContext', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    // Reset <html> to a clean slate between tests.
+    document.documentElement.classList.remove('light', 'dark');
+    document.documentElement.removeAttribute('data-theme');
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('defaults to light when no saved theme and system prefers light', () => {
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>,
+    );
+    expect(screen.getByText(/Current theme: light/i)).toBeDefined();
+  });
+
+  it('applies the light class and data-theme attribute to <html>', () => {
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>,
+    );
+    expect(document.documentElement.classList.contains('light')).toBe(true);
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+  });
+
+  it('toggles from light to dark and persists the choice', () => {
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>,
+    );
+    fireEvent.click(screen.getByText('Toggle'));
+    expect(screen.getByText(/Current theme: dark/i)).toBeDefined();
+    expect(localStorage.getItem('theme')).toBe('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+  });
+
+  it('initializes from a saved dark theme in localStorage', () => {
+    localStorage.setItem('theme', 'dark');
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>,
+    );
+    expect(screen.getByText(/Current theme: dark/i)).toBeDefined();
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('falls back to system preference when no saved theme', () => {
+    (window.matchMedia as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      (query: string) => ({
+        matches: query === '(prefers-color-scheme: dark)',
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }),
+    );
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>,
+    );
+    expect(screen.getByText(/Current theme: dark/i)).toBeDefined();
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('toggles from dark back to light', () => {
+    localStorage.setItem('theme', 'dark');
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>,
+    );
+    fireEvent.click(screen.getByText('Toggle'));
+    expect(screen.getByText(/Current theme: light/i)).toBeDefined();
+    expect(localStorage.getItem('theme')).toBe('light');
+    expect(document.documentElement.classList.contains('light')).toBe(true);
+  });
+
+  it('throws when useTheme is used outside a ThemeProvider', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const ThrowTest = () => {
+      useTheme();
+      return null;
+    };
+    expect(() => render(<ThrowTest />)).toThrow(
+      'useTheme must be used within a ThemeProvider',
+    );
+    consoleError.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a manual light/dark theme toggle to the hub UI (packages/hub-ui).

Previously the hub relied solely on the OS `prefers-color-scheme` to pick a theme. The brand token layer (packages/brand/tokens.css) already defines `.dark`/`.light` class + `[data-theme]` overrides that beat the OS preference — this change adds the missing manual toggle that owns the choice.

## Changes
- **ThemeContext.tsx** (new): `ThemeProvider` + `useTheme`. Resolves initial theme (saved localStorage > system prefers-color-scheme > light), applies the `.light`/`.dark` class + `data-theme` attribute on `<html>`, and persists the choice to `localStorage`. SSR-safe `typeof window` guards.
- **main.tsx**: mounts `ThemeProvider` at the app root (above `BrowserRouter`) so every route — including Login/Setup outside the Layout — is covered.
- **Layout.tsx**: adds a compact `ThemeToggle` button to the sidebar header (next to the logo). Icon-only (Sun/Moon from lucide-react) with `aria-label` + `title` naming the target state for a11y.
- **ThemeContext.test.tsx** (new, 7 tests): default theme, `<html>` class+attr application, toggle+persist, init from storage, system-preference fallback, dark→light round-trip, throw outside provider.
- **LayoutThemeToggle.test.tsx** (new, 3 tests): sidebar renders the aria-labelled toggle, click flips light→dark (persist + class), second click flips dark→light.

## Verification
- TDD: red phase committed (modules absent, tests failing), then green.
- Full suite: 190 files / 1952 tests passing.
- hub-ui build (`tsc -b && vite build`): green.

## Notes
- No token/CSS changes required — tokens already supported both modes.
- Self-review (REVIEW step) completed: correctness, edge cases, security, performance, coverage, breaking changes, a11y all checked; no issues.
- Non-blocking observation: theme is applied in a `useEffect` (after first paint); a hard reload with a saved dark theme on a light OS could briefly flash light. Matches the proven packages/ui pattern; acceptable for this task.