### PR TITLE
feat(cli,ui): agenfk ui --open <itemId> — deep-link item highlight (CGLAB-100)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -105,6 +105,7 @@ enforced by the server. Each workflow tool name in this skill maps to a CLI comm
 | `query_token_events(...)` | `agenfk tokens [--item <id>][--project <id>][--client <name>][--since <ts>][--until <ts>][--limit <n>][--json]` |
 | `register_pr(...)` / `update_pr_sizing(...)` | `agenfk pr-register --item <id> --number <n> --repo <r> --epic <n> --story <n> --task <n> --bug <n> --model <id> --harness <name>` / `agenfk pr-resize --number <n> --repo <r> --epic <n> --story <n> --task <n> --bug <n> --model <id> --harness <name>` (`--model` and `--harness` are **REQUIRED** on both) |
 | `analyze_request(req)` | `agenfk analyze "<request>"` |
+| *(show item in the dashboard)* | `agenfk ui [--open <itemId>]` — opens the dashboard in the browser; `--open <itemId>` deep-links the web UI so that item is highlighted (the Search Box pre-fills with the id and navigates to it, exactly like a manual search). No MCP equivalent — CLI only. |
 
 **Read output**: append `--json` to any read command (`list`, `get`, `list-projects`,
 `current-project`, `flow show`, `tokens`, …) for machine-readable output you can parse
@@ -248,6 +249,7 @@ Use this skill whenever you are performing software engineering tasks to ensure 
 *   `agenfk verify <id> --evidence "<text>" ["<command>"]`: Step-completion gate — `evidence` (how you satisfied the exit criteria, logged as a tagged comment) is required; the command is optional. Advances to next step on success.
 *   `agenfk pause-work <id> --summary "<s>" --resume-instructions "<r>"`: Save context snapshot and pause item.
 *   `agenfk resume-work <id>`: Restore context and resume paused item.
+*   `agenfk ui [--open <itemId>]`: Open the dashboard in the browser. With `--open <itemId>` it opens the web UI with that item highlighted (the Search Box pre-fills with the id and navigates to it, like a manual search). **When the user asks to *show* an item — "show me that task", "open <id> in the dashboard", "where is <id> on the board" — run `agenfk ui --open <itemId>`.** It is a read-only display operation: no workflow state changes, no gatekeeper needed.
 
 Token usage is captured automatically by the server-side ingestion worker — agents do not need to (and cannot) self-report tokens.
 

