### PR TITLE
fix(security): override 5 transitive deps to patched versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1218,9 +1218,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "1.19.17",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -5767,9 +5767,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -6280,9 +6280,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.27",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
-      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.3.tgz",
+      "integrity": "sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -6506,9 +6506,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.3.1.tgz",
+      "integrity": "sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -10029,9 +10029,9 @@
       }
     },
     "node_modules/socket.io-parser": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
-      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.7.tgz",
+      "integrity": "sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==",
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,13 @@
   "engines": {
     "node": ">=22.5.0"
   },
+  "overrides": {
+    "hono": "^4.12.34",
+    "@hono/node-server": "^1.19.15",
+    "fast-uri": "3.1.5",
+    "ip-address": "10.3.1",
+    "socket.io-parser": "4.2.7"
+  },
   "type": "module",
   "devDependencies": {
     "@testing-library/jest-dom": "^7.0.1",


### PR DESCRIPTION
## What

Adds an npm `overrides` block to the root `package.json` and surgically bumps 5 transitive runtime dependencies in `package-lock.json` to their patched versions. This clears the 5 remaining **high/medium Dependabot runtime findings** on `main` (currently 15 high / 16 medium / 5 low).

## Why a plain dependency bump won't do it

All 5 are **transitive** and their upstream ranges still resolve to vulnerable versions, so `npm update` / a Dependabot PR cannot fix them on its own:

| Package | main → patched | Pulled in by | Finding |
|---|---|---|---|
| `hono` | 4.12.27 → 4.13.3 | `@modelcontextprotocol/sdk` | high |
| `@hono/node-server` | 1.19.14 → 1.19.17 | `@modelcontextprotocol/sdk` | medium |
| `fast-uri` | 3.1.2 → 3.1.5 | `ajv` → `@modelcontextprotocol/sdk` | high |
| `ip-address` | 10.2.0 → 10.3.1 | `express-rate-limit` → `@modelcontextprotocol/sdk` | high |
| `socket.io-parser` | 4.2.6 → 4.2.7 | `socket.io` / `socket.io-client` | high |

Even the latest `@modelcontextprotocol/sdk@1.30.0` pins `hono ^4.11.4`, `@hono/node-server ^1.19.9 || ^2.0.5`, `express-rate-limit ^8.2.1`, and `ajv ^8.17.1`, which resolve to the still-vulnerable versions.

## Safety

- Every override is a **patch/minor bump within the same major**, inside the ranges the parents already permit (MCP SDK allows `hono ^4` and `@hono/node-server ^1.19.9||^2.0.5`; socket.io 4.8.3 pins `socket.io-parser ~4.2.4`).
- `engines`/`peerDependencies` metadata is **identical** between the locked and patched versions, so the lockfile diff is limited to the 5 intended entries.
- Patched tarballs + `integrity` hashes verified from the npm registry; `npm ci` accepts the resulting lockfile.

## Remaining alerts

These 5 are the runtime leftovers. The remaining open alerts (js-yaml, undici, immutable, brace-expansion) are **development/test-only** tooling and will fall out of the upcoming Dependabot dev-group batches.
