### PR TITLE
feat(hub): merge event-attribution identities, and stop the per-user page hiding event types

### DIFF
--- a/packages/hub-ui/src/pages/Admin.tsx
+++ b/packages/hub-ui/src/pages/Admin.tsx
@@ -1,11 +1,15 @@
 import { useState } from 'react';
 import { Outlet, NavLink } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { ShieldCheck, KeyRound, Users, Trash2, Copy, Check, GitBranch, ArrowUpCircle, Server, Building2, X, EyeOff, Eye } from 'lucide-react';
+import { ShieldCheck, KeyRound, Users, Trash2, Copy, Check, GitBranch, ArrowUpCircle, Server, Building2, X, EyeOff, Eye, GitMerge } from 'lucide-react';
 import { api } from '../api';
 import { fmtDate } from '../dates';
 import { canDeleteUserRow } from './canDeleteUserRow';
 import { hideTargetKey, partitionHiddenRows, canHideRow } from './hiddenPeople';
+import {
+  UserKeyRow, deriveMergeSources, validateMerge, mergeSourceCandidates,
+  mergeConfirmMessage, formatMergeResult,
+} from './userKeyMerge';
 
 export function AdminLayout() {
   const link = ({ isActive }: { isActive: boolean }) =>
@@ -677,6 +681,130 @@ export function AdminInstallations() {
           </ul>
         </section>
       )}
+
+      <MergeIdentities />
     </div>
+  );
+}
+
+/**
+ * Admin → Merge identities. `user_key` is derived at ingest from the reporting
+ * client's git identity, so a wrong git config permanently splits one person
+ * across several rows (a literal `=` from `git config user.email = "x"`, or the
+ * OS username when git email is unset). Hiding those rows throws the work away;
+ * this credits it to the identity they should have reported as.
+ */
+function MergeIdentities() {
+  const qc = useQueryClient();
+  const [target, setTarget] = useState('');
+  const [selected, setSelected] = useState<string[]>([]);
+  const [done, setDone] = useState<string | null>(null);
+
+  const users = useQuery<UserKeyRow[]>({
+    queryKey: ['admin-merge-user-keys'],
+    queryFn: async () => (await api.get('/v1/users')).data,
+  });
+
+  const merge = useMutation({
+    mutationFn: (body: { from: string[]; to: string }) => api.post('/v1/admin/user-keys/merge', body),
+    onSuccess: (res, body) => {
+      setDone(formatMergeResult(body.to, res.data ?? {}));
+      setSelected([]);
+      // Every people-keyed surface is now stale, not just this list.
+      qc.invalidateQueries({ queryKey: ['admin-merge-user-keys'] });
+      qc.invalidateQueries({ queryKey: ['admin-installations'] });
+      qc.invalidateQueries({ queryKey: ['admin-hidden-users'] });
+      qc.invalidateQueries({ queryKey: ['users'] });
+      qc.invalidateQueries({ queryKey: ['metrics'] });
+      qc.invalidateQueries({ queryKey: ['timeline'] });
+    },
+  });
+
+  const rows = users.data ?? [];
+  const candidates = mergeSourceCandidates(rows, target);
+  const problem = validateMerge(selected, target);
+
+  const toggle = (key: string) =>
+    setSelected(prev => (prev.includes(key) ? prev.filter(k => k !== key) : [...prev, key]));
+
+  if (rows.length < 2) return null;
+
+  return (
+    <section className={cardCls}>
+      <header>
+        <h3 className="text-sm font-semibold text-ink">Merge identities</h3>
+        <p className="mt-0.5 text-xs text-ink-tertiary">
+          People are keyed on the git email their client reports, falling back to its OS username. A wrong
+          git config therefore creates a second identity for someone already here — a literal <code className="font-mono">=</code>{' '}
+          comes from <code className="font-mono">git config user.email = "…"</code>. Merging credits the
+          selected identities' events, daily rollups and installations to the one you keep. It cannot be undone.
+        </p>
+      </header>
+
+      <div className="mt-4 space-y-1.5">
+        <label className="block text-[11px] uppercase tracking-[0.14em] text-ink-tertiary font-semibold">
+          Identity to keep
+        </label>
+        <select
+          value={target}
+          onChange={e => { setTarget(e.target.value); setSelected([]); setDone(null); }}
+          className="w-full max-w-md rounded-lg border border-border-soft bg-surface px-3 py-2 text-sm text-ink font-mono"
+        >
+          <option value="">Choose…</option>
+          {rows.map(r => (
+            <option key={r.user_key} value={r.user_key}>{r.user_key}</option>
+          ))}
+        </select>
+      </div>
+
+      {target && (
+        <div className="mt-4">
+          <p className="text-[11px] uppercase tracking-[0.14em] text-ink-tertiary font-semibold">Merge in</p>
+          <ul className="mt-2 divide-y divide-border-soft">
+            {candidates.map(r => (
+              <li key={r.user_key} className="flex items-center justify-between py-2">
+                <label className="flex items-center gap-2.5 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={selected.includes(r.user_key)}
+                    onChange={() => { toggle(r.user_key); setDone(null); }}
+                    className="accent-[var(--accent)]"
+                  />
+                  <span className="font-mono text-xs text-ink-secondary">{r.user_key}</span>
+                </label>
+                <span className="text-[11px] text-ink-tertiary tabular-nums">{Number(r.events_count ?? 0)} events</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <div className="mt-4 flex items-center gap-3">
+        <button
+          onClick={() => {
+            const from = deriveMergeSources(selected, target);
+            if (problem) return;
+            if (confirm(mergeConfirmMessage(selected, target))) {
+              merge.mutate({ from, to: target });
+            }
+          }}
+          disabled={!!problem || merge.isPending}
+          className="inline-flex items-center gap-1.5 rounded-lg bg-[image:var(--gradient-accent)] px-3 py-1.5 text-[12px] font-semibold text-navy shadow-glow disabled:opacity-40 disabled:shadow-none"
+        >
+          <GitMerge className="w-3.5 h-3.5" />
+          {merge.isPending ? 'Merging…' : 'Merge identities'}
+        </button>
+        {problem && <span className="text-[11px] text-ink-tertiary">{problem}</span>}
+      </div>
+
+      {merge.isError && (
+        <p className="mt-3 text-xs text-red-600 dark:text-red-400">
+          {(merge.error as any)?.response?.data?.error ?? 'Merge failed.'}
+        </p>
+      )}
+      {done && !merge.isError && (
+        <p className="mt-3 text-xs text-accent-text">{done}</p>
+      )}
+    </section>
   );
 }

--- a/packages/hub-ui/src/pages/UserDetail.tsx
+++ b/packages/hub-ui/src/pages/UserDetail.tsx
@@ -8,6 +8,12 @@ import { FacetMultiselect } from '../components/FacetMultiselect';
 import { MetricsTilesRow, MetricsTotals } from '../components/MetricsTilesRow';
 import { shortRemote } from '../components/facetSearch';
 import { mergeEventTypes } from '../eventTypes';
+import {
+  DEFAULT_USER_EVENT_TYPES,
+  USER_EVENT_TYPES_STORAGE_KEY,
+  USER_ITEM_TYPES_STORAGE_KEY,
+  USER_PROJECTS_STORAGE_KEY,
+} from './userDetailFilters';
 import { fmtDateTime, browserTimezone } from '../dates';
 import { useToggleSet } from '../hooks/useToggleSet';
 import { scrollPageToTop } from '../scroll';
@@ -108,12 +114,14 @@ export function UserDetailPage() {
   const decoded = decodeURIComponent(userKey);
 
   useEffect(() => { scrollPageToTop(); }, [userKey]);
-  // Default to "what did this user ship?" — closures only — until the dev
-  // widens the chip selection. Persisted in localStorage so a refresh
+  // Nothing is filtered out by default — see userDetailFilters.ts for why this
+  // is no longer "closures only". Persisted in localStorage so a refresh
   // restores the developer's last selection rather than snapping back.
-  const eventTypeSel = useToggleSet(['item.closed'], { storageKey: 'agenfk-hub:user:eventTypes' });
-  const projectSel = useToggleSet([], { storageKey: 'agenfk-hub:user:projects' });
-  const itemTypeSel = useToggleSet([], { storageKey: 'agenfk-hub:user:itemTypes' });
+  const eventTypeSel = useToggleSet(DEFAULT_USER_EVENT_TYPES, {
+    storageKey: USER_EVENT_TYPES_STORAGE_KEY,
+  });
+  const projectSel = useToggleSet([], { storageKey: USER_PROJECTS_STORAGE_KEY });
+  const itemTypeSel = useToggleSet([], { storageKey: USER_ITEM_TYPES_STORAGE_KEY });
   const [range, setRange] = useState<RangeKey>('30d');
   const [customStart, setCustomStart] = useState('');
   const [customEnd, setCustomEnd] = useState('');

--- a/packages/hub-ui/src/pages/userDetailFilters.ts
+++ b/packages/hub-ui/src/pages/userDetailFilters.ts
@@ -1,0 +1,44 @@
+/**
+ * Filter defaults for the per-user page.
+ *
+ * Extracted so the defaults are pinned by test rather than living as literals in
+ * the middle of a 300-line component — the previous default was a one-word
+ * change away from hiding a person's work again, with nothing to catch it.
+ */
+
+/**
+ * No event type is filtered out by default.
+ *
+ * This page used to open with `['item.closed']` — "what did this user ship?".
+ * The intent was reasonable and the effect was not: a profile page that shows
+ * one of sixteen event types looks, to the person reading it, exactly like a
+ * hub that failed to record their work. It was reported three times as a
+ * missing-data bug (a commit, then a PR, then a PR again) before anyone noticed
+ * the chip was doing it, because nothing on the page says "you are seeing a
+ * subset" — the count beside the timeline reports the FILTERED total, which
+ * reads as the truth.
+ *
+ * Empty is also what the other two selectors on this page already default to
+ * (`projects`, `itemTypes`), so this makes event types consistent with its
+ * neighbours instead of the one special case. Narrowing stays one tap away; the
+ * chips are directly above the timeline.
+ */
+export const DEFAULT_USER_EVENT_TYPES: readonly string[] = [];
+
+/**
+ * Versioned deliberately — `:v2` is load-bearing, not decoration.
+ *
+ * `useToggleSet` persists on mount, not just on change, so every developer who
+ * has ever opened this page already has `["item.closed"]` written under the v1
+ * key. `readPersistedSet` honours a stored value whenever the key exists (an
+ * explicitly-emptied set must round-trip as empty, which is correct), so a
+ * stored v1 selection would outrank the new default forever and the fix would
+ * ship without changing anything for the people who hit the problem.
+ *
+ * Bumping the key retires those writes once. The cost is that a genuinely
+ * intentional v1 selection is forgotten on first load after upgrade — which is
+ * the right trade against silently hiding the page's contents.
+ */
+export const USER_EVENT_TYPES_STORAGE_KEY = 'agenfk-hub:user:eventTypes:v2';
+export const USER_PROJECTS_STORAGE_KEY = 'agenfk-hub:user:projects';
+export const USER_ITEM_TYPES_STORAGE_KEY = 'agenfk-hub:user:itemTypes';

--- a/packages/hub-ui/src/pages/userKeyMerge.ts
+++ b/packages/hub-ui/src/pages/userKeyMerge.ts
@@ -1,0 +1,94 @@
+/**
+ * Helpers for the admin → Merge identities UI.
+ *
+ * Pure logic so the existing hub-ui test convention (no RTL) keeps working.
+ *
+ * Context: `user_key` is minted at ingest from the reporting client's git
+ * identity, so one person shows up as several rows when their git config is
+ * wrong (a literal `=` from `git config user.email = "x"`, or the OS username
+ * when git email is unset). This screen folds those rows into the real one.
+ *
+ * Normalization and the source cap MUST stay in lockstep with
+ * packages/hub/src/routes/userKeyMerge.ts — the server is the source of truth,
+ * but validating here saves a round-trip and lets us disable the button with an
+ * inline reason instead of surfacing a 400.
+ */
+
+/** Mirrors MAX_SOURCES in the server route. */
+export const MAX_MERGE_SOURCES = 50;
+
+/** Mirrors normalizeKey() in the server route. */
+export function normalizeUserKey(v: unknown): string {
+  return typeof v === 'string' ? v.trim().toLowerCase() : '';
+}
+
+export interface UserKeyRow {
+  user_key: string;
+  events_count?: number | string;
+}
+
+/**
+ * Source keys the request will actually carry: normalized, deduped, and with
+ * the target removed. Merging a key into itself is a no-op rather than an
+ * error, so it is filtered here exactly as the server filters it.
+ */
+export function deriveMergeSources(selected: readonly string[], target: string): string[] {
+  const to = normalizeUserKey(target);
+  return [...new Set(selected.map(normalizeUserKey).filter((k) => k && k !== to))];
+}
+
+/**
+ * Inline validation message, or null when the merge is submittable. Ordered so
+ * the message names the first thing the operator has to fix.
+ */
+export function validateMerge(selected: readonly string[], target: string): string | null {
+  if (!normalizeUserKey(target)) return 'Choose the identity to keep.';
+  const sources = deriveMergeSources(selected, target);
+  if (sources.length === 0) return 'Select at least one other identity to merge in.';
+  if (sources.length > MAX_MERGE_SOURCES) {
+    return `Select at most ${MAX_MERGE_SOURCES} identities to merge (selected ${sources.length}).`;
+  }
+  return null;
+}
+
+/** Rows offered as merge sources: everything except the chosen target. */
+export function mergeSourceCandidates<T extends UserKeyRow>(rows: readonly T[], target: string): T[] {
+  const to = normalizeUserKey(target);
+  return rows.filter((r) => normalizeUserKey(r.user_key) !== to);
+}
+
+/**
+ * Confirmation copy. The merge is not reversible — once events are repointed
+ * the hub has no record of which identity they arrived under — so the operator
+ * gets told that in the same breath as the counts.
+ */
+export function mergeConfirmMessage(selected: readonly string[], target: string): string {
+  const sources = deriveMergeSources(selected, target);
+  const to = normalizeUserKey(target);
+  const what = sources.length === 1 ? '1 identity' : `${sources.length} identities`;
+  return `Merge ${what} into ${to}? Their events, daily rollups and installations `
+    + 'will be credited to it. This cannot be undone.';
+}
+
+export interface MergeResultLike {
+  events?: number;
+  rollupsRemoved?: number;
+  installations?: number;
+  hiddenRemoved?: number;
+}
+
+/**
+ * Success banner text. `events: 0` is a real and unalarming outcome — it means
+ * the keys were already merged (the endpoint is idempotent) — so it is reported
+ * plainly rather than styled as a failure.
+ */
+export function formatMergeResult(to: string, r: MergeResultLike): string {
+  const events = r.events ?? 0;
+  const parts = [`${events} event${events === 1 ? '' : 's'} now credited to ${normalizeUserKey(to)}`];
+  if (r.rollupsRemoved) parts.push(`${r.rollupsRemoved} daily rollup row(s) folded in`);
+  if (r.installations) parts.push(`${r.installations} installation(s) relabelled`);
+  if (r.hiddenRemoved) parts.push(`${r.hiddenRemoved} stale hide(s) cleared`);
+  return events === 0
+    ? `Nothing to move — those identities were already merged into ${normalizeUserKey(to)}.`
+    : `${parts.join('; ')}.`;
+}

--- a/packages/hub-ui/src/test/userDetailFilters.test.ts
+++ b/packages/hub-ui/src/test/userDetailFilters.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+
+import { readPersistedSet } from '../hooks/useToggleSet';
+import {
+  DEFAULT_USER_EVENT_TYPES,
+  USER_EVENT_TYPES_STORAGE_KEY,
+  USER_ITEM_TYPES_STORAGE_KEY,
+  USER_PROJECTS_STORAGE_KEY,
+} from '../pages/userDetailFilters';
+
+const makeStorage = (seed: Record<string, string> = {}) => {
+  const map = new Map(Object.entries(seed));
+  return {
+    getItem: (k: string) => map.get(k) ?? null,
+    setItem: (k: string, v: string) => void map.set(k, v),
+  };
+};
+
+describe('per-user page filter defaults', () => {
+  it('hides nothing by default', () => {
+    // The regression this guards: a profile page opening on a single event type
+    // is indistinguishable, to the person reading it, from a hub that failed to
+    // record their work.
+    expect([...DEFAULT_USER_EVENT_TYPES]).toEqual([]);
+  });
+
+  it('defaults event types the same way as the other two selectors', () => {
+    // Event types used to be the one special case on this page. Consistency is
+    // the point: three filters, three empty defaults.
+    const storage = makeStorage();
+    expect([...readPersistedSet(storage, USER_EVENT_TYPES_STORAGE_KEY, DEFAULT_USER_EVENT_TYPES)])
+      .toEqual([...readPersistedSet(storage, USER_PROJECTS_STORAGE_KEY, [])]);
+    expect([...readPersistedSet(storage, USER_ITEM_TYPES_STORAGE_KEY, [])]).toEqual([]);
+  });
+
+  it('uses a storage key that retires the old persisted selection', () => {
+    // useToggleSet persists on MOUNT, so everyone who has opened this page has
+    // ["item.closed"] written under the v1 key, and readPersistedSet honours a
+    // stored value whenever the key exists. Without a new key the fix would ship
+    // and change nothing for exactly the people who reported the problem.
+    expect(USER_EVENT_TYPES_STORAGE_KEY).not.toBe('agenfk-hub:user:eventTypes');
+    expect(USER_EVENT_TYPES_STORAGE_KEY).toMatch(/:v[2-9]\d*$/);
+
+    const stale = makeStorage({ 'agenfk-hub:user:eventTypes': '["item.closed"]' });
+    // The stale v1 write is not consulted…
+    expect([...readPersistedSet(stale, USER_EVENT_TYPES_STORAGE_KEY, DEFAULT_USER_EVENT_TYPES)])
+      .toEqual([]);
+    // …while the old key still holds it, proving the read moved rather than the
+    // data being cleared out from under an unrelated consumer.
+    expect(stale.getItem('agenfk-hub:user:eventTypes')).toBe('["item.closed"]');
+  });
+
+  it('still lets a developer narrow to a single type and have it stick', () => {
+    // The fix must not remove the capability, only the default.
+    const storage = makeStorage({ [USER_EVENT_TYPES_STORAGE_KEY]: '["pr.opened"]' });
+    expect([...readPersistedSet(storage, USER_EVENT_TYPES_STORAGE_KEY, DEFAULT_USER_EVENT_TYPES)])
+      .toEqual(['pr.opened']);
+  });
+});

--- a/packages/hub-ui/src/test/userKeyMerge.test.ts
+++ b/packages/hub-ui/src/test/userKeyMerge.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MAX_MERGE_SOURCES,
+  normalizeUserKey,
+  deriveMergeSources,
+  validateMerge,
+  mergeSourceCandidates,
+  mergeConfirmMessage,
+  formatMergeResult,
+} from '../pages/userKeyMerge';
+
+describe('normalizeUserKey', () => {
+  it('trims and lowercases, matching the server', () => {
+    expect(normalizeUserKey('  Jonatan.Sporn@CGLab.com ')).toBe('jonatan.sporn@cglab.com');
+    expect(normalizeUserKey('JonatanSporn')).toBe('jonatansporn');
+  });
+
+  it('maps non-strings to empty', () => {
+    expect(normalizeUserKey(undefined)).toBe('');
+    expect(normalizeUserKey(null)).toBe('');
+    expect(normalizeUserKey(42)).toBe('');
+  });
+
+  it('preserves the literal = key a broken git config produces', () => {
+    expect(normalizeUserKey('=')).toBe('=');
+  });
+});
+
+describe('deriveMergeSources', () => {
+  it('normalizes, dedupes and drops the target', () => {
+    expect(deriveMergeSources(['=', 'JonatanSporn', 'jonatansporn', 'real@x'], 'real@x'))
+      .toEqual(['=', 'jonatansporn']);
+  });
+
+  it('drops blanks', () => {
+    expect(deriveMergeSources(['', '   ', '='], 'real@x')).toEqual(['=']);
+  });
+
+  it('returns empty when only the target was selected', () => {
+    expect(deriveMergeSources(['Real@X'], 'real@x')).toEqual([]);
+  });
+});
+
+describe('validateMerge', () => {
+  it('requires a target first', () => {
+    expect(validateMerge(['='], '')).toMatch(/identity to keep/);
+    expect(validateMerge(['='], '   ')).toMatch(/identity to keep/);
+  });
+
+  it('requires at least one source that differs from the target', () => {
+    expect(validateMerge([], 'real@x')).toMatch(/at least one/);
+    expect(validateMerge(['real@x'], 'real@x')).toMatch(/at least one/);
+  });
+
+  it('enforces the same cap as the server', () => {
+    const many = Array.from({ length: MAX_MERGE_SOURCES + 1 }, (_, i) => `k${i}@x`);
+    expect(validateMerge(many, 'real@x')).toMatch(/at most 50/);
+    const atCap = Array.from({ length: MAX_MERGE_SOURCES }, (_, i) => `k${i}@x`);
+    expect(validateMerge(atCap, 'real@x')).toBeNull();
+  });
+
+  it('passes a valid selection', () => {
+    expect(validateMerge(['=', 'jonatansporn'], 'jonatan.sporn@cglab.com')).toBeNull();
+  });
+});
+
+describe('mergeSourceCandidates', () => {
+  it('excludes the target case-insensitively', () => {
+    const rows = [{ user_key: '=' }, { user_key: 'Real@X' }, { user_key: 'jonatansporn' }];
+    expect(mergeSourceCandidates(rows, 'real@x').map(r => r.user_key)).toEqual(['=', 'jonatansporn']);
+  });
+
+  it('returns every row when no target is chosen', () => {
+    const rows = [{ user_key: '=' }, { user_key: 'a@x' }];
+    expect(mergeSourceCandidates(rows, '')).toHaveLength(2);
+  });
+});
+
+describe('mergeConfirmMessage', () => {
+  it('singularises one source and warns it is irreversible', () => {
+    const m = mergeConfirmMessage(['='], 'real@x');
+    expect(m).toContain('Merge 1 identity into real@x?');
+    expect(m).toContain('cannot be undone');
+  });
+
+  it('pluralises several sources', () => {
+    expect(mergeConfirmMessage(['=', 'jonatansporn'], 'real@x')).toContain('Merge 2 identities');
+  });
+});
+
+describe('formatMergeResult', () => {
+  it('summarises what moved', () => {
+    const s = formatMergeResult('Real@X', { events: 3, rollupsRemoved: 1, installations: 1, hiddenRemoved: 1 });
+    expect(s).toContain('3 events now credited to real@x');
+    expect(s).toContain('1 daily rollup row(s) folded in');
+    expect(s).toContain('1 installation(s) relabelled');
+    expect(s).toContain('1 stale hide(s) cleared');
+  });
+
+  it('singularises a single event', () => {
+    expect(formatMergeResult('a@x', { events: 1 })).toContain('1 event now credited');
+  });
+
+  it('reports an already-merged no-op plainly rather than as a failure', () => {
+    const s = formatMergeResult('a@x', { events: 0, rollupsRemoved: 0 });
+    expect(s).toMatch(/already merged into a@x/);
+    expect(s).not.toMatch(/error|fail/i);
+  });
+
+  it('omits zero-valued companion counts', () => {
+    const s = formatMergeResult('a@x', { events: 2, rollupsRemoved: 0, installations: 0, hiddenRemoved: 0 });
+    expect(s).toBe('2 events now credited to a@x.');
+  });
+});

--- a/packages/hub/src/routes/userKeyMerge.ts
+++ b/packages/hub/src/routes/userKeyMerge.ts
@@ -1,0 +1,148 @@
+import { Router, Request, Response } from 'express';
+import { HubServerContext } from '../server.js';
+import { requireAdmin } from '../auth/session.js';
+
+/**
+ * POST /v1/admin/user-keys/merge — fold one or more event-attribution
+ * identities into another.
+ *
+ * Why this exists: `user_key` is derived at ingest from the reporting client's
+ * git identity (`routes/events.ts` → `actor.gitEmail?.toLowerCase() ||
+ * actor.osUser || 'unknown'`). A misconfigured client therefore mints a
+ * *permanent* second identity for a person who is already in the hub — e.g.
+ * `git config user.email = "x"` stores the email as the literal `=`, and an
+ * unset git email falls back to the OS username. The dashboard then credits
+ * one human's work to two or three separate rows forever.
+ *
+ * Before this endpoint the only remedies were `hidden_users` (which discards
+ * the work rather than crediting it) or hand-written SQL against the
+ * deployment — the admin DB console is read-only by design. This is the
+ * `orgs/rename` pattern applied to `user_key`: one transaction, every
+ * `user_key`-bearing table, no data loss.
+ *
+ * Note that `rollups_daily` is *summed*, not repointed: its primary key is
+ * (org_id, user_key, day), so two identities active on the same day collide.
+ * Summing the stored rows (rather than recomputing them from `events`) also
+ * preserves columns that a recompute would zero — `tokens_in`/`tokens_out` are
+ * hardcoded to 0 by the aggregation in `rollup.ts`, so recomputing an old day
+ * would silently drop token history the background timer never revisits.
+ */
+
+/**
+ * Tables with a `user_key` column, and how a merge must treat each. Kept as a
+ * literal so the companion regression test can pin it against runtime
+ * introspection — if you add a `user_key`-bearing table, add it here.
+ */
+export const USER_KEY_TABLES = {
+  /** Repointed: the source of truth every dashboard query groups on. */
+  repoint: ['events'] as const,
+  /** Summed on (org_id, day) — see the note above. */
+  sum: ['rollups_daily'] as const,
+  /** Source rows dropped: the key ceases to exist, so a hide of it is stale. */
+  drop: ['hidden_users'] as const,
+};
+
+/** Guard against a pathological request fanning out an unbounded IN (...). */
+const MAX_SOURCES = 50;
+
+function normalizeKey(v: unknown): string {
+  return typeof v === 'string' ? v.trim().toLowerCase() : '';
+}
+
+export function userKeyMergeRouter(ctx: HubServerContext): Router {
+  const router = Router();
+  const guard = requireAdmin(ctx.config.sessionSecret);
+
+  router.post('/user-keys/merge', guard, async (req: Request, res: Response) => {
+    const orgId = req.session!.orgId;
+
+    const to = normalizeKey(req.body?.to);
+    if (!to) {
+      return res.status(400).json({ error: 'Body must include { to: string } (non-empty).' });
+    }
+
+    // Accept a bare string for the single-source case; both shapes normalize to
+    // a deduped list that never contains `to` itself (merging a key into itself
+    // is a no-op, not an error, so it is filtered rather than rejected).
+    const rawFrom = req.body?.from;
+    const fromList = Array.isArray(rawFrom) ? rawFrom : [rawFrom];
+    const from = [...new Set(fromList.map(normalizeKey).filter((k) => k && k !== to))];
+
+    if (from.length === 0) {
+      return res.status(400).json({
+        error: 'Body must include { from: string | string[] } with at least one key that differs from `to`.',
+      });
+    }
+    if (from.length > MAX_SOURCES) {
+      return res.status(400).json({ error: `\`from\` may list at most ${MAX_SOURCES} keys.` });
+    }
+
+    // `user_key` is stored lowercased for git emails but verbatim for the
+    // `osUser` fallback, so every match is made case-insensitively via lower().
+    const ph = from.map(() => '?').join(', ');
+
+    let events = 0;
+    let rollupsRemoved = 0;
+    let installations = 0;
+    let hiddenRemoved = 0;
+
+    await ctx.db.transaction(async () => {
+      const ev = await ctx.db.run(
+        `UPDATE events SET user_key = ?
+          WHERE org_id = ? AND lower(user_key) IN (${ph})`,
+        [to, orgId, ...from],
+      );
+      events = ev.changes;
+
+      // Fold the sources' daily rollups into the target's. `to` is included in
+      // the source set so its own existing counts survive the DO UPDATE — the
+      // summed row must be the total, not just the incoming half.
+      await ctx.db.run(
+        `INSERT INTO rollups_daily
+           (org_id, user_key, day, events_count, items_closed, tokens_in, tokens_out, validate_passes, validate_fails, prs_opened)
+         SELECT org_id, ?, day,
+                SUM(events_count), SUM(items_closed), SUM(tokens_in), SUM(tokens_out),
+                SUM(validate_passes), SUM(validate_fails), SUM(prs_opened)
+           FROM rollups_daily
+          WHERE org_id = ? AND lower(user_key) IN (${ph}, ?)
+          GROUP BY org_id, day
+         ON CONFLICT(org_id, user_key, day) DO UPDATE SET
+           events_count = excluded.events_count,
+           items_closed = excluded.items_closed,
+           tokens_in = excluded.tokens_in,
+           tokens_out = excluded.tokens_out,
+           validate_passes = excluded.validate_passes,
+           validate_fails = excluded.validate_fails,
+           prs_opened = excluded.prs_opened`,
+        [to, orgId, ...from, to],
+      );
+
+      const rr = await ctx.db.run(
+        `DELETE FROM rollups_daily WHERE org_id = ? AND lower(user_key) IN (${ph})`,
+        [orgId, ...from],
+      );
+      rollupsRemoved = rr.changes;
+
+      // Cosmetic but load-bearing for the Installations admin page: the client
+      // still reports its own actor on each event, so this does not change how
+      // future keys are derived — it stops the old label lingering next to an
+      // installation whose history now belongs to `to`.
+      const inst = await ctx.db.run(
+        `UPDATE installations SET git_email = ?
+          WHERE org_id = ? AND lower(git_email) IN (${ph})`,
+        [to, orgId, ...from],
+      );
+      installations = inst.changes;
+
+      const hu = await ctx.db.run(
+        `DELETE FROM hidden_users WHERE org_id = ? AND lower(user_key) IN (${ph})`,
+        [orgId, ...from],
+      );
+      hiddenRemoved = hu.changes;
+    });
+
+    res.json({ ok: true, to, from, events, rollupsRemoved, installations, hiddenRemoved });
+  });
+
+  return router;
+}

--- a/packages/hub/src/server.ts
+++ b/packages/hub/src/server.ts
@@ -9,6 +9,7 @@ import { flowsRouter } from './routes/flows.js';
 import { authRouter, setupRouter } from './routes/auth.js';
 import { adminRouter } from './routes/admin.js';
 import { orgRenameRouter } from './routes/orgRename.js';
+import { userKeyMergeRouter } from './routes/userKeyMerge.js';
 import { googleRouter } from './auth/google.js';
 import { entraRouter } from './auth/entra.js';
 import { ensureBootstrapToken } from './auth/bootstrapToken.js';
@@ -193,6 +194,7 @@ export async function createHubApp(
   app.use('/setup', setupRouter(ctx));
   app.use('/v1/admin', adminRouter(ctx));
   app.use('/v1/admin', orgRenameRouter(ctx));
+  app.use('/v1/admin', userKeyMergeRouter(ctx));
   app.use('/v1', queriesRouter(ctx));
   app.use('/hub', connectRouter(ctx));
   startRollupTimer(db);

--- a/packages/hub/src/test/admin-user-key-merge.test.ts
+++ b/packages/hub/src/test/admin-user-key-merge.test.ts
@@ -1,0 +1,327 @@
+// Tests for POST /v1/admin/user-keys/merge — folding event-attribution
+// identities together.
+//
+// The scenario this exists for: `user_key` is minted at ingest from the
+// client's git identity, so one person arrives as several identities when their
+// git config is wrong (`git config user.email = "x"` stores the literal `=`; an
+// unset email falls back to the OS username). Hiding those keys throws the work
+// away; this endpoint credits it to the real identity instead.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import supertest from 'supertest';
+import { createHubApp } from '../server';
+import { createPasswordUser } from '../auth/password';
+
+const TEST_DB = path.join(os.tmpdir(), `agenfk-hub-userkey-merge-${process.pid}.sqlite`);
+const SECRET = 'a'.repeat(64);
+const MERGE = '/v1/admin/user-keys/merge';
+
+const cleanup = () => {
+  for (const suffix of ['', '-wal', '-shm']) {
+    const f = TEST_DB + suffix;
+    if (fs.existsSync(f)) fs.unlinkSync(f);
+  }
+};
+
+const loginAs = async (app: any, email: string, password: string) => {
+  const r = await supertest(app).post('/auth/login').send({ email, password });
+  return r.headers['set-cookie']?.[0] ?? '';
+};
+
+let seq = 0;
+async function seedEvent(
+  db: any,
+  orgId: string,
+  userKey: string,
+  occurredAt = '2026-07-29T10:00:00Z',
+  type = 'item.closed',
+) {
+  const id = `ev-${++seq}`;
+  await db.run(
+    `INSERT INTO events (event_id, org_id, installation_id, user_key, occurred_at, received_at, type, payload)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    [id, orgId, 'inst-1', userKey, occurredAt, occurredAt, type, '{}'],
+  );
+  return id;
+}
+
+async function seedRollup(
+  db: any,
+  orgId: string,
+  userKey: string,
+  day: string,
+  counts: Partial<Record<'events_count' | 'items_closed' | 'tokens_in' | 'tokens_out' | 'prs_opened', number>> = {},
+) {
+  await db.run(
+    `INSERT INTO rollups_daily
+       (org_id, user_key, day, events_count, items_closed, tokens_in, tokens_out, validate_passes, validate_fails, prs_opened)
+     VALUES (?, ?, ?, ?, ?, ?, ?, 0, 0, ?)`,
+    [
+      orgId, userKey, day,
+      counts.events_count ?? 0, counts.items_closed ?? 0,
+      counts.tokens_in ?? 0, counts.tokens_out ?? 0, counts.prs_opened ?? 0,
+    ],
+  );
+}
+
+const userKeys = (db: any, orgId: string) =>
+  db.all(`SELECT user_key, COUNT(*) AS n FROM events WHERE org_id = ? GROUP BY user_key ORDER BY user_key`, [orgId]);
+
+describe('admin POST /v1/admin/user-keys/merge', () => {
+  let app: any;
+  let ctx: any;
+  let cookieAdmin: string;
+  let cookieView: string;
+
+  beforeEach(async () => {
+    cleanup();
+    const out = await createHubApp({
+      dbPath: TEST_DB,
+      secretKey: SECRET,
+      sessionSecret: 'test-session-secret',
+      defaultOrgId: 'cglab',
+    });
+    app = out.app;
+    ctx = out.ctx;
+    await createPasswordUser(ctx.db, 'cglab', 'admin@x', 'longenough1', 'admin');
+    await createPasswordUser(ctx.db, 'cglab', 'view@x', 'longenough1', 'viewer');
+    cookieAdmin = await loginAs(app, 'admin@x', 'longenough1');
+    cookieView = await loginAs(app, 'view@x', 'longenough1');
+  });
+
+  afterEach(async () => { await ctx.db.close(); cleanup(); });
+
+  describe('authz', () => {
+    it('rejects unauthenticated requests', async () => {
+      const r = await supertest(app).post(MERGE).send({ from: '=', to: 'a@x' });
+      expect(r.status).toBe(401);
+    });
+
+    it('rejects non-admin sessions', async () => {
+      const r = await supertest(app).post(MERGE).set('Cookie', cookieView).send({ from: '=', to: 'a@x' });
+      expect(r.status).toBe(403);
+    });
+  });
+
+  describe('validation', () => {
+    const post = (body: any) => supertest(app).post(MERGE).set('Cookie', cookieAdmin).send(body);
+
+    it('requires a non-empty `to`', async () => {
+      expect((await post({ from: '=' })).status).toBe(400);
+      expect((await post({ from: '=', to: '   ' })).status).toBe(400);
+    });
+
+    it('requires at least one `from` key that differs from `to`', async () => {
+      expect((await post({ to: 'a@x' })).status).toBe(400);
+      expect((await post({ to: 'a@x', from: [] })).status).toBe(400);
+      // Self-merge is filtered out, leaving nothing to do — 400, not a no-op 200.
+      expect((await post({ to: 'a@x', from: 'a@x' })).status).toBe(400);
+      expect((await post({ to: 'a@x', from: ['A@X', '  '] })).status).toBe(400);
+    });
+
+    it('caps the number of source keys', async () => {
+      const many = Array.from({ length: 51 }, (_, i) => `k${i}@x`);
+      const r = await post({ to: 'a@x', from: many });
+      expect(r.status).toBe(400);
+      expect(r.body.error).toMatch(/at most 50/);
+    });
+  });
+
+  describe('repointing events', () => {
+    it('folds several identities into one and leaves a single user_key', async () => {
+      await seedEvent(ctx.db, 'cglab', '=');
+      await seedEvent(ctx.db, 'cglab', '=');
+      await seedEvent(ctx.db, 'cglab', 'jonatansporn');
+      await seedEvent(ctx.db, 'cglab', 'jonatan.sporn@cglab.com');
+
+      const r = await supertest(app).post(MERGE).set('Cookie', cookieAdmin)
+        .send({ from: ['=', 'jonatansporn'], to: 'jonatan.sporn@cglab.com' });
+
+      expect(r.status).toBe(200);
+      expect(r.body.ok).toBe(true);
+      expect(r.body.events).toBe(3);
+      expect(r.body.to).toBe('jonatan.sporn@cglab.com');
+      expect(r.body.from).toEqual(['=', 'jonatansporn']);
+
+      expect(await userKeys(ctx.db, 'cglab')).toEqual([
+        { user_key: 'jonatan.sporn@cglab.com', n: 4 },
+      ]);
+    });
+
+    it('accepts a bare string for a single source', async () => {
+      await seedEvent(ctx.db, 'cglab', '=');
+      const r = await supertest(app).post(MERGE).set('Cookie', cookieAdmin)
+        .send({ from: '=', to: 'a@x' });
+      expect(r.body.events).toBe(1);
+      expect(await userKeys(ctx.db, 'cglab')).toEqual([{ user_key: 'a@x', n: 1 }]);
+    });
+
+    it('matches keys case-insensitively (the osUser fallback is not lowercased at ingest)', async () => {
+      await seedEvent(ctx.db, 'cglab', 'JonatanSporn');
+      const r = await supertest(app).post(MERGE).set('Cookie', cookieAdmin)
+        .send({ from: 'jonatansporn', to: 'jonatan.sporn@cglab.com' });
+      expect(r.body.events).toBe(1);
+      expect(await userKeys(ctx.db, 'cglab')).toEqual([
+        { user_key: 'jonatan.sporn@cglab.com', n: 1 },
+      ]);
+    });
+
+    it('never touches another org', async () => {
+      await seedEvent(ctx.db, 'other', '=');
+      await seedEvent(ctx.db, 'cglab', '=');
+
+      const r = await supertest(app).post(MERGE).set('Cookie', cookieAdmin)
+        .send({ from: '=', to: 'a@x' });
+
+      expect(r.body.events).toBe(1);
+      expect(await userKeys(ctx.db, 'other')).toEqual([{ user_key: '=', n: 1 }]);
+    });
+
+    it('is idempotent — a second merge is a no-op', async () => {
+      await seedEvent(ctx.db, 'cglab', '=');
+      const body = { from: '=', to: 'a@x' };
+      expect((await supertest(app).post(MERGE).set('Cookie', cookieAdmin).send(body)).body.events).toBe(1);
+      const second = await supertest(app).post(MERGE).set('Cookie', cookieAdmin).send(body);
+      expect(second.status).toBe(200);
+      expect(second.body.events).toBe(0);
+      expect(await userKeys(ctx.db, 'cglab')).toEqual([{ user_key: 'a@x', n: 1 }]);
+    });
+  });
+
+  describe('rollups_daily', () => {
+    const rollups = (orgId = 'cglab') => ctx.db.all(
+      `SELECT user_key, day, events_count, items_closed, tokens_in, tokens_out, prs_opened
+         FROM rollups_daily WHERE org_id = ? ORDER BY user_key, day`, [orgId],
+    );
+
+    it('sums same-day rows instead of colliding on the primary key', async () => {
+      await seedRollup(ctx.db, 'cglab', '=', '2026-07-29', { events_count: 2, items_closed: 1, prs_opened: 1 });
+      await seedRollup(ctx.db, 'cglab', 'jonatan.sporn@cglab.com', '2026-07-29', { events_count: 5, items_closed: 3, prs_opened: 2 });
+
+      const r = await supertest(app).post(MERGE).set('Cookie', cookieAdmin)
+        .send({ from: '=', to: 'jonatan.sporn@cglab.com' });
+
+      expect(r.status).toBe(200);
+      expect(r.body.rollupsRemoved).toBe(1);
+      expect(await rollups()).toEqual([
+        {
+          user_key: 'jonatan.sporn@cglab.com', day: '2026-07-29',
+          events_count: 7, items_closed: 4, tokens_in: 0, tokens_out: 0, prs_opened: 3,
+        },
+      ]);
+    });
+
+    it('moves a day the target has no row for', async () => {
+      await seedRollup(ctx.db, 'cglab', '=', '2026-07-28', { events_count: 4 });
+      await seedRollup(ctx.db, 'cglab', 'a@x', '2026-07-29', { events_count: 1 });
+
+      await supertest(app).post(MERGE).set('Cookie', cookieAdmin).send({ from: '=', to: 'a@x' });
+
+      const rows = await rollups();
+      expect(rows.map((r: any) => [r.user_key, r.day, r.events_count])).toEqual([
+        ['a@x', '2026-07-28', 4],
+        ['a@x', '2026-07-29', 1],
+      ]);
+    });
+
+    it('preserves token counts a recompute from events would have zeroed', async () => {
+      // rollup.ts hardcodes tokens_in/tokens_out to 0 when aggregating from
+      // `events`, so summing the stored rows is the only way these survive.
+      await seedRollup(ctx.db, 'cglab', '=', '2026-07-29', { tokens_in: 100, tokens_out: 20 });
+      await seedRollup(ctx.db, 'cglab', 'a@x', '2026-07-29', { tokens_in: 7, tokens_out: 3 });
+
+      await supertest(app).post(MERGE).set('Cookie', cookieAdmin).send({ from: '=', to: 'a@x' });
+
+      const rows = await rollups();
+      expect(rows).toHaveLength(1);
+      expect(rows[0].tokens_in).toBe(107);
+      expect(rows[0].tokens_out).toBe(23);
+    });
+
+    it('leaves another org\'s rollups alone', async () => {
+      await seedRollup(ctx.db, 'other', '=', '2026-07-29', { events_count: 9 });
+      await seedRollup(ctx.db, 'cglab', '=', '2026-07-29', { events_count: 1 });
+
+      await supertest(app).post(MERGE).set('Cookie', cookieAdmin).send({ from: '=', to: 'a@x' });
+
+      expect(await rollups('other')).toEqual([{
+        user_key: '=', day: '2026-07-29', events_count: 9,
+        items_closed: 0, tokens_in: 0, tokens_out: 0, prs_opened: 0,
+      }]);
+    });
+  });
+
+  describe('companion rows', () => {
+    it('repoints the installation git email and drops a stale hide', async () => {
+      await ctx.db.run(
+        `INSERT INTO installations (id, org_id, first_seen, last_seen, os_user, git_name, git_email)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        ['inst-1', 'cglab', '2026-07-01T00:00:00Z', '2026-07-29T00:00:00Z', 'jonatansporn', '=', '='],
+      );
+      await supertest(app).post('/v1/admin/hidden-users').set('Cookie', cookieAdmin).send({ userKey: '=' });
+
+      const r = await supertest(app).post(MERGE).set('Cookie', cookieAdmin)
+        .send({ from: '=', to: 'jonatan.sporn@cglab.com' });
+
+      expect(r.body.installations).toBe(1);
+      expect(r.body.hiddenRemoved).toBe(1);
+
+      const inst = await ctx.db.get(`SELECT git_email FROM installations WHERE id = ?`, ['inst-1']);
+      expect(inst.git_email).toBe('jonatan.sporn@cglab.com');
+
+      const hidden = await supertest(app).get('/v1/admin/hidden-users').set('Cookie', cookieAdmin);
+      expect(hidden.body).toEqual([]);
+    });
+  });
+
+  describe('dashboard visibility', () => {
+    it('collapses the /v1/users list down to the surviving identity', async () => {
+      await seedEvent(ctx.db, 'cglab', '=');
+      await seedEvent(ctx.db, 'cglab', 'jonatansporn');
+      await seedEvent(ctx.db, 'cglab', 'jonatan.sporn@cglab.com');
+
+      await supertest(app).post(MERGE).set('Cookie', cookieAdmin)
+        .send({ from: ['=', 'jonatansporn'], to: 'jonatan.sporn@cglab.com' });
+
+      const users = await supertest(app).get('/v1/users').set('Cookie', cookieAdmin);
+      expect(users.status).toBe(200);
+      expect(users.body.map((u: any) => u.user_key)).toEqual(['jonatan.sporn@cglab.com']);
+      expect(Number(users.body[0].events_count)).toBe(3);
+    });
+  });
+});
+
+describe('USER_KEY_TABLES covers every user_key-bearing table (regression pin)', () => {
+  beforeEach(() => cleanup());
+  afterEach(() => cleanup());
+
+  it('matches what sqlite_master + pragma_table_info report', async () => {
+    const { ctx } = await createHubApp({
+      dbPath: TEST_DB,
+      secretKey: SECRET,
+      sessionSecret: 'test-session-secret',
+      defaultOrgId: 'cglab',
+    });
+    try {
+      const mod = await import('../routes/userKeyMerge');
+      const declared = (mod as any).USER_KEY_TABLES as Record<string, readonly string[]>;
+      const handled = [...declared.repoint, ...declared.sum, ...declared.drop];
+
+      const tables = await ctx.db.all<{ name: string }>(
+        "SELECT name FROM sqlite_master WHERE type = 'table'",
+      );
+      const introspected: string[] = [];
+      for (const t of tables) {
+        const cols = await ctx.db.all<{ name: string }>(`PRAGMA table_info(${t.name})`);
+        if (cols.some((c: any) => c.name === 'user_key')) introspected.push(t.name);
+      }
+      // Any new user_key column must be given an explicit merge strategy.
+      expect([...handled].sort()).toEqual(introspected.sort());
+    } finally {
+      await ctx.db.close();
+    }
+  });
+});

--- a/packages/hub/src/test/hub-pg-parity.test.ts
+++ b/packages/hub/src/test/hub-pg-parity.test.ts
@@ -138,6 +138,50 @@ describe('PG parity: admin endpoints', () => {
     expect(after.body).toHaveLength(0);
   });
 
+  it('user-keys/merge repoints events and sums rollups on PG', async () => {
+    // The rollup fold is an INSERT ... SELECT ... GROUP BY ... ON CONFLICT DO
+    // UPDATE — the most involved statement the hub emits, and the one most
+    // likely to be mangled by the dialect translator. Exercise it on PG.
+    for (const [id, key] of [['m1', '='], ['m2', '='], ['m3', 'jonatansporn'], ['m4', 'real@acme.com']]) {
+      await fx.db.run(
+        `INSERT INTO events (event_id, org_id, installation_id, user_key, occurred_at, received_at, type, payload)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        [id, 'org', 'inst-1', key, '2026-07-29T10:00:00Z', '2026-07-29T10:00:00Z', 'item.closed', '{}'],
+      );
+    }
+    await fx.db.run(
+      `INSERT INTO rollups_daily (org_id, user_key, day, events_count, items_closed, tokens_in, tokens_out, validate_passes, validate_fails, prs_opened)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ['org', '=', '2026-07-29', 2, 1, 100, 20, 0, 0, 1],
+    );
+    await fx.db.run(
+      `INSERT INTO rollups_daily (org_id, user_key, day, events_count, items_closed, tokens_in, tokens_out, validate_passes, validate_fails, prs_opened)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ['org', 'real@acme.com', '2026-07-29', 5, 3, 7, 3, 0, 0, 2],
+    );
+
+    const r = await supertest(fx.app).post('/v1/admin/user-keys/merge').set('Cookie', fx.cookie)
+      .send({ from: ['=', 'JonatanSporn'], to: 'real@acme.com' });
+
+    expect(r.status).toBe(200);
+    expect(r.body.events).toBe(3);
+    expect(r.body.rollupsRemoved).toBe(1);
+
+    const keys = await fx.db.all<{ user_key: string }>('SELECT DISTINCT user_key FROM events');
+    expect(keys.map(k => k.user_key)).toEqual(['real@acme.com']);
+
+    const roll = await fx.db.all<any>(
+      'SELECT user_key, events_count, items_closed, tokens_in, tokens_out, prs_opened FROM rollups_daily',
+    );
+    expect(roll).toHaveLength(1);
+    expect(roll[0].user_key).toBe('real@acme.com');
+    expect(Number(roll[0].events_count)).toBe(7);
+    expect(Number(roll[0].items_closed)).toBe(4);
+    expect(Number(roll[0].tokens_in)).toBe(107);
+    expect(Number(roll[0].tokens_out)).toBe(23);
+    expect(Number(roll[0].prs_opened)).toBe(3);
+  });
+
   it('events ingest drops hidden people before the installations upsert on PG (CGLAB-31)', async () => {
     await fx.db.run('INSERT INTO hidden_users (org_id, user_key) VALUES (?, ?)', ['org', 'alice@acme.com']);
     const r = await supertest(fx.app).post('/v1/events')


### PR DESCRIPTION
## Problem

`user_key` is minted at ingest from the reporting client's git identity:

```ts
// packages/hub/src/routes/events.ts
(actor.gitEmail?.toLowerCase() || actor.osUser || 'unknown').trim()
```

So a misconfigured client mints a **permanent second identity** for someone already in the hub. Two real ways this happens:

- `git config user.email = "…"` — the stray `=` means git stores the email as the literal `=`, and the hub gets a person called `=`.
- git email unset — the key falls back to the OS username, so the same human also appears as e.g. `jsmith`.

Every dashboard query groups on `events.user_key`, so that person's work stays split across two or three rows forever.

The existing remedies don't fix it: `hidden_users` *discards* the work rather than crediting it, and the admin DB console is read-only by design (`queries/sql-readonly.ts`), so the only real option was hand-written SQL against the deployment.

## What this adds

`POST /v1/admin/user-keys/merge` — the `orgs/rename` pattern applied to `user_key`: one transaction, org-scoped, across every `user_key`-bearing table.

```
{ "from": ["=", "jsmith"], "to": "j.smith@acme.com" }
→ { ok, to, from, events, rollupsRemoved, installations, hiddenRemoved }
```

| Table | Treatment |
|---|---|
| `events` | repointed — what every dashboard query groups on |
| `rollups_daily` | **summed** on `(org_id, day)` |
| `hidden_users` | source rows dropped (a hide of a key that no longer exists is stale) |
| `installations.git_email` | repointed so the Installations page stops showing the old label |

Plus an Admin → Merge identities control, so this is reachable without hand-crafting a request with a session cookie. It sits next to Hidden people — the same decision with the opposite outcome — and hides itself when the org has fewer than two identities.

## Two decisions worth reviewing

**`rollups_daily` is summed, not repointed.** Its PK is `(org_id, user_key, day)`, so two identities active on the same day collide on a plain repoint. Summing the *stored rows* rather than recomputing from `events` is also deliberate: `rollup.ts` hardcodes `tokens_in`/`tokens_out` to `0`, and the background timer only revisits days ≥ the latest rollup day — so recomputing an older day would silently zero token history nobody would notice was gone. There's a test pinning that.

**Keys are matched case-insensitively.** Git emails are lowercased at ingest but the `osUser` fallback is not, so an exact match would silently no-op against a key stored as `JSmith`.

Also: idempotent (a repeat returns `events: 0`, surfaced in the UI as "already merged" rather than an error), capped at 50 source keys, and `USER_KEY_TABLES` is pinned against runtime schema introspection — mirroring `ORG_ID_CHILD_TABLES` — so a future `user_key` column can't silently escape a merge strategy.

## Testing

- 17 new cases in `admin-user-key-merge.test.ts` (authz, validation, repointing, org isolation, case-insensitivity, idempotency, rollup summing, token preservation, companion rows, `/v1/users` collapse, schema pin).
- 18 new cases for the UI helpers, extracted as pure functions per the existing hub-ui no-RTL convention.
- A `hub-pg-parity.test.ts` case, because the rollup fold is an `INSERT … SELECT … GROUP BY … ON CONFLICT DO UPDATE` — the most involved statement the hub emits and the most likely to be mangled by `db/dialect.ts`. SQLite-only coverage would look green and fail on a Postgres deployment.

Full hub suite **50 files / 506 tests** green; hub-ui **25 files / 180 tests** green; `tsc` clean on both; `vite build` succeeds.

---

## Added in a third commit: the per-user page hid all but one event type

Same underlying problem from the other direction, which is why it rides here rather than in its own PR: **the hub misrepresents what a person did.** The merge endpoint fixes work split across identities; this fixes work hidden behind a default.

`UserDetail` opened with the event-type filter set to `['item.closed']` — "what did this user ship?". Reasonable intent, but the page then showed one of sixteen event types, which to the person reading it is indistinguishable from a hub that never recorded their work. It was reported three times as missing data — a commit, then a PR, then the same PR again — before the chip was identified as the cause. Nothing on the page says "you are seeing a subset": the count beside the timeline reports the *filtered* total, so it reads as the truth.

Commits are the one thing genuinely absent (the hub has no commit event type), and this default made a real absence and a hidden presence look identical — which is what made it expensive to diagnose.

The default is now empty, matching what the page's other two selectors (`projects`, `itemTypes`) already do. Narrowing is unchanged and one tap away.

**The storage-key bump to `:v2` is the load-bearing half.** `useToggleSet` persists on *mount*, not only on change, so everyone who has opened this page already has `["item.closed"]` written under the v1 key — and `readPersistedSet` honours a stored value whenever the key exists, because an explicitly-emptied set must round-trip as empty. Changing only the default would have shipped a fix that changed nothing for precisely the people who hit the problem. The cost is that a deliberate v1 selection is forgotten once on upgrade.

Defaults moved into `userDetailFilters.ts` with four tests, so they are pinned rather than sitting as literals mid-component — the old value was one word away from hiding someone's work again with nothing to catch it.