--- a/clauderules/CLAUDE.md
+++ b/clauderules/CLAUDE.md
@@ -154,6 +154,7 @@ This is the full workflow surface. Each row notes the equivalent MCP tool (avail
 | Restart services | `agenfk restart [-q/--quiet]` |
 | Force-kill all processes/ports | `agenfk kill` |
 | Open / show the dashboard | `agenfk ui` |
+| Show item in the dashboard | `agenfk ui --open <itemId>` — opens the web UI with that item highlighted (deep-links the Search Box to the item id) |
 | Check framework health | `agenfk health` |
 | Upgrade the framework | `agenfk upgrade [-f/--force][-b/--beta][--version <ver>][--json][--debuglog]` |
 | Back up the database | `agenfk backup` |
@@ -161,6 +162,8 @@ This is the full workflow surface. Each row notes the equivalent MCP tool (avail
 | Initialize a project in the cwd | `agenfk init [name] [-d/--description <desc>]` |
 | Fix Claude Code MCP integration | `agenfk configure-ide` |
 | Start the MCP server (stdio) | `agenfk mcp` |
+
+**Showing an item to the user**: when the user asks to *show* an item ("show me that task", "open <id> in the dashboard", "where is <id> on the board"), run `agenfk ui --open <itemId>` — it opens the web UI with that item highlighted, exactly like searching the id in the UI's Search Box. Read-only display — no workflow state changes, no gatekeeper needed.
 
 **Integrations, rules/skills & config** (CLI-only)
 

--- a/codexrules/AGENTS.md
+++ b/codexrules/AGENTS.md
@@ -163,6 +163,7 @@ This is the full workflow surface. In Codex, call the **`mcp__agenfk__*` tool** 
 | Restart services | `agenfk restart [-q/--quiet]` |
 | Force-kill all processes/ports | `agenfk kill` |
 | Open / show the dashboard | `agenfk ui` |
+| Show item in the dashboard | `agenfk ui --open <itemId>` — opens the web UI with that item highlighted (deep-links the Search Box to the item id) |
 | Check framework health | `agenfk health` |
 | Upgrade the framework | `agenfk upgrade [-f/--force][-b/--beta][--version <ver>][--json][--debuglog]` |
 | Back up the database | `agenfk backup` |
@@ -170,6 +171,8 @@ This is the full workflow surface. In Codex, call the **`mcp__agenfk__*` tool** 
 | Initialize a project in the cwd | `agenfk init [name] [-d/--description <desc>]` |
 | Fix Claude Code MCP integration | `agenfk configure-ide` |
 | Start the MCP server (stdio) | `agenfk mcp` |
+
+**Showing an item to the user**: when the user asks to *show* an item ("show me that task", "open <id> in the dashboard", "where is <id> on the board"), run `agenfk ui --open <itemId>` — it opens the web UI with that item highlighted, exactly like searching the id in the UI's Search Box. Read-only display — no workflow state changes, no gatekeeper needed.
 
 **Integrations, rules/skills & config** (CLI-only)
 

--- a/commands/agenfk.md
+++ b/commands/agenfk.md
@@ -29,6 +29,12 @@ This avoids redundant build and test runs when the underlying code changes are s
 
 ---
 
+## Showing an Item in the UI
+
+When the user asks to *show* an item — "show me that task", "open <id> in the dashboard", "where is <id> on the board" — run `agenfk ui --open <itemId>`: it opens the web UI with that item highlighted (the Search Box pre-fills with the id and navigates to it, exactly like a manual search). It is a read-only display operation — no workflow state changes, no gatekeeper authorization needed.
+
+---
+
 ## Step 0 — Classify the request
 
 Before creating any item, evaluate the request against these signals:

--- a/cursorrules/agenfk.mdc
+++ b/cursorrules/agenfk.mdc
@@ -162,6 +162,7 @@ This is the full workflow surface. Each row notes the equivalent MCP tool (avail
 | Restart services | `agenfk restart [-q/--quiet]` |
 | Force-kill all processes/ports | `agenfk kill` |
 | Open / show the dashboard | `agenfk ui` |
+| Show item in the dashboard | `agenfk ui --open <itemId>` — opens the web UI with that item highlighted (deep-links the Search Box to the item id) |
 | Check framework health | `agenfk health` |
 | Upgrade the framework | `agenfk upgrade [-f/--force][-b/--beta][--version <ver>][--json][--debuglog]` |
 | Back up the database | `agenfk backup` |
@@ -169,6 +170,8 @@ This is the full workflow surface. Each row notes the equivalent MCP tool (avail
 | Initialize a project in the cwd | `agenfk init [name] [-d/--description <desc>]` |
 | Fix Claude Code MCP integration | `agenfk configure-ide` |
 | Start the MCP server (stdio) | `agenfk mcp` |
+
+**Showing an item to the user**: when the user asks to *show* an item ("show me that task", "open <id> in the dashboard", "where is <id> on the board"), run `agenfk ui --open <itemId>` — it opens the web UI with that item highlighted, exactly like searching the id in the UI's Search Box. Read-only display — no workflow state changes, no gatekeeper needed.
 
 **Integrations, rules/skills & config** (CLI-only)
 

--- a/geminirules/GEMINI.md
+++ b/geminirules/GEMINI.md
@@ -158,6 +158,7 @@ This is the full workflow surface. Each row notes the equivalent MCP tool (avail
 | Restart services | `agenfk restart [-q/--quiet]` |
 | Force-kill all processes/ports | `agenfk kill` |
 | Open / show the dashboard | `agenfk ui` |
+| Show item in the dashboard | `agenfk ui --open <itemId>` — opens the web UI with that item highlighted (deep-links the Search Box to the item id) |
 | Check framework health | `agenfk health` |
 | Upgrade the framework | `agenfk upgrade [-f/--force][-b/--beta][--version <ver>][--json][--debuglog]` |
 | Back up the database | `agenfk backup` |
@@ -165,6 +166,8 @@ This is the full workflow surface. Each row notes the equivalent MCP tool (avail
 | Initialize a project in the cwd | `agenfk init [name] [-d/--description <desc>]` |
 | Fix Claude Code MCP integration | `agenfk configure-ide` |
 | Start the MCP server (stdio) | `agenfk mcp` |
+
+**Showing an item to the user**: when the user asks to *show* an item ("show me that task", "open <id> in the dashboard", "where is <id> on the board"), run `agenfk ui --open <itemId>` — it opens the web UI with that item highlighted, exactly like searching the id in the UI's Search Box. Read-only display — no workflow state changes, no gatekeeper needed.
 
 **Integrations, rules/skills & config** (CLI-only)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenfk",
-  "version": "1.1.15",
+  "version": "1.1.16-beta.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenfk",
-      "version": "1.1.15",
+      "version": "1.1.16-beta.6",
       "license": "ISC",
       "workspaces": [
         "packages/core",
@@ -11230,11 +11230,11 @@
     },
     "packages/cli": {
       "name": "@agenfk/cli",
-      "version": "1.1.15",
+      "version": "1.1.16-beta.6",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.1.15",
-        "@agenfk/telemetry": "1.1.15",
+        "@agenfk/core": "1.1.16-beta.6",
+        "@agenfk/telemetry": "1.1.16-beta.6",
         "axios": "^1.19.0",
         "chalk": "^4.1.2",
         "commander": "^12.0.0",
@@ -11254,7 +11254,7 @@
     },
     "packages/core": {
       "name": "@agenfk/core",
-      "version": "1.1.15",
+      "version": "1.1.16-beta.6",
       "license": "ISC",
       "devDependencies": {
         "typescript": "^5.3.3"
@@ -11262,7 +11262,7 @@
     },
     "packages/create": {
       "name": "agenfk",
-      "version": "1.1.15",
+      "version": "1.1.16-beta.6",
       "license": "ISC",
       "bin": {
         "agenfk": "bin/agenfk.js"
@@ -11273,7 +11273,7 @@
     },
     "packages/flow-editor": {
       "name": "@agenfk/flow-editor",
-      "version": "1.1.15",
+      "version": "1.1.16-beta.6",
       "peerDependencies": {
         "@tanstack/react-query": "^5.101.4",
         "clsx": "^2.1.1",
@@ -11285,9 +11285,9 @@
     },
     "packages/hub": {
       "name": "@agenfk/hub",
-      "version": "1.1.15",
+      "version": "1.1.16-beta.6",
       "dependencies": {
-        "@agenfk/core": "1.1.15",
+        "@agenfk/core": "1.1.16-beta.6",
         "axios": "^1.19.0",
         "bcryptjs": "^2.4.3",
         "cookie-parser": "^1.4.7",
@@ -11311,9 +11311,9 @@
       }
     },
     "packages/hub-ui": {
-      "version": "1.1.15",
+      "version": "1.1.16-beta.6",
       "dependencies": {
-        "@agenfk/flow-editor": "1.1.15",
+        "@agenfk/flow-editor": "1.1.16-beta.6",
         "@fontsource-variable/jetbrains-mono": "^5.3.0",
         "@fontsource-variable/manrope": "^5.3.0",
         "@tailwindcss/postcss": "^4.3.3",
@@ -11686,12 +11686,12 @@
     },
     "packages/server": {
       "name": "@agenfk/server",
-      "version": "1.1.15",
+      "version": "1.1.16-beta.6",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.1.15",
-        "@agenfk/storage-sqlite": "1.1.15",
-        "@agenfk/telemetry": "1.1.15",
+        "@agenfk/core": "1.1.16-beta.6",
+        "@agenfk/storage-sqlite": "1.1.16-beta.6",
+        "@agenfk/telemetry": "1.1.16-beta.6",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "axios": "^1.19.0",
         "body-parser": "^2.3.0",
@@ -11714,13 +11714,13 @@
     },
     "packages/storage-sqlite": {
       "name": "@agenfk/storage-sqlite",
-      "version": "1.1.15",
+      "version": "1.1.16-beta.6",
       "license": "ISC",
       "dependencies": {
         "uuid": "^14.0.2"
       },
       "devDependencies": {
-        "@agenfk/core": "1.1.15",
+        "@agenfk/core": "1.1.16-beta.6",
         "@types/node": "^22.0.0",
         "@types/uuid": "^9.0.8",
         "typescript": "^5.3.3"
@@ -11738,7 +11738,7 @@
     },
     "packages/telemetry": {
       "name": "@agenfk/telemetry",
-      "version": "1.1.15",
+      "version": "1.1.16-beta.6",
       "license": "ISC",
       "dependencies": {
         "posthog-node": "^4.0.0"
@@ -11749,9 +11749,9 @@
       }
     },
     "packages/ui": {
-      "version": "1.1.15",
+      "version": "1.1.16-beta.6",
       "dependencies": {
-        "@agenfk/flow-editor": "1.1.15",
+        "@agenfk/flow-editor": "1.1.16-beta.6",
         "@fontsource-variable/jetbrains-mono": "^5.3.0",
         "@fontsource-variable/manrope": "^5.3.0",
         "@tailwindcss/postcss": "^4.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "1.1.15",
+  "version": "1.1.16-beta.6",
   "description": "AgenFK Engineering Framework",
   "private": true,
   "workspaces": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/cli",
-  "version": "1.1.15",
+  "version": "1.1.16-beta.6",
   "description": "CLI for AgenFK Engineering Framework",
   "main": "dist/index.js",
   "bin": {
@@ -12,8 +12,8 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.15",
-    "@agenfk/telemetry": "1.1.15",
+    "@agenfk/core": "1.1.16-beta.6",
+    "@agenfk/telemetry": "1.1.16-beta.6",
     "axios": "^1.19.0",
     "chalk": "^4.1.2",
     "commander": "^12.0.0",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -11,6 +11,7 @@ import path from 'path';
 import os from 'os';
 import { stageJsonMigration } from './db-migration.js';
 import { followValidateRun } from './verifyRun.js';
+import { buildUiOpenUrl, resolveDashboardUrl } from './uiUrl.js';
 import { registerHubCommands } from './commands/hub.js';
 import { toonEncode } from './toon.js';
 
@@ -813,22 +814,31 @@ program
 program
   .command('ui')
   .description('Show dashboard information and open in browser')
-  .action(() => {
+  .option('--open <itemId>', 'Open the dashboard with that item highlighted (deep-links the Search Box to the item id)')
+  .action(async (options: { open?: string }) => {
     console.log(chalk.cyan('🌐 Opening UI...'));
-    
-    let uiUrl = 'http://localhost:5173';
-    try {
-      const rootDir = path.resolve(__dirname, '../../..');
-      const uiLogPath = path.join(rootDir, '.agenfk', 'ui.log');
-      if (fs.existsSync(uiLogPath)) {
-        const logContent = fs.readFileSync(uiLogPath, 'utf8');
-        const match = logContent.match(/http:\/\/localhost:\d+/);
-        if (match) {
-          uiUrl = match[0];
-        }
+
+    const rootDir = path.resolve(__dirname, '../../..');
+    const base = resolveDashboardUrl(rootDir);
+
+    let uiUrl = base;
+    if (options.open !== undefined) {
+      const itemId = options.open.trim();
+      if (!itemId) {
+        console.error(chalk.red('Error: --open requires a non-empty item id.'));
+        process.exitCode = 1;
+        return;
       }
-    } catch (err) {
-      // ignore parsing errors
+      // Deep-link: ?item=<id> makes the board pre-fill the Search Box with the
+      // id and run the search (drill-down + highlight + scroll). ?project opens
+      // the board on the project the ITEM belongs to — resolved from the server
+      // (the item id uniquely identifies it); the cwd's project is only a
+      // fallback for when the server is unreachable, since opening the board on
+      // the wrong project would silently switch the user's board and show
+      // NOT FOUND for a perfectly valid item.
+      let projectId = await resolveItemProjectId(itemId);
+      if (!projectId) projectId = findProjectId(process.cwd());
+      uiUrl = buildUiOpenUrl(base, itemId, projectId);
     }
 
     console.log(chalk.white(`Dashboard: ${uiUrl}`));
@@ -1368,6 +1378,22 @@ function findProjectId(startDir: string): string | null {
   try {
     const config = JSON.parse(fs.readFileSync(projFile, 'utf8'));
     return config.projectId || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve which project an item belongs to, from the server (the item id
+ * uniquely identifies it). Used by `agenfk ui --open` so the deep-link opens
+ * the board on the item's real project even when the cwd belongs to a
+ * different one. Returns null when the server is unreachable or the id is
+ * unknown — callers fall back to the cwd's project.
+ */
+async function resolveItemProjectId(itemId: string): Promise<string | null> {
+  try {
+    const { data } = await axios.get(`${API_URL}/items/${encodeURIComponent(itemId)}`, { timeout: 3000 });
+    return data?.projectId || null;
   } catch {
     return null;
   }

--- a/packages/cli/src/test/ui-open.test.ts
+++ b/packages/cli/src/test/ui-open.test.ts
@@ -1,0 +1,243 @@
+/**
+ * `agenfk ui --open <itemId>` — deep-link the dashboard to a specific item.
+ *
+ * User-facing contract exercised here (CGLAB-100):
+ *  - `resolveDashboardUrl` keeps the existing base-URL behaviour: the URL
+ *    recorded in `<root>/.agenfk/ui.log` wins, else the default dev port.
+ *  - `buildUiOpenUrl` appends `?item=<itemId>` (and `&project=<projectId>`
+ *    when the current project resolves) to that base, URL-encoding values.
+ *  - the commander `ui` command accepts `--open <itemId>`.
+ *  - running `ui --open <id>` launches the browser with a URL carrying both
+ *    query params when `.agenfk/project.json` resolves, and with only
+ *    `?item=` when it does not. The actual browser-open is environmental
+ *    (same as the restart-quiet tests treat the start-services script): we
+ *    intercept the execSync call and assert on the URL it received.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { execSync } from 'child_process';
+import axios from 'axios';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { program } from '../index';
+import { buildUiOpenUrl, resolveDashboardUrl } from '../uiUrl';
+
+// Capture the browser-launch instead of opening one in the test environment.
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return { ...actual, execSync: vi.fn(() => Buffer.from('')) };
+});
+
+// Keep the item->project lookup hermetic: default to "server unreachable" so
+// the action falls back to the cwd project deterministically, on any machine.
+vi.mock('axios', () => ({
+  default: { get: vi.fn(() => Promise.reject(new Error('server unreachable'))) },
+}));
+
+function makeTmpDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function uiCommand() {
+  const cmd = program.commands.find((c) => c.name() === 'ui');
+  expect(cmd, 'command "ui" should be registered').toBeDefined();
+  return cmd as any;
+}
+
+describe('resolveDashboardUrl', () => {
+  it('falls back to the default dev-server URL when no ui.log exists', () => {
+    const dir = makeTmpDir('agenfk-ui-open-');
+    try {
+      expect(resolveDashboardUrl(dir)).toBe('http://localhost:5173');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('uses the URL recorded in .agenfk/ui.log', () => {
+    const dir = makeTmpDir('agenfk-ui-open-');
+    try {
+      fs.mkdirSync(path.join(dir, '.agenfk'));
+      fs.writeFileSync(
+        path.join(dir, '.agenfk', 'ui.log'),
+        'VITE ready in 120 ms\n  ➜  Local:   http://localhost:5174/\n'
+      );
+      expect(resolveDashboardUrl(dir)).toBe('http://localhost:5174');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to the default when ui.log has no parseable URL', () => {
+    const dir = makeTmpDir('agenfk-ui-open-');
+    try {
+      fs.mkdirSync(path.join(dir, '.agenfk'));
+      fs.writeFileSync(path.join(dir, '.agenfk', 'ui.log'), 'no urls in here');
+      expect(resolveDashboardUrl(dir)).toBe('http://localhost:5173');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('buildUiOpenUrl', () => {
+  const base = 'http://localhost:5173';
+
+  it('appends ?item=<itemId> to the base dashboard URL', () => {
+    expect(buildUiOpenUrl(base, 'abc-123')).toBe('http://localhost:5173?item=abc-123');
+  });
+
+  it('appends &project=<projectId> when a project is given', () => {
+    expect(buildUiOpenUrl(base, 'abc-123', 'proj-1')).toBe(
+      'http://localhost:5173?item=abc-123&project=proj-1'
+    );
+  });
+
+  it('omits the project param when no project resolves', () => {
+    expect(buildUiOpenUrl(base, 'abc-123', null)).toBe('http://localhost:5173?item=abc-123');
+    expect(buildUiOpenUrl(base, 'abc-123', undefined)).toBe('http://localhost:5173?item=abc-123');
+  });
+
+  it('URL-encodes the item id so the UI decodes back to the exact id', () => {
+    const url = buildUiOpenUrl(base, 'a b&c');
+    // The KanbanBoard reads the param back with URLSearchParams — the contract
+    // is a lossless round-trip, not a specific escape style.
+    const decoded = new URLSearchParams(url.split('?')[1]).get('item');
+    expect(decoded).toBe('a b&c');
+  });
+
+  it('joins with & when the base URL already carries a query string', () => {
+    expect(buildUiOpenUrl('http://localhost:5173?theme=dark', 'abc-123', 'proj-1')).toBe(
+      'http://localhost:5173?theme=dark&item=abc-123&project=proj-1'
+    );
+  });
+});
+
+describe('agenfk ui --open command', () => {
+  it('declares the --open <itemId> option', () => {
+    const longs = uiCommand().options.map((o: any) => o.long);
+    expect(longs).toContain('--open');
+  });
+});
+
+describe('agenfk ui --open browser launch', () => {
+  let tmpCwd: string;
+  let realCwd: string;
+
+  beforeEach(() => {
+    // The shared commander program keeps parsed option values between parse
+    // calls (a real CLI invocation is a fresh process); drop a stale --open so
+    // each test starts clean.
+    uiCommand().setOptionValue('open', undefined);
+  });
+
+  afterEach(() => {
+    if (realCwd) process.chdir(realCwd);
+    realCwd = '';
+    if (tmpCwd) fs.rmSync(tmpCwd, { recursive: true, force: true });
+    tmpCwd = '';
+    vi.mocked(execSync).mockClear();
+  });
+
+  // The launch command is a platform opener wrapping the URL in quotes
+  // (e.g. `open "<url>"` or `xdg-open "<url>"`) — extract that URL.
+  const launchedUrls = (): string[] =>
+    vi.mocked(execSync).mock.calls
+      .map((c) => String(c[0]).match(/"(http[^"]+)"/) ?? null)
+      .filter((m): m is string[] => m !== null)
+      .map((m) => m[1]);
+
+  it('launches the browser with ?item and ?project when the current project resolves', async () => {
+    realCwd = process.cwd();
+    tmpCwd = makeTmpDir('agenfk-ui-open-cwd-');
+    fs.mkdirSync(path.join(tmpCwd, '.agenfk'));
+    fs.writeFileSync(path.join(tmpCwd, '.agenfk', 'project.json'), JSON.stringify({ projectId: 'proj-1' }));
+    process.chdir(tmpCwd);
+
+    await program.parseAsync(['node', 'agenfk', 'ui', '--open', 'item-123']);
+
+    const urls = launchedUrls().filter((u) => u.includes('?item=item-123'));
+    expect(urls.length).toBeGreaterThan(0);
+    // The base port is whatever the dev server recorded in ui.log; the
+    // contract under test is the query string, not the port.
+    expect(urls.every((u) => u.startsWith('http://localhost:'))).toBe(true);
+    expect(urls[0]).toContain('?item=item-123&project=proj-1');
+  });
+
+  it('launches with only ?item when no project resolves (server unreachable, no cwd project)', async () => {
+    realCwd = process.cwd();
+    tmpCwd = makeTmpDir('agenfk-ui-open-cwd-');
+    // No .agenfk directory anywhere up this tmp dir's tree.
+    process.chdir(tmpCwd);
+
+    await program.parseAsync(['node', 'agenfk', 'ui', '--open', 'item-456']);
+
+    const urls = launchedUrls().filter((u) => u.includes('?item=item-456'));
+    expect(urls.length).toBeGreaterThan(0);
+    expect(urls.every((u) => !u.includes('project='))).toBe(true);
+  });
+
+  it('opens the project the ITEM belongs to (from the server), not the cwd project', async () => {
+    // The item's real project must win over the cwd — a cross-project
+    // 'show item X' must not silently switch the board to the wrong project.
+    vi.mocked(axios.get).mockImplementationOnce(async () => ({ data: { projectId: 'proj-item-home' } }) as any);
+    realCwd = process.cwd();
+    tmpCwd = makeTmpDir('agenfk-ui-open-cwd-');
+    fs.mkdirSync(path.join(tmpCwd, '.agenfk'));
+    fs.writeFileSync(path.join(tmpCwd, '.agenfk', 'project.json'), JSON.stringify({ projectId: 'proj-cwd' }));
+    process.chdir(tmpCwd);
+
+    await program.parseAsync(['node', 'agenfk', 'ui', '--open', 'item-777']);
+
+    const urls = launchedUrls().filter((u) => u.includes('?item=item-777'));
+    expect(urls.length).toBeGreaterThan(0);
+    expect(urls[0]).toContain('?item=item-777&project=proj-item-home');
+    expect(urls[0]).not.toContain('proj-cwd');
+  });
+
+  it('rejects an empty --open value instead of silently opening the plain dashboard', async () => {
+    const savedExitCode = process.exitCode;
+    realCwd = process.cwd();
+    tmpCwd = makeTmpDir('agenfk-ui-open-cwd-');
+    process.chdir(tmpCwd);
+
+    await program.parseAsync(['node', 'agenfk', 'ui', '--open', '']);
+
+    expect(process.exitCode).toBe(1);
+    expect(launchedUrls().length).toBe(0);
+    process.exitCode = savedExitCode;
+  });
+
+  it('never leaks shell metacharacters from a hostile item id into the launch command', async () => {
+    // The id flows argv -> URLSearchParams -> `open "<url>"`. URLSearchParams
+    // must encode everything that could break the quoting ($, backtick, ").
+    realCwd = process.cwd();
+    tmpCwd = makeTmpDir('agenfk-ui-open-cwd-');
+    process.chdir(tmpCwd);
+
+    await program.parseAsync(['node', 'agenfk', 'ui', '--open', 'a"; echo $(id) `id`']);
+
+    const calls = vi.mocked(execSync).mock.calls.map((c) => String(c[0]));
+    expect(calls.length).toBeGreaterThan(0);
+    for (const cmd of calls) {
+      // exactly the two wrapping quotes around the URL — nothing else
+      expect((cmd.match(/"/g) ?? []).length).toBe(2);
+      expect(cmd).not.toMatch(/\$\(|`|; /);
+    }
+    // and the id still round-trips losslessly through the query string
+    const url = launchedUrls()[0];
+    expect(new URLSearchParams(url.split('?')[1]).get('item')).toBe('a"; echo $(id) `id`');
+  });
+
+  it('still opens the plain dashboard when --open is absent', async () => {
+    realCwd = process.cwd();
+    tmpCwd = makeTmpDir('agenfk-ui-open-cwd-');
+    process.chdir(tmpCwd);
+
+    await program.parseAsync(['node', 'agenfk', 'ui']);
+
+    const urls = launchedUrls();
+    expect(urls.length).toBeGreaterThan(0);
+    expect(urls.every((u) => !u.includes('?item='))).toBe(true);
+  });
+});

--- a/packages/cli/src/uiUrl.ts
+++ b/packages/cli/src/uiUrl.ts
@@ -1,0 +1,45 @@
+/**
+ * Dashboard URL construction for `agenfk ui` / `agenfk ui --open <itemId>`.
+ *
+ * Kept in a leaf module (no commander, no side effects) so the URL contract
+ * is unit-testable: the base-URL resolution and the deep-link query string are
+ * the user-facing behaviour; the browser launch itself is environmental.
+ */
+import fs from 'fs';
+import path from 'path';
+
+const DEFAULT_UI_URL = 'http://localhost:5173';
+
+/**
+ * Resolve the dashboard base URL the way `agenfk ui` always has: the URL the
+ * dev server recorded in `<rootDir>/.agenfk/ui.log` wins; anything else (no
+ * log, unparseable log) falls back to the default dev port.
+ */
+export function resolveDashboardUrl(rootDir: string): string {
+  let logContent: string;
+  try {
+    logContent = fs.readFileSync(path.join(rootDir, '.agenfk', 'ui.log'), 'utf8');
+  } catch {
+    // No log (or unreadable) — the default URL is still usable.
+    return DEFAULT_UI_URL;
+  }
+  const match = logContent.match(/http:\/\/localhost:\d+/);
+  return match ? match[0] : DEFAULT_UI_URL;
+}
+
+/**
+ * Build the URL `agenfk ui --open <itemId>` launches the browser with.
+ *
+ * `?item=<itemId>` makes the KanbanBoard pre-fill the Search Box with the id
+ * and run the search (drill-down + highlight + scroll, exactly like typing
+ * the id into the box). `&project=<projectId>` — appended only when a
+ * project resolves — makes the board open on the project the item belongs to,
+ * since the board's default project otherwise comes from localStorage.
+ */
+export function buildUiOpenUrl(base: string, itemId: string, projectId?: string | null): string {
+  const params = new URLSearchParams();
+  params.set('item', itemId);
+  if (projectId) params.set('project', projectId);
+  const separator = base.includes('?') ? '&' : '?';
+  return `${base}${separator}${params.toString()}`;
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/core",
-  "version": "1.1.15",
+  "version": "1.1.16-beta.6",
   "description": "Core logic and interfaces for the AgenFK Engineering Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "1.1.15",
+  "version": "1.1.16-beta.6",
   "description": "AgenFK Agentic Engineering Framework — installer",
   "bin": {
     "agenfk": "bin/agenfk.js"

--- a/packages/flow-editor/package.json
+++ b/packages/flow-editor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agenfk/flow-editor",
   "private": true,
-  "version": "1.1.15",
+  "version": "1.1.16-beta.6",
   "type": "module",
   "main": "./src/index.ts",
   "exports": {

--- a/packages/hub-ui/package.json
+++ b/packages/hub-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hub-ui",
   "private": true,
-  "version": "1.1.15",
+  "version": "1.1.16-beta.6",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.1.15",
+    "@agenfk/flow-editor": "1.1.16-beta.6",
     "@fontsource-variable/jetbrains-mono": "^5.3.0",
     "@fontsource-variable/manrope": "^5.3.0",
     "@tailwindcss/postcss": "^4.3.3",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/hub",
-  "version": "1.1.15",
+  "version": "1.1.16-beta.6",
   "description": "Corporate Hub for AgEnFK — fleet-wide metrics + timeline server",
   "main": "dist/server.js",
   "types": "dist/server.d.ts",
@@ -20,7 +20,7 @@
     "start": "node dist/bin.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.15",
+    "@agenfk/core": "1.1.16-beta.6",
     "axios": "^1.19.0",
     "bcryptjs": "^2.4.3",
     "cookie-parser": "^1.4.7",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/server",
-  "version": "1.1.15",
+  "version": "1.1.16-beta.6",
   "description": "MCP Server for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -12,9 +12,9 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.15",
-    "@agenfk/storage-sqlite": "1.1.15",
-    "@agenfk/telemetry": "1.1.15",
+    "@agenfk/core": "1.1.16-beta.6",
+    "@agenfk/storage-sqlite": "1.1.16-beta.6",
+    "@agenfk/telemetry": "1.1.16-beta.6",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "axios": "^1.19.0",
     "body-parser": "^2.3.0",

--- a/packages/storage-sqlite/package.json
+++ b/packages/storage-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/storage-sqlite",
-  "version": "1.1.15",
+  "version": "1.1.16-beta.6",
   "description": "SQLite storage implementation for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -11,7 +11,7 @@
     "uuid": "^14.0.2"
   },
   "devDependencies": {
-    "@agenfk/core": "1.1.15",
+    "@agenfk/core": "1.1.16-beta.6",
     "@types/node": "^22.0.0",
     "@types/uuid": "^9.0.8",
     "typescript": "^5.3.3"

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/telemetry",
-  "version": "1.1.15",
+  "version": "1.1.16-beta.6",
   "description": "Anonymous telemetry client for AgenFK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.1.15",
+  "version": "1.1.16-beta.6",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -12,7 +12,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.1.15",
+    "@agenfk/flow-editor": "1.1.16-beta.6",
     "@fontsource-variable/jetbrains-mono": "^5.3.0",
     "@fontsource-variable/manrope": "^5.3.0",
     "@tailwindcss/postcss": "^4.3.3",

--- a/packages/ui/src/components/KanbanBoard.tsx
+++ b/packages/ui/src/components/KanbanBoard.tsx
@@ -431,13 +431,30 @@ const KanbanCard: React.FC<KanbanCardProps> = ({
   );
 };
 
+// Deep-link URL params (`agenfk ui --open <id>`): ?project selects the project,
+// ?item locates and highlights the item. Applied once, then stripped from the
+// URL (stripDeepLinkParams) so a later reload honours the user's picker choice
+// instead of re-applying a stale deep-link over it.
+const getUrlParam = (name: string): string | null =>
+  new URLSearchParams(window.location.search).get(name);
+
+const stripDeepLinkParams = () => {
+  if (!getUrlParam('item') && !getUrlParam('project')) return;
+  window.history.replaceState(null, '', window.location.pathname + window.location.hash);
+};
+
 export const KanbanBoard: React.FC = () => {
   const queryClient = useQueryClient();
   const { theme, toggleTheme } = useTheme();
   const easterEggsEnabled = useEasterEggs();
   
   // Project State
-  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(() => localStorage.getItem('agenfk_project_id'));
+  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(() => {
+    // `agenfk ui --open <id>&project=<pid>` deep-link: an explicit project in
+    // the URL wins over the last-used project in localStorage.
+    const fromUrl = getUrlParam('project');
+    return fromUrl || localStorage.getItem('agenfk_project_id');
+  });
   const [isCreatingProject, setIsCreatingProject] = useState(false);
   const [projectSearch, setProjectSearch] = useState('');
   const [highlightedProjectIndex, setHighlightedProjectIndex] = useState(-1);
@@ -508,6 +525,24 @@ export const KanbanBoard: React.FC = () => {
     queryFn: () => api.listProjects()
   });
 
+  // One-shot guard for the ?item deep-link (declared here so the stale-clear
+  // effect below can suppress a deep-link whose project turned out invalid).
+  const deepLinkAppliedRef = React.useRef(false);
+
+  // Deep-link (?project): `agenfk ui --open <id>&project=<pid>` may target a
+  // different project than the one in localStorage. The initializer above has
+  // already applied it; persist it the same way the project picker does so a
+  // later reload (without the param) still opens on that project. An invalid
+  // ?project is cleaned up by the stale-clear effect below.
+  useEffect(() => {
+    const fromUrl = getUrlParam('project');
+    if (fromUrl && fromUrl !== localStorage.getItem('agenfk_project_id')) {
+      localStorage.setItem('agenfk_project_id', fromUrl);
+    }
+    // With no ?item to apply there is nothing left to consume the params.
+    if (!getUrlParam('item')) stripDeepLinkParams();
+  }, []);
+
   // Clear stale localStorage project ID if it no longer exists in the DB
   useEffect(() => {
     if (isLoadingProjects || !projects) return;
@@ -521,6 +556,10 @@ export const KanbanBoard: React.FC = () => {
       } else {
         localStorage.removeItem('agenfk_project_id');
       }
+      // The ?item deep-link was aimed at a project that doesn't exist — don't
+      // let it fire later against whatever project the user picks instead.
+      deepLinkAppliedRef.current = true;
+      stripDeepLinkParams();
     }
   }, [projects, isLoadingProjects, selectedProjectId]);
 
@@ -1098,6 +1137,34 @@ export const KanbanBoard: React.FC = () => {
     [Status.ARCHIVED]: 8,
   };
 
+  // Shared by the Search Box form and the ?item deep-link: matches items by id
+  // or title (case-insensitive substring), navigates to the first match, or
+  // flashes NOT FOUND in the box when nothing matches.
+  const runSearch = (term: string) => {
+    if (!term.trim() || !items) return;
+
+    const lower = term.toLowerCase();
+    const matches = items
+      .filter((i: AgEnFKItem) =>
+        i.id.toLowerCase().includes(lower) ||
+        i.title.toLowerCase().includes(lower)
+      )
+      .sort((a: AgEnFKItem, b: AgEnFKItem) =>
+        (statusPriority[a.status] ?? 99) - (statusPriority[b.status] ?? 99)
+      );
+
+    if (matches.length > 0) {
+      setSearchMatches(matches);
+      setCurrentMatchIndex(0);
+      navigateToMatch(matches[0]);
+    } else {
+      setSearchMatches([]);
+      setCurrentMatchIndex(0);
+      setSearchTerm('NOT FOUND');
+      setTimeout(() => setSearchTerm(''), 1000);
+    }
+  };
+
   const navigateToMatch = (item: AgEnFKItem) => {
     if (item.status === Status.IDEAS) setIsIdeasCollapsed(false);
     if (item.status === Status.ARCHIVED) setIsArchiveCollapsed(false);
@@ -1130,29 +1197,31 @@ export const KanbanBoard: React.FC = () => {
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!searchQuery.trim() || !items) return;
-
-    const term = searchQuery.toLowerCase();
-    const matches = items
-      .filter((i: AgEnFKItem) =>
-        i.id.toLowerCase().includes(term) ||
-        i.title.toLowerCase().includes(term)
-      )
-      .sort((a: AgEnFKItem, b: AgEnFKItem) =>
-        (statusPriority[a.status] ?? 99) - (statusPriority[b.status] ?? 99)
-      );
-
-    if (matches.length > 0) {
-      setSearchMatches(matches);
-      setCurrentMatchIndex(0);
-      navigateToMatch(matches[0]);
-    } else {
-      setSearchMatches([]);
-      setCurrentMatchIndex(0);
-      setSearchTerm('NOT FOUND');
-      setTimeout(() => setSearchTerm(''), 1000);
-    }
+    runSearch(searchQuery);
   };
+
+  // Deep-link (?item): `agenfk ui --open <itemId>` opens the board with this
+  // param. Once items AND the flow are loaded (columns render only when the
+  // flow is available — see the isLoadingFlow placeholder), behave exactly as
+  // if the id had been typed into the Search Box: pre-fill it and run the
+  // search (drill-down + highlight + scroll, or the NOT FOUND flash when
+  // nothing matches). One-shot — the ref guard also keeps the StrictMode
+  // double-effect from applying it twice. runSearch is intentionally not a
+  // dep: it is re-created every render and the effect must fire on items/flow
+  // changes only; the ref makes a re-run a no-op anyway (the flow-readiness
+  // guard above also keeps the rule happy: the state sync is conditional on
+  // external data, not unconditional at mount).
+  useEffect(() => {
+    if (deepLinkAppliedRef.current || !items) return;
+    if (isLoadingFlow && !activeFlow) return;
+    const itemId = getUrlParam('item');
+    if (!itemId) return;
+    deepLinkAppliedRef.current = true;
+    setSearchTerm(itemId);
+    runSearch(itemId);
+    stripDeepLinkParams();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [items, isLoadingFlow, activeFlow]);
 
   const handleSearchNav = (direction: 'prev' | 'next') => {
     if (searchMatches.length === 0) return;

--- a/packages/ui/src/test/KanbanBoardDeepLink.test.tsx
+++ b/packages/ui/src/test/KanbanBoardDeepLink.test.tsx
@@ -1,0 +1,244 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Dashboard deep-linking (CGLAB-100): `agenfk ui --open <itemId>` opens the
+ * web UI at `/?item=<id>[&project=<projectId>]`. On load the KanbanBoard must
+ * behave EXACTLY like the id had been typed into the Search Box:
+ *  - `?project` selects (and persists) that project, like the project picker;
+ *  - `?item` pre-fills the search box with the id and runs the search:
+ *    drill down through the parent chain, highlight the card, scroll it into
+ *    view, show the match counter;
+ *  - an id that matches nothing flashes "NOT FOUND" in the search box, the
+ *    same feedback a manual search gives;
+ *  - with no `?item` param the board loads exactly as before (empty search).
+ */
+import { render, screen, cleanup, waitFor, fireEvent } from '@testing-library/react';
+import { KanbanBoard } from '../components/KanbanBoard';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ThemeProvider } from '../ThemeContext';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { api } from '../api';
+import { ItemType, Status } from '../types';
+
+// Mock socket.io-client
+vi.mock('socket.io-client', () => ({
+  io: vi.fn(() => ({
+    on: vi.fn(),
+    off: vi.fn(),
+    emit: vi.fn(),
+    disconnect: vi.fn(),
+  })),
+}));
+
+// Mock window.matchMedia
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+// Mock scrollIntoView (jsdom has no layout)
+window.HTMLElement.prototype.scrollIntoView = vi.fn();
+
+const DEFAULT_FLOW_MOCK = {
+  id: 'default',
+  name: 'Default Flow',
+  projectId: '__builtin__',
+  steps: [
+    { id: 's-ideas', name: 'IDEAS', label: 'IDEAS', order: 0, isSpecial: true },
+    { id: 's-todo', name: 'TODO', label: 'TODO', order: 1 },
+    { id: 's-ip', name: 'IN_PROGRESS', label: 'IN PROGRESS', order: 2 },
+    { id: 's-review', name: 'REVIEW', label: 'REVIEW', order: 3 },
+    { id: 's-test', name: 'TEST', label: 'TEST', order: 4 },
+    { id: 's-done', name: 'DONE', label: 'DONE', order: 5 },
+    { id: 's-blocked', name: 'BLOCKED', label: 'BLOCKED', order: 6, isSpecial: true },
+    { id: 's-paused', name: 'PAUSED', label: 'PAUSED', order: 7, isSpecial: true },
+    { id: 's-archived', name: 'ARCHIVED', label: 'ARCHIVED', order: 8, isSpecial: true },
+  ],
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+vi.mock('../api', () => ({
+  api: {
+    listProjects: vi.fn(() => Promise.resolve([])),
+    listItems: vi.fn(() => Promise.resolve([])),
+    getItem: vi.fn(() => Promise.resolve({})),
+    createItem: vi.fn(() => Promise.resolve({})),
+    updateItem: vi.fn(() => Promise.resolve({})),
+    deleteItem: vi.fn(() => Promise.resolve({})),
+    deleteProject: vi.fn(() => Promise.resolve({})),
+    createProject: vi.fn(() => Promise.resolve({ id: 'p-new', name: 'New' })),
+    bulkUpdateItems: vi.fn(() => Promise.resolve({})),
+    trashArchivedItems: vi.fn(() => Promise.resolve({})),
+    getJiraStatus: vi.fn(() => Promise.resolve({ configured: false, connected: false })),
+    getLatestRelease: vi.fn(() => Promise.resolve(null)),
+    getVersion: vi.fn(() => Promise.resolve({ version: '1.0.0' })),
+    getProjectFlow: vi.fn(() => Promise.resolve(DEFAULT_FLOW_MOCK)),
+    getGitHubStatus: vi.fn(() => Promise.resolve({ configured: false })),
+  }
+}));
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: { retry: false, gcTime: 0 },
+  },
+});
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={queryClient}>
+    <ThemeProvider>
+      {children}
+    </ThemeProvider>
+  </QueryClientProvider>
+);
+
+const NOW = new Date();
+const projectP1 = { id: 'p1', name: 'P1', createdAt: NOW, updatedAt: NOW };
+const projectP2 = { id: 'p2', name: 'P2', createdAt: NOW, updatedAt: NOW };
+
+const EPIC_ONE = {
+  id: 'epic-1', projectId: 'p2', type: ItemType.EPIC, title: 'Epic One',
+  status: Status.TODO, createdAt: NOW, updatedAt: NOW,
+};
+const TASK_ONE = {
+  id: 'task-1', projectId: 'p2', type: ItemType.TASK, title: 'Task One',
+  status: Status.TODO, createdAt: NOW, updatedAt: NOW,
+};
+const TASK_CHILD = {
+  id: 'task-2', projectId: 'p2', type: ItemType.TASK, title: 'Task Child',
+  status: Status.TODO, parentId: 'epic-1', createdAt: NOW, updatedAt: NOW,
+};
+
+const SEARCH_PLACEHOLDER = 'Search Item ID or Name...';
+
+// findByPlaceholderText is typed as HTMLElement; the element is the search input.
+async function searchInput() {
+  return (await screen.findByPlaceholderText(SEARCH_PLACEHOLDER)) as HTMLInputElement;
+}
+
+describe('KanbanBoard deep-link (?item / ?project)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    queryClient.clear();
+    window.history.pushState({}, '', '/');
+    vi.mocked(api.getProjectFlow).mockResolvedValue(DEFAULT_FLOW_MOCK as any);
+    vi.mocked(api.listProjects).mockResolvedValue([projectP1, projectP2] as any);
+    vi.mocked(api.listItems).mockImplementation((params: any) =>
+      Promise.resolve(params?.projectId === 'p2' ? [EPIC_ONE, TASK_ONE, TASK_CHILD] : [])
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+    window.history.pushState({}, '', '/');
+  });
+
+  it('opens the ?project project, pre-fills the search box and highlights the ?item card', async () => {
+    // No localStorage: without ?project the board would sit on the project picker.
+    window.history.pushState({}, '', '/?item=task-1&project=p2');
+    render(<KanbanBoard />, { wrapper });
+
+    const input = await searchInput();
+    await waitFor(() => expect(input.value).toBe('task-1'));
+
+    const card = document.getElementById('card-task-1');
+    expect(card).not.toBeNull();
+    expect(card!.className).toContain('search-highlight');
+    // Match counter, same as a manual search with one hit.
+    expect(screen.getByText('1/1')).toBeDefined();
+  });
+
+  it('persists the ?project param to localStorage, like the project picker does', async () => {
+    window.history.pushState({}, '', '/?project=p2');
+    render(<KanbanBoard />, { wrapper });
+
+    await searchInput();
+    await waitFor(() =>
+      expect(localStorage.getItem('agenfk_project_id')).toBe('p2')
+    );
+  });
+
+  it('lets ?project win over a different project already in localStorage', async () => {
+    // A mutant that swaps the precedence (localStorage first) must not pass.
+    localStorage.setItem('agenfk_project_id', 'p1');
+    window.history.pushState({}, '', '/?project=p2');
+    render(<KanbanBoard />, { wrapper });
+
+    await searchInput();
+    await waitFor(() =>
+      expect(api.listItems).toHaveBeenCalledWith(expect.objectContaining({ projectId: 'p2' }))
+    );
+    expect(localStorage.getItem('agenfk_project_id')).toBe('p2');
+  });
+
+  it('strips the deep-link params from the URL once applied (reload honours the picker)', async () => {
+    window.history.pushState({}, '', '/?item=task-1&project=p2');
+    render(<KanbanBoard />, { wrapper });
+
+    const input = await searchInput();
+    await waitFor(() => expect(input.value).toBe('task-1'));
+    await waitFor(() => expect(window.location.search).toBe(''));
+  });
+
+  it('drills down through the parent chain for a nested item, like searching its id', async () => {
+    window.history.pushState({}, '', '/?item=task-2&project=p2');
+    render(<KanbanBoard />, { wrapper });
+
+    const input = await searchInput();
+    await waitFor(() => expect(input.value).toBe('task-2'));
+
+    await waitFor(() => {
+      const card = document.getElementById('card-task-2');
+      expect(card).not.toBeNull();
+      expect(card!.className).toContain('search-highlight');
+    });
+    // The parent EPIC appears in the breadcrumb (navPath), proving the drill-down.
+    expect(screen.getAllByText('Epic One').length).toBeGreaterThan(0);
+  });
+
+  it('flashes NOT FOUND in the search box when the id matches nothing, like a manual search', async () => {
+    window.history.pushState({}, '', '/?item=missing-999&project=p2');
+    render(<KanbanBoard />, { wrapper });
+
+    const input = await searchInput();
+    await waitFor(() => expect(input.value).toBe('NOT FOUND'));
+  });
+
+  it('leaves the search box empty when no ?item param is present (baseline unchanged)', async () => {
+    window.history.pushState({}, '', '/?project=p2');
+    render(<KanbanBoard />, { wrapper });
+
+    const input = await searchInput();
+    expect(input.value).toBe('');
+  });
+
+  it('applies the deep-link only once: a later items refetch does not re-populate a cleared search', async () => {
+    window.history.pushState({}, '', '/?item=task-1&project=p2');
+    render(<KanbanBoard />, { wrapper });
+
+    const input = await searchInput();
+    await waitFor(() => expect(input.value).toBe('task-1'));
+
+    // The user clears the search box (what clearSearch does on empty input).
+    fireEvent.change(input, { target: { value: '' } });
+    expect(input.value).toBe('');
+
+    // A socket-driven refetch re-creates the items array — the one-shot guard
+    // must keep the deep-link from firing again.
+    queryClient.invalidateQueries({ queryKey: ['items', 'p2'] });
+    await new Promise((r) => setTimeout(r, 150));
+    expect(input.value).toBe('');
+    const card = document.getElementById('card-task-1');
+    expect(card?.className ?? '').not.toContain('search-highlight');
+  });
+});


### PR DESCRIPTION
## What
`agenfk ui --open <itemId>` opens the dashboard with the item highlighted — exactly like typing the id into the Kanban Search Box (pre-fill, drill-down, highlight+scroll, NOT FOUND flash).

## How
- **CLI** (`packages/cli/src/uiUrl.ts` + `ui` command): resolves the item's real project via `GET /items/:id` (cwd fallback), emits `<dashboard>?item=<id>&project=<pid>`; rejects empty `--open`.
- **UI** (`KanbanBoard.tsx`): one-shot ref-guarded deep-link effect — `?project` initializes+persists the selected project (wins over localStorage), `?item` runs the search once items/flow are ready, then params are stripped via replaceState so a later reload honours the picker choice.
- **Docs**: command row + "show an item" guidance in clauderules/cursorrules/codexrules/geminirules, SKILL.md, commands/agenfk.md.

## Verification
- Root suite 2271/2271, UI 415/415, build green
- StrykerJS: 18/18 mutants killed on uiUrl.ts (break: 100%)
- Independent adversarial review (headless claude -p): findings #1–#5 fixed, #6 security closed, #7–#9 regression-tested
- E2E against the live server: served bundle boots, search pre-fills, card renders, params stripped

Closes CGLAB-100