### PR TITLE
feat(test-guard): confirm changes in existing tests

### DIFF
--- a/AFK_ARCHITECTURE.md
+++ b/AFK_ARCHITECTURE.md
@@ -56,7 +56,7 @@ AgenFK supports six AI coding assistants. Each integrates with the same MCP serv
 
 | Client | MCP Registration | Workflow Rules | Pre-edit hook | Post-tool hook (PR sizing) |
 |--------|-----------------|----------------|---------------|----------------------------|
-| **Claude Code** | `claude mcp add` (user scope) | `~/.claude/CLAUDE.md` | `PreToolUse` — `agenfk-gatekeeper` + `agenfk-mcp-enforcer` | `PostToolUse` matcher `Bash` — `agenfk-pr-hook --client claude-code` |
+| **Claude Code** | `claude mcp add` (user scope) | `~/.claude/CLAUDE.md` | `PreToolUse` — `agenfk-gatekeeper` + `agenfk-mcp-enforcer` + `agenfk-test-guard` | `PostToolUse` matcher `Bash` — `agenfk-pr-hook --client claude-code` |
 | **OpenCode** | `~/.config/opencode/opencode.json` | `~/.config/opencode/skills/agenfk/SKILL.md` | `tool.execute.before` plugin (`agenfk-mcp-enforcer-opencode.mjs`) | `tool.execute.after` plugin (`agenfk-pr-hook-opencode.mjs`) |
 | **pi** (0.79+) | opt-in (pi MCP config; not auto-registered) | (not yet bundled — extension provides enforcement) | native extension `~/.pi/agent/extensions/agenfk.ts` — `tool_call(edit\|write)` → gatekeeper, `tool_call(bash)` → mcp-enforcer (delegates to `~/.agenfk/bin/*.mjs`) | same extension — `tool_result(bash)` → `agenfk-pr-hook --client pi`, with the live model from `ctx.getModel()` injected into the reminder |
 | **Codex CLI** | `codex mcp add` | `~/.codex/AGENTS.md` | (no equivalent — CLAUDE.md-style instructional) | `hooks.PostToolUse` matcher `Bash` (Codex matches the shell tool as `Bash`) — `agenfk-pr-hook --client codex` |
@@ -66,6 +66,7 @@ AgenFK supports six AI coding assistants. Each integrates with the same MCP serv
 ### Enforcement model
 
 - **Pre-edit gatekeeping** (is a TASK/BUG in an active working step?) is mechanical on Claude Code, OpenCode, and **pi** — their hook systems support pre-tool blocking (pi via the `tool_call` event returning `{ block, reason }`). On Codex / Gemini / Cursor, this remains **instructional** via the per-client rule docs — backed by the server-side `workflow_gatekeeper` audit trail.
+- **Existing-test protection** (is the agent rewriting, skipping or deleting a test that already exists?) is mechanical on **Claude Code** via `agenfk-test-guard`, which returns `permissionDecision: "ask"` rather than blocking — the developer answers the permission prompt itself: approve = accept the change to the test, deny = keep the test and fix the code. It is deliberately not a `deny`: a hard block has no way to express "the developer said yes". Other clients cannot turn a hook verdict into a developer-facing question, so there it stays **instructional** via the Quality Guards rule in each rule bundle.
 - **PR sizing prompt** (after `gh pr create` / `git push`) is mechanical on **all six** clients via their respective post-tool hook events. On pi the reminder additionally carries the deterministically-detected model id (`ctx.getModel()`), so the agent reports the real model instead of guessing. Even when the post-tool directive isn't followed, the per-client instruction docs include a belt-and-suspenders rule asking the agent to call `register_pr` / `update_pr_sizing`.
 
 ### Note on Codex hook coverage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ The old version is read from the root `package.json`; commit the manifest change
 
 **MCP surface**: the server registers MCP tools (`mcp__agenfk__*`) backed by the same handlers as the REST endpoints. Tool definitions live in `packages/server/src` alongside the Express routes. Adding a new MCP tool means: handler in core, REST route in server, MCP tool registration in server, and (usually) a CLI subcommand in `packages/cli` for the fallback path.
 
-**Client integrations**: three clients are supported, with different enforcement models — see `AFK_ARCHITECTURE.md` for the full table. Claude Code and OpenCode get *mechanical* PreToolUse hooks (`agenfk-gatekeeper`, `agenfk-mcp-enforcer`) that hard-block edits without an active task and block bypass routes (direct DB reads, `curl localhost:3000`, raw CLI state queries). Cursor has no hook system, so enforcement there is instructional via `cursorrules/agenfk.mdc` (`alwaysApply: true`) plus the server-side gatekeeper.
+**Client integrations**: three clients are supported, with different enforcement models — see `AFK_ARCHITECTURE.md` for the full table. Claude Code and OpenCode get *mechanical* PreToolUse hooks (`agenfk-gatekeeper`, `agenfk-mcp-enforcer`) that hard-block edits without an active task and block bypass routes (direct DB reads, `curl localhost:3000`, raw CLI state queries). Claude Code additionally gets `agenfk-test-guard`, which returns `permissionDecision: "ask"` (never `deny`) when an *existing* test is about to be rewritten, skipped or deleted, so the developer picks between accepting the test change and fixing the code. Cursor has no hook system, so enforcement there is instructional via `cursorrules/agenfk.mdc` (`alwaysApply: true`) plus the server-side gatekeeper.
 
 ## Testing notes
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -201,6 +201,16 @@ MCP is opt-in (`--with-mcp`). When MCP tools are present, they are equivalent to
 - **End-to-end verification**: After implementing any feature, verify it works end-to-end by tracing the full path from UI interaction to backend response. Do not mark a feature as complete until you've confirmed the UI actually triggers the expected behavior.
 - **Evidence-based claims**: Before claiming a feature already exists or is implemented, search the actual codebase for the specific UI components, API endpoints, and database queries. Never assume implementation status without evidence.
 
+### Changing Existing Tests
+- **Existing tests are a contract**: NEVER rewrite, relax, skip (`.skip`, `xit`, `@pytest.mark.skip`, `t.Skip`, `@Ignore`) or delete an **existing** test to make your change pass. A failing existing test is a signal, not a chore — it may be the only guard on a real requirement.
+- **Ask, don't decide**: STOP and put the choice to the developer:
+  1. **Accept the change to the test** — it encoded behaviour that is now intentionally outdated. State which requirement changed.
+  2. **Keep the test as-is and fix the code** — the test caught a real regression.
+
+  Never choose for them, and never assume (1) because it is faster.
+- **New tests are free**: Adding new test cases or new test files never needs approval — the guard only covers test code that already exists.
+- **Mechanical backstop**: On Claude Code the `agenfk-test-guard` PreToolUse hook raises this prompt automatically on Edit/Write/NotebookEdit of an existing test file and on `rm`/`git rm` of one. Approving it means (1); denying it means (2) — restore the test untouched and fix the code under test. Other clients enforce the rule instructionally.
+
 ### Bug & Error Fixing
 - **Root cause first**: When debugging errors, investigate the root cause fully before applying fixes. Avoid adding workarounds (like force-relogin) that can create new problems (infinite loops). Trace errors from the symptom back to the actual source.
 - **One fix at a time**: Apply a single targeted fix, verify it resolves the issue, then move on. Do not stack multiple speculative fixes.

--- a/bin/agenfk-test-guard.mjs
+++ b/bin/agenfk-test-guard.mjs
@@ -159,12 +159,12 @@ export function buildReason({ filePath, reason }) {
     `  Why:    ${reason}`,
     '',
     'A failing or inconvenient existing test is a signal, not a chore — it may be',
-    'the only guard on a real requirement. Ask the developer which they want:',
+    'the only guard on a real requirement. Which do you want:',
     '',
     '  (1) ACCEPT the test change — the test encoded behaviour that is now outdated.',
     '  (2) KEEP the test as-is and fix the production code instead.',
     '',
-    'Approve this call only for (1). If it is denied, treat that as (2): restore the',
+    'Approve this call only for (1). If it is denied, it will be treated as (2): restore the',
     'test untouched and fix the code under test. Adding NEW tests never needs approval.',
   ].join('\n');
 }

--- a/bin/agenfk-test-guard.mjs
+++ b/bin/agenfk-test-guard.mjs
@@ -1,0 +1,242 @@
+#!/usr/bin/env node
+/**
+ * AgEnFK Test Guard — PreToolUse hook.
+ *
+ * A failing existing test is a signal, not a chore: it may be the only guard on
+ * a real requirement. When an agent is about to CHANGE (rewrite, relax, skip or
+ * delete) a test that already exists, this hook stops and hands the decision to
+ * the developer:
+ *
+ *   (1) accept the change to the test, or
+ *   (2) keep the test as-is and fix the production code instead.
+ *
+ * It does NOT hard-block: on Claude Code it emits `permissionDecision: "ask"`,
+ * so the developer answers with the permission prompt itself and the approved
+ * edit goes through on the same turn. Adding NEW tests, and creating new test
+ * files, are never flagged — only edits that alter test code that already exists.
+ *
+ * Usage in client config: `agenfk-test-guard --client <name>`
+ */
+import fs from 'fs';
+import path from 'path';
+
+// ── Pure helpers (also exported for unit tests) ──────────────────────────────
+
+/** Source-ish extensions we consider "test code" when the path says test. */
+const CODE_EXT = /\.(?:[cm]?[jt]sx?|py|rb|go|java|kt|kts|cs|scala|php|rs|swift|dart|ex|exs|ipynb)$/i;
+
+/** Directory segments that mark a test tree. */
+const TEST_DIRS = new Set(['test', 'tests', '__tests__', 'spec', 'specs', 'testing', 'e2e', 'it']);
+
+/** Filename conventions that mark a test file, across the common ecosystems. */
+const TEST_FILENAME = [
+  /\.(?:test|spec)\.[cm]?[jt]sx?$/i,        // foo.test.ts, foo.spec.jsx
+  /^test_[^/]*\.py$/i,                      // test_foo.py
+  /_test\.py$/i,                            // foo_test.py
+  /_test\.go$/i,                            // foo_test.go
+  /_(?:test|spec)\.rb$/i,                   // foo_test.rb, foo_spec.rb
+  /_(?:test|spec)\.(?:exs?|php|dart)$/i,    // foo_test.exs, FooTest.php variants below
+  /(?:Test|Tests|Spec|Specs)\.(?:java|kt|kts|cs|scala|php)$/, // FooTest.java, FooSpec.scala
+  /\.(?:test|spec)\.(?:py|rb|php|dart|ipynb)$/i,
+];
+
+/**
+ * True when `filePath` looks like test code. Two independent signals: a
+ * filename convention, or a code file sitting inside a test directory (which is
+ * how Go/JVM/pytest suites and this repo's own `src/test/**` are laid out).
+ */
+export function isTestFile(filePath) {
+  if (!filePath || typeof filePath !== 'string') return false;
+  const normalized = filePath.replace(/\\/g, '/');
+  const base = normalized.split('/').pop() || '';
+  if (TEST_FILENAME.some((re) => re.test(base))) return true;
+  if (!CODE_EXT.test(base)) return false;
+  return normalized.split('/').slice(0, -1).some((seg) => TEST_DIRS.has(seg.toLowerCase()));
+}
+
+/** Markers that disable a test rather than change it — always worth a prompt. */
+const SKIP_MARKERS = [
+  /\b(?:it|test|describe|context|suite|bench)\s*\.\s*(?:skip|todo|failing)\b/,
+  /\bx(?:it|test|describe|context)\s*\(/,
+  /@pytest\.mark\.(?:skip|skipif|xfail)\b/,
+  /\bunittest\.skip\b/,
+  /@(?:Ignore|Disabled)\b/,
+  /\bt\.Skip\s*\(/,
+  /\bt\.Parallel\s*\(\s*\)\s*;\s*t\.Skip\b/,
+  /\[(?:Ignore|Skip)\]/,
+  /\bskip\s*:\s*true\b/,
+];
+
+function addsSkipMarker(oldString, newString) {
+  return SKIP_MARKERS.some((re) => re.test(newString || '') && !re.test(oldString || ''));
+}
+
+/**
+ * Decide whether a single Edit-style replacement needs the developer's call.
+ * Returns a short reason string, or null when the change is safe to wave through.
+ *
+ * Pure ADDITION is safe: if the new text still contains the old text verbatim,
+ * nothing that existed was rewritten or removed — the agent is appending new
+ * test cases, which never needs approval. Anything else rewrites or deletes
+ * assertions that already existed.
+ */
+export function classifyEdit(oldString, newString) {
+  const before = typeof oldString === 'string' ? oldString : '';
+  const after = typeof newString === 'string' ? newString : '';
+  if (addsSkipMarker(before, after)) return 'it disables a test (skip / todo / ignore marker)';
+  if (!before) return null;                       // pure insertion
+  if (after.includes(before)) return null;        // existing text preserved verbatim
+  if (!after.trim()) return 'it deletes existing test code';
+  return 'it rewrites test code that already exists';
+}
+
+/**
+ * Decide whether a whole tool call needs the developer's call.
+ * `exists` tells the classifier whether the target file is already on disk —
+ * a brand-new test file is always allowed through.
+ *
+ * Returns { filePath, reason } when the developer must decide, else null.
+ */
+export function classifyToolCall(tool, toolInput, exists) {
+  const name = String(tool || '').toLowerCase();
+  const input = toolInput && typeof toolInput === 'object' ? toolInput : {};
+  const filePath = input.file_path || input.filePath || input.notebook_path || input.notebookPath || '';
+
+  if (name === 'bash') return classifyBashCommand(input.command || input.cmd || '');
+  if (!['edit', 'write', 'multiedit', 'notebookedit'].includes(name)) return null;
+  if (!filePath || !isTestFile(filePath)) return null;
+  if (!exists) return null; // creating a new test file — never gated
+
+  if (name === 'write') {
+    return { filePath, reason: 'it overwrites an existing test file wholesale' };
+  }
+
+  if (name === 'notebookedit') {
+    // NotebookEdit sends only the replacement source, never the old cell — there
+    // is no diff to reason about, so anything but a pure insert goes to the
+    // developer.
+    const mode = String(input.edit_mode || input.editMode || 'replace').toLowerCase();
+    if (mode === 'insert') return null;
+    return { filePath, reason: `it ${mode === 'delete' ? 'deletes' : 'replaces'} a cell in an existing test notebook` };
+  }
+
+  // Edit / MultiEdit: judge every replacement; the first one that isn't a pure
+  // addition decides. `edits` covers MultiEdit-shaped input.
+  const edits = Array.isArray(input.edits) && input.edits.length
+    ? input.edits
+    : [{ old_string: input.old_string ?? input.oldString, new_string: input.new_string ?? input.newString }];
+  for (const edit of edits) {
+    const reason = classifyEdit(edit?.old_string ?? edit?.oldString, edit?.new_string ?? edit?.newString);
+    if (reason) return { filePath, reason };
+  }
+  return null;
+}
+
+/**
+ * Deleting a test file happens through the shell, not through Edit — so the
+ * guard also watches `rm` / `git rm` for test paths. Quote characters are
+ * stripped so `rm "src/foo.test.ts"` is caught too.
+ */
+export function classifyBashCommand(command) {
+  if (typeof command !== 'string' || !command) return null;
+  if (!/(?:^|[\s;&|])(?:rm|unlink)\s|(?:^|[\s;&|])git\s+rm\s/.test(command)) return null;
+  for (const raw of command.split(/[\s;&|]+/)) {
+    const token = raw.replace(/^["']|["']$/g, '');
+    if (token.startsWith('-')) continue;
+    if (isTestFile(token) && fs.existsSync(path.resolve(token))) {
+      return { filePath: token, reason: 'it deletes an existing test file' };
+    }
+  }
+  return null;
+}
+
+/** The message the developer (and the agent) sees. */
+export function buildReason({ filePath, reason }) {
+  return [
+    'AgEnFK TEST GUARD — this changes an EXISTING test.',
+    '',
+    `  File:   ${filePath}`,
+    `  Why:    ${reason}`,
+    '',
+    'A failing or inconvenient existing test is a signal, not a chore — it may be',
+    'the only guard on a real requirement. Ask the developer which they want:',
+    '',
+    '  (1) ACCEPT the test change — the test encoded behaviour that is now outdated.',
+    '  (2) KEEP the test as-is and fix the production code instead.',
+    '',
+    'Approve this call only for (1). If it is denied, treat that as (2): restore the',
+    'test untouched and fix the code under test. Adding NEW tests never needs approval.',
+  ].join('\n');
+}
+
+/** Per-client shape for "stop and let the developer decide". */
+export function buildDirective(client, reason) {
+  switch (client) {
+    case 'claude-code':
+      return {
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'ask',
+          permissionDecisionReason: reason,
+        },
+      };
+    case 'codex':
+      return { decision: 'ask', reason };
+    case 'gemini':
+      return { decision: 'ask', context: reason };
+    case 'cursor':
+      return { permission: 'ask', userMessage: reason };
+    case 'opencode':
+    case 'pi':
+      return { decision: 'ask', reason, message: reason };
+    default:
+      return { decision: 'ask', reason };
+  }
+}
+
+// ── Runtime glue ─────────────────────────────────────────────────────────────
+
+async function readStdinJson() {
+  return new Promise((resolve) => {
+    let data = '';
+    const timeout = setTimeout(() => resolve(null), 500);
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (c) => (data += c));
+    process.stdin.on('end', () => {
+      clearTimeout(timeout);
+      try { resolve(data.trim() ? JSON.parse(data) : null); } catch { resolve(null); }
+    });
+    process.stdin.on('close', () => { clearTimeout(timeout); resolve(null); });
+  });
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const clientIdx = args.indexOf('--client');
+  const client = clientIdx >= 0 ? args[clientIdx + 1] : 'claude-code';
+
+  const input = await readStdinJson();
+  if (!input) process.exit(0);
+
+  const tool = input.tool || input.tool_name || input.toolName || '';
+  const toolInput = input.tool_input || input.toolInput || input.args || input.input || {};
+  const filePath = toolInput?.file_path || toolInput?.filePath || toolInput?.notebook_path || toolInput?.notebookPath || '';
+  const exists = Boolean(filePath) && fs.existsSync(path.resolve(filePath));
+
+  const verdict = classifyToolCall(tool, toolInput, exists);
+  if (!verdict) process.exit(0);
+
+  process.stdout.write(JSON.stringify(buildDirective(client, buildReason(verdict))));
+  process.exit(0);
+}
+
+// ESM entry detection: only run when executed directly, not when imported by tests.
+const isMain = (() => {
+  try {
+    const url = new URL(import.meta.url);
+    return process.argv[1] && url.pathname === process.argv[1];
+  } catch { return false; }
+})();
+if (isMain) {
+  main().catch(() => process.exit(0));
+}

--- a/clauderules/CLAUDE.md
+++ b/clauderules/CLAUDE.md
@@ -59,6 +59,11 @@ After running `gh pr create`, you MUST run `agenfk pr-register --item <id> --num
 - **Feature verification**: After implementing any feature, verify it works end-to-end by tracing the full path from UI interaction to backend response. Do not mark complete until confirmed.
 - **Evidence-based claims**: Before claiming a feature already exists, search the codebase for the specific UI components, API endpoints, and database queries. Never assume without evidence.
 - **Root cause debugging**: When fixing errors, investigate the root cause fully before applying fixes. Avoid workarounds that create new problems (e.g. infinite loops). Trace from symptom to source. One fix at a time.
+- **Existing tests are a contract**: NEVER rewrite, relax, skip (`.skip`, `xit`, `@pytest.mark.skip`, `t.Skip`, `@Ignore`) or delete an **existing** test to make your change pass. A failing existing test is a signal, not a chore — it may be the only guard on a real requirement. STOP and ask the developer to choose:
+  1. **Accept the change to the test** — it encoded behaviour that is now intentionally outdated. Say which requirement changed.
+  2. **Keep the test as-is and fix the code** — the test caught a real regression.
+
+  Never choose for them, and never assume (1) because it is faster. Adding **new** tests never needs approval. On Claude Code the `agenfk-test-guard` PreToolUse hook raises this prompt mechanically — approving it means (1), denying it means (2), so restore the test untouched and fix the code under test.
 
 ### STRICTLY FORBIDDEN shortcuts
 
@@ -69,9 +74,10 @@ After running `gh pr create`, you MUST run `agenfk pr-register --item <id> --num
 | Reading `.agenfk/db.sqlite` or `.agenfk/db.json` directly (Bash or Read) | `agenfk list --json`, `agenfk get <id> --json` |
 | `curl` / `wget` to `http://localhost:3000` | `agenfk list`, `agenfk create`, `agenfk update`, `agenfk verify` |
 
-Two PreToolUse hooks enforce the workflow:
+Three PreToolUse hooks enforce the workflow:
 - `agenfk-gatekeeper` — blocks Edit/Write/NotebookEdit when no active task.
 - `agenfk-mcp-enforcer` — blocks the direct-DB and `curl localhost:3000` bypass routes above. (In CLI-only mode it permits the `agenfk` CLI; when MCP is registered it steers state queries to the MCP tools instead.)
+- `agenfk-test-guard` — asks the developer to confirm before an **existing** test is rewritten, skipped or deleted (including `rm` / `git rm` of a test file). It never blocks new tests or added test cases.
 
 ### Command Reference — the `agenfk` CLI
 

--- a/codexrules/AGENTS.md
+++ b/codexrules/AGENTS.md
@@ -70,6 +70,11 @@ After running `gh pr create`, you MUST run `agenfk pr-register --item <id> --num
 - **Feature verification**: After implementing any feature, verify it works end-to-end by tracing the full path from UI interaction to backend response. Do not mark complete until confirmed.
 - **Evidence-based claims**: Before claiming a feature already exists, search the codebase for the specific UI components, API endpoints, and database queries. Never assume without evidence.
 - **Root cause debugging**: When fixing errors, investigate the root cause fully before applying fixes. Avoid workarounds that create new problems (e.g. infinite loops). Trace from symptom to source. One fix at a time.
+- **Existing tests are a contract**: NEVER rewrite, relax, skip (`.skip`, `xit`, `@pytest.mark.skip`, `t.Skip`, `@Ignore`) or delete an **existing** test to make your change pass. A failing existing test is a signal, not a chore — it may be the only guard on a real requirement. STOP and ask the developer to choose:
+  1. **Accept the change to the test** — it encoded behaviour that is now intentionally outdated. Say which requirement changed.
+  2. **Keep the test as-is and fix the code** — the test caught a real regression.
+
+  Never choose for them, and never assume (1) because it is faster. Adding **new** tests never needs approval. There is no mechanical hook for this on your client, so the rule is yours to honour: ask, wait for the answer, then act.
 
 ### STRICTLY FORBIDDEN shortcuts
 

--- a/commands/agenfk-test.md
+++ b/commands/agenfk-test.md
@@ -15,6 +15,7 @@ You are executing the `/agenfk-test <id>` command as a **Testing Agent**. Follow
 **Step 2 — Generate Missing Tests**
 - If new logic was added without tests, generate the necessary test cases using the project's testing framework.
 - Ensure edge cases and error paths are covered.
+- **Never touch an existing test to go green.** Adding new tests is free; rewriting, relaxing, skipping or deleting a test that already exists is the developer's call. If an existing test fails or looks outdated, STOP and ask them to choose: (1) accept the change to the test, or (2) keep the test as-is and fix the code. On Claude Code the `agenfk-test-guard` hook raises that prompt for you.
 
 **Step 3 — Execute & Verify Coverage**
 - Run the project's test suite with coverage reporting (e.g., `npm run test:coverage`, `npx vitest run --coverage`).

--- a/cursorrules/agenfk.mdc
+++ b/cursorrules/agenfk.mdc
@@ -69,6 +69,11 @@ After running `gh pr create`, you MUST run `agenfk pr-register --item <id> --num
 - **Feature verification**: After implementing any feature, verify it works end-to-end by tracing the full path from UI interaction to backend response. Do not mark complete until confirmed.
 - **Evidence-based claims**: Before claiming a feature already exists, search the codebase for the specific UI components, API endpoints, and database queries. Never assume without evidence.
 - **Root cause debugging**: When fixing errors, investigate the root cause fully before applying fixes. Avoid workarounds that create new problems (e.g. infinite loops). Trace from symptom to source. One fix at a time.
+- **Existing tests are a contract**: NEVER rewrite, relax, skip (`.skip`, `xit`, `@pytest.mark.skip`, `t.Skip`, `@Ignore`) or delete an **existing** test to make your change pass. A failing existing test is a signal, not a chore — it may be the only guard on a real requirement. STOP and ask the developer to choose:
+  1. **Accept the change to the test** — it encoded behaviour that is now intentionally outdated. Say which requirement changed.
+  2. **Keep the test as-is and fix the code** — the test caught a real regression.
+
+  Never choose for them, and never assume (1) because it is faster. Adding **new** tests never needs approval. There is no mechanical hook for this on your client, so the rule is yours to honour: ask, wait for the answer, then act.
 
 ### STRICTLY FORBIDDEN shortcuts
 

--- a/geminirules/GEMINI.md
+++ b/geminirules/GEMINI.md
@@ -65,6 +65,11 @@ After running `gh pr create`, you MUST run `agenfk pr-register --item <id> --num
 - **Feature verification**: After implementing any feature, verify it works end-to-end by tracing the full path from UI interaction to backend response. Do not mark complete until confirmed.
 - **Evidence-based claims**: Before claiming a feature already exists, search the codebase for the specific UI components, API endpoints, and database queries. Never assume without evidence.
 - **Root cause debugging**: When fixing errors, investigate the root cause fully before applying fixes. Avoid workarounds that create new problems (e.g. infinite loops). Trace from symptom to source. One fix at a time.
+- **Existing tests are a contract**: NEVER rewrite, relax, skip (`.skip`, `xit`, `@pytest.mark.skip`, `t.Skip`, `@Ignore`) or delete an **existing** test to make your change pass. A failing existing test is a signal, not a chore — it may be the only guard on a real requirement. STOP and ask the developer to choose:
+  1. **Accept the change to the test** — it encoded behaviour that is now intentionally outdated. Say which requirement changed.
+  2. **Keep the test as-is and fix the code** — the test caught a real regression.
+
+  Never choose for them, and never assume (1) because it is faster. Adding **new** tests never needs approval. There is no mechanical hook for this on your client, so the rule is yours to honour: ask, wait for the answer, then act.
 
 ### STRICTLY FORBIDDEN shortcuts
 

--- a/packages/cli/src/test/install-cli-only-default.test.ts
+++ b/packages/cli/src/test/install-cli-only-default.test.ts
@@ -52,6 +52,22 @@ describe('install.mjs — default (CLI-only) install writes the expected artifac
     expect(settings).toContain('agenfk-pr-hook');
   });
 
+  it('installs and wires the test guard, as an "ask" hook rather than a blocker', () => {
+    // The guard hands the accept-the-test-change vs fix-the-code call to the
+    // developer. It is only useful if it is actually registered on the edit AND
+    // Bash tools (Bash so `rm`/`git rm` of a test file is caught too), and it
+    // must never be installed as a hard block.
+    expect(existsSync(r.p('.local', 'bin', 'agenfk-test-guard'))).toBe(true);
+    expect(existsSync(r.p('.agenfk', 'bin', 'agenfk-test-guard.mjs'))).toBe(true);
+
+    const entry = readJson('.claude', 'settings.json').hooks.PreToolUse
+      .find((e: any) => JSON.stringify(e).includes('agenfk-test-guard'));
+    expect(entry).toBeDefined();
+    expect(entry.matcher).toContain('Edit');
+    expect(entry.matcher).toContain('Bash');
+    expect(readFileSync(r.p('.local', 'bin', 'agenfk-test-guard'), 'utf8')).not.toContain("'deny'");
+  });
+
   it('installs the agenfk skills and slash commands', () => {
     const skills = readdirSync(r.p('.claude', 'skills')).filter((n) => n.startsWith('agenfk'));
     const commands = readdirSync(r.p('.claude', 'commands')).filter((n) => n.startsWith('agenfk'));

--- a/packages/cli/src/test/uninstall-issue88.test.ts
+++ b/packages/cli/src/test/uninstall-issue88.test.ts
@@ -32,22 +32,27 @@ const UNINSTALL = path.join(ROOT, 'scripts', 'uninstall.mjs');
 // Part A — pure helpers
 // ---------------------------------------------------------------------------
 describe('issue #88 — uninstall-helpers', () => {
-  it('tracks all three hook variants, not just the gatekeeper (Bug 2)', () => {
+  it('tracks every hook variant, not just the gatekeeper (Bug 2)', () => {
     expect(HOOK_VARIANTS).toEqual(
-      expect.arrayContaining(['agenfk-gatekeeper', 'agenfk-mcp-enforcer', 'agenfk-pr-hook'])
+      expect.arrayContaining([
+        'agenfk-gatekeeper', 'agenfk-mcp-enforcer', 'agenfk-pr-hook', 'agenfk-test-guard',
+      ])
     );
-    expect(HOOK_VARIANTS).toHaveLength(3);
+    expect(HOOK_VARIANTS).toHaveLength(4);
   });
 
-  it('hookBinFilenames includes the CLI symlink + all 3 hooks, with .cmd on win32', () => {
+  it('hookBinFilenames includes the CLI symlink + every hook, with .cmd on win32', () => {
     expect(hookBinFilenames('linux')).toEqual([
-      'agenfk', 'agenfk-gatekeeper', 'agenfk-mcp-enforcer', 'agenfk-pr-hook',
+      'agenfk', 'agenfk-gatekeeper', 'agenfk-mcp-enforcer', 'agenfk-pr-hook', 'agenfk-test-guard',
     ]);
     expect(hookBinFilenames('win32')).toEqual([
       'agenfk.cmd', 'agenfk-gatekeeper.cmd', 'agenfk-mcp-enforcer.cmd', 'agenfk-pr-hook.cmd',
+      'agenfk-test-guard.cmd',
     ]);
   });
 
+  // Not derived from HOOK_VARIANTS: the test guard is a Claude Code PreToolUse
+  // hook with no Opencode plugin, so the plugin list stays at three.
   it('opencodePluginFilenames are the three .mjs plugins (Bug 3)', () => {
     expect(opencodePluginFilenames()).toEqual([
       'agenfk-gatekeeper.mjs', 'agenfk-mcp-enforcer.mjs', 'agenfk-pr-hook.mjs',

--- a/packages/server/src/test/test-guard-hook.test.ts
+++ b/packages/server/src/test/test-guard-hook.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Behaviour tests for the test-guard PreToolUse hook (bin/agenfk-test-guard.mjs).
+ *
+ * The guard exists so an agent can never quietly rewrite, relax, skip or delete
+ * a test that already exists to make a red suite go green — the developer gets
+ * the call: accept the test change, or keep the test and fix the code. The
+ * behaviours worth pinning are therefore (a) it recognises test files across
+ * ecosystems, (b) it stays silent for new tests and pure additions, and (c) it
+ * asks — never hard-blocks — when existing test code is rewritten.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawn } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+// @ts-ignore — .mjs hook has no .d.ts; these are plain JS exports.
+import {
+  isTestFile,
+  classifyEdit,
+  classifyToolCall,
+  classifyBashCommand,
+  buildDirective,
+} from '../../../../bin/agenfk-test-guard.mjs';
+
+const HOOK = path.resolve(__dirname, '../../../../bin/agenfk-test-guard.mjs');
+
+function runHook(payload: unknown, client = 'claude-code'): Promise<{ status: number | null; stdout: string }> {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [HOOK, '--client', client]);
+    let stdout = '';
+    child.stdout.on('data', (c) => (stdout += c));
+    child.on('close', (status) => resolve({ status, stdout }));
+    child.stdin.write(JSON.stringify(payload));
+    child.stdin.end();
+  });
+}
+
+describe('isTestFile', () => {
+  it.each([
+    'packages/server/src/test/foo.test.ts',
+    'src/Button.spec.tsx',
+    'api/tests/test_users.py',
+    'api/users_test.py',
+    'internal/store/store_test.go',
+    'spec/models/user_spec.rb',
+    'src/main/java/com/x/UserTest.java',
+    'src/test/java/com/x/Helpers.java',
+    'apps/web/__tests__/helpers.ts',
+  ])('recognises %s as test code', (p) => {
+    expect(isTestFile(p)).toBe(true);
+  });
+
+  it.each([
+    'packages/server/src/routes/items.ts',
+    'README.md',
+    'docs/tests/overview.md',      // test-named dir, but not code
+    'src/latest.ts',               // 'test' only as a substring
+    '',
+  ])('does not flag %s', (p) => {
+    expect(isTestFile(p as string)).toBe(false);
+  });
+
+  it('handles Windows-style separators', () => {
+    expect(isTestFile('packages\\server\\src\\test\\foo.ts')).toBe(true);
+  });
+});
+
+describe('classifyEdit', () => {
+  it('allows a pure insertion (no old text)', () => {
+    expect(classifyEdit('', 'it("new case", () => {})')).toBeNull();
+  });
+
+  it('allows an append that keeps the existing text verbatim', () => {
+    const before = 'it("a", () => expect(x).toBe(1));';
+    expect(classifyEdit(before, `${before}\nit("b", () => expect(y).toBe(2));`)).toBeNull();
+  });
+
+  it('asks when an existing assertion is rewritten', () => {
+    expect(classifyEdit('expect(x).toBe(1)', 'expect(x).toBe(2)')).toMatch(/rewrites/);
+  });
+
+  it('asks when existing test code is deleted', () => {
+    expect(classifyEdit('it("a", () => expect(x).toBe(1));', '')).toMatch(/deletes/);
+  });
+
+  it.each([
+    ['it("a", () => {})', 'it.skip("a", () => {})'],
+    ['def test_a():', '@pytest.mark.skip\ndef test_a():'],
+    ['@Test\npublic void a() {}', '@Ignore\n@Test\npublic void a() {}'],
+    ['func TestA(t *testing.T) {', 'func TestA(t *testing.T) {\n\tt.Skip("flaky")'],
+  ])('asks when a skip marker is introduced (%#)', (before, after) => {
+    expect(classifyEdit(before, after)).toMatch(/disables a test/);
+  });
+});
+
+describe('classifyToolCall', () => {
+  it('ignores non-test files entirely', () => {
+    expect(classifyToolCall('Edit', { file_path: 'src/app.ts', old_string: 'a', new_string: 'b' }, true)).toBeNull();
+  });
+
+  it('ignores a brand-new test file (nothing exists to protect)', () => {
+    expect(classifyToolCall('Write', { file_path: 'src/app.test.ts', content: 'x' }, false)).toBeNull();
+  });
+
+  it('asks when an existing test file is overwritten wholesale', () => {
+    const verdict = classifyToolCall('Write', { file_path: 'src/app.test.ts', content: 'x' }, true);
+    expect(verdict?.reason).toMatch(/overwrites/);
+  });
+
+  it('asks when any one edit in a MultiEdit batch rewrites existing test code', () => {
+    const verdict = classifyToolCall('Edit', {
+      file_path: 'src/app.test.ts',
+      edits: [
+        { old_string: 'a', new_string: 'a\nb' },       // additive — fine on its own
+        { old_string: 'toBe(1)', new_string: 'toBe(2)' }, // this one decides
+      ],
+    }, true);
+    expect(verdict?.reason).toMatch(/rewrites/);
+  });
+
+  it('allows a notebook cell insert but asks on replace', () => {
+    expect(classifyToolCall('NotebookEdit', { notebook_path: 'tests/a.test.ipynb', edit_mode: 'insert' }, true)).toBeNull();
+    expect(classifyToolCall('NotebookEdit', { notebook_path: 'tests/a.test.ipynb', edit_mode: 'replace' }, true)?.reason)
+      .toMatch(/replaces a cell/);
+  });
+});
+
+describe('classifyBashCommand', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agenfk-test-guard-'));
+  const testFile = path.join(dir, 'thing.test.ts');
+  const srcFile = path.join(dir, 'thing.ts');
+
+  beforeAll(() => {
+    fs.writeFileSync(testFile, 'it("a", () => {});');
+    fs.writeFileSync(srcFile, 'export const a = 1;');
+  });
+  afterAll(() => { try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ } });
+
+  it('asks when an existing test file is rm-ed', () => {
+    expect(classifyBashCommand(`rm ${testFile}`)?.reason).toMatch(/deletes an existing test file/);
+    expect(classifyBashCommand(`git rm -f "${testFile}"`)?.reason).toMatch(/deletes an existing test file/);
+  });
+
+  it('ignores rm of non-test files and unrelated commands', () => {
+    expect(classifyBashCommand(`rm ${srcFile}`)).toBeNull();
+    expect(classifyBashCommand('npm test')).toBeNull();
+    expect(classifyBashCommand(`cat ${testFile}`)).toBeNull();
+  });
+
+  it('ignores a path that does not exist (nothing to protect)', () => {
+    expect(classifyBashCommand(`rm ${path.join(dir, 'ghost.test.ts')}`)).toBeNull();
+  });
+});
+
+describe('buildDirective', () => {
+  it('asks — never blocks — on Claude Code, so the developer answers inline', () => {
+    const directive = buildDirective('claude-code', 'because');
+    expect(directive.hookSpecificOutput.hookEventName).toBe('PreToolUse');
+    expect(directive.hookSpecificOutput.permissionDecision).toBe('ask');
+    expect(directive.hookSpecificOutput.permissionDecisionReason).toBe('because');
+    expect(JSON.stringify(directive)).not.toContain('"deny"');
+  });
+
+  it('carries the reason for every other client shape', () => {
+    for (const client of ['codex', 'gemini', 'cursor', 'opencode', 'pi', 'unknown']) {
+      expect(JSON.stringify(buildDirective(client, 'because'))).toContain('because');
+    }
+  });
+});
+
+describe('the hook end to end', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agenfk-test-guard-e2e-'));
+  const testFile = path.join(dir, 'thing.test.ts');
+
+  beforeAll(() => { fs.writeFileSync(testFile, 'it("a", () => expect(x).toBe(1));'); });
+  afterAll(() => { try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ } });
+
+  it('asks the developer when an existing test is rewritten, offering both options', async () => {
+    const { status, stdout } = await runHook({
+      tool: 'Edit',
+      tool_input: { file_path: testFile, old_string: 'toBe(1)', new_string: 'toBe(2)' },
+    });
+    expect(status).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.hookSpecificOutput.permissionDecision).toBe('ask');
+    const reason = parsed.hookSpecificOutput.permissionDecisionReason;
+    expect(reason).toContain('ACCEPT the test change');
+    expect(reason).toContain('KEEP the test as-is and fix the production code');
+  });
+
+  it('stays silent when new test cases are appended', async () => {
+    const before = 'it("a", () => expect(x).toBe(1));';
+    const { status, stdout } = await runHook({
+      tool: 'Edit',
+      tool_input: { file_path: testFile, old_string: before, new_string: `${before}\nit("b", () => {});` },
+    });
+    expect(status).toBe(0);
+    expect(stdout.trim()).toBe('');
+  });
+
+  it('stays silent for production code', async () => {
+    const { stdout } = await runHook({
+      tool: 'Edit',
+      tool_input: { file_path: path.join(dir, 'thing.ts'), old_string: 'a', new_string: 'b' },
+    });
+    expect(stdout.trim()).toBe('');
+  });
+});

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -520,6 +520,8 @@ async function run() {
     const enforcerDest = os.platform() === 'win32' ? `${enforcerDestBase}.cmd` : enforcerDestBase;
     const prHookDestBase = path.join(localBinDir, 'agenfk-pr-hook');
     const prHookDest = os.platform() === 'win32' ? `${prHookDestBase}.cmd` : prHookDestBase;
+    const testGuardDestBase = path.join(localBinDir, 'agenfk-test-guard');
+    const testGuardDest = os.platform() === 'win32' ? `${testGuardDestBase}.cmd` : testGuardDestBase;
 
     // --rules-only: skip steps 3b–12, jump straight to rules installation (step 13)
     if (rulesOnly) {
@@ -1213,7 +1215,7 @@ process.exit(0);
     const gatekeeperSource = path.join(rootDir, 'bin', 'agenfk-gatekeeper.mjs');
     const internalBinDir = path.join(agenfkHome, 'bin');
     await fs.mkdir(internalBinDir, { recursive: true });
-    for (const script of ['agenfk-gatekeeper.mjs', 'agenfk-mcp-enforcer.mjs', 'agenfk-pr-hook.mjs']) {
+    for (const script of ['agenfk-gatekeeper.mjs', 'agenfk-mcp-enforcer.mjs', 'agenfk-pr-hook.mjs', 'agenfk-test-guard.mjs']) {
         const src = path.join(rootDir, 'bin', script);
         if (existsSync(src)) {
             await fs.copyFile(src, path.join(internalBinDir, script));
@@ -1272,6 +1274,24 @@ process.exit(0);
             }
         }
         console.log(`  Installed: ${prHookDestBase}${os.platform() === 'win32' ? '.cmd' : ''}`);
+
+        // 12f. Install agenfk-test-guard into ~/.local/bin (asks the developer
+        // before an EXISTING test is rewritten, skipped or deleted).
+        const testGuardSource = path.join(rootDir, 'bin', 'agenfk-test-guard.mjs');
+
+        if (os.platform() === 'win32') {
+            await fs.writeFile(`${testGuardDestBase}.cmd`, `@echo off\nnode "${testGuardSource}" %*`, 'utf8');
+            if (isMinGW) {
+                await fs.writeFile(testGuardDestBase, `#!/bin/sh\nnode "${testGuardSource}" "$@"`, 'utf8');
+                chmodSync(testGuardDestBase, 0o755);
+            }
+        } else {
+            if (existsSync(testGuardSource)) {
+                await fs.copyFile(testGuardSource, testGuardDestBase);
+                chmodSync(testGuardDestBase, 0o755);
+            }
+        }
+        console.log(`  Installed: ${testGuardDestBase}${os.platform() === 'win32' ? '.cmd' : ''}`);
     }
 
     // 12c. Install Opencode MCP enforcer plugin
@@ -1501,12 +1521,21 @@ process.exit(0);
         
         settings.hooks.PreToolUse = settings.hooks.PreToolUse.filter(entry =>
             !JSON.stringify(entry).includes('agenfk-gatekeeper') &&
-            !JSON.stringify(entry).includes('agenfk-mcp-enforcer')
+            !JSON.stringify(entry).includes('agenfk-mcp-enforcer') &&
+            !JSON.stringify(entry).includes('agenfk-test-guard')
         );
 
         settings.hooks.PreToolUse.push({
             matcher: 'Edit|Write|NotebookEdit',
             hooks: [{ type: 'command', command: gatekeeperDest }]
+        });
+
+        // Test guard: asks the developer to choose (accept the test change vs fix
+        // the code) before existing test code is rewritten, skipped or deleted.
+        // Bash is matched too so `rm`/`git rm` of a test file is caught as well.
+        settings.hooks.PreToolUse.push({
+            matcher: 'Edit|Write|NotebookEdit|Bash',
+            hooks: [{ type: 'command', command: `${testGuardDest} --client claude-code` }]
         });
 
         settings.hooks.PreToolUse.push({

--- a/scripts/uninstall-helpers.mjs
+++ b/scripts/uninstall-helpers.mjs
@@ -9,18 +9,21 @@
 
 // Every hook variant the installer writes. Used both for bin removal and for
 // filtering hook entries out of every client's settings/hooks file.
-export const HOOK_VARIANTS = ['agenfk-gatekeeper', 'agenfk-mcp-enforcer', 'agenfk-pr-hook'];
+export const HOOK_VARIANTS = ['agenfk-gatekeeper', 'agenfk-mcp-enforcer', 'agenfk-pr-hook', 'agenfk-test-guard'];
 
 // Bin filenames the installer drops into ~/.local/bin. The `agenfk` CLI symlink
-// plus all three hook variants. On Windows each is a `.cmd` shim.
+// plus every hook variant. On Windows each is a `.cmd` shim.
 export function hookBinFilenames(platform) {
   const suffix = platform === 'win32' ? '.cmd' : '';
   return ['agenfk', ...HOOK_VARIANTS].map((n) => `${n}${suffix}`);
 }
 
 // Opencode plugin filenames the installer copies into ~/.config/opencode/plugins.
+// Listed explicitly rather than derived from HOOK_VARIANTS: not every hook ships
+// an Opencode plugin (the test guard is a Claude Code PreToolUse hook, because
+// only that client can turn the verdict into a developer-facing prompt).
 export function opencodePluginFilenames() {
-  return HOOK_VARIANTS.map((n) => `${n}.mjs`);
+  return ['agenfk-gatekeeper', 'agenfk-mcp-enforcer', 'agenfk-pr-hook'].map((n) => `${n}.mjs`);
 }
 
 // True if a single hook entry (from any client's hook array) references an AgenFK

--- a/scripts/uninstall.mjs
+++ b/scripts/uninstall.mjs
@@ -7,6 +7,7 @@ import { spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import {
     HOOK_VARIANTS,
+    opencodePluginFilenames,
     stripAgenfkHookEntries,
     resolveConfirmation,
     summarizeResults,
@@ -174,7 +175,7 @@ async function run() {
         console.log("  - Gemini CLI workflow rules (~/.gemini/GEMINI.md) + AfterTool hook");
         console.log("  - AgenFK workflow rules from ~/.claude/CLAUDE.md");
         console.log("  - AgenFK Pre/PostToolUse hooks from ~/.claude/settings.json");
-        console.log("  - Hook scripts (gatekeeper, mcp-enforcer, pr-hook) from ~/.local/bin");
+        console.log("  - Hook scripts (gatekeeper, mcp-enforcer, pr-hook, test-guard) from ~/.local/bin");
         console.log("  - ~/.agenfk (config + verify token) and ~/.agenfk-system (the framework files)");
         console.log("");
     }
@@ -339,8 +340,8 @@ async function run() {
         console.log(`${GREEN}[6a] Removing Opencode plugins...${NC}`);
         const pluginsDir = path.join(os.homedir(), '.config', 'opencode', 'plugins');
         let removed = false;
-        for (const variant of HOOK_VARIANTS) {
-            const dest = path.join(pluginsDir, `${variant}.mjs`);
+        for (const plugin of opencodePluginFilenames()) {
+            const dest = path.join(pluginsDir, plugin);
             if (await rmIfExists(dest)) {
                 console.log(`  Removed: ${dest}`);
                 removed = true;


### PR DESCRIPTION
## Summary

Adds `agenfk-test-guard`, a Claude Code PreToolUse hook that asks the developer to confirm before an **existing** test is rewritten, skipped, or deleted. It never blocks new tests or added test cases, and it returns `permissionDecision: "ask"` (never `deny`) so the developer picks between accepting the test change and fixing the code under test.

<img width="666" height="302" alt="test-guard-in-action" src="https://github.com/user-attachments/assets/beccc222-3e08-4509-83f8-9048551d4ee2" />


## Changes

- `bin/agenfk-test-guard.mjs` — new hook: detects edits that relax/skip/delete existing tests (including `rm` / `git rm` of test files) and raises a confirmation prompt.
- `scripts/install.mjs`, `scripts/uninstall*.mjs` — register/unregister the hook alongside `agenfk-gatekeeper` and `agenfk-mcp-enforcer`.
- Rule bundles kept in sync: `clauderules/CLAUDE.md`, `codexrules/AGENTS.md`, `cursorrules/agenfk.mdc`, `geminirules/GEMINI.md`, `SKILL.md`, `commands/agenfk-test.md`, plus `CLAUDE.md` and `AFK_ARCHITECTURE.md`.

## Tests

- New: `packages/server/src/test/test-guard-hook.test.ts` (208 lines) covering the hook's decision surface.
- Updated install/uninstall tests to assert the third hook is written and removed.