### PR TITLE
feat(hub-ui): add light/dark theme toggle

### DIFF
--- a/packages/hub-ui/src/ThemeContext.tsx
+++ b/packages/hub-ui/src/ThemeContext.tsx
@@ -1,0 +1,44 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextType {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>(() => {
+    const savedTheme = localStorage.getItem('theme');
+    if (savedTheme === 'light' || savedTheme === 'dark') return savedTheme;
+    return (typeof window.matchMedia === 'function' && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'dark' : 'light';
+  });
+
+  useEffect(() => {
+    const root = window.document.documentElement;
+    root.classList.remove('light', 'dark');
+    root.classList.add(theme);
+    root.setAttribute('data-theme', theme);
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme(prev => (prev === 'light' ? 'dark' : 'light'));
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+};

--- a/packages/hub-ui/src/components/Layout.tsx
+++ b/packages/hub-ui/src/components/Layout.tsx
@@ -1,7 +1,8 @@
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { api, MeResponse } from '../api';
-import { LayoutDashboard, Shield, LogOut, AlertTriangle, GitPullRequest } from 'lucide-react';
+import { LayoutDashboard, Shield, LogOut, AlertTriangle, GitPullRequest, Sun, Moon } from 'lucide-react';
+import { useTheme } from '../ThemeContext';
 import { Logo } from './Logo';
 
 interface NavItemProps { to: string; icon: React.ReactNode; label: string }
@@ -37,6 +38,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
     mutationFn: () => api.post('/auth/logout'),
     onSuccess: () => { nav('/login'); window.location.reload(); },
   });
+  const { theme, toggleTheme } = useTheme();
   return (
     <div className="min-h-screen flex bg-canvas text-ink">
       <aside className="w-60 shrink-0 border-r border-border-brand bg-nav-surface backdrop-blur-sm p-4 flex flex-col gap-1">
@@ -48,7 +50,15 @@ export function Layout({ children }: { children: React.ReactNode }) {
         {me.data?.role === 'admin' && (
           <NavItem to="/admin" icon={<Shield className="w-4 h-4" />} label="Admin" />
         )}
-        <div className="mt-auto px-2 py-2 rounded-lg border border-border-soft bg-card-glass">
+        <button
+          onClick={toggleTheme}
+          className="mt-auto mb-2 mx-2 flex items-center justify-center gap-1.5 px-2 py-1.5 rounded-md text-[11px] font-semibold border border-border-soft text-ink-secondary hover:bg-chip hover:text-accent-text transition-colors"
+          title={theme === 'dark' ? 'Switch to Light Mode' : 'Switch to Dark Mode'}
+        >
+          {theme === 'dark' ? <Sun className="w-3 h-3" /> : <Moon className="w-3 h-3" />}
+          {theme === 'dark' ? 'Light' : 'Dark'}
+        </button>
+        <div className="px-2 py-2 rounded-lg border border-border-soft bg-card-glass">
           <div className="text-[10px] uppercase tracking-[0.16em] text-ink-tertiary">Signed in</div>
           <div className="mt-0.5 text-[12px] font-mono text-ink truncate">{me.data?.userId ?? '—'}</div>
           <div className="mt-0.5 text-[10px] uppercase tracking-[0.14em] text-accent-text">{me.data?.role}</div>

--- a/packages/hub-ui/src/index.css
+++ b/packages/hub-ui/src/index.css
@@ -14,6 +14,8 @@
  * hub-ui's compiled CSS — otherwise the modal renders unsized. */
 @source "../../flow-editor/src/**/*.{ts,tsx}";
 
+@variant dark (&:where(.dark, .dark *, [data-theme="dark"], [data-theme="dark"] *));
+
 :root { color-scheme: light dark; }
 
 html, body, #root { height: 100%; }

--- a/packages/hub-ui/src/main.tsx
+++ b/packages/hub-ui/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { App } from './App';
+import { ThemeProvider } from './ThemeContext';
 import './index.css';
 
 const qc = new QueryClient({ defaultOptions: { queries: { refetchInterval: 30_000, refetchOnWindowFocus: false } } });
@@ -10,9 +11,11 @@ const qc = new QueryClient({ defaultOptions: { queries: { refetchInterval: 30_00
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <QueryClientProvider client={qc}>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
+      <ThemeProvider>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </ThemeProvider>
     </QueryClientProvider>
   </React.StrictMode>,
 );

--- a/packages/hub-ui/src/test/LayoutThemeToggle.test.tsx
+++ b/packages/hub-ui/src/test/LayoutThemeToggle.test.tsx
@@ -1,6 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
+import React from 'react';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { ThemeProvider } from '../ThemeContext';
 import { Layout } from '../components/Layout';

--- a/packages/hub-ui/src/test/LayoutThemeToggle.test.tsx
+++ b/packages/hub-ui/src/test/LayoutThemeToggle.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { ThemeProvider } from '../ThemeContext';
+import { Layout } from '../components/Layout';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../api', () => ({
+  api: {
+    get: vi.fn().mockImplementation((url: string) => {
+      if (url === '/healthz') return Promise.resolve({ data: { ok: true, version: 'test' } });
+      if (url === '/auth/me') return Promise.resolve({ data: { userId: 'u1', role: 'admin' } });
+      if (url === '/v1/admin/system/pending') return Promise.resolve({ data: { pendingEnvOrgId: null } });
+      return Promise.resolve({ data: {} });
+    }),
+    post: vi.fn().mockResolvedValue({ data: {} }),
+  },
+}));
+
+const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+function wrap(ui: React.ReactNode) {
+  return (
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <ThemeProvider>{ui}</ThemeProvider>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('Layout theme toggle', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove('light', 'dark');
+    document.documentElement.removeAttribute('data-theme');
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders a "Switch to Dark Mode" button when theme is light', () => {
+    render(wrap(<Layout><div>content</div></Layout>));
+    expect(screen.getByTitle(/Switch to Dark Mode/i)).toBeDefined();
+  });
+
+  it('flips to dark, persists, and sets the html class + data-theme on click', () => {
+    render(wrap(<Layout><div>content</div></Layout>));
+    const btn = screen.getByTitle(/Switch to Dark Mode/i);
+    fireEvent.click(btn);
+    expect(screen.getByTitle(/Switch to Light Mode/i)).toBeDefined();
+    expect(localStorage.getItem('theme')).toBe('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(document.documentElement.classList.contains('light')).toBe(false);
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+  });
+});

--- a/packages/hub-ui/src/test/ThemeContext.test.tsx
+++ b/packages/hub-ui/src/test/ThemeContext.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { ThemeProvider, useTheme } from '../ThemeContext';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import React from 'react';
+
+// Mock window.matchMedia
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+const ThemeTester = () => {
+  const { theme, toggleTheme } = useTheme();
+  return (
+    <div>
+      <span>Current theme: {theme}</span>
+      <button onClick={toggleTheme}>Toggle</button>
+    </div>
+  );
+};
+
+describe('ThemeContext', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('should provide default theme', () => {
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>
+    );
+    expect(screen.getByText(/Current theme: light/i)).toBeDefined();
+  });
+
+  it('should toggle theme', () => {
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>
+    );
+    const toggleBtn = screen.getByText('Toggle');
+    fireEvent.click(toggleBtn);
+    expect(screen.getByText(/Current theme: dark/i)).toBeDefined();
+    expect(localStorage.getItem('theme')).toBe('dark');
+  });
+
+  it('should initialize with dark theme from localStorage', () => {
+    localStorage.setItem('theme', 'dark');
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>
+    );
+    expect(screen.getByText(/Current theme: dark/i)).toBeDefined();
+  });
+
+  it('should provide dark theme when system prefers dark and no localStorage', () => {
+    (window.matchMedia as ReturnType<typeof vi.fn>).mockImplementationOnce((query: string) => ({
+      matches: query === '(prefers-color-scheme: dark)',
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>
+    );
+    expect(screen.getByText(/Current theme: dark/i)).toBeDefined();
+  });
+
+  it('should toggle from dark back to light', () => {
+    localStorage.setItem('theme', 'dark');
+    render(
+      <ThemeProvider>
+        <ThemeTester />
+      </ThemeProvider>
+    );
+    const toggleBtn = screen.getByText('Toggle');
+    fireEvent.click(toggleBtn);
+    expect(screen.getByText(/Current theme: light/i)).toBeDefined();
+    expect(localStorage.getItem('theme')).toBe('light');
+  });
+
+  it('useTheme should throw when used outside ThemeProvider', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const ThrowTest = () => {
+      useTheme();
+      return null;
+    };
+    expect(() => render(<ThrowTest />)).toThrow('useTheme must be used within a ThemeProvider');
+    consoleError.mockRestore();
+  });
+});


### PR DESCRIPTION
## What

Adds a manual light/dark **theme toggle** to the hub UI (packages/hub-ui), so users can switch themes regardless of their OS `prefers-color-scheme` setting. The choice persists across sessions.

## Why

The hub-ui relied solely on `prefers-color-scheme` for theming (the `dark:` Tailwind variant followed the OS). There was no manual toggle, while the sibling Kanban package (`packages/ui`) already had one. `packages/brand/tokens.css` already defines explicit `.dark`/`.light` + `[data-theme]` overrides — only the provider, UI control, and variant wiring were missing.

## Changes

- **`packages/hub-ui/src/ThemeContext.tsx`** (new) — mirrors `packages/ui`'s pattern: `ThemeProvider` + `useTheme`, localStorage `'theme'` with OS `prefers-color-scheme` fallback, syncs `.light`/`.dark` class + `data-theme` attribute on `<html>`. Stale/corrupt localStorage values fall through to OS detection.
- **`packages/hub-ui/src/main.tsx`** — wraps the app in `<ThemeProvider>` (inside `QueryClientProvider`, outside `BrowserRouter`).
- **`packages/hub-ui/src/components/Layout.tsx`** — adds a Sun/Moon toggle button to the sidebar nav (title: "Switch to Dark/Light Mode"); `mt-auto` moved from the signed-in card to the button so the toggle pins to the bottom.
- **`packages/hub-ui/src/index.css`** — adds `@variant dark` (byte-identical to `packages/ui`) so existing `dark:` utilities follow the manual `.dark`/`[data-theme=dark]` toggle instead of only `prefers-color-scheme`.
- **Tests** (TDD): `ThemeContext.test.tsx` (6: default/toggle/localStorage-init/OS-pref/round-trip/throw-outside-provider) + `LayoutThemeToggle.test.tsx` (2: render + click-flips-persists-class-attr).

## Verification

- TDD red→green: 8/8 theme-toggle tests pass.
- Full hub-ui suite: **130/130 pass** (21 files, no regressions).
- `tsc -b` clean; `vite build` succeeds.
- Cross-model adversarial review (GLM 5.2 reviewer vs Qwen author): approved — no security/correctness/breaking-change issues. localStorage values only compared against `'light'`/`'dark'` literals and used as a class name + attribute (sanitized, no injection). `@variant dark` line identical to `packages/ui`.

## Notes / follow-ups

- Minor non-blocking nit: no inline pre-React theme script in `index.html`, so a brief flash of the OS-default theme can occur before React mounts when a saved preference differs from the OS — same limitation as `packages/ui` (parity, not a regression); candidate for a follow-up.
- Orchestrated multi-agent run: GLM 5.2 orchestrator + Qwen 3.6:27b (CGLab) coding worker, AgEnFK TDD flow gates.