### PR TITLE
feat(cli,ui): agenfk ui --open <itemId> — deep-link item highlight (CGLAB-100)

### DIFF
--- a/.claude/commands/agenfk-release-beta.md
+++ b/.claude/commands/agenfk-release-beta.md
@@ -45,7 +45,11 @@ Run `git push` and show the output to the user.
 - Ask for a release title (default: same as tag).
 - Offer to auto-generate release notes from git log: run `git log $(git describe --tags --abbrev=0)..HEAD --oneline` and summarise the commits as bullet points.
 - Confirm the notes with the user, allow edits.
-- **Package Distributable**: Run `node scripts/package-dist.mjs` and verify `agenfk-dist.tar.gz` exists.
+- **Package Distributable**: Run `node scripts/package-dist.mjs` and verify `agenfk-dist.tar.gz` exists. Then verify it carries no macOS metadata — **do not use `tar -tzf`**, which on macOS silently merges AppleDouble entries into their parent and reports a clean archive (this is how CGLAB-94 shipped in every release from v1.1.13 to v1.1.16-beta.4):
+  ```bash
+  node -e "const{gunzipSync}=require('zlib'),{readFileSync}=require('fs');const b=gunzipSync(readFileSync('agenfk-dist.tar.gz'));let o=0,n=[];while(o+512<=b.length){const f=b.subarray(o,o+100),i=f.indexOf(0),m=f.subarray(0,i===-1?100:i).toString();if(!m){o+=512;continue}n.push(m);o+=512+Math.ceil((parseInt(b.subarray(o+124,o+136).toString('ascii').replace(/\0.*$/,'').trim(),8)||0)/512)*512}const bad=n.filter(x=>(x.replace(/\/$/,'').split('/').pop()||'').startsWith('._')||x.endsWith('.DS_Store'));console.log(bad.length?'DIRTY: '+bad.length+' macOS metadata entries':'CLEAN: '+n.length+' members');process.exit(bad.length?1:0)"
+  ```
+  Abort the release if it reports `DIRTY`.
 - **Tag & Push**: Run `git tag <tag>` to create the tag locally on the version-bump commit, then run `git push origin HEAD --tags` to push both the commit and the tag to the remote.
 - **Create Beta Release**: Run `gh release create <tag> agenfk-dist.tar.gz --prerelease --title "<title>" --notes "<notes>"`.
 - Show the release URL returned by `gh`.

--- a/.claude/commands/agenfk-release.md
+++ b/.claude/commands/agenfk-release.md
@@ -59,7 +59,11 @@ If YES:
   - **STRICT SCOPE**: Only include changes that appear in the `git log` output above. Do NOT carry forward items from previous release notes, from other projects, or from your conversation context. Each release note must map 1-to-1 to a commit in the log range.
   - **Cross-project guard**: If a commit message contains a task ID in brackets (e.g. `[1a18154d-...]`), verify it belongs to the current project by checking `.agenfk/project.json`. If the project ID does not match, omit the task reference from the release note and note it as a possible mislabelled commit.
 - Confirm the notes with the user, allow edits.
-- **Package Distributable**: Run `node scripts/package-dist.mjs` and verify `agenfk-dist.tar.gz` exists.
+- **Package Distributable**: Run `node scripts/package-dist.mjs` and verify `agenfk-dist.tar.gz` exists. Then verify it carries no macOS metadata — **do not use `tar -tzf`**, which on macOS silently merges AppleDouble entries into their parent and reports a clean archive (this is how CGLAB-94 shipped in every release from v1.1.13 to v1.1.16-beta.4):
+  ```bash
+  node -e "const{gunzipSync}=require('zlib'),{readFileSync}=require('fs');const b=gunzipSync(readFileSync('agenfk-dist.tar.gz'));let o=0,n=[];while(o+512<=b.length){const f=b.subarray(o,o+100),i=f.indexOf(0),m=f.subarray(0,i===-1?100:i).toString();if(!m){o+=512;continue}n.push(m);o+=512+Math.ceil((parseInt(b.subarray(o+124,o+136).toString('ascii').replace(/\0.*$/,'').trim(),8)||0)/512)*512}const bad=n.filter(x=>(x.replace(/\/$/,'').split('/').pop()||'').startsWith('._')||x.endsWith('.DS_Store'));console.log(bad.length?'DIRTY: '+bad.length+' macOS metadata entries':'CLEAN: '+n.length+' members');process.exit(bad.length?1:0)"
+  ```
+  Abort the release if it reports `DIRTY`.
 - **Tag & Push**: Run `git tag <tag>` to create the tag locally on the version-bump commit, then run `git push origin HEAD --tags` to push both the commit and the tag to the remote.
 - **Create Release**: Run `gh release create <tag> agenfk-dist.tar.gz --title "<title>" --notes "<notes">`.
 - Show the release URL returned by `gh`.

--- a/SKILL.md
+++ b/SKILL.md
@@ -105,6 +105,7 @@ enforced by the server. Each workflow tool name in this skill maps to a CLI comm
 | `query_token_events(...)` | `agenfk tokens [--item <id>][--project <id>][--client <name>][--since <ts>][--until <ts>][--limit <n>][--json]` |
 | `register_pr(...)` / `update_pr_sizing(...)` | `agenfk pr-register --item <id> --number <n> --repo <r> --epic <n> --story <n> --task <n> --bug <n> --model <id> --harness <name>` / `agenfk pr-resize --number <n> --repo <r> --epic <n> --story <n> --task <n> --bug <n> --model <id> --harness <name>` (`--model` and `--harness` are **REQUIRED** on both) |
 | `analyze_request(req)` | `agenfk analyze "<request>"` |
+| *(show item in the dashboard)* | `agenfk ui [--open <itemId>]` — opens the dashboard in the browser; `--open <itemId>` deep-links the web UI so that item is highlighted (the Search Box pre-fills with the id and navigates to it, exactly like a manual search). No MCP equivalent — CLI only. |
 
 **Read output**: append `--json` to any read command (`list`, `get`, `list-projects`,
 `current-project`, `flow show`, `tokens`, …) for machine-readable output you can parse
@@ -248,6 +249,7 @@ Use this skill whenever you are performing software engineering tasks to ensure 
 *   `agenfk verify <id> --evidence "<text>" ["<command>"]`: Step-completion gate — `evidence` (how you satisfied the exit criteria, logged as a tagged comment) is required; the command is optional. Advances to next step on success.
 *   `agenfk pause-work <id> --summary "<s>" --resume-instructions "<r>"`: Save context snapshot and pause item.
 *   `agenfk resume-work <id>`: Restore context and resume paused item.
+*   `agenfk ui [--open <itemId>]`: Open the dashboard in the browser. With `--open <itemId>` it opens the web UI with that item highlighted (the Search Box pre-fills with the id and navigates to it, like a manual search). **When the user asks to *show* an item — "show me that task", "open <id> in the dashboard", "where is <id> on the board" — run `agenfk ui --open <itemId>`.** It is a read-only display operation: no workflow state changes, no gatekeeper needed.
 
 Token usage is captured automatically by the server-side ingestion worker — agents do not need to (and cannot) self-report tokens.
 

--- a/bin/agenfk-pr-hook.mjs
+++ b/bin/agenfk-pr-hook.mjs
@@ -106,7 +106,15 @@ export function buildDirective(client, message) {
     case 'claude-code':
       return { hookSpecificOutput: { hookEventName: 'PostToolUse', additionalContext: message } };
     case 'codex':
-      return { decision: 'continue', reason: message };
+      // CGLAB-86: the old { decision: 'continue', reason } envelope was REJECTED
+      // by Codex with "hook returned invalid post-tool-use JSON output" —
+      // `continue` is a field of the Stop-family hook output, not a PostToolUse
+      // decision value. Verified empirically against codex-cli 0.149.0: the old
+      // shape => "hook: PostToolUse Failed"; the hookSpecificOutput envelope
+      // below => "hook: PostToolUse Completed" (its wire struct carries
+      // hookEventName / additionalContext / updatedMCPToolOutput; the only
+      // valid top-level decision is `block`, which this nudge never wants).
+      return { hookSpecificOutput: { hookEventName: 'PostToolUse', additionalContext: message } };
     case 'gemini':
       return { decision: 'continue', context: message };
     case 'cursor':

--- a/bin/agenfk-pr-hook.mjs
+++ b/bin/agenfk-pr-hook.mjs
@@ -196,7 +196,13 @@ async function main() {
   }
 
   // push trigger: only nudge if the branch already has a registered PR.
-  const branch = trigger.branch || getCurrentBranch();
+  // `HEAD` is a symbolic push SOURCE ("push the current branch"), not a branch
+  // name — `git push -u origin HEAD` is the form the workflow itself recommends
+  // ("push your branch"), so resolve it to the real branch instead of nudging
+  // with the literal 'HEAD' (independent review finding, CGLAB-86). The
+  // classifier stays a pure string parser; git resolution happens here.
+  const branch =
+    trigger.branch && trigger.branch !== 'HEAD' ? trigger.branch : getCurrentBranch();
   if (!branch) process.exit(0);
   // We don't currently index PRs by branch, but the agent can still answer the
   // "did I add items to this PR?" question itself. Emit the directive

--- a/bin/agenfk.js
+++ b/bin/agenfk.js
@@ -74,7 +74,16 @@ function toPosixPath(p) {
 
 // On Windows, BSD tar treats "C:" as a remote hostname; --force-local disables that.
 // On MinGW we also convert paths to POSIX form as a belt-and-suspenders measure.
-const tarFlags = process.platform === 'win32' ? '--force-local -xzf' : '-xzf';
+// Refuse macOS metadata on the way IN. This is the path that actually polluted
+// users: every published release up to v1.1.16-beta.4 was ~half AppleDouble
+// (`._*`) entries, and this extraction lands the tarball straight into the
+// install dir — after the filtered cpSync above, so that filter never sees it.
+// Excluding here makes the outcome independent of any later sweep.
+// (CGLAB-94 / issue #163)
+const tarExcludes = "--exclude='._*' --exclude='.DS_Store'";
+const tarFlags = process.platform === 'win32'
+  ? `--force-local ${tarExcludes} -xzf`
+  : `${tarExcludes} -xzf`;
 
 // compareSemver gates the redownload-on-update downgrade guard. It is imported
 // from ./version-utils.mjs (top of file) so prerelease ordering is correct
@@ -140,6 +149,28 @@ function downloadAsset(repo, tag, pattern, outputPath) {
   execSync(`gh release download ${tag} --repo ${repo} --pattern '${pattern}' --output "${outputPath}"`, { stdio: 'inherit' });
 }
 
+
+// Never copy macOS AppleDouble / Finder metadata into the install dir. Releases
+// packaged on macOS carried a `._<name>` twin for every file with an extended
+// attribute; copied verbatim, they reached the skills sync and were surfaced as
+// garbage skills in every agent session (CGLAB-94 / issue #163).
+const isMacMetadata = (name) => name.startsWith('._') || name === '.DS_Store';
+const copyFilter = (src) => !isMacMetadata(path.basename(src));
+// Fallback path for Node builds without fs.cpSync: `cp -r` can't filter, so
+// remove the artifacts after the fact.
+function sweepMacMetadata(dir) {
+  if (!fs.existsSync(dir)) return;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name === '.git') continue;
+    const full = path.join(dir, entry.name);
+    if (isMacMetadata(entry.name)) {
+      try { fs.rmSync(full, { recursive: true, force: true }); } catch { /* ignore */ }
+    } else if (entry.isDirectory()) {
+      sweepMacMetadata(full);
+    }
+  }
+}
+
 if (isNpxCache) {
   const isUpdate = fs.existsSync(INSTALL_DIR);
 
@@ -147,16 +178,18 @@ if (isNpxCache) {
     console.log(`${GREEN}Updating AgEnFK at ${INSTALL_DIR}...${RESET}`);
     // Overlay new files from the npx cache onto the existing install
     if (fs.cpSync) {
-      fs.cpSync(REPO_ROOT, INSTALL_DIR, { recursive: true });
+      fs.cpSync(REPO_ROOT, INSTALL_DIR, { recursive: true, filter: copyFilter });
     } else {
       execSync(`cp -r ${JSON.stringify(REPO_ROOT)}/. ${JSON.stringify(INSTALL_DIR)}/`, { stdio: 'inherit', shell: true });
+      sweepMacMetadata(INSTALL_DIR);
     }
   } else {
     console.log(`${GREEN}Installing AgEnFK to ${INSTALL_DIR}...${RESET}`);
     if (fs.cpSync) {
-      fs.cpSync(REPO_ROOT, INSTALL_DIR, { recursive: true });
+      fs.cpSync(REPO_ROOT, INSTALL_DIR, { recursive: true, filter: copyFilter });
     } else {
       execSync(`cp -r ${JSON.stringify(REPO_ROOT)} ${JSON.stringify(INSTALL_DIR)}`, { stdio: 'inherit', shell: true });
+      sweepMacMetadata(INSTALL_DIR);
     }
   }
 

--- a/clauderules/CLAUDE.md
+++ b/clauderules/CLAUDE.md
@@ -154,6 +154,7 @@ This is the full workflow surface. Each row notes the equivalent MCP tool (avail
 | Restart services | `agenfk restart [-q/--quiet]` |
 | Force-kill all processes/ports | `agenfk kill` |
 | Open / show the dashboard | `agenfk ui` |
+| Show item in the dashboard | `agenfk ui --open <itemId>` — opens the web UI with that item highlighted (deep-links the Search Box to the item id) |
 | Check framework health | `agenfk health` |
 | Upgrade the framework | `agenfk upgrade [-f/--force][-b/--beta][--version <ver>][--json][--debuglog]` |
 | Back up the database | `agenfk backup` |
@@ -161,6 +162,8 @@ This is the full workflow surface. Each row notes the equivalent MCP tool (avail
 | Initialize a project in the cwd | `agenfk init [name] [-d/--description <desc>]` |
 | Fix Claude Code MCP integration | `agenfk configure-ide` |
 | Start the MCP server (stdio) | `agenfk mcp` |
+
+**Showing an item to the user**: when the user asks to *show* an item ("show me that task", "open <id> in the dashboard", "where is <id> on the board"), run `agenfk ui --open <itemId>` — it opens the web UI with that item highlighted, exactly like searching the id in the UI's Search Box. Read-only display — no workflow state changes, no gatekeeper needed.
 
 **Integrations, rules/skills & config** (CLI-only)
 

--- a/codexrules/AGENTS.md
+++ b/codexrules/AGENTS.md
@@ -86,6 +86,14 @@ After running `gh pr create`, you MUST run `agenfk pr-register --item <id> --num
 - **Evidence-based claims**: Before claiming a feature already exists, search the codebase for the specific UI components, API endpoints, and database queries. Never assume without evidence.
 - **Root cause debugging**: When fixing errors, investigate the root cause fully before applying fixes. Avoid workarounds that create new problems (e.g. infinite loops). Trace from symptom to source. One fix at a time.
 
+### Long-running commands — async execution MANDATORY
+
+Codex's shell tool yields after a bounded window (the default `yield_time_ms` is ~30s). AgEnFK commands that run a full test suite — the project test command behind `agenfk log-test <id> --command "..."` — and the final-step `agenfk verify <id> --evidence "..."` (which runs the project's verify command to land DONE) routinely exceed it. A synchronously-truncated tool call never sees the completed result, so for any command expected to outlast the yield window:
+
+- Run it as an async task: pass `yield_time_ms` (e.g. 30000) in the shell tool call so it yields with the process still running instead of being cut off, then **wait** — poll the running process (an empty `write_stdin` write polls without sending input) until it **completes**, and read its final output and exit status.
+- Only once the process has finished, log the result (`agenfk log-test <id> ... --status PASSED|FAILED`) or advance the step (`agenfk verify ...`). A suite that was still running when you stopped waiting has NOT passed: never log PASSED on an incomplete run, and never land DONE without the completed verify output in hand.
+- Short commands (gatekeeper, comments, item reads, status checks) stay synchronous as usual — this rule targets the slow ones: full test runs, the final-step verify, heavy builds.
+
 ### STRICTLY FORBIDDEN shortcuts
 
 **NEVER** bypass the `agenfk` CLI/server by using these shortcuts:

--- a/codexrules/AGENTS.md
+++ b/codexrules/AGENTS.md
@@ -163,6 +163,7 @@ This is the full workflow surface. In Codex, call the **`mcp__agenfk__*` tool** 
 | Restart services | `agenfk restart [-q/--quiet]` |
 | Force-kill all processes/ports | `agenfk kill` |
 | Open / show the dashboard | `agenfk ui` |
+| Show item in the dashboard | `agenfk ui --open <itemId>` — opens the web UI with that item highlighted (deep-links the Search Box to the item id) |
 | Check framework health | `agenfk health` |
 | Upgrade the framework | `agenfk upgrade [-f/--force][-b/--beta][--version <ver>][--json][--debuglog]` |
 | Back up the database | `agenfk backup` |
@@ -170,6 +171,8 @@ This is the full workflow surface. In Codex, call the **`mcp__agenfk__*` tool** 
 | Initialize a project in the cwd | `agenfk init [name] [-d/--description <desc>]` |
 | Fix Claude Code MCP integration | `agenfk configure-ide` |
 | Start the MCP server (stdio) | `agenfk mcp` |
+
+**Showing an item to the user**: when the user asks to *show* an item ("show me that task", "open <id> in the dashboard", "where is <id> on the board"), run `agenfk ui --open <itemId>` — it opens the web UI with that item highlighted, exactly like searching the id in the UI's Search Box. Read-only display — no workflow state changes, no gatekeeper needed.
 
 **Integrations, rules/skills & config** (CLI-only)
 

--- a/commands/agenfk.md
+++ b/commands/agenfk.md
@@ -29,6 +29,12 @@ This avoids redundant build and test runs when the underlying code changes are s
 
 ---
 
+## Showing an Item in the UI
+
+When the user asks to *show* an item — "show me that task", "open <id> in the dashboard", "where is <id> on the board" — run `agenfk ui --open <itemId>`: it opens the web UI with that item highlighted (the Search Box pre-fills with the id and navigates to it, exactly like a manual search). It is a read-only display operation — no workflow state changes, no gatekeeper authorization needed.
+
+---
+
 ## Step 0 — Classify the request
 
 Before creating any item, evaluate the request against these signals:

--- a/cursorrules/agenfk.mdc
+++ b/cursorrules/agenfk.mdc
@@ -162,6 +162,7 @@ This is the full workflow surface. Each row notes the equivalent MCP tool (avail
 | Restart services | `agenfk restart [-q/--quiet]` |
 | Force-kill all processes/ports | `agenfk kill` |
 | Open / show the dashboard | `agenfk ui` |
+| Show item in the dashboard | `agenfk ui --open <itemId>` — opens the web UI with that item highlighted (deep-links the Search Box to the item id) |
 | Check framework health | `agenfk health` |
 | Upgrade the framework | `agenfk upgrade [-f/--force][-b/--beta][--version <ver>][--json][--debuglog]` |
 | Back up the database | `agenfk backup` |
@@ -169,6 +170,8 @@ This is the full workflow surface. Each row notes the equivalent MCP tool (avail
 | Initialize a project in the cwd | `agenfk init [name] [-d/--description <desc>]` |
 | Fix Claude Code MCP integration | `agenfk configure-ide` |
 | Start the MCP server (stdio) | `agenfk mcp` |
+
+**Showing an item to the user**: when the user asks to *show* an item ("show me that task", "open <id> in the dashboard", "where is <id> on the board"), run `agenfk ui --open <itemId>` — it opens the web UI with that item highlighted, exactly like searching the id in the UI's Search Box. Read-only display — no workflow state changes, no gatekeeper needed.
 
 **Integrations, rules/skills & config** (CLI-only)
 

--- a/geminirules/GEMINI.md
+++ b/geminirules/GEMINI.md
@@ -158,6 +158,7 @@ This is the full workflow surface. Each row notes the equivalent MCP tool (avail
 | Restart services | `agenfk restart [-q/--quiet]` |
 | Force-kill all processes/ports | `agenfk kill` |
 | Open / show the dashboard | `agenfk ui` |
+| Show item in the dashboard | `agenfk ui --open <itemId>` — opens the web UI with that item highlighted (deep-links the Search Box to the item id) |
 | Check framework health | `agenfk health` |
 | Upgrade the framework | `agenfk upgrade [-f/--force][-b/--beta][--version <ver>][--json][--debuglog]` |
 | Back up the database | `agenfk backup` |
@@ -165,6 +166,8 @@ This is the full workflow surface. Each row notes the equivalent MCP tool (avail
 | Initialize a project in the cwd | `agenfk init [name] [-d/--description <desc>]` |
 | Fix Claude Code MCP integration | `agenfk configure-ide` |
 | Start the MCP server (stdio) | `agenfk mcp` |
+
+**Showing an item to the user**: when the user asks to *show* an item ("show me that task", "open <id> in the dashboard", "where is <id> on the board"), run `agenfk ui --open <itemId>` — it opens the web UI with that item highlighted, exactly like searching the id in the UI's Search Box. Read-only display — no workflow state changes, no gatekeeper needed.
 
 **Integrations, rules/skills & config** (CLI-only)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenfk",
-  "version": "1.1.15",
+  "version": "1.1.16-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenfk",
-      "version": "1.1.15",
+      "version": "1.1.16-beta.4",
       "license": "ISC",
       "workspaces": [
         "packages/core",
@@ -11230,11 +11230,11 @@
     },
     "packages/cli": {
       "name": "@agenfk/cli",
-      "version": "1.1.15",
+      "version": "1.1.16-beta.4",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.1.15",
-        "@agenfk/telemetry": "1.1.15",
+        "@agenfk/core": "1.1.16-beta.4",
+        "@agenfk/telemetry": "1.1.16-beta.4",
         "axios": "^1.19.0",
         "chalk": "^4.1.2",
         "commander": "^12.0.0",
@@ -11254,7 +11254,7 @@
     },
     "packages/core": {
       "name": "@agenfk/core",
-      "version": "1.1.15",
+      "version": "1.1.16-beta.4",
       "license": "ISC",
       "devDependencies": {
         "typescript": "^5.3.3"
@@ -11262,7 +11262,7 @@
     },
     "packages/create": {
       "name": "agenfk",
-      "version": "1.1.15",
+      "version": "1.1.16-beta.4",
       "license": "ISC",
       "bin": {
         "agenfk": "bin/agenfk.js"
@@ -11273,7 +11273,7 @@
     },
     "packages/flow-editor": {
       "name": "@agenfk/flow-editor",
-      "version": "1.1.15",
+      "version": "1.1.16-beta.4",
       "peerDependencies": {
         "@tanstack/react-query": "^5.101.4",
         "clsx": "^2.1.1",
@@ -11285,9 +11285,9 @@
     },
     "packages/hub": {
       "name": "@agenfk/hub",
-      "version": "1.1.15",
+      "version": "1.1.16-beta.4",
       "dependencies": {
-        "@agenfk/core": "1.1.15",
+        "@agenfk/core": "1.1.16-beta.4",
         "axios": "^1.19.0",
         "bcryptjs": "^2.4.3",
         "cookie-parser": "^1.4.7",
@@ -11311,9 +11311,9 @@
       }
     },
     "packages/hub-ui": {
-      "version": "1.1.15",
+      "version": "1.1.16-beta.4",
       "dependencies": {
-        "@agenfk/flow-editor": "1.1.15",
+        "@agenfk/flow-editor": "1.1.16-beta.4",
         "@fontsource-variable/jetbrains-mono": "^5.3.0",
         "@fontsource-variable/manrope": "^5.3.0",
         "@tailwindcss/postcss": "^4.3.3",
@@ -11686,12 +11686,12 @@
     },
     "packages/server": {
       "name": "@agenfk/server",
-      "version": "1.1.15",
+      "version": "1.1.16-beta.4",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.1.15",
-        "@agenfk/storage-sqlite": "1.1.15",
-        "@agenfk/telemetry": "1.1.15",
+        "@agenfk/core": "1.1.16-beta.4",
+        "@agenfk/storage-sqlite": "1.1.16-beta.4",
+        "@agenfk/telemetry": "1.1.16-beta.4",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "axios": "^1.19.0",
         "body-parser": "^2.3.0",
@@ -11714,13 +11714,13 @@
     },
     "packages/storage-sqlite": {
       "name": "@agenfk/storage-sqlite",
-      "version": "1.1.15",
+      "version": "1.1.16-beta.4",
       "license": "ISC",
       "dependencies": {
         "uuid": "^14.0.2"
       },
       "devDependencies": {
-        "@agenfk/core": "1.1.15",
+        "@agenfk/core": "1.1.16-beta.4",
         "@types/node": "^22.0.0",
         "@types/uuid": "^9.0.8",
         "typescript": "^5.3.3"
@@ -11738,7 +11738,7 @@
     },
     "packages/telemetry": {
       "name": "@agenfk/telemetry",
-      "version": "1.1.15",
+      "version": "1.1.16-beta.4",
       "license": "ISC",
       "dependencies": {
         "posthog-node": "^4.0.0"
@@ -11749,9 +11749,9 @@
       }
     },
     "packages/ui": {
-      "version": "1.1.15",
+      "version": "1.1.16-beta.4",
       "dependencies": {
-        "@agenfk/flow-editor": "1.1.15",
+        "@agenfk/flow-editor": "1.1.16-beta.4",
         "@fontsource-variable/jetbrains-mono": "^5.3.0",
         "@fontsource-variable/manrope": "^5.3.0",
         "@tailwindcss/postcss": "^4.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenfk",
-  "version": "1.1.16-beta.4",
+  "version": "1.1.16-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenfk",
-      "version": "1.1.16-beta.4",
+      "version": "1.1.16-beta.5",
       "license": "ISC",
       "workspaces": [
         "packages/core",
@@ -11230,11 +11230,11 @@
     },
     "packages/cli": {
       "name": "@agenfk/cli",
-      "version": "1.1.16-beta.4",
+      "version": "1.1.16-beta.5",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.1.16-beta.4",
-        "@agenfk/telemetry": "1.1.16-beta.4",
+        "@agenfk/core": "1.1.16-beta.5",
+        "@agenfk/telemetry": "1.1.16-beta.5",
         "axios": "^1.19.0",
         "chalk": "^4.1.2",
         "commander": "^12.0.0",
@@ -11254,7 +11254,7 @@
     },
     "packages/core": {
       "name": "@agenfk/core",
-      "version": "1.1.16-beta.4",
+      "version": "1.1.16-beta.5",
       "license": "ISC",
       "devDependencies": {
         "typescript": "^5.3.3"
@@ -11262,7 +11262,7 @@
     },
     "packages/create": {
       "name": "agenfk",
-      "version": "1.1.16-beta.4",
+      "version": "1.1.16-beta.5",
       "license": "ISC",
       "bin": {
         "agenfk": "bin/agenfk.js"
@@ -11273,7 +11273,7 @@
     },
     "packages/flow-editor": {
       "name": "@agenfk/flow-editor",
-      "version": "1.1.16-beta.4",
+      "version": "1.1.16-beta.5",
       "peerDependencies": {
         "@tanstack/react-query": "^5.101.4",
         "clsx": "^2.1.1",
@@ -11285,9 +11285,9 @@
     },
     "packages/hub": {
       "name": "@agenfk/hub",
-      "version": "1.1.16-beta.4",
+      "version": "1.1.16-beta.5",
       "dependencies": {
-        "@agenfk/core": "1.1.16-beta.4",
+        "@agenfk/core": "1.1.16-beta.5",
         "axios": "^1.19.0",
         "bcryptjs": "^2.4.3",
         "cookie-parser": "^1.4.7",
@@ -11311,9 +11311,9 @@
       }
     },
     "packages/hub-ui": {
-      "version": "1.1.16-beta.4",
+      "version": "1.1.16-beta.5",
       "dependencies": {
-        "@agenfk/flow-editor": "1.1.16-beta.4",
+        "@agenfk/flow-editor": "1.1.16-beta.5",
         "@fontsource-variable/jetbrains-mono": "^5.3.0",
         "@fontsource-variable/manrope": "^5.3.0",
         "@tailwindcss/postcss": "^4.3.3",
@@ -11686,12 +11686,12 @@
     },
     "packages/server": {
       "name": "@agenfk/server",
-      "version": "1.1.16-beta.4",
+      "version": "1.1.16-beta.5",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.1.16-beta.4",
-        "@agenfk/storage-sqlite": "1.1.16-beta.4",
-        "@agenfk/telemetry": "1.1.16-beta.4",
+        "@agenfk/core": "1.1.16-beta.5",
+        "@agenfk/storage-sqlite": "1.1.16-beta.5",
+        "@agenfk/telemetry": "1.1.16-beta.5",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "axios": "^1.19.0",
         "body-parser": "^2.3.0",
@@ -11714,13 +11714,13 @@
     },
     "packages/storage-sqlite": {
       "name": "@agenfk/storage-sqlite",
-      "version": "1.1.16-beta.4",
+      "version": "1.1.16-beta.5",
       "license": "ISC",
       "dependencies": {
         "uuid": "^14.0.2"
       },
       "devDependencies": {
-        "@agenfk/core": "1.1.16-beta.4",
+        "@agenfk/core": "1.1.16-beta.5",
         "@types/node": "^22.0.0",
         "@types/uuid": "^9.0.8",
         "typescript": "^5.3.3"
@@ -11738,7 +11738,7 @@
     },
     "packages/telemetry": {
       "name": "@agenfk/telemetry",
-      "version": "1.1.16-beta.4",
+      "version": "1.1.16-beta.5",
       "license": "ISC",
       "dependencies": {
         "posthog-node": "^4.0.0"
@@ -11749,9 +11749,9 @@
       }
     },
     "packages/ui": {
-      "version": "1.1.16-beta.4",
+      "version": "1.1.16-beta.5",
       "dependencies": {
-        "@agenfk/flow-editor": "1.1.16-beta.4",
+        "@agenfk/flow-editor": "1.1.16-beta.5",
         "@fontsource-variable/jetbrains-mono": "^5.3.0",
         "@fontsource-variable/manrope": "^5.3.0",
         "@tailwindcss/postcss": "^4.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3872,9 +3872,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -6434,9 +6434,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.8.tgz",
-      "integrity": "sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==",
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.9.tgz",
+      "integrity": "sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -6739,9 +6739,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -10589,9 +10589,9 @@
       "link": true
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11410,9 +11410,9 @@
       }
     },
     "packages/hub/node_modules/body-parser": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenfk",
-  "version": "1.1.15",
+  "version": "1.1.16-beta.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenfk",
-      "version": "1.1.15",
+      "version": "1.1.16-beta.6",
       "license": "ISC",
       "workspaces": [
         "packages/core",
@@ -11230,11 +11230,11 @@
     },
     "packages/cli": {
       "name": "@agenfk/cli",
-      "version": "1.1.15",
+      "version": "1.1.16-beta.6",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.1.15",
-        "@agenfk/telemetry": "1.1.15",
+        "@agenfk/core": "1.1.16-beta.6",
+        "@agenfk/telemetry": "1.1.16-beta.6",
         "axios": "^1.19.0",
         "chalk": "^4.1.2",
         "commander": "^12.0.0",
@@ -11254,7 +11254,7 @@
     },
     "packages/core": {
       "name": "@agenfk/core",
-      "version": "1.1.15",
+      "version": "1.1.16-beta.6",
       "license": "ISC",
       "devDependencies": {
         "typescript": "^5.3.3"
@@ -11262,7 +11262,7 @@
     },
     "packages/create": {
       "name": "agenfk",
-      "version": "1.1.15",
+      "version": "1.1.16-beta.6",
       "license": "ISC",
       "bin": {
         "agenfk": "bin/agenfk.js"
@@ -11273,7 +11273,7 @@
     },
     "packages/flow-editor": {
       "name": "@agenfk/flow-editor",
-      "version": "1.1.15",
+      "version": "1.1.16-beta.6",
       "peerDependencies": {
         "@tanstack/react-query": "^5.101.4",
         "clsx": "^2.1.1",
@@ -11285,9 +11285,9 @@
     },
     "packages/hub": {
       "name": "@agenfk/hub",
-      "version": "1.1.15",
+      "version": "1.1.16-beta.6",
       "dependencies": {
-        "@agenfk/core": "1.1.15",
+        "@agenfk/core": "1.1.16-beta.6",
         "axios": "^1.19.0",
         "bcryptjs": "^2.4.3",
         "cookie-parser": "^1.4.7",
@@ -11311,9 +11311,9 @@
       }
     },
     "packages/hub-ui": {
-      "version": "1.1.15",
+      "version": "1.1.16-beta.6",
       "dependencies": {
-        "@agenfk/flow-editor": "1.1.15",
+        "@agenfk/flow-editor": "1.1.16-beta.6",
         "@fontsource-variable/jetbrains-mono": "^5.3.0",
         "@fontsource-variable/manrope": "^5.3.0",
         "@tailwindcss/postcss": "^4.3.3",
@@ -11686,12 +11686,12 @@
     },
     "packages/server": {
       "name": "@agenfk/server",
-      "version": "1.1.15",
+      "version": "1.1.16-beta.6",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.1.15",
-        "@agenfk/storage-sqlite": "1.1.15",
-        "@agenfk/telemetry": "1.1.15",
+        "@agenfk/core": "1.1.16-beta.6",
+        "@agenfk/storage-sqlite": "1.1.16-beta.6",
+        "@agenfk/telemetry": "1.1.16-beta.6",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "axios": "^1.19.0",
         "body-parser": "^2.3.0",
@@ -11714,13 +11714,13 @@
     },
     "packages/storage-sqlite": {
       "name": "@agenfk/storage-sqlite",
-      "version": "1.1.15",
+      "version": "1.1.16-beta.6",
       "license": "ISC",
       "dependencies": {
         "uuid": "^14.0.2"
       },
       "devDependencies": {
-        "@agenfk/core": "1.1.15",
+        "@agenfk/core": "1.1.16-beta.6",
         "@types/node": "^22.0.0",
         "@types/uuid": "^9.0.8",
         "typescript": "^5.3.3"
@@ -11738,7 +11738,7 @@
     },
     "packages/telemetry": {
       "name": "@agenfk/telemetry",
-      "version": "1.1.15",
+      "version": "1.1.16-beta.6",
       "license": "ISC",
       "dependencies": {
         "posthog-node": "^4.0.0"
@@ -11749,9 +11749,9 @@
       }
     },
     "packages/ui": {
-      "version": "1.1.15",
+      "version": "1.1.16-beta.6",
       "dependencies": {
-        "@agenfk/flow-editor": "1.1.15",
+        "@agenfk/flow-editor": "1.1.16-beta.6",
         "@fontsource-variable/jetbrains-mono": "^5.3.0",
         "@fontsource-variable/manrope": "^5.3.0",
         "@tailwindcss/postcss": "^4.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "1.1.15",
+  "version": "1.1.16-beta.6",
   "description": "AgenFK Engineering Framework",
   "private": true,
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "1.1.15",
+  "version": "1.1.16-beta.4",
   "description": "AgenFK Engineering Framework",
   "private": true,
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "1.1.16-beta.4",
+  "version": "1.1.16-beta.5",
   "description": "AgenFK Engineering Framework",
   "private": true,
   "workspaces": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/cli",
-  "version": "1.1.15",
+  "version": "1.1.16-beta.6",
   "description": "CLI for AgenFK Engineering Framework",
   "main": "dist/index.js",
   "bin": {
@@ -12,8 +12,8 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.15",
-    "@agenfk/telemetry": "1.1.15",
+    "@agenfk/core": "1.1.16-beta.6",
+    "@agenfk/telemetry": "1.1.16-beta.6",
     "axios": "^1.19.0",
     "chalk": "^4.1.2",
     "commander": "^12.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/cli",
-  "version": "1.1.16-beta.4",
+  "version": "1.1.16-beta.5",
   "description": "CLI for AgenFK Engineering Framework",
   "main": "dist/index.js",
   "bin": {
@@ -12,8 +12,8 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.16-beta.4",
-    "@agenfk/telemetry": "1.1.16-beta.4",
+    "@agenfk/core": "1.1.16-beta.5",
+    "@agenfk/telemetry": "1.1.16-beta.5",
     "axios": "^1.19.0",
     "chalk": "^4.1.2",
     "commander": "^12.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/cli",
-  "version": "1.1.15",
+  "version": "1.1.16-beta.4",
   "description": "CLI for AgenFK Engineering Framework",
   "main": "dist/index.js",
   "bin": {
@@ -12,8 +12,8 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.15",
-    "@agenfk/telemetry": "1.1.15",
+    "@agenfk/core": "1.1.16-beta.4",
+    "@agenfk/telemetry": "1.1.16-beta.4",
     "axios": "^1.19.0",
     "chalk": "^4.1.2",
     "commander": "^12.0.0",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3356,6 +3356,42 @@ branchCmd
     }
   });
 
+branchCmd
+  .command('link <itemId> <branchName>')
+  .description('Link an existing local git branch to an item')
+  .action(async (itemId, branchName) => {
+    try {
+      const { data: item } = await axios.get(`${API_URL}/items/${itemId}`);
+      if (item.parentId) {
+        console.error(chalk.red(`❌ Branches are tracked on top-level items only. Item [${itemId.substring(0, 8)}] is a child of [${item.parentId.substring(0, 8)}]. Run this command on the parent item instead.`));
+        process.exit(1);
+        return;
+      }
+
+      // Validate branch name to prevent shell injection
+      if (/[^a-zA-Z0-9\-_./]/.test(branchName)) {
+        console.error(chalk.red(`❌ Invalid branch name: '${branchName}'. Branch names may only contain letters, digits, hyphens, underscores, dots, and forward slashes.`));
+        process.exit(1);
+        return;
+      }
+
+      // Verify the branch exists locally
+      try {
+        execSync(`git rev-parse --verify --end-of-options ${branchName}`, { stdio: 'ignore' });
+      } catch {
+        console.error(chalk.red(`❌ Branch '${branchName}' does not exist locally.`));
+        process.exit(1);
+        return;
+      }
+
+      await axios.put(`${API_URL}/items/${itemId}`, { branchName });
+      console.log(chalk.green(`✅ Branch '${branchName}' linked to item [${itemId.substring(0, 8)}].`));
+    } catch (e: any) {
+      console.error(chalk.red('Error:'), e.response?.data?.error || e.message);
+      process.exit(1);
+    }
+  });
+
 // ── PR commands ───────────────────────────────────────────────────────────────
 
 function checkGhCli(): boolean {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -605,7 +605,10 @@ program
         log(chalk.gray(`Downloading pre-built binary for ${resolvedTag}...`));
         downloadReleaseAsset(REPO, resolvedTag, 'agenfk-dist.tar.gz', path.join(tempDir, 'agenfk-dist.tar.gz'));
         log(chalk.gray('Extracting update...'));
-        execSync(`tar -xzf "${path.join(tempDir, 'agenfk-dist.tar.gz')}" -C "${rootDir}"`, { stdio: isJson ? 'ignore' : 'inherit' });
+        // --exclude: published releases up to v1.1.16-beta.4 were ~half macOS
+        // AppleDouble (`._*`) entries; never let them into the install dir
+        // (CGLAB-94 / issue #163).
+        execSync(`tar --exclude='._*' --exclude='.DS_Store' -xzf "${path.join(tempDir, 'agenfk-dist.tar.gz')}" -C "${rootDir}"`, { stdio: isJson ? 'ignore' : 'inherit' });
       } catch (e: any) {
         log(chalk.yellow('Pre-built binary not available, falling back to source build...'));
       } finally {
@@ -2373,7 +2376,7 @@ function removeLegacyCommands(): void {
     const dir = dirFn();
     if (!fs.existsSync(dir)) continue;
     for (const entry of fs.readdirSync(dir)) {
-      if (!entry.startsWith('agenfk')) continue;
+      if (!isAgenfkOwnedEntry(entry)) continue;
       const full = path.join(dir, entry);
       try {
         const stat = fs.statSync(full);
@@ -2436,10 +2439,58 @@ const GEMINI_TOML_PLATFORMS: Array<{
   },
 ];
 
+// --- macOS metadata guards (CGLAB-94 / issue #163) -------------------------
+//
+// Releases packaged on macOS carried an AppleDouble `._<name>` twin for every
+// file with an extended attribute. `._agenfk.md` satisfies `endsWith('.md')`,
+// so the sync steps below used to install them into ~/.claude/skills et al,
+// where each `._agenfk-*` directory is surfaced as a skill whose description is
+// mojibake binary — in the system prompt of every agent session. The removal
+// steps used to miss them, because `._agenfk` does not start with `agenfk`.
+
+/** macOS resource-fork / Finder metadata of any origin. */
+function isMacMetadata(name: string): boolean {
+  return name.startsWith('._') || name === '.DS_Store';
+}
+
+/** Source files a sync step may install: real payload only. */
+function isInstallableMarkdown(name: string): boolean {
+  return name.endsWith('.md') && !isMacMetadata(name);
+}
+
+/** The name an AppleDouble twin shadows: `._agenfk.md` -> `agenfk.md`. */
+function shadowedName(name: string): string {
+  return name.startsWith('._') ? name.slice(2) : name;
+}
+
+// Removal is scoped to what we own. These dirs are SHARED with other tools, and
+// an AppleDouble twin is named after the file it shadows, so ours are exactly
+// `._agenfk*`. A bare `._*` test would delete another tool's twin too.
+
+/** Entries a removal step owns: ours, or the AppleDouble twin of one of ours. */
+function isAgenfkOwnedEntry(name: string): boolean {
+  return shadowedName(name).startsWith('agenfk');
+}
+
+/** Same, restricted to a given extension, checked on the shadowed name. */
+function isAgenfkOwnedFile(name: string, ext: string): boolean {
+  const shadowed = shadowedName(name);
+  return shadowed.startsWith('agenfk') && shadowed.endsWith(ext);
+}
+
+/**
+ * A macOS metadata artifact shadowing one of OUR files. Commands dirs can hold
+ * AppleDouble *directories* (`._agenfk-calc-tokens/`, the twin of a skill dir),
+ * which carry no extension and so are not matched by isAgenfkOwnedFile.
+ */
+function isAgenfkOwnedArtifact(name: string): boolean {
+  return isMacMetadata(name) && isAgenfkOwnedEntry(name);
+}
+
 /** Install commands as flat .md files (for OpenCode slash commands) */
 function syncCommandsFlat(srcDir: string, destDir: string, platformKey?: string): string[] {
   if (!fs.existsSync(srcDir)) return [];
-  const files = (fs.readdirSync(srcDir) as string[]).filter((f: string) => f.endsWith('.md'));
+  const files = (fs.readdirSync(srcDir) as string[]).filter(isInstallableMarkdown);
   const installed: string[] = [];
   fs.mkdirSync(destDir, { recursive: true });
   for (const file of files) {
@@ -2461,7 +2512,7 @@ function syncCommandsFlat(srcDir: string, destDir: string, platformKey?: string)
 function removeAgenfkFlatFromDir(dir: string): void {
   if (!fs.existsSync(dir)) return;
   for (const entry of fs.readdirSync(dir) as string[]) {
-    if (entry.startsWith('agenfk') && entry.endsWith('.md')) {
+    if (isAgenfkOwnedFile(entry, '.md') || isAgenfkOwnedArtifact(entry)) {
       try { fs.unlinkSync(path.join(dir, entry)); } catch { /* ignore */ }
     }
   }
@@ -2470,7 +2521,7 @@ function removeAgenfkFlatFromDir(dir: string): void {
 /** Generate Gemini TOML slash commands from commands/*.md files */
 function syncCommandsToml(srcDir: string, destDir: string): string[] {
   if (!fs.existsSync(srcDir)) return [];
-  const files = (fs.readdirSync(srcDir) as string[]).filter((f: string) => f.endsWith('.md'));
+  const files = (fs.readdirSync(srcDir) as string[]).filter(isInstallableMarkdown);
   const installed: string[] = [];
   fs.mkdirSync(destDir, { recursive: true });
   for (const file of files) {
@@ -2495,7 +2546,7 @@ function syncCommandsToml(srcDir: string, destDir: string): string[] {
 function removeAgenfkTomlFromDir(dir: string): void {
   if (!fs.existsSync(dir)) return;
   for (const entry of fs.readdirSync(dir) as string[]) {
-    if (entry.startsWith('agenfk') && entry.endsWith('.toml')) {
+    if (isAgenfkOwnedFile(entry, '.toml') || isAgenfkOwnedArtifact(entry)) {
       try { fs.unlinkSync(path.join(dir, entry)); } catch { /* ignore */ }
     }
   }
@@ -2509,7 +2560,7 @@ function syncCommandsToDir(
   platformKey?: string
 ): string[] {
   if (!fs.existsSync(srcDir)) return [];
-  const files = (fs.readdirSync(srcDir) as string[]).filter((f: string) => f.endsWith('.md'));
+  const files = (fs.readdirSync(srcDir) as string[]).filter(isInstallableMarkdown);
   const installed: string[] = [];
   for (const file of files) {
     let src = path.join(srcDir, file);
@@ -2541,7 +2592,7 @@ function removeCommandsFromDir(
   transform?: (filename: string) => string
 ): void {
   if (!fs.existsSync(srcDir) || !fs.existsSync(destDir)) return;
-  const files = (fs.readdirSync(srcDir) as string[]).filter((f: string) => f.endsWith('.md'));
+  const files = (fs.readdirSync(srcDir) as string[]).filter(isInstallableMarkdown);
   for (const file of files) {
     const relDest = transform ? transform(file) : file;
     const dest = path.join(destDir, relDest);
@@ -2563,17 +2614,13 @@ function removeCommandsFromDir(
 function removeAgenfkSkillsFromDir(destDir: string): void {
   if (!fs.existsSync(destDir)) return;
   for (const entry of fs.readdirSync(destDir) as string[]) {
-    if (!entry.startsWith('agenfk')) continue;
+    if (!isAgenfkOwnedEntry(entry)) continue;
     const full = path.join(destDir, entry);
     // Remove SKILL.md inside the skill dir, then the dir itself
-    const skillFile = path.join(full, 'SKILL.md');
-    if (fs.existsSync(skillFile)) {
-      fs.unlinkSync(skillFile);
-    } else if (fs.existsSync(full)) {
-      // Plain file (old flat format)
-      try { fs.unlinkSync(full); } catch { /* ignore */ }
-    }
-    try { fs.rmdirSync(full); } catch { /* ignore — not empty or doesn't exist */ }
+    // Recursive: a skill dir may hold more than SKILL.md (and an AppleDouble
+    // twin dir holds arbitrary metadata), in which case rmdirSync throws into a
+    // swallowed catch and the dir survives. Mirrors scripts/uninstall.mjs.
+    try { fs.rmSync(full, { recursive: true, force: true }); } catch { /* ignore */ }
   }
   // Remove destDir itself if now empty, then try the parent too
   try {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -11,6 +11,7 @@ import path from 'path';
 import os from 'os';
 import { stageJsonMigration } from './db-migration.js';
 import { followValidateRun } from './verifyRun.js';
+import { buildUiOpenUrl, resolveDashboardUrl } from './uiUrl.js';
 import { registerHubCommands } from './commands/hub.js';
 import { toonEncode } from './toon.js';
 
@@ -813,22 +814,31 @@ program
 program
   .command('ui')
   .description('Show dashboard information and open in browser')
-  .action(() => {
+  .option('--open <itemId>', 'Open the dashboard with that item highlighted (deep-links the Search Box to the item id)')
+  .action(async (options: { open?: string }) => {
     console.log(chalk.cyan('🌐 Opening UI...'));
-    
-    let uiUrl = 'http://localhost:5173';
-    try {
-      const rootDir = path.resolve(__dirname, '../../..');
-      const uiLogPath = path.join(rootDir, '.agenfk', 'ui.log');
-      if (fs.existsSync(uiLogPath)) {
-        const logContent = fs.readFileSync(uiLogPath, 'utf8');
-        const match = logContent.match(/http:\/\/localhost:\d+/);
-        if (match) {
-          uiUrl = match[0];
-        }
+
+    const rootDir = path.resolve(__dirname, '../../..');
+    const base = resolveDashboardUrl(rootDir);
+
+    let uiUrl = base;
+    if (options.open !== undefined) {
+      const itemId = options.open.trim();
+      if (!itemId) {
+        console.error(chalk.red('Error: --open requires a non-empty item id.'));
+        process.exitCode = 1;
+        return;
       }
-    } catch (err) {
-      // ignore parsing errors
+      // Deep-link: ?item=<id> makes the board pre-fill the Search Box with the
+      // id and run the search (drill-down + highlight + scroll). ?project opens
+      // the board on the project the ITEM belongs to — resolved from the server
+      // (the item id uniquely identifies it); the cwd's project is only a
+      // fallback for when the server is unreachable, since opening the board on
+      // the wrong project would silently switch the user's board and show
+      // NOT FOUND for a perfectly valid item.
+      let projectId = await resolveItemProjectId(itemId);
+      if (!projectId) projectId = findProjectId(process.cwd());
+      uiUrl = buildUiOpenUrl(base, itemId, projectId);
     }
 
     console.log(chalk.white(`Dashboard: ${uiUrl}`));
@@ -1368,6 +1378,22 @@ function findProjectId(startDir: string): string | null {
   try {
     const config = JSON.parse(fs.readFileSync(projFile, 'utf8'));
     return config.projectId || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve which project an item belongs to, from the server (the item id
+ * uniquely identifies it). Used by `agenfk ui --open` so the deep-link opens
+ * the board on the item's real project even when the cwd belongs to a
+ * different one. Returns null when the server is unreachable or the id is
+ * unknown — callers fall back to the cwd's project.
+ */
+async function resolveItemProjectId(itemId: string): Promise<string | null> {
+  try {
+    const { data } = await axios.get(`${API_URL}/items/${encodeURIComponent(itemId)}`, { timeout: 3000 });
+    return data?.projectId || null;
   } catch {
     return null;
   }

--- a/packages/cli/src/test/appledouble-pollution.test.ts
+++ b/packages/cli/src/test/appledouble-pollution.test.ts
@@ -1,0 +1,194 @@
+/**
+ * CGLAB-94 / issue #163 — no macOS AppleDouble (`._*`) artifact may reach a
+ * platform's skills or commands directory, and uninstall must clean up the ones
+ * already-published releases left behind.
+ *
+ * Claude Code (and Cursor/Codex/Gemini/OpenCode) discover skills by listing the
+ * directory, so a stray `._agenfk-foo/SKILL.md` is surfaced as a skill whose
+ * description is mojibake binary — injected into the system prompt of every
+ * session. The sync filters only checked `endsWith('.md')`, which `._agenfk.md`
+ * satisfies; the removal filters only checked `startsWith('agenfk')`, which
+ * `._agenfk.md` does not.
+ *
+ * Behaviour-based: seed real artifacts, run the real installer/uninstaller
+ * against a throwaway $HOME, assert on the files on disk.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { existsSync, readdirSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import path from 'path';
+import { runInstall, runUninstall, makeHome, cleanupHome, REPO_ROOT, type RunResult } from './helpers/runInstaller';
+import { isInstallableMarkdown, isMacMetadata, isAgenfkOwnedEntry } from '../../../../scripts/install-helpers.mjs';
+import { isAgenfkOwnedFile } from '../../../../scripts/uninstall-helpers.mjs';
+
+/** Every dir the installer syncs skills or commands into, relative to $HOME. */
+const PLATFORM_DIRS: string[][] = [
+  ['.agents', 'skills'],
+  ['.claude', 'skills'],
+  ['.claude', 'commands'],
+  ['.cursor', 'skills'],
+  ['.codex', 'skills'],
+  ['.gemini', 'skills'],
+  ['.config', 'opencode', 'skills'],
+  ['.config', 'opencode', 'commands'],
+];
+
+/** Our AppleDouble artifacts only — third-party `._*` is not ours to delete. */
+function appleDoubleIn(dir: string): string[] {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir).filter((n: string) => n.startsWith('._agenfk'));
+}
+
+function allAppleDoubleUnderHome(r: RunResult): string[] {
+  return PLATFORM_DIRS.flatMap((segs) =>
+    appleDoubleIn(r.p(...segs)).map((n) => path.join(...segs, n))
+  );
+}
+
+/** Seed `._agenfk*` artifacts into every platform dir under a throwaway HOME. */
+function seedPollution(homePath: (...s: string[]) => string): void {
+  for (const segs of PLATFORM_DIRS) {
+    const dir = homePath(...segs);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(path.join(dir, '._agenfk.md'), 'AppleDouble junk');
+    mkdirSync(path.join(dir, '._agenfk-calc-tokens'), { recursive: true });
+    writeFileSync(path.join(dir, '._agenfk-calc-tokens', 'SKILL.md'), 'AppleDouble junk');
+    // An AppleDouble dir holding more than SKILL.md: a non-recursive rmdir
+    // throws on this and silently leaves the whole directory behind.
+    writeFileSync(path.join(dir, '._agenfk-calc-tokens', 'extra.bin'), 'junk');
+  }
+}
+
+/** Files belonging to OTHER tools that agenfk must never touch. */
+function seedThirdParty(homePath: (...s: string[]) => string): string[] {
+  const seeded: string[] = [];
+  for (const segs of [['.claude', 'skills'], ['.claude', 'commands']]) {
+    const dir = homePath(...segs);
+    mkdirSync(dir, { recursive: true });
+    for (const name of ['._other-tool-skill', '.DS_Store', '._somebody-elses-note.md']) {
+      const full = path.join(dir, name);
+      writeFileSync(full, 'not ours');
+      seeded.push(full);
+    }
+  }
+  return seeded;
+}
+
+describe('installer — never propagates ._* artifacts from the source tree', () => {
+  let r: RunResult;
+  // Registered BEFORE the writes so a throw mid-seed still gets cleaned up.
+  const seeded = [
+    path.join(REPO_ROOT, 'commands', '._agenfk-probe.md'),
+    path.join(REPO_ROOT, 'skills', 'claude-code', '._agenfk-probe'),
+  ];
+
+  beforeAll(() => {
+    // A polluted payload is exactly what every published release shipped, so
+    // reproduce it at the source: an AppleDouble file sitting in commands/.
+    writeFileSync(seeded[0], 'AppleDouble junk');
+    mkdirSync(seeded[1], { recursive: true });
+    writeFileSync(path.join(seeded[1], 'SKILL.md'), 'AppleDouble junk');
+
+    r = runInstall(['--rules-scope=global']);
+  });
+
+  afterAll(() => {
+    for (const s of seeded) rmSync(s, { recursive: true, force: true });
+    cleanupHome(r.home);
+  });
+
+  it('still installs the real skills', () => {
+    const skills = readdirSync(r.p('.agents', 'skills')).filter((n: string) => n.startsWith('agenfk'));
+    expect(skills.length).toBeGreaterThan(5);
+  });
+
+  it('lets no ._* entry into any platform skills or commands dir', () => {
+    expect(allAppleDoubleUnderHome(r)).toEqual([]);
+  });
+});
+
+describe('installer — heals machines polluted by an earlier release', () => {
+  let r: RunResult;
+  let thirdParty: string[] = [];
+
+  beforeAll(() => {
+    const home = makeHome('agenfk-appledouble-heal');
+    const at = (...s: string[]) => path.join(home, ...s);
+    seedPollution(at);
+    thirdParty = seedThirdParty(at);
+    r = runInstall(['--rules-scope=global'], home);
+  });
+
+  afterAll(() => cleanupHome(r.home));
+
+  it('sweeps pre-existing ._agenfk* artifacts out of every platform dir', () => {
+    expect(allAppleDoubleUnderHome(r)).toEqual([]);
+  });
+
+  it('leaves other tools’ files alone', () => {
+    expect(thirdParty.filter((f) => !existsSync(f))).toEqual([]);
+  });
+});
+
+describe('uninstaller — removes ._agenfk* artifacts a polluted release left behind', () => {
+  let uninstalled: RunResult;
+  let thirdParty: string[] = [];
+
+  beforeAll(() => {
+    const home = makeHome('agenfk-appledouble-uninstall');
+    runInstall(['--rules-scope=global'], home);
+    // Simulate a machine that installed a polluted release: the real skills are
+    // present alongside AppleDouble twins.
+    const at = (...s: string[]) => path.join(home, ...s);
+    seedPollution(at);
+    thirdParty = seedThirdParty(at);
+    uninstalled = runUninstall(['-y'], home);
+  });
+
+  afterAll(() => cleanupHome(uninstalled.home));
+
+  it('leaves no ._agenfk* entry behind in any platform dir', () => {
+    expect(allAppleDoubleUnderHome(uninstalled)).toEqual([]);
+  });
+
+  it('leaves other tools’ files alone', () => {
+    expect(thirdParty.filter((f) => !existsSync(f))).toEqual([]);
+  });
+});
+
+// The predicates every sync/removal site shares. The installer behaviour above
+// proves they are wired in; these pin the classification itself, including the
+// case the original filters got wrong in BOTH directions: `._agenfk.md` ends
+// with .md (so the old sync filter installed it) and does not start with
+// `agenfk` (so the old removal filter left it behind).
+describe('macOS metadata predicates', () => {
+  it('installs real payload markdown', () => {
+    expect(isInstallableMarkdown('agenfk.md')).toBe(true);
+    expect(isInstallableMarkdown('agenfk-calc-tokens.md')).toBe(true);
+  });
+
+  it('refuses AppleDouble markdown that satisfies a naive .md check', () => {
+    expect('._agenfk.md'.endsWith('.md')).toBe(true); // why the old filter passed it
+    expect(isInstallableMarkdown('._agenfk.md')).toBe(false);
+    expect(isInstallableMarkdown('.DS_Store')).toBe(false);
+  });
+
+  it('claims our AppleDouble artifacts despite the agenfk prefix check', () => {
+    expect('._agenfk.md'.startsWith('agenfk')).toBe(false); // why the old filter kept it
+    expect(isAgenfkOwnedEntry('._agenfk-calc-tokens')).toBe(true);
+    expect(isAgenfkOwnedFile('._agenfk.md', '.md')).toBe(true);
+    expect(isMacMetadata('._agenfk')).toBe(true);
+  });
+
+  it('does not claim files belonging to other tools', () => {
+    expect(isAgenfkOwnedEntry('some-other-skill')).toBe(false);
+    expect(isAgenfkOwnedEntry('._other-tool-skill')).toBe(false);
+    expect(isAgenfkOwnedEntry('.DS_Store')).toBe(false);
+    expect(isAgenfkOwnedFile('._somebody-elses-note.md', '.md')).toBe(false);
+  });
+
+  it('checks the extension against the shadowed name', () => {
+    // `._agenfk.json` must not be swept by a call site that handles `.md`.
+    expect(isAgenfkOwnedFile('._agenfk.json', '.md')).toBe(false);
+    expect(isAgenfkOwnedFile('._agenfk.toml', '.toml')).toBe(true);
+  });
+});

--- a/packages/cli/src/test/branch-link.test.ts
+++ b/packages/cli/src/test/branch-link.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { program } from '../index';
+import axios from 'axios';
+import * as child_process from 'child_process';
+import * as fs from 'fs';
+
+vi.mock('axios');
+vi.mock('child_process');
+vi.mock('fs');
+
+const mockedAxios = vi.mocked(axios, true);
+const mockedChildProcess = vi.mocked(child_process, true);
+const mockedFs = vi.mocked(fs, true);
+
+describe('branch link command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedFs.existsSync.mockReturnValue(true);
+    mockedFs.readFileSync.mockReturnValue('{"items": []}');
+  });
+
+  it('should link an existing branch to an item', async () => {
+    const itemId = 'a1b2c3d4-0000-0000-0000-000000000001';
+    mockedAxios.get.mockResolvedValue({
+      data: { id: itemId, title: 'Test', type: 'TASK', parentId: undefined },
+    });
+    mockedChildProcess.execSync.mockReturnValue(Buffer.from('feat/CGLAB-86_fix-bugs-to-fix\n'));
+    mockedAxios.put.mockResolvedValue({ data: {} });
+
+    await program.parseAsync([
+      'node', 'agenfk', 'branch', 'link', itemId, 'feat/CGLAB-86_fix-bugs-to-fix',
+    ]);
+
+    expect(mockedChildProcess.execSync).toHaveBeenCalledWith(
+      expect.stringContaining('git rev-parse --verify'),
+      expect.any(Object)
+    );
+    expect(mockedAxios.put).toHaveBeenCalledWith(
+      expect.stringContaining(`/items/${itemId}`),
+      { branchName: 'feat/CGLAB-86_fix-bugs-to-fix' }
+    );
+  });
+
+  it('should reject linking a branch that does not exist locally', async () => {
+    const itemId = 'a1b2c3d4-0000-0000-0000-000000000002';
+    mockedAxios.get.mockResolvedValue({
+      data: { id: itemId, title: 'Test', type: 'TASK', parentId: undefined },
+    });
+    mockedChildProcess.execSync.mockImplementation((cmd: any) => {
+      if (typeof cmd === 'string' && cmd.includes('git rev-parse')) {
+        throw new Error('fatal: ambiguous argument');
+      }
+      return Buffer.from('');
+    });
+
+    const spy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+    await program.parseAsync([
+      'node', 'agenfk', 'branch', 'link', itemId, 'nonexistent-branch',
+    ]);
+    expect(spy).toHaveBeenCalledWith(1);
+    expect(mockedAxios.put).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('should reject linking for child items (only top-level allowed)', async () => {
+    const itemId = 'a1b2c3d4-0000-0000-0000-000000000003';
+    const parentId = 'e5f6a7b8-0000-0000-0000-000000000004';
+    mockedAxios.get.mockResolvedValue({
+      data: { id: itemId, title: 'Test', type: 'TASK', parentId },
+    });
+
+    const spy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+    await program.parseAsync([
+      'node', 'agenfk', 'branch', 'link', itemId, 'some-branch',
+    ]);
+    expect(spy).toHaveBeenCalledWith(1);
+    expect(mockedAxios.put).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('should reject branch names with invalid characters', async () => {
+    const itemId = 'a1b2c3d4-0000-0000-0000-000000000005';
+    mockedAxios.get.mockResolvedValue({
+      data: { id: itemId, title: 'Test', type: 'TASK', parentId: undefined },
+    });
+
+    const spy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+    await program.parseAsync([
+      'node', 'agenfk', 'branch', 'link', itemId, 'bad;branch-name',
+    ]);
+    expect(spy).toHaveBeenCalledWith(1);
+    expect(mockedChildProcess.execSync).not.toHaveBeenCalled();
+    expect(mockedAxios.put).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});

--- a/packages/cli/src/test/codex-async-guidance.test.ts
+++ b/packages/cli/src/test/codex-async-guidance.test.ts
@@ -1,0 +1,70 @@
+/**
+ * CGLAB-86 — Codex: long-running commands must run as async tasks.
+ *
+ * Codex's shell tool (exec_command) yields after ~30s by default. AgEnFK's
+ * long-running commands — a full test suite (via `agenfk log-test`) and the
+ * final-step `agenfk verify` (which runs the project's verifyCommand to land
+ * DONE) — routinely exceed that window, so running them synchronously gets
+ * the tool call cut off and the completed result is never observed.
+ *
+ * The shipped Codex rule bundle (codexrules/AGENTS.md) must therefore carry
+ * explicit guidance to run those commands as async tasks (exec_command's
+ * `yield_time_ms` + waiting on the process for its completed result). This
+ * test pins the guidance so a future rewrite of the bundle can't drop it.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+
+const ROOT = path.resolve(__dirname, '../../../..');
+const bundle = readFileSync(path.join(ROOT, 'codexrules', 'AGENTS.md'), 'utf8');
+
+/** Return the body of the section whose heading matches `re` (up to the next heading of same-or-higher level). */
+function sectionBody(markdown: string, re: RegExp): string | null {
+  const lines = markdown.split('\n');
+  const out: string[] = [];
+  let capturing = false;
+  let level = 0;
+  for (const line of lines) {
+    const m = line.match(/^(#{1,6})\s+(.*)$/);
+    if (m) {
+      const thisLevel = m[1].length;
+      if (capturing && thisLevel <= level) break;
+      if (!capturing && re.test(m[2])) {
+        capturing = true;
+        level = thisLevel;
+        continue;
+      }
+    }
+    if (capturing) out.push(line);
+  }
+  return capturing ? out.join('\n') : null;
+}
+
+describe('CGLAB-86 — codexrules/AGENTS.md async long-command guidance', () => {
+  it('has a dedicated section about long-running / async commands', () => {
+    const body = sectionBody(bundle, /long[- ]running|async|background/i);
+    expect(body, 'bundle must contain a heading matching long-running/async/background').not.toBeNull();
+  });
+
+  it('names Codex\'s async mechanism (yield_time_ms) so the agent can actually do it', () => {
+    const body = sectionBody(bundle, /long[- ]running|async|background/i);
+    expect(body ?? '').toContain('yield_time_ms');
+  });
+
+  it('covers the test-suite scenario (agenfk log-test / the project test command)', () => {
+    const body = sectionBody(bundle, /long[- ]running|async|background/i);
+    expect(body ?? '').toMatch(/log-test|test suite|tests/i);
+  });
+
+  it('covers the transition-to-DONE scenario (agenfk verify running the verify command)', () => {
+    const body = sectionBody(bundle, /long[- ]running|async|background/i);
+    expect(body ?? '').toMatch(/verify/);
+    expect(body ?? '').toMatch(/DONE/);
+  });
+
+  it('instructs waiting for the completed result rather than assuming the outcome', () => {
+    const body = sectionBody(bundle, /long[- ]running|async|background/i);
+    expect(body ?? '').toMatch(/wait|complet|finished/i);
+  });
+});

--- a/packages/cli/src/test/helpers/tarEntries.ts
+++ b/packages/cli/src/test/helpers/tarEntries.ts
@@ -1,0 +1,59 @@
+/**
+ * List the member names of a .tar.gz WITHOUT shelling out to tar.
+ *
+ * This exists because macOS bsdtar *transparently merges AppleDouble (`._*`)
+ * members back into their parent file when listing, so `tar -tzf` reports a
+ * clean archive even when half its entries are resource-fork metadata. That
+ * illusion is exactly how CGLAB-94 survived several releases unnoticed — any
+ * test that audits an archive via `tar -t` is testing nothing on the machine
+ * that actually cuts the release.
+ *
+ * Scope: this walks ustar headers well enough to enumerate every member name in
+ * the archives we build, including the `prefix` field for long paths. It does
+ * NOT reassemble PAX/GNU extended long names — a member whose name lives in a
+ * preceding `x`/`L` record is reported by its (possibly truncated) ustar name,
+ * and the extended-header records themselves are reported as members. That is
+ * deliberate: the PaxHeader entries are something we assert the ABSENCE of.
+ */
+import { gunzipSync } from 'zlib';
+import { readFileSync } from 'fs';
+
+export interface TarEntry {
+  name: string;
+  /** ustar typeflag: '0'/'\0' file, '5' dir, 'x'/'g' PAX, 'L'/'K' GNU long name */
+  typeflag: string;
+}
+
+export function listTarEntries(tgzPath: string): TarEntry[] {
+  const buf = gunzipSync(readFileSync(tgzPath));
+  const str = (start: number, len: number): string => {
+    const field = buf.subarray(start, start + len);
+    const nul = field.indexOf(0);
+    return field.subarray(0, nul === -1 ? len : nul).toString('utf8');
+  };
+  const entries: TarEntry[] = [];
+  for (let off = 0; off + 512 <= buf.length; ) {
+    const name = str(off, 100);
+    if (name === '') { off += 512; continue; }          // padding / end-of-archive
+    const prefix = str(off + 345, 155);                 // ustar long-path prefix
+    const size = parseInt(
+      buf.subarray(off + 124, off + 136).toString('ascii').replace(/\0.*$/, '').trim(),
+      8
+    ) || 0;
+    entries.push({ name: prefix ? `${prefix}/${name}` : name, typeflag: str(off + 156, 1) });
+    off += 512 + Math.ceil(size / 512) * 512;
+  }
+  return entries;
+}
+
+export function tarEntryNames(tgzPath: string): string[] {
+  return listTarEntries(tgzPath).map((e) => e.name);
+}
+
+/** Member names that are macOS AppleDouble resource-fork metadata. */
+export function appleDoubleEntries(tgzPath: string): string[] {
+  return tarEntryNames(tgzPath).filter((n) => {
+    const base = n.replace(/\/$/, '').split('/').pop() || '';
+    return base.startsWith('._');
+  });
+}

--- a/packages/cli/src/test/packaging-appledouble.test.ts
+++ b/packages/cli/src/test/packaging-appledouble.test.ts
@@ -1,0 +1,85 @@
+/**
+ * CGLAB-94 / issue #163 — the release tarball must never carry macOS
+ * AppleDouble (`._*`) resource-fork metadata or `.DS_Store`.
+ *
+ * Every published release from at least v1.1.13 through v1.1.16-beta.4 was
+ * roughly half AppleDouble (436 of 872 members in v1.1.16-beta.3) because
+ * scripts/package-dist.mjs ran a bare `tar -czf` on macOS, where bsdtar emits a
+ * `._<name>` companion for every file carrying an extended attribute.
+ *
+ * Behaviour-based: build a real archive from a fixture tree with the same
+ * helper the release scripts use, then read the members back without `tar -t`
+ * (see helpers/tarEntries — macOS tar hides exactly the members under test).
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync } from 'fs';
+import { spawnSync } from 'child_process';
+import os from 'os';
+import path from 'path';
+import { createTarball } from '../../../../scripts/package-helpers.mjs';
+import { tarEntryNames, appleDoubleEntries } from './helpers/tarEntries';
+
+describe('release packaging — excludes macOS metadata', () => {
+  let dir: string;
+  let out: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(path.join(os.tmpdir(), 'agenfk-pack-'));
+    mkdirSync(path.join(dir, 'commands'), { recursive: true });
+    writeFileSync(path.join(dir, 'commands', 'agenfk.md'), '# real payload\n');
+    // Artifacts a polluted working tree (or a previously-extracted polluted
+    // tarball) leaves lying around. These must never enter the archive.
+    writeFileSync(path.join(dir, 'commands', '._agenfk.md'), 'AppleDouble junk');
+    writeFileSync(path.join(dir, 'commands', '.DS_Store'), 'finder junk');
+    out = path.join(dir, 'out.tar.gz');
+    createTarball({ cwd: dir, outFile: 'out.tar.gz', include: ['commands/'] });
+  });
+
+  afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('includes the real payload', () => {
+    expect(tarEntryNames(out).some((n) => n.endsWith('commands/agenfk.md'))).toBe(true);
+  });
+
+  it('excludes ._* files that are physically present in the source tree', () => {
+    expect(appleDoubleEntries(out)).toEqual([]);
+  });
+
+  it('carries no xattr PAX headers (GNU tar warns once per file for each)', () => {
+    expect(tarEntryNames(out).filter((n) => n.includes('PaxHeader'))).toEqual([]);
+  });
+
+  it('excludes .DS_Store', () => {
+    const base = tarEntryNames(out).map((n) => n.split('/').pop());
+    expect(base).not.toContain('.DS_Store');
+  });
+
+  // The regression that actually shipped: files carrying an extended attribute
+  // make bsdtar synthesise an AppleDouble member that never existed on disk.
+  // Only reproducible on macOS, which is where releases are cut.
+  it.runIf(process.platform === 'darwin')(
+    'emits no AppleDouble member for files carrying extended attributes',
+    () => {
+      const xattrDir = mkdtempSync(path.join(os.tmpdir(), 'agenfk-xattr-'));
+      try {
+        mkdirSync(path.join(xattrDir, 'commands'), { recursive: true });
+        const f = path.join(xattrDir, 'commands', 'agenfk.md');
+        writeFileSync(f, '# real payload\n');
+        const set = spawnSync('xattr', ['-w', 'com.apple.provenance', 'x', f], { encoding: 'utf8' });
+        expect(set.status, 'could not seed an xattr; test would be vacuous').toBe(0);
+
+        // Guard against the test itself going vacuous: prove a bare tar DOES
+        // synthesise the artifact here, so the assertion below has teeth.
+        spawnSync('tar', ['-czf', 'bare.tar.gz', 'commands/'], { cwd: xattrDir });
+        expect(appleDoubleEntries(path.join(xattrDir, 'bare.tar.gz')).length).toBeGreaterThan(0);
+
+        createTarball({ cwd: xattrDir, outFile: 'out.tar.gz', include: ['commands/'] });
+        const tgz = path.join(xattrDir, 'out.tar.gz');
+        expect(existsSync(tgz)).toBe(true);
+        expect(appleDoubleEntries(tgz)).toEqual([]);
+      } finally {
+        rmSync(xattrDir, { recursive: true, force: true });
+      }
+    }
+  );
+});

--- a/packages/cli/src/test/ui-open.test.ts
+++ b/packages/cli/src/test/ui-open.test.ts
@@ -1,0 +1,243 @@
+/**
+ * `agenfk ui --open <itemId>` — deep-link the dashboard to a specific item.
+ *
+ * User-facing contract exercised here (CGLAB-100):
+ *  - `resolveDashboardUrl` keeps the existing base-URL behaviour: the URL
+ *    recorded in `<root>/.agenfk/ui.log` wins, else the default dev port.
+ *  - `buildUiOpenUrl` appends `?item=<itemId>` (and `&project=<projectId>`
+ *    when the current project resolves) to that base, URL-encoding values.
+ *  - the commander `ui` command accepts `--open <itemId>`.
+ *  - running `ui --open <id>` launches the browser with a URL carrying both
+ *    query params when `.agenfk/project.json` resolves, and with only
+ *    `?item=` when it does not. The actual browser-open is environmental
+ *    (same as the restart-quiet tests treat the start-services script): we
+ *    intercept the execSync call and assert on the URL it received.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { execSync } from 'child_process';
+import axios from 'axios';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { program } from '../index';
+import { buildUiOpenUrl, resolveDashboardUrl } from '../uiUrl';
+
+// Capture the browser-launch instead of opening one in the test environment.
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return { ...actual, execSync: vi.fn(() => Buffer.from('')) };
+});
+
+// Keep the item->project lookup hermetic: default to "server unreachable" so
+// the action falls back to the cwd project deterministically, on any machine.
+vi.mock('axios', () => ({
+  default: { get: vi.fn(() => Promise.reject(new Error('server unreachable'))) },
+}));
+
+function makeTmpDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function uiCommand() {
+  const cmd = program.commands.find((c) => c.name() === 'ui');
+  expect(cmd, 'command "ui" should be registered').toBeDefined();
+  return cmd as any;
+}
+
+describe('resolveDashboardUrl', () => {
+  it('falls back to the default dev-server URL when no ui.log exists', () => {
+    const dir = makeTmpDir('agenfk-ui-open-');
+    try {
+      expect(resolveDashboardUrl(dir)).toBe('http://localhost:5173');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('uses the URL recorded in .agenfk/ui.log', () => {
+    const dir = makeTmpDir('agenfk-ui-open-');
+    try {
+      fs.mkdirSync(path.join(dir, '.agenfk'));
+      fs.writeFileSync(
+        path.join(dir, '.agenfk', 'ui.log'),
+        'VITE ready in 120 ms\n  ➜  Local:   http://localhost:5174/\n'
+      );
+      expect(resolveDashboardUrl(dir)).toBe('http://localhost:5174');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to the default when ui.log has no parseable URL', () => {
+    const dir = makeTmpDir('agenfk-ui-open-');
+    try {
+      fs.mkdirSync(path.join(dir, '.agenfk'));
+      fs.writeFileSync(path.join(dir, '.agenfk', 'ui.log'), 'no urls in here');
+      expect(resolveDashboardUrl(dir)).toBe('http://localhost:5173');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('buildUiOpenUrl', () => {
+  const base = 'http://localhost:5173';
+
+  it('appends ?item=<itemId> to the base dashboard URL', () => {
+    expect(buildUiOpenUrl(base, 'abc-123')).toBe('http://localhost:5173?item=abc-123');
+  });
+
+  it('appends &project=<projectId> when a project is given', () => {
+    expect(buildUiOpenUrl(base, 'abc-123', 'proj-1')).toBe(
+      'http://localhost:5173?item=abc-123&project=proj-1'
+    );
+  });
+
+  it('omits the project param when no project resolves', () => {
+    expect(buildUiOpenUrl(base, 'abc-123', null)).toBe('http://localhost:5173?item=abc-123');
+    expect(buildUiOpenUrl(base, 'abc-123', undefined)).toBe('http://localhost:5173?item=abc-123');
+  });
+
+  it('URL-encodes the item id so the UI decodes back to the exact id', () => {
+    const url = buildUiOpenUrl(base, 'a b&c');
+    // The KanbanBoard reads the param back with URLSearchParams — the contract
+    // is a lossless round-trip, not a specific escape style.
+    const decoded = new URLSearchParams(url.split('?')[1]).get('item');
+    expect(decoded).toBe('a b&c');
+  });
+
+  it('joins with & when the base URL already carries a query string', () => {
+    expect(buildUiOpenUrl('http://localhost:5173?theme=dark', 'abc-123', 'proj-1')).toBe(
+      'http://localhost:5173?theme=dark&item=abc-123&project=proj-1'
+    );
+  });
+});
+
+describe('agenfk ui --open command', () => {
+  it('declares the --open <itemId> option', () => {
+    const longs = uiCommand().options.map((o: any) => o.long);
+    expect(longs).toContain('--open');
+  });
+});
+
+describe('agenfk ui --open browser launch', () => {
+  let tmpCwd: string;
+  let realCwd: string;
+
+  beforeEach(() => {
+    // The shared commander program keeps parsed option values between parse
+    // calls (a real CLI invocation is a fresh process); drop a stale --open so
+    // each test starts clean.
+    uiCommand().setOptionValue('open', undefined);
+  });
+
+  afterEach(() => {
+    if (realCwd) process.chdir(realCwd);
+    realCwd = '';
+    if (tmpCwd) fs.rmSync(tmpCwd, { recursive: true, force: true });
+    tmpCwd = '';
+    vi.mocked(execSync).mockClear();
+  });
+
+  // The launch command is a platform opener wrapping the URL in quotes
+  // (e.g. `open "<url>"` or `xdg-open "<url>"`) — extract that URL.
+  const launchedUrls = (): string[] =>
+    vi.mocked(execSync).mock.calls
+      .map((c) => String(c[0]).match(/"(http[^"]+)"/) ?? null)
+      .filter((m): m is string[] => m !== null)
+      .map((m) => m[1]);
+
+  it('launches the browser with ?item and ?project when the current project resolves', async () => {
+    realCwd = process.cwd();
+    tmpCwd = makeTmpDir('agenfk-ui-open-cwd-');
+    fs.mkdirSync(path.join(tmpCwd, '.agenfk'));
+    fs.writeFileSync(path.join(tmpCwd, '.agenfk', 'project.json'), JSON.stringify({ projectId: 'proj-1' }));
+    process.chdir(tmpCwd);
+
+    await program.parseAsync(['node', 'agenfk', 'ui', '--open', 'item-123']);
+
+    const urls = launchedUrls().filter((u) => u.includes('?item=item-123'));
+    expect(urls.length).toBeGreaterThan(0);
+    // The base port is whatever the dev server recorded in ui.log; the
+    // contract under test is the query string, not the port.
+    expect(urls.every((u) => u.startsWith('http://localhost:'))).toBe(true);
+    expect(urls[0]).toContain('?item=item-123&project=proj-1');
+  });
+
+  it('launches with only ?item when no project resolves (server unreachable, no cwd project)', async () => {
+    realCwd = process.cwd();
+    tmpCwd = makeTmpDir('agenfk-ui-open-cwd-');
+    // No .agenfk directory anywhere up this tmp dir's tree.
+    process.chdir(tmpCwd);
+
+    await program.parseAsync(['node', 'agenfk', 'ui', '--open', 'item-456']);
+
+    const urls = launchedUrls().filter((u) => u.includes('?item=item-456'));
+    expect(urls.length).toBeGreaterThan(0);
+    expect(urls.every((u) => !u.includes('project='))).toBe(true);
+  });
+
+  it('opens the project the ITEM belongs to (from the server), not the cwd project', async () => {
+    // The item's real project must win over the cwd — a cross-project
+    // 'show item X' must not silently switch the board to the wrong project.
+    vi.mocked(axios.get).mockImplementationOnce(async () => ({ data: { projectId: 'proj-item-home' } }) as any);
+    realCwd = process.cwd();
+    tmpCwd = makeTmpDir('agenfk-ui-open-cwd-');
+    fs.mkdirSync(path.join(tmpCwd, '.agenfk'));
+    fs.writeFileSync(path.join(tmpCwd, '.agenfk', 'project.json'), JSON.stringify({ projectId: 'proj-cwd' }));
+    process.chdir(tmpCwd);
+
+    await program.parseAsync(['node', 'agenfk', 'ui', '--open', 'item-777']);
+
+    const urls = launchedUrls().filter((u) => u.includes('?item=item-777'));
+    expect(urls.length).toBeGreaterThan(0);
+    expect(urls[0]).toContain('?item=item-777&project=proj-item-home');
+    expect(urls[0]).not.toContain('proj-cwd');
+  });
+
+  it('rejects an empty --open value instead of silently opening the plain dashboard', async () => {
+    const savedExitCode = process.exitCode;
+    realCwd = process.cwd();
+    tmpCwd = makeTmpDir('agenfk-ui-open-cwd-');
+    process.chdir(tmpCwd);
+
+    await program.parseAsync(['node', 'agenfk', 'ui', '--open', '']);
+
+    expect(process.exitCode).toBe(1);
+    expect(launchedUrls().length).toBe(0);
+    process.exitCode = savedExitCode;
+  });
+
+  it('never leaks shell metacharacters from a hostile item id into the launch command', async () => {
+    // The id flows argv -> URLSearchParams -> `open "<url>"`. URLSearchParams
+    // must encode everything that could break the quoting ($, backtick, ").
+    realCwd = process.cwd();
+    tmpCwd = makeTmpDir('agenfk-ui-open-cwd-');
+    process.chdir(tmpCwd);
+
+    await program.parseAsync(['node', 'agenfk', 'ui', '--open', 'a"; echo $(id) `id`']);
+
+    const calls = vi.mocked(execSync).mock.calls.map((c) => String(c[0]));
+    expect(calls.length).toBeGreaterThan(0);
+    for (const cmd of calls) {
+      // exactly the two wrapping quotes around the URL — nothing else
+      expect((cmd.match(/"/g) ?? []).length).toBe(2);
+      expect(cmd).not.toMatch(/\$\(|`|; /);
+    }
+    // and the id still round-trips losslessly through the query string
+    const url = launchedUrls()[0];
+    expect(new URLSearchParams(url.split('?')[1]).get('item')).toBe('a"; echo $(id) `id`');
+  });
+
+  it('still opens the plain dashboard when --open is absent', async () => {
+    realCwd = process.cwd();
+    tmpCwd = makeTmpDir('agenfk-ui-open-cwd-');
+    process.chdir(tmpCwd);
+
+    await program.parseAsync(['node', 'agenfk', 'ui']);
+
+    const urls = launchedUrls();
+    expect(urls.length).toBeGreaterThan(0);
+    expect(urls.every((u) => !u.includes('?item='))).toBe(true);
+  });
+});

--- a/packages/cli/src/test/vite-cjs-deprecation.test.ts
+++ b/packages/cli/src/test/vite-cjs-deprecation.test.ts
@@ -1,0 +1,93 @@
+/**
+ * CGLAB-86 — "The CJS build of Vite's Node API is deprecated."
+ *
+ * That warning was emitted by Vite 5/6 whenever Vite's Node API was loaded
+ * through a CJS require of the `vite` package. The repo no longer has that failure mode:
+ * both UI workspaces are ESM (`"type": "module"`, so their `vite.config.ts`
+ * is loaded as ESM) and the locked Vite is >= 7, where the CJS Node entry —
+ * and therefore the deprecation warning — no longer exists.
+ *
+ * This suite pins that invariant so the warning cannot creep back in:
+ *   - a downgrade of the locked Vite below 7 (back to a CJS-capable build),
+ *   - a workspace losing `"type": "module"` while keeping a vite config,
+ *   - any source file reintroducing a CJS require of Vite's Node API (see the
+ *     CJS_REQUIRE_VITE pattern below — deliberately built from parts so this
+ *     file cannot flag itself).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, existsSync, statSync } from 'fs';
+import path from 'path';
+
+const ROOT = path.resolve(__dirname, '../../../..');
+
+// Built from parts so the pattern's own source text never contains the
+// literal it hunts for (a doc comment mentioning it would self-flag).
+const CJS_REQUIRE_VITE = new RegExp(`require\\(\\s*['"]vite['"]\\s*\\)`);
+const IGNORED_DIRS = new Set(['node_modules', 'dist', '.git']);
+
+/** Collect source files (js/ts/mjs/cjs/cts/mts) under dir, skipping ignored dirs. */
+function collectSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      if (!IGNORED_DIRS.has(entry)) out.push(...collectSourceFiles(full));
+    } else if (/\.(js|ts|mjs|cjs|cts|mts)$/.test(entry)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe('CGLAB-86 — Vite CJS Node API deprecation guard', () => {
+  it('both UI workspaces are ESM so their vite configs load through the ESM Node API', () => {
+    for (const ws of ['packages/ui', 'packages/hub-ui']) {
+      const pkg = JSON.parse(readFileSync(path.join(ROOT, ws, 'package.json'), 'utf8'));
+      expect(pkg.type, `${ws}/package.json must declare "type": "module"`).toBe('module');
+      // and the workspace actually uses Vite (the invariant is only meaningful if it does)
+      const usesVite =
+        JSON.stringify(pkg.scripts ?? {}).includes('vite') ||
+        (pkg.devDependencies ?? {}).vite ||
+        (pkg.dependencies ?? {}).vite;
+      expect(usesVite, `${ws} expected to use vite`).toBeTruthy();
+    }
+  });
+
+  it('no source file loads Vite\'s Node API via CJS require', () => {
+    const offenders: string[] = [];
+    const scan = (dir: string) => {
+      for (const file of collectSourceFiles(dir)) {
+        const text = readFileSync(file, 'utf8');
+        if (CJS_REQUIRE_VITE.test(text)) offenders.push(path.relative(ROOT, file));
+      }
+    };
+    scan(path.join(ROOT, 'packages'));
+    scan(path.join(ROOT, 'scripts'));
+    scan(path.join(ROOT, 'bin'));
+    // root-level config files (vite/vitest configs at the monorepo root)
+    for (const f of readdirSync(ROOT)) {
+      if (/\.(js|mjs|cjs|ts)$/.test(f) && CJS_REQUIRE_VITE.test(readFileSync(path.join(ROOT, f), 'utf8'))) {
+        offenders.push(f);
+      }
+    }
+    expect(offenders, `CJS require of Vite's Node API found in: ${offenders.join(', ')}`).toHaveLength(0);
+  });
+
+  it('the locked Vite is >= 7 (CJS Node entry and the deprecation warning were removed)', () => {
+    const lock = JSON.parse(readFileSync(path.join(ROOT, 'package-lock.json'), 'utf8'));
+    const viteEntry = lock.packages?.['node_modules/vite'];
+    expect(viteEntry, 'package-lock.json must pin node_modules/vite').toBeDefined();
+    const major = Number(viteEntry.version.split('.')[0]);
+    expect(major, `locked vite ${viteEntry.version} must be >= 7`).toBeGreaterThanOrEqual(7);
+  });
+
+  it('the installed vite (when present) matches the locked major', () => {
+    const vitePkg = path.join(ROOT, 'node_modules', 'vite', 'package.json');
+    if (!existsSync(vitePkg)) return; // clean checkout without install — skip
+    const installed = Number(JSON.parse(readFileSync(vitePkg, 'utf8')).version.split('.')[0]);
+    const lock = JSON.parse(readFileSync(path.join(ROOT, 'package-lock.json'), 'utf8'));
+    const locked = Number(lock.packages['node_modules/vite'].version.split('.')[0]);
+    expect(installed, `installed vite major ${installed} must match lockfile major ${locked}`).toBe(locked);
+  });
+});

--- a/packages/cli/src/test/vite-cjs-deprecation.test.ts
+++ b/packages/cli/src/test/vite-cjs-deprecation.test.ts
@@ -2,17 +2,19 @@
  * CGLAB-86 — "The CJS build of Vite's Node API is deprecated."
  *
  * That warning was emitted by Vite 5/6 whenever Vite's Node API was loaded
- * through a CJS require of the `vite` package. The repo no longer has that failure mode:
- * both UI workspaces are ESM (`"type": "module"`, so their `vite.config.ts`
- * is loaded as ESM) and the locked Vite is >= 7, where the CJS Node entry —
- * and therefore the deprecation warning — no longer exists.
+ * through a CJS require of the `vite` package. The repo no longer has that
+ * failure mode: both UI workspaces are ESM (`"type": "module"`, so their
+ * `vite.config.ts` is loaded as ESM) and the locked Vite is >= 7, where the
+ * CJS Node entry — and therefore the deprecation warning — no longer exists.
  *
  * This suite pins that invariant so the warning cannot creep back in:
  *   - a downgrade of the locked Vite below 7 (back to a CJS-capable build),
  *   - a workspace losing `"type": "module"` while keeping a vite config,
- *   - any source file reintroducing a CJS require of Vite's Node API (see the
- *     CJS_REQUIRE_VITE pattern below — deliberately built from parts so this
- *     file cannot flag itself).
+ *   - any source file reintroducing a CJS load of Vite's Node API
+ *     (require('vite') incl. spaced/commented forms, TS import-equals).
+ * The file scan skips this file itself (its mutation test cases contain the
+ * very literals it hunts for); the matcher is unit-tested against those
+ * forms directly below.
  */
 import { describe, it, expect } from 'vitest';
 import { readFileSync, readdirSync, existsSync, statSync } from 'fs';
@@ -20,9 +22,16 @@ import path from 'path';
 
 const ROOT = path.resolve(__dirname, '../../../..');
 
-// Built from parts so the pattern's own source text never contains the
-// literal it hunts for (a doc comment mentioning it would self-flag).
-const CJS_REQUIRE_VITE = new RegExp(`require\\(\\s*['"]vite['"]\\s*\\)`);
+// CJS loads of the vite package: require('vite'), require ('vite'),
+// require(/* c */ 'vite'), require( 'vite'), and TS import-equals
+// (import x = require('vite')). Exact package name only — 'vite-plugin-x'
+// does NOT match, and neither do ESM forms (import ... from 'vite',
+// dynamic import('vite')). Single line on purpose: in non-`v` regexes
+// literal whitespace is significant, so a multi-line pattern would demand
+// the indentation as part of the match.
+const CJS_LOAD_VITE = new RegExp(
+  String.raw`(?:require\s*(?:/\*[\s\S]*?\*/)?\s*\(|import\s+[\w$]+\s*=\s*require\s*(?:/\*[\s\S]*?\*/)?\s*\()\s*(?:/\*[\s\S]*?\*/)?\s*['"]vite['"]`
+);
 const IGNORED_DIRS = new Set(['node_modules', 'dist', '.git']);
 
 /** Collect source files (js/ts/mjs/cjs/cts/mts) under dir, skipping ignored dirs. */
@@ -41,6 +50,28 @@ function collectSourceFiles(dir: string): string[] {
 }
 
 describe('CGLAB-86 — Vite CJS Node API deprecation guard', () => {
+  it('the matcher catches CJS load forms and does not false-positive on ESM', () => {
+    const bad = [
+      "require('vite')",
+      'require ("vite")',
+      "require/* load */('vite')",
+      "require(/* load */ 'vite')",
+      "require( 'vite')",
+      "require (/* x */'vite')",
+      "import vite = require('vite')",
+    ];
+    for (const s of bad) expect(CJS_LOAD_VITE.test(s), `should flag: ${s}`).toBe(true);
+
+    const good = [
+      "import { defineConfig } from 'vite';",
+      "const vite = await import('vite');",
+      "import('vite')",
+      "require('vite-plugin-react')",
+      "require('vitest')",
+    ];
+    for (const s of good) expect(CJS_LOAD_VITE.test(s), `should not flag: ${s}`).toBe(false);
+  });
+
   it('both UI workspaces are ESM so their vite configs load through the ESM Node API', () => {
     for (const ws of ['packages/ui', 'packages/hub-ui']) {
       const pkg = JSON.parse(readFileSync(path.join(ROOT, ws, 'package.json'), 'utf8'));
@@ -55,23 +86,24 @@ describe('CGLAB-86 — Vite CJS Node API deprecation guard', () => {
   });
 
   it('no source file loads Vite\'s Node API via CJS require', () => {
+    const SELF = path.join(__dirname, 'vite-cjs-deprecation.test.ts');
     const offenders: string[] = [];
+    const scanFile = (file: string) => {
+      if (file === SELF) return; // this file's mutation cases contain the literals by design
+      if (CJS_LOAD_VITE.test(readFileSync(file, 'utf8'))) offenders.push(path.relative(ROOT, file));
+    };
     const scan = (dir: string) => {
-      for (const file of collectSourceFiles(dir)) {
-        const text = readFileSync(file, 'utf8');
-        if (CJS_REQUIRE_VITE.test(text)) offenders.push(path.relative(ROOT, file));
-      }
+      for (const file of collectSourceFiles(dir)) scanFile(file);
     };
     scan(path.join(ROOT, 'packages'));
     scan(path.join(ROOT, 'scripts'));
     scan(path.join(ROOT, 'bin'));
     // root-level config files (vite/vitest configs at the monorepo root)
     for (const f of readdirSync(ROOT)) {
-      if (/\.(js|mjs|cjs|ts)$/.test(f) && CJS_REQUIRE_VITE.test(readFileSync(path.join(ROOT, f), 'utf8'))) {
-        offenders.push(f);
-      }
+      const full = path.join(ROOT, f);
+      if (full !== SELF && /\.(js|mjs|cjs|ts)$/.test(f)) scanFile(full);
     }
-    expect(offenders, `CJS require of Vite's Node API found in: ${offenders.join(', ')}`).toHaveLength(0);
+    expect(offenders, `CJS load of Vite's Node API found in: ${offenders.join(', ')}`).toHaveLength(0);
   });
 
   it('the locked Vite is >= 7 (CJS Node entry and the deprecation warning were removed)', () => {

--- a/packages/cli/src/uiUrl.ts
+++ b/packages/cli/src/uiUrl.ts
@@ -1,0 +1,45 @@
+/**
+ * Dashboard URL construction for `agenfk ui` / `agenfk ui --open <itemId>`.
+ *
+ * Kept in a leaf module (no commander, no side effects) so the URL contract
+ * is unit-testable: the base-URL resolution and the deep-link query string are
+ * the user-facing behaviour; the browser launch itself is environmental.
+ */
+import fs from 'fs';
+import path from 'path';
+
+const DEFAULT_UI_URL = 'http://localhost:5173';
+
+/**
+ * Resolve the dashboard base URL the way `agenfk ui` always has: the URL the
+ * dev server recorded in `<rootDir>/.agenfk/ui.log` wins; anything else (no
+ * log, unparseable log) falls back to the default dev port.
+ */
+export function resolveDashboardUrl(rootDir: string): string {
+  let logContent: string;
+  try {
+    logContent = fs.readFileSync(path.join(rootDir, '.agenfk', 'ui.log'), 'utf8');
+  } catch {
+    // No log (or unreadable) — the default URL is still usable.
+    return DEFAULT_UI_URL;
+  }
+  const match = logContent.match(/http:\/\/localhost:\d+/);
+  return match ? match[0] : DEFAULT_UI_URL;
+}
+
+/**
+ * Build the URL `agenfk ui --open <itemId>` launches the browser with.
+ *
+ * `?item=<itemId>` makes the KanbanBoard pre-fill the Search Box with the id
+ * and run the search (drill-down + highlight + scroll, exactly like typing
+ * the id into the box). `&project=<projectId>` — appended only when a
+ * project resolves — makes the board open on the project the item belongs to,
+ * since the board's default project otherwise comes from localStorage.
+ */
+export function buildUiOpenUrl(base: string, itemId: string, projectId?: string | null): string {
+  const params = new URLSearchParams();
+  params.set('item', itemId);
+  if (projectId) params.set('project', projectId);
+  const separator = base.includes('?') ? '&' : '?';
+  return `${base}${separator}${params.toString()}`;
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/core",
-  "version": "1.1.15",
+  "version": "1.1.16-beta.4",
   "description": "Core logic and interfaces for the AgenFK Engineering Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/core",
-  "version": "1.1.16-beta.4",
+  "version": "1.1.16-beta.5",
   "description": "Core logic and interfaces for the AgenFK Engineering Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/core",
-  "version": "1.1.15",
+  "version": "1.1.16-beta.6",
   "description": "Core logic and interfaces for the AgenFK Engineering Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "1.1.15",
+  "version": "1.1.16-beta.6",
   "description": "AgenFK Agentic Engineering Framework — installer",
   "bin": {
     "agenfk": "bin/agenfk.js"

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "1.1.15",
+  "version": "1.1.16-beta.4",
   "description": "AgenFK Agentic Engineering Framework — installer",
   "bin": {
     "agenfk": "bin/agenfk.js"

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "1.1.16-beta.4",
+  "version": "1.1.16-beta.5",
   "description": "AgenFK Agentic Engineering Framework — installer",
   "bin": {
     "agenfk": "bin/agenfk.js"

--- a/packages/flow-editor/package.json
+++ b/packages/flow-editor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agenfk/flow-editor",
   "private": true,
-  "version": "1.1.16-beta.4",
+  "version": "1.1.16-beta.5",
   "type": "module",
   "main": "./src/index.ts",
   "exports": {

--- a/packages/flow-editor/package.json
+++ b/packages/flow-editor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agenfk/flow-editor",
   "private": true,
-  "version": "1.1.15",
+  "version": "1.1.16-beta.6",
   "type": "module",
   "main": "./src/index.ts",
   "exports": {

--- a/packages/flow-editor/package.json
+++ b/packages/flow-editor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agenfk/flow-editor",
   "private": true,
-  "version": "1.1.15",
+  "version": "1.1.16-beta.4",
   "type": "module",
   "main": "./src/index.ts",
   "exports": {

--- a/packages/hub-ui/package.json
+++ b/packages/hub-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hub-ui",
   "private": true,
-  "version": "1.1.16-beta.4",
+  "version": "1.1.16-beta.5",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.1.16-beta.4",
+    "@agenfk/flow-editor": "1.1.16-beta.5",
     "@fontsource-variable/jetbrains-mono": "^5.3.0",
     "@fontsource-variable/manrope": "^5.3.0",
     "@tailwindcss/postcss": "^4.3.3",

--- a/packages/hub-ui/package.json
+++ b/packages/hub-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hub-ui",
   "private": true,
-  "version": "1.1.15",
+  "version": "1.1.16-beta.6",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.1.15",
+    "@agenfk/flow-editor": "1.1.16-beta.6",
     "@fontsource-variable/jetbrains-mono": "^5.3.0",
     "@fontsource-variable/manrope": "^5.3.0",
     "@tailwindcss/postcss": "^4.3.3",

--- a/packages/hub-ui/package.json
+++ b/packages/hub-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hub-ui",
   "private": true,
-  "version": "1.1.15",
+  "version": "1.1.16-beta.4",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.1.15",
+    "@agenfk/flow-editor": "1.1.16-beta.4",
     "@fontsource-variable/jetbrains-mono": "^5.3.0",
     "@fontsource-variable/manrope": "^5.3.0",
     "@tailwindcss/postcss": "^4.3.3",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/hub",
-  "version": "1.1.15",
+  "version": "1.1.16-beta.6",
   "description": "Corporate Hub for AgEnFK — fleet-wide metrics + timeline server",
   "main": "dist/server.js",
   "types": "dist/server.d.ts",
@@ -20,7 +20,7 @@
     "start": "node dist/bin.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.15",
+    "@agenfk/core": "1.1.16-beta.6",
     "axios": "^1.19.0",
     "bcryptjs": "^2.4.3",
     "cookie-parser": "^1.4.7",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/hub",
-  "version": "1.1.15",
+  "version": "1.1.16-beta.4",
   "description": "Corporate Hub for AgEnFK — fleet-wide metrics + timeline server",
   "main": "dist/server.js",
   "types": "dist/server.d.ts",
@@ -20,7 +20,7 @@
     "start": "node dist/bin.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.15",
+    "@agenfk/core": "1.1.16-beta.4",
     "axios": "^1.19.0",
     "bcryptjs": "^2.4.3",
     "cookie-parser": "^1.4.7",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/hub",
-  "version": "1.1.16-beta.4",
+  "version": "1.1.16-beta.5",
   "description": "Corporate Hub for AgEnFK — fleet-wide metrics + timeline server",
   "main": "dist/server.js",
   "types": "dist/server.d.ts",
@@ -20,7 +20,7 @@
     "start": "node dist/bin.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.16-beta.4",
+    "@agenfk/core": "1.1.16-beta.5",
     "axios": "^1.19.0",
     "bcryptjs": "^2.4.3",
     "cookie-parser": "^1.4.7",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/server",
-  "version": "1.1.15",
+  "version": "1.1.16-beta.6",
   "description": "MCP Server for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -12,9 +12,9 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.15",
-    "@agenfk/storage-sqlite": "1.1.15",
-    "@agenfk/telemetry": "1.1.15",
+    "@agenfk/core": "1.1.16-beta.6",
+    "@agenfk/storage-sqlite": "1.1.16-beta.6",
+    "@agenfk/telemetry": "1.1.16-beta.6",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "axios": "^1.19.0",
     "body-parser": "^2.3.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/server",
-  "version": "1.1.15",
+  "version": "1.1.16-beta.4",
   "description": "MCP Server for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -12,9 +12,9 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.15",
-    "@agenfk/storage-sqlite": "1.1.15",
-    "@agenfk/telemetry": "1.1.15",
+    "@agenfk/core": "1.1.16-beta.4",
+    "@agenfk/storage-sqlite": "1.1.16-beta.4",
+    "@agenfk/telemetry": "1.1.16-beta.4",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "axios": "^1.19.0",
     "body-parser": "^2.3.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/server",
-  "version": "1.1.16-beta.4",
+  "version": "1.1.16-beta.5",
   "description": "MCP Server for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -12,9 +12,9 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.16-beta.4",
-    "@agenfk/storage-sqlite": "1.1.16-beta.4",
-    "@agenfk/telemetry": "1.1.16-beta.4",
+    "@agenfk/core": "1.1.16-beta.5",
+    "@agenfk/storage-sqlite": "1.1.16-beta.5",
+    "@agenfk/telemetry": "1.1.16-beta.5",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "axios": "^1.19.0",
     "body-parser": "^2.3.0",

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -2310,10 +2310,17 @@ app.put("/items/:id", asyncHandler(async (req: any, res: any) => {
     if (!validTypes.includes(type)) {
       return res.status(400).json({ error: `Invalid type '${type}'. Must be one of: ${validTypes.join(', ')}` });
     }
-    // Prevent type change on items with children
-    const children = await storage.listChildren(req.params.id);
-    if (children.length > 0 && type !== currentItem.type) {
-      return res.status(400).json({ error: `Cannot change type of item with children. Remove or reassign children first.` });
+    if (type !== currentItem.type) {
+      // With sub-items, the ONLY allowed type change is EPIC -> STORY: an
+      // epic's children are stories, so demoting the parent to a story keeps
+      // the EPIC -> STORY -> TASK hierarchy coherent. Every other transition
+      // on an item that has children would break the shape the board relies
+      // on, so it stays blocked (CGLAB-86).
+      const children = await storage.listChildren(req.params.id);
+      const epicToStory = currentItem.type === ItemType.EPIC && type === ItemType.STORY;
+      if (children.length > 0 && !epicToStory) {
+        return res.status(400).json({ error: `Cannot change type of an item with children. Only EPIC -> STORY is allowed when the item has sub-items; for any other transition, remove or reassign the children first.` });
+      }
     }
   }
 

--- a/packages/server/src/test/item-type-change.test.ts
+++ b/packages/server/src/test/item-type-change.test.ts
@@ -1,0 +1,144 @@
+/**
+ * CGLAB-86 — type change on items with children.
+ *
+ * `PUT /items/:id` previously blocked ANY type change on an item that has
+ * children ("Cannot change type of item with children"), which surfaced to
+ * users as "there is no way to change an item type" — the UI, CLI and MCP
+ * all expose the type field, the server just refused it whenever the item
+ * had sub-items.
+ *
+ * The rule (user-specified): when the item has sub-items, the ONLY allowed
+ * type change is EPIC -> STORY. Rationale: an EPIC's children are stories;
+ * demoting the parent to a STORY keeps the tree coherent, while every other
+ * transition (STORY -> EPIC, EPIC -> TASK, STORY -> TASK, ...) would break
+ * the EPIC -> STORY -> TASK hierarchy the board relies on.
+ *
+ * These tests pin the rule and are expected to fail until the server
+ * validation is updated (the EPIC -> STORY case currently 400s).
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import request from 'supertest';
+import { app, initStorage } from '../server';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const TEST_DB = path.resolve('./item-type-change-test-db.sqlite');
+
+describe('item type change (CGLAB-86)', () => {
+  let projectId: string;
+
+  beforeAll(async () => {
+    process.env.AGENFK_DB_PATH = TEST_DB;
+    if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+    await initStorage();
+  });
+
+  afterAll(() => {
+    if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+  });
+
+  beforeEach(async () => {
+    if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+    await initStorage();
+    const r = await request(app).post('/projects').send({ name: 'type-change-test' });
+    expect(r.status).toBe(201);
+    projectId = r.body.id;
+  });
+
+  const makeItem = async (type: string, title: string, opts: { parentId?: string } = {}) => {
+    const r = await request(app).post('/items').send({
+      type,
+      title,
+      projectId,
+      ...(opts.parentId ? { parentId: opts.parentId } : {}),
+    });
+    expect(r.status).toBe(201);
+    return r.body;
+  };
+
+  const putType = async (id: string, type: string) =>
+    request(app).put(`/items/${id}`).send({ type });
+
+  it('allows EPIC -> STORY when the epic has children (the reported bug)', async () => {
+    const epic = await makeItem('EPIC', 'Parent epic');
+    const child = await makeItem('STORY', 'Child story', { parentId: epic.id });
+
+    const res = await putType(epic.id, 'STORY');
+    expect(res.status).toBe(200);
+    expect(res.body.type).toBe('STORY');
+
+    // The child must survive the retype intact and still attached.
+    const after = await request(app).get(`/items/${child.id}`);
+    expect(after.status).toBe(200);
+    expect(after.body.parentId).toBe(epic.id);
+    expect(after.body.type).toBe('STORY');
+  });
+
+  it('still blocks every other type change on an item with children', async () => {
+    // STORY with a task child -> EPIC
+    const story = await makeItem('STORY', 'Story with task');
+    await makeItem('TASK', 'Task child', { parentId: story.id });
+    const r1 = await putType(story.id, 'EPIC');
+    expect(r1.status).toBe(400);
+    expect(r1.body.error).toMatch(/EPIC.*STORY|children/i);
+
+    // EPIC with children -> TASK
+    const epic = await makeItem('EPIC', 'Epic');
+    await makeItem('STORY', 'Story child', { parentId: epic.id });
+    const r2 = await putType(epic.id, 'TASK');
+    expect(r2.status).toBe(400);
+    expect(r2.body.error).toMatch(/children/i);
+
+    // STORY with children -> TASK
+    const story2 = await makeItem('STORY', 'Story 2');
+    await makeItem('TASK', 'Task child 2', { parentId: story2.id });
+    const r3 = await putType(story2.id, 'TASK');
+    expect(r3.status).toBe(400);
+    expect(r3.body.error).toMatch(/children/i);
+  });
+
+  it('states the allowed transition in the error so users and agents can act on it', async () => {
+    const epic = await makeItem('EPIC', 'Epic');
+    await makeItem('STORY', 'Story child', { parentId: epic.id });
+    const res = await putType(epic.id, 'BUG');
+    expect(res.status).toBe(400);
+    // The error must name the one allowed transition (EPIC -> STORY) rather
+    // than a bare "remove children first" that leaves the user stuck.
+    expect(res.body.error).toMatch(/EPIC/);
+    expect(res.body.error).toMatch(/STORY/);
+  });
+
+  it('allows any type change on items without children (existing behaviour)', async () => {
+    const task = await makeItem('TASK', 'Lonely task');
+    const res = await putType(task.id, 'BUG');
+    expect(res.status).toBe(200);
+    expect(res.body.type).toBe('BUG');
+
+    const bug = await makeItem('BUG', 'Lonely bug');
+    const res2 = await putType(bug.id, 'EPIC');
+    expect(res2.status).toBe(200);
+    expect(res2.body.type).toBe('EPIC');
+  });
+
+  it('allows EPIC -> STORY without children (same rule, no children needed)', async () => {
+    const epic = await makeItem('EPIC', 'Epic no kids');
+    const res = await putType(epic.id, 'STORY');
+    expect(res.status).toBe(200);
+    expect(res.body.type).toBe('STORY');
+  });
+
+  it('setting the same type on an item with children is a no-op, not an error', async () => {
+    const epic = await makeItem('EPIC', 'Epic same type');
+    await makeItem('STORY', 'Story child', { parentId: epic.id });
+    const res = await putType(epic.id, 'EPIC');
+    expect(res.status).toBe(200);
+    expect(res.body.type).toBe('EPIC');
+  });
+
+  it('still rejects invalid type values', async () => {
+    const task = await makeItem('TASK', 'Task');
+    const res = await request(app).put(`/items/${task.id}`).send({ type: 'MEGA' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Invalid type/i);
+  });
+});

--- a/packages/server/src/test/pr-hook-classifier.test.ts
+++ b/packages/server/src/test/pr-hook-classifier.test.ts
@@ -37,11 +37,22 @@ describe('buildDirective', () => {
     });
   });
 
-  it('codex: emits decision/reason envelope', () => {
+  // CGLAB-86: Codex 0.149.0 rejects the old {decision:'continue',reason}
+  // envelope with "hook returned invalid post-tool-use JSON output" —
+  // `continue` is a field of the Stop-family output, not a PostToolUse
+  // decision value. Verified empirically against codex-cli 0.149.0: the old
+  // shape prints "hook: PostToolUse Failed", the hookSpecificOutput shape
+  // prints "hook: PostToolUse Completed". The valid nudge shape mirrors
+  // Claude Code's hookSpecificOutput envelope (PostToolUseHookSpecificOutput
+  // wire struct: hookEventName / additionalContext / updatedMCPToolOutput).
+  it('codex: emits the valid PostToolUse hookSpecificOutput envelope', () => {
     expect(buildDirective('codex', message)).toEqual({
-      decision: 'continue',
-      reason: message,
+      hookSpecificOutput: { hookEventName: 'PostToolUse', additionalContext: message },
     });
+  });
+
+  it('codex: never emits a top-level decision field (only `block` is a valid PostToolUse decision)', () => {
+    expect(buildDirective('codex', message)).not.toHaveProperty('decision');
   });
 
   it('gemini: emits context injection', () => {
@@ -90,6 +101,44 @@ describe('runtime command extraction', () => {
 
     expect(res.status).toBe(0);
     expect(res.stdout).toContain('update_pr_sizing');
+  });
+
+  // CGLAB-86 regression: the exact payload shape Codex pipes to PostToolUse
+  // hooks (captured from a live codex-cli 0.149.0 session) must produce
+  // schema-valid JSON on stdout for the codex client.
+  it('emits valid PostToolUse JSON for a real Codex push payload', () => {
+    const codexPayload = {
+      session_id: '01a03454-b72d-7f92-bab5-d5fe4b3db16c',
+      turn_id: '01a03454-b756-7051-8081-97f92946ed1f',
+      hook_event_name: 'PostToolUse',
+      model: 'gpt-5.6-terra',
+      permission_mode: 'bypassPermissions',
+      tool_name: 'Bash',
+      tool_input: { command: 'git add -A && git commit -m x && git push -u origin HEAD' },
+      tool_response: 'ok\n',
+      tool_use_id: 'exec-44ec5461-ccbb-41d9-b2ab-dcd6e6e909d0',
+    };
+    const res = spawnSync(process.execPath, [hookPath, '--client', 'codex'], {
+      input: JSON.stringify(codexPayload),
+      encoding: 'utf8',
+    });
+
+    expect(res.status).toBe(0);
+    const out = JSON.parse(res.stdout);
+    expect(out).not.toHaveProperty('decision'); // `decision: continue` is what codex rejected
+    expect(out.hookSpecificOutput).toEqual({
+      hookEventName: 'PostToolUse',
+      additionalContext: expect.stringContaining("'HEAD'"),
+    });
+  });
+
+  it('emits nothing (valid no-op) when no trigger is present', () => {
+    const res = spawnSync(process.execPath, [hookPath, '--client', 'codex'], {
+      input: JSON.stringify({ tool_input: { command: 'npm test' } }),
+      encoding: 'utf8',
+    });
+    expect(res.status).toBe(0);
+    expect(res.stdout).toBe('');
   });
 });
 

--- a/packages/server/src/test/pr-hook-classifier.test.ts
+++ b/packages/server/src/test/pr-hook-classifier.test.ts
@@ -126,10 +126,13 @@ describe('runtime command extraction', () => {
     expect(res.status).toBe(0);
     const out = JSON.parse(res.stdout);
     expect(out).not.toHaveProperty('decision'); // `decision: continue` is what codex rejected
-    expect(out.hookSpecificOutput).toEqual({
-      hookEventName: 'PostToolUse',
-      additionalContext: expect.stringContaining("'HEAD'"),
-    });
+    expect(out.hookSpecificOutput.hookEventName).toBe('PostToolUse');
+    // `git push -u origin HEAD` must resolve to the real branch (the hook runs
+    // git in the test process cwd = repo root), not the literal symbolic
+    // 'HEAD' — unless the repo is genuinely detached, in which case 'HEAD'
+    // is the honest answer.
+    const actualBranch = spawnSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { encoding: 'utf8' }).stdout.trim();
+    expect(out.hookSpecificOutput.additionalContext).toContain(`pushed to '${actualBranch}'`);
   });
 
   it('emits nothing (valid no-op) when no trigger is present', () => {

--- a/packages/storage-sqlite/package.json
+++ b/packages/storage-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/storage-sqlite",
-  "version": "1.1.15",
+  "version": "1.1.16-beta.4",
   "description": "SQLite storage implementation for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -11,7 +11,7 @@
     "uuid": "^14.0.2"
   },
   "devDependencies": {
-    "@agenfk/core": "1.1.15",
+    "@agenfk/core": "1.1.16-beta.4",
     "@types/node": "^22.0.0",
     "@types/uuid": "^9.0.8",
     "typescript": "^5.3.3"

--- a/packages/storage-sqlite/package.json
+++ b/packages/storage-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/storage-sqlite",
-  "version": "1.1.15",
+  "version": "1.1.16-beta.6",
   "description": "SQLite storage implementation for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -11,7 +11,7 @@
     "uuid": "^14.0.2"
   },
   "devDependencies": {
-    "@agenfk/core": "1.1.15",
+    "@agenfk/core": "1.1.16-beta.6",
     "@types/node": "^22.0.0",
     "@types/uuid": "^9.0.8",
     "typescript": "^5.3.3"

--- a/packages/storage-sqlite/package.json
+++ b/packages/storage-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/storage-sqlite",
-  "version": "1.1.16-beta.4",
+  "version": "1.1.16-beta.5",
   "description": "SQLite storage implementation for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -11,7 +11,7 @@
     "uuid": "^14.0.2"
   },
   "devDependencies": {
-    "@agenfk/core": "1.1.16-beta.4",
+    "@agenfk/core": "1.1.16-beta.5",
     "@types/node": "^22.0.0",
     "@types/uuid": "^9.0.8",
     "typescript": "^5.3.3"

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/telemetry",
-  "version": "1.1.15",
+  "version": "1.1.16-beta.4",
   "description": "Anonymous telemetry client for AgenFK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/telemetry",
-  "version": "1.1.15",
+  "version": "1.1.16-beta.6",
   "description": "Anonymous telemetry client for AgenFK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/telemetry",
-  "version": "1.1.16-beta.4",
+  "version": "1.1.16-beta.5",
   "description": "Anonymous telemetry client for AgenFK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.1.16-beta.4",
+  "version": "1.1.16-beta.5",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -12,7 +12,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.1.16-beta.4",
+    "@agenfk/flow-editor": "1.1.16-beta.5",
     "@fontsource-variable/jetbrains-mono": "^5.3.0",
     "@fontsource-variable/manrope": "^5.3.0",
     "@tailwindcss/postcss": "^4.3.3",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.1.15",
+  "version": "1.1.16-beta.4",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -12,7 +12,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.1.15",
+    "@agenfk/flow-editor": "1.1.16-beta.4",
     "@fontsource-variable/jetbrains-mono": "^5.3.0",
     "@fontsource-variable/manrope": "^5.3.0",
     "@tailwindcss/postcss": "^4.3.3",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.1.15",
+  "version": "1.1.16-beta.6",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -12,7 +12,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.1.15",
+    "@agenfk/flow-editor": "1.1.16-beta.6",
     "@fontsource-variable/jetbrains-mono": "^5.3.0",
     "@fontsource-variable/manrope": "^5.3.0",
     "@tailwindcss/postcss": "^4.3.3",

--- a/packages/ui/src/components/KanbanBoard.tsx
+++ b/packages/ui/src/components/KanbanBoard.tsx
@@ -431,13 +431,30 @@ const KanbanCard: React.FC<KanbanCardProps> = ({
   );
 };
 
+// Deep-link URL params (`agenfk ui --open <id>`): ?project selects the project,
+// ?item locates and highlights the item. Applied once, then stripped from the
+// URL (stripDeepLinkParams) so a later reload honours the user's picker choice
+// instead of re-applying a stale deep-link over it.
+const getUrlParam = (name: string): string | null =>
+  new URLSearchParams(window.location.search).get(name);
+
+const stripDeepLinkParams = () => {
+  if (!getUrlParam('item') && !getUrlParam('project')) return;
+  window.history.replaceState(null, '', window.location.pathname + window.location.hash);
+};
+
 export const KanbanBoard: React.FC = () => {
   const queryClient = useQueryClient();
   const { theme, toggleTheme } = useTheme();
   const easterEggsEnabled = useEasterEggs();
   
   // Project State
-  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(() => localStorage.getItem('agenfk_project_id'));
+  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(() => {
+    // `agenfk ui --open <id>&project=<pid>` deep-link: an explicit project in
+    // the URL wins over the last-used project in localStorage.
+    const fromUrl = getUrlParam('project');
+    return fromUrl || localStorage.getItem('agenfk_project_id');
+  });
   const [isCreatingProject, setIsCreatingProject] = useState(false);
   const [projectSearch, setProjectSearch] = useState('');
   const [highlightedProjectIndex, setHighlightedProjectIndex] = useState(-1);
@@ -508,6 +525,24 @@ export const KanbanBoard: React.FC = () => {
     queryFn: () => api.listProjects()
   });
 
+  // One-shot guard for the ?item deep-link (declared here so the stale-clear
+  // effect below can suppress a deep-link whose project turned out invalid).
+  const deepLinkAppliedRef = React.useRef(false);
+
+  // Deep-link (?project): `agenfk ui --open <id>&project=<pid>` may target a
+  // different project than the one in localStorage. The initializer above has
+  // already applied it; persist it the same way the project picker does so a
+  // later reload (without the param) still opens on that project. An invalid
+  // ?project is cleaned up by the stale-clear effect below.
+  useEffect(() => {
+    const fromUrl = getUrlParam('project');
+    if (fromUrl && fromUrl !== localStorage.getItem('agenfk_project_id')) {
+      localStorage.setItem('agenfk_project_id', fromUrl);
+    }
+    // With no ?item to apply there is nothing left to consume the params.
+    if (!getUrlParam('item')) stripDeepLinkParams();
+  }, []);
+
   // Clear stale localStorage project ID if it no longer exists in the DB
   useEffect(() => {
     if (isLoadingProjects || !projects) return;
@@ -521,6 +556,10 @@ export const KanbanBoard: React.FC = () => {
       } else {
         localStorage.removeItem('agenfk_project_id');
       }
+      // The ?item deep-link was aimed at a project that doesn't exist — don't
+      // let it fire later against whatever project the user picks instead.
+      deepLinkAppliedRef.current = true;
+      stripDeepLinkParams();
     }
   }, [projects, isLoadingProjects, selectedProjectId]);
 
@@ -1098,6 +1137,34 @@ export const KanbanBoard: React.FC = () => {
     [Status.ARCHIVED]: 8,
   };
 
+  // Shared by the Search Box form and the ?item deep-link: matches items by id
+  // or title (case-insensitive substring), navigates to the first match, or
+  // flashes NOT FOUND in the box when nothing matches.
+  const runSearch = (term: string) => {
+    if (!term.trim() || !items) return;
+
+    const lower = term.toLowerCase();
+    const matches = items
+      .filter((i: AgEnFKItem) =>
+        i.id.toLowerCase().includes(lower) ||
+        i.title.toLowerCase().includes(lower)
+      )
+      .sort((a: AgEnFKItem, b: AgEnFKItem) =>
+        (statusPriority[a.status] ?? 99) - (statusPriority[b.status] ?? 99)
+      );
+
+    if (matches.length > 0) {
+      setSearchMatches(matches);
+      setCurrentMatchIndex(0);
+      navigateToMatch(matches[0]);
+    } else {
+      setSearchMatches([]);
+      setCurrentMatchIndex(0);
+      setSearchTerm('NOT FOUND');
+      setTimeout(() => setSearchTerm(''), 1000);
+    }
+  };
+
   const navigateToMatch = (item: AgEnFKItem) => {
     if (item.status === Status.IDEAS) setIsIdeasCollapsed(false);
     if (item.status === Status.ARCHIVED) setIsArchiveCollapsed(false);
@@ -1130,29 +1197,31 @@ export const KanbanBoard: React.FC = () => {
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!searchQuery.trim() || !items) return;
-
-    const term = searchQuery.toLowerCase();
-    const matches = items
-      .filter((i: AgEnFKItem) =>
-        i.id.toLowerCase().includes(term) ||
-        i.title.toLowerCase().includes(term)
-      )
-      .sort((a: AgEnFKItem, b: AgEnFKItem) =>
-        (statusPriority[a.status] ?? 99) - (statusPriority[b.status] ?? 99)
-      );
-
-    if (matches.length > 0) {
-      setSearchMatches(matches);
-      setCurrentMatchIndex(0);
-      navigateToMatch(matches[0]);
-    } else {
-      setSearchMatches([]);
-      setCurrentMatchIndex(0);
-      setSearchTerm('NOT FOUND');
-      setTimeout(() => setSearchTerm(''), 1000);
-    }
+    runSearch(searchQuery);
   };
+
+  // Deep-link (?item): `agenfk ui --open <itemId>` opens the board with this
+  // param. Once items AND the flow are loaded (columns render only when the
+  // flow is available — see the isLoadingFlow placeholder), behave exactly as
+  // if the id had been typed into the Search Box: pre-fill it and run the
+  // search (drill-down + highlight + scroll, or the NOT FOUND flash when
+  // nothing matches). One-shot — the ref guard also keeps the StrictMode
+  // double-effect from applying it twice. runSearch is intentionally not a
+  // dep: it is re-created every render and the effect must fire on items/flow
+  // changes only; the ref makes a re-run a no-op anyway (the flow-readiness
+  // guard above also keeps the rule happy: the state sync is conditional on
+  // external data, not unconditional at mount).
+  useEffect(() => {
+    if (deepLinkAppliedRef.current || !items) return;
+    if (isLoadingFlow && !activeFlow) return;
+    const itemId = getUrlParam('item');
+    if (!itemId) return;
+    deepLinkAppliedRef.current = true;
+    setSearchTerm(itemId);
+    runSearch(itemId);
+    stripDeepLinkParams();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [items, isLoadingFlow, activeFlow]);
 
   const handleSearchNav = (direction: 'prev' | 'next') => {
     if (searchMatches.length === 0) return;

--- a/packages/ui/src/test/KanbanBoardDeepLink.test.tsx
+++ b/packages/ui/src/test/KanbanBoardDeepLink.test.tsx
@@ -1,0 +1,244 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Dashboard deep-linking (CGLAB-100): `agenfk ui --open <itemId>` opens the
+ * web UI at `/?item=<id>[&project=<projectId>]`. On load the KanbanBoard must
+ * behave EXACTLY like the id had been typed into the Search Box:
+ *  - `?project` selects (and persists) that project, like the project picker;
+ *  - `?item` pre-fills the search box with the id and runs the search:
+ *    drill down through the parent chain, highlight the card, scroll it into
+ *    view, show the match counter;
+ *  - an id that matches nothing flashes "NOT FOUND" in the search box, the
+ *    same feedback a manual search gives;
+ *  - with no `?item` param the board loads exactly as before (empty search).
+ */
+import { render, screen, cleanup, waitFor, fireEvent } from '@testing-library/react';
+import { KanbanBoard } from '../components/KanbanBoard';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ThemeProvider } from '../ThemeContext';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { api } from '../api';
+import { ItemType, Status } from '../types';
+
+// Mock socket.io-client
+vi.mock('socket.io-client', () => ({
+  io: vi.fn(() => ({
+    on: vi.fn(),
+    off: vi.fn(),
+    emit: vi.fn(),
+    disconnect: vi.fn(),
+  })),
+}));
+
+// Mock window.matchMedia
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+// Mock scrollIntoView (jsdom has no layout)
+window.HTMLElement.prototype.scrollIntoView = vi.fn();
+
+const DEFAULT_FLOW_MOCK = {
+  id: 'default',
+  name: 'Default Flow',
+  projectId: '__builtin__',
+  steps: [
+    { id: 's-ideas', name: 'IDEAS', label: 'IDEAS', order: 0, isSpecial: true },
+    { id: 's-todo', name: 'TODO', label: 'TODO', order: 1 },
+    { id: 's-ip', name: 'IN_PROGRESS', label: 'IN PROGRESS', order: 2 },
+    { id: 's-review', name: 'REVIEW', label: 'REVIEW', order: 3 },
+    { id: 's-test', name: 'TEST', label: 'TEST', order: 4 },
+    { id: 's-done', name: 'DONE', label: 'DONE', order: 5 },
+    { id: 's-blocked', name: 'BLOCKED', label: 'BLOCKED', order: 6, isSpecial: true },
+    { id: 's-paused', name: 'PAUSED', label: 'PAUSED', order: 7, isSpecial: true },
+    { id: 's-archived', name: 'ARCHIVED', label: 'ARCHIVED', order: 8, isSpecial: true },
+  ],
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+vi.mock('../api', () => ({
+  api: {
+    listProjects: vi.fn(() => Promise.resolve([])),
+    listItems: vi.fn(() => Promise.resolve([])),
+    getItem: vi.fn(() => Promise.resolve({})),
+    createItem: vi.fn(() => Promise.resolve({})),
+    updateItem: vi.fn(() => Promise.resolve({})),
+    deleteItem: vi.fn(() => Promise.resolve({})),
+    deleteProject: vi.fn(() => Promise.resolve({})),
+    createProject: vi.fn(() => Promise.resolve({ id: 'p-new', name: 'New' })),
+    bulkUpdateItems: vi.fn(() => Promise.resolve({})),
+    trashArchivedItems: vi.fn(() => Promise.resolve({})),
+    getJiraStatus: vi.fn(() => Promise.resolve({ configured: false, connected: false })),
+    getLatestRelease: vi.fn(() => Promise.resolve(null)),
+    getVersion: vi.fn(() => Promise.resolve({ version: '1.0.0' })),
+    getProjectFlow: vi.fn(() => Promise.resolve(DEFAULT_FLOW_MOCK)),
+    getGitHubStatus: vi.fn(() => Promise.resolve({ configured: false })),
+  }
+}));
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: { retry: false, gcTime: 0 },
+  },
+});
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={queryClient}>
+    <ThemeProvider>
+      {children}
+    </ThemeProvider>
+  </QueryClientProvider>
+);
+
+const NOW = new Date();
+const projectP1 = { id: 'p1', name: 'P1', createdAt: NOW, updatedAt: NOW };
+const projectP2 = { id: 'p2', name: 'P2', createdAt: NOW, updatedAt: NOW };
+
+const EPIC_ONE = {
+  id: 'epic-1', projectId: 'p2', type: ItemType.EPIC, title: 'Epic One',
+  status: Status.TODO, createdAt: NOW, updatedAt: NOW,
+};
+const TASK_ONE = {
+  id: 'task-1', projectId: 'p2', type: ItemType.TASK, title: 'Task One',
+  status: Status.TODO, createdAt: NOW, updatedAt: NOW,
+};
+const TASK_CHILD = {
+  id: 'task-2', projectId: 'p2', type: ItemType.TASK, title: 'Task Child',
+  status: Status.TODO, parentId: 'epic-1', createdAt: NOW, updatedAt: NOW,
+};
+
+const SEARCH_PLACEHOLDER = 'Search Item ID or Name...';
+
+// findByPlaceholderText is typed as HTMLElement; the element is the search input.
+async function searchInput() {
+  return (await screen.findByPlaceholderText(SEARCH_PLACEHOLDER)) as HTMLInputElement;
+}
+
+describe('KanbanBoard deep-link (?item / ?project)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    queryClient.clear();
+    window.history.pushState({}, '', '/');
+    vi.mocked(api.getProjectFlow).mockResolvedValue(DEFAULT_FLOW_MOCK as any);
+    vi.mocked(api.listProjects).mockResolvedValue([projectP1, projectP2] as any);
+    vi.mocked(api.listItems).mockImplementation((params: any) =>
+      Promise.resolve(params?.projectId === 'p2' ? [EPIC_ONE, TASK_ONE, TASK_CHILD] : [])
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+    window.history.pushState({}, '', '/');
+  });
+
+  it('opens the ?project project, pre-fills the search box and highlights the ?item card', async () => {
+    // No localStorage: without ?project the board would sit on the project picker.
+    window.history.pushState({}, '', '/?item=task-1&project=p2');
+    render(<KanbanBoard />, { wrapper });
+
+    const input = await searchInput();
+    await waitFor(() => expect(input.value).toBe('task-1'));
+
+    const card = document.getElementById('card-task-1');
+    expect(card).not.toBeNull();
+    expect(card!.className).toContain('search-highlight');
+    // Match counter, same as a manual search with one hit.
+    expect(screen.getByText('1/1')).toBeDefined();
+  });
+
+  it('persists the ?project param to localStorage, like the project picker does', async () => {
+    window.history.pushState({}, '', '/?project=p2');
+    render(<KanbanBoard />, { wrapper });
+
+    await searchInput();
+    await waitFor(() =>
+      expect(localStorage.getItem('agenfk_project_id')).toBe('p2')
+    );
+  });
+
+  it('lets ?project win over a different project already in localStorage', async () => {
+    // A mutant that swaps the precedence (localStorage first) must not pass.
+    localStorage.setItem('agenfk_project_id', 'p1');
+    window.history.pushState({}, '', '/?project=p2');
+    render(<KanbanBoard />, { wrapper });
+
+    await searchInput();
+    await waitFor(() =>
+      expect(api.listItems).toHaveBeenCalledWith(expect.objectContaining({ projectId: 'p2' }))
+    );
+    expect(localStorage.getItem('agenfk_project_id')).toBe('p2');
+  });
+
+  it('strips the deep-link params from the URL once applied (reload honours the picker)', async () => {
+    window.history.pushState({}, '', '/?item=task-1&project=p2');
+    render(<KanbanBoard />, { wrapper });
+
+    const input = await searchInput();
+    await waitFor(() => expect(input.value).toBe('task-1'));
+    await waitFor(() => expect(window.location.search).toBe(''));
+  });
+
+  it('drills down through the parent chain for a nested item, like searching its id', async () => {
+    window.history.pushState({}, '', '/?item=task-2&project=p2');
+    render(<KanbanBoard />, { wrapper });
+
+    const input = await searchInput();
+    await waitFor(() => expect(input.value).toBe('task-2'));
+
+    await waitFor(() => {
+      const card = document.getElementById('card-task-2');
+      expect(card).not.toBeNull();
+      expect(card!.className).toContain('search-highlight');
+    });
+    // The parent EPIC appears in the breadcrumb (navPath), proving the drill-down.
+    expect(screen.getAllByText('Epic One').length).toBeGreaterThan(0);
+  });
+
+  it('flashes NOT FOUND in the search box when the id matches nothing, like a manual search', async () => {
+    window.history.pushState({}, '', '/?item=missing-999&project=p2');
+    render(<KanbanBoard />, { wrapper });
+
+    const input = await searchInput();
+    await waitFor(() => expect(input.value).toBe('NOT FOUND'));
+  });
+
+  it('leaves the search box empty when no ?item param is present (baseline unchanged)', async () => {
+    window.history.pushState({}, '', '/?project=p2');
+    render(<KanbanBoard />, { wrapper });
+
+    const input = await searchInput();
+    expect(input.value).toBe('');
+  });
+
+  it('applies the deep-link only once: a later items refetch does not re-populate a cleared search', async () => {
+    window.history.pushState({}, '', '/?item=task-1&project=p2');
+    render(<KanbanBoard />, { wrapper });
+
+    const input = await searchInput();
+    await waitFor(() => expect(input.value).toBe('task-1'));
+
+    // The user clears the search box (what clearSearch does on empty input).
+    fireEvent.change(input, { target: { value: '' } });
+    expect(input.value).toBe('');
+
+    // A socket-driven refetch re-creates the items array — the one-shot guard
+    // must keep the deep-link from firing again.
+    queryClient.invalidateQueries({ queryKey: ['items', 'p2'] });
+    await new Promise((r) => setTimeout(r, 150));
+    expect(input.value).toBe('');
+    const card = document.getElementById('card-task-1');
+    expect(card?.className ?? '').not.toContain('search-highlight');
+  });
+});

--- a/scripts/install-helpers.mjs
+++ b/scripts/install-helpers.mjs
@@ -109,3 +109,42 @@ export function shellSourceHint({ rcModified, shell } = {}) {
     default: return 'source your shell rc file';
   }
 }
+
+// --- macOS metadata guards (CGLAB-94 / issue #163) -------------------------
+//
+// Releases cut on macOS shipped an AppleDouble `._<name>` companion for every
+// file carrying an extended attribute. Those entries look like ordinary files
+// to every consumer: `._agenfk.md` satisfies an `endsWith('.md')` filter, so
+// the skills/commands sync copied them into ~/.claude/skills et al, where each
+// `._agenfk-*` directory was surfaced as a skill whose description is mojibake
+// binary — injected into the system prompt of every agent session.
+//
+// Packaging is fixed at the source (scripts/package-helpers.mjs), but these
+// guards must stay: a user upgrading from a polluted release still has the
+// artifacts on disk, and the installer must neither propagate nor preserve them.
+
+// True for macOS resource-fork / Finder metadata: never install it, and sweep it
+// when a previous (polluted) release left it in a skills/commands dir.
+// Deliberately matches any `._*` entry, not just `._agenfk*` — the AppleDouble
+// twin of a real agenfk skill is named after the skill.
+export function isMacMetadata(name) {
+  return typeof name === 'string' && (name.startsWith('._') || name === '.DS_Store');
+}
+
+// Filter for source files a sync step may install: real payload only.
+export function isInstallableMarkdown(name) {
+  return typeof name === 'string' && name.endsWith('.md') && !isMacMetadata(name);
+}
+
+// The name an AppleDouble twin shadows: `._agenfk.md` -> `agenfk.md`.
+function shadowedName(name) {
+  return name.startsWith('._') ? name.slice(2) : name;
+}
+
+// True for an entry we own in a SHARED skills/commands dir: one of ours, or the
+// AppleDouble twin of one of ours. Deliberately mirrored in uninstall-helpers.mjs
+// rather than imported: the uninstaller must keep working on a partial install
+// where this module may be missing, which is exactly when it gets run.
+export function isAgenfkOwnedEntry(name) {
+  return typeof name === 'string' && shadowedName(name).startsWith('agenfk');
+}

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -6,7 +6,7 @@ import { spawn, spawnSync, execSync } from 'child_process';
 import crypto from 'crypto';
 import { fileURLToPath } from 'url';
 import readline from 'readline';
-import { resolveRulesScope, shellSourceHint, buildCodexHooksConfig, shouldRegisterCodexMcp } from './install-helpers.mjs';
+import { resolveRulesScope, shellSourceHint, buildCodexHooksConfig, shouldRegisterCodexMcp, isInstallableMarkdown, isMacMetadata, isAgenfkOwnedEntry } from './install-helpers.mjs';
 
 const GREEN = '\x1b[32m';
 const BLUE = '\x1b[34m';
@@ -945,7 +945,7 @@ process.exit(0);
         if (existsSync(commandsDir)) {
             const files = await fs.readdir(commandsDir);
             for (const file of files) {
-                if (!file.endsWith('.md')) continue;
+                if (!isInstallableMarkdown(file)) continue;
                 const skillName = file.replace(/\.md$/, '');
                 const skillDir = path.join(claudeSkillsDir, skillName);
                 await fs.mkdir(skillDir, { recursive: true });
@@ -1035,7 +1035,7 @@ process.exit(0);
         if (existsSync(commandsDir)) {
             const files = await fs.readdir(commandsDir);
             for (const file of files) {
-                if (!file.endsWith('.md')) continue;
+                if (!isInstallableMarkdown(file)) continue;
                 const skillName = file.replace(/\.md$/, '');
                 const skillDir = path.join(agentsSkillsDir, skillName);
                 await fs.mkdir(skillDir, { recursive: true });
@@ -1159,7 +1159,7 @@ process.exit(0);
             if (existsSync(commandsDir)) {
                 const files = await fs.readdir(commandsDir);
                 for (const file of files) {
-                    if (file.endsWith('.md')) {
+                    if (isInstallableMarkdown(file)) {
                         await fs.copyFile(path.join(commandsDir, file), path.join(integration.targetBase, file));
                         console.log(`  Installed: ${path.join(integration.targetBase, file)}`);
                     }
@@ -1180,7 +1180,7 @@ process.exit(0);
             if (existsSync(commandsDir)) {
                 const files = await fs.readdir(commandsDir);
                 for (const file of files) {
-                    if (!file.endsWith('.md')) continue;
+                    if (!isInstallableMarkdown(file)) continue;
                     const mdPath = path.join(commandsDir, file);
                     const mdContent = readFileSync(mdPath, 'utf8');
                     // Parse description from YAML frontmatter
@@ -1207,6 +1207,71 @@ process.exit(0);
         } else if (!onlyPlatform) {
             console.log(`${GREEN}[10c/14] Gemini CLI not found. Skipping Gemini slash commands.${NC}`);
         }
+    }
+
+    // 11b. Sweep macOS AppleDouble / .DS_Store artifacts left by earlier releases.
+    // Every release up to v1.1.16-beta.4 was packaged with a bare `tar -czf` on
+    // macOS, which emits a `._<name>` companion for each file carrying an
+    // extended attribute — roughly half of every published tarball. The sync
+    // filters no longer propagate them, but a machine that installed a polluted
+    // release still has them on disk, where each `._agenfk-*` entry is surfaced
+    // by Claude Code (and Cursor/Codex/Gemini/OpenCode) as a skill whose
+    // description is mojibake binary, in the system prompt of every session.
+    // Upgrading must clean them up rather than leave the user a manual `find`.
+    //
+    // MUST run after every sync step (8b/8e skills AND 10/11/10c commands), or
+    // it heals only the dirs written before it. (CGLAB-94 / issue #163)
+    console.log(`${GREEN}[11b/14] Sweeping stale macOS metadata artifacts...${NC}`);
+    {
+        // Shared dirs: only ever remove OUR litter. An AppleDouble twin is named
+        // after the file it shadows, so ours are exactly `._agenfk*`; a bare
+        // `._*` sweep would delete another tool's twin and its `.DS_Store` too.
+        const sweepDirs = [
+            path.join(os.homedir(), '.agents', 'skills'),
+            path.join(os.homedir(), '.claude', 'skills'),
+            path.join(os.homedir(), '.claude', 'commands'),
+            path.join(os.homedir(), '.cursor', 'skills'),
+            path.join(os.homedir(), '.codex', 'skills'),
+            path.join(os.homedir(), '.gemini', 'skills'),
+            path.join(os.homedir(), '.gemini', 'commands'),
+            path.join(os.homedir(), '.gemini', 'commands', 'agenfk'),
+            path.join(os.homedir(), '.config', 'opencode', 'skills'),
+            path.join(os.homedir(), '.config', 'opencode', 'commands'),
+        ];
+        let swept = 0;
+        for (const dir of sweepDirs) {
+            if (!existsSync(dir)) continue;
+            for (const entry of readdirSync(dir)) {
+                if (!isMacMetadata(entry) || !isAgenfkOwnedEntry(entry)) continue;
+                try {
+                    await fs.rm(path.join(dir, entry), { recursive: true, force: true });
+                    swept++;
+                } catch { /* ignore — best effort, never fail the install */ }
+            }
+        }
+        // The install dir is entirely ours, so any `._*` there is ours to remove.
+        // Guarded the same way as cleanStaleSrc(): a distributed tarball never
+        // contains .git, so its presence means this is a dev checkout and the
+        // tree is the developer's working copy, not ours to prune.
+        const isDevCheckout = existsSync(path.join(rootDir, '.git'));
+        const sweepTree = (dir) => {
+            if (!existsSync(dir)) return;
+            for (const entry of readdirSync(dir, { withFileTypes: true })) {
+                if (entry.name === 'node_modules' || entry.name === '.git') continue;
+                const full = path.join(dir, entry.name);
+                if (isMacMetadata(entry.name)) {
+                    try { rmSync(full, { recursive: true, force: true }); swept++; } catch { /* ignore */ }
+                } else if (entry.isDirectory()) {
+                    sweepTree(full);
+                }
+            }
+        };
+        if (isDevCheckout) {
+            console.log('  Skipping install-dir sweep (dev checkout detected: .git present).');
+        } else {
+            sweepTree(rootDir);
+        }
+        console.log(swept > 0 ? `  Removed ${swept} stale macOS metadata artifact(s)` : '  None found');
     }
 
     // 12. Mirror the shared hook scripts into ~/.agenfk/bin. This MUST happen

--- a/scripts/package-dist.mjs
+++ b/scripts/package-dist.mjs
@@ -3,6 +3,7 @@ import fs from 'fs/promises';
 import { existsSync } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { createTarball } from './package-helpers.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, '..');
@@ -71,8 +72,7 @@ async function run() {
 
     // 4. Create the archive
     console.log(`  Creating ${distFile}...`);
-    const includeStr = include.join(' ');
-    execSync(`tar -czf ${distFile} ${includeStr}`, { cwd: rootDir, stdio: 'inherit' });
+    createTarball({ cwd: rootDir, outFile: distFile, include });
 
     console.log(`✨ Distributable created: ${path.join(rootDir, distFile)}`);
 }

--- a/scripts/package-helpers.mjs
+++ b/scripts/package-helpers.mjs
@@ -1,0 +1,42 @@
+import { execSync } from 'child_process';
+
+/**
+ * macOS metadata that must never enter a release archive.
+ *
+ * On macOS, bsdtar writes an AppleDouble `._<name>` companion entry for every
+ * file carrying an extended attribute, unless COPYFILE_DISABLE is set. Because
+ * this checkout's files carry `com.apple.provenance`, every release cut from a
+ * Mac shipped roughly one `._*` entry per real file (436 of 872 members in
+ * v1.1.16-beta.3). Consumers then saw them as real files: the installer copied
+ * them verbatim and the skills sync surfaced `._agenfk-*` as garbage skills in
+ * every agent session (CGLAB-94 / issue #163).
+ *
+ * Belt and braces, because the two mechanisms cover different cases:
+ *  - COPYFILE_DISABLE=1 stops bsdtar SYNTHESISING AppleDouble entries from
+ *    xattrs that exist only as metadata.
+ *  - --exclude drops `._*` / .DS_Store files that are physically on disk (e.g.
+ *    left behind by extracting an older, polluted tarball) on every platform.
+ */
+export const EXCLUDED_PATTERNS = ['._*', '.DS_Store'];
+
+/**
+ * Create a .tar.gz release archive with macOS metadata suppressed.
+ *
+ * @param {object} opts
+ * @param {string} opts.cwd      directory to archive from
+ * @param {string} opts.outFile  archive filename, relative to cwd
+ * @param {string[]} opts.include paths to include, relative to cwd
+ */
+export function createTarball({ cwd, outFile, include }) {
+    const excludes = EXCLUDED_PATTERNS.map((p) => `--exclude='${p}'`).join(' ');
+    // --no-xattrs drops the LIBARCHIVE.xattr.* / SCHILY.xattr.* PAX headers that
+    // bsdtar attaches for `com.apple.provenance`. They are inert payload here,
+    // and GNU tar prints "Ignoring unknown extended header keyword" for every
+    // one of them on extraction — one warning per file, on every Linux install.
+    // Supported by both bsdtar (macOS) and GNU tar (CI).
+    execSync(`tar --no-xattrs ${excludes} -czf ${outFile} ${include.join(' ')}`, {
+        cwd,
+        stdio: 'inherit',
+        env: { ...process.env, COPYFILE_DISABLE: '1' },
+    });
+}

--- a/scripts/package-hub-dist.mjs
+++ b/scripts/package-hub-dist.mjs
@@ -3,6 +3,7 @@ import fs from 'fs/promises';
 import { existsSync } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { createTarball } from './package-helpers.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, '..');
@@ -46,8 +47,7 @@ async function run() {
 
     // 4. Create the archive
     console.log(`  Creating ${distFile}...`);
-    const includeStr = include.join(' ');
-    execSync(`tar -czf ${distFile} ${includeStr}`, { cwd: rootDir, stdio: 'inherit' });
+    createTarball({ cwd: rootDir, outFile: distFile, include });
 
     console.log(`✨ Hub distributable created: ${path.join(rootDir, distFile)}`);
 }

--- a/scripts/uninstall-helpers.mjs
+++ b/scripts/uninstall-helpers.mjs
@@ -62,3 +62,49 @@ export function summarizeResults(results = []) {
     exitCode: failed.length > 0 ? 1 : 0,
   };
 }
+
+// --- macOS metadata guards (CGLAB-94 / issue #163) -------------------------
+//
+// Releases packaged on macOS shipped an AppleDouble `._<name>` twin for every
+// file carrying an extended attribute, and the sync steps installed the ones
+// named `._agenfk*.md` into every platform's skills/commands dir. Uninstall
+// used to miss them entirely: its filters match names that START WITH
+// "agenfk", and "._agenfk" does not — so removing agenfk left the garbage
+// skills behind, still polluting every agent session.
+//
+// Scope matters here. These directories are SHARED with other tools, so we may
+// only claim our own litter: an AppleDouble twin is named after the file it
+// shadows, so ours are exactly `._agenfk*`. A bare `._*` test would also delete
+// another tool's twin and any `.DS_Store` — files whose data we do not own.
+
+// True for macOS resource-fork / Finder metadata of any origin.
+export function isMacMetadata(name) {
+  return typeof name === 'string' && (name.startsWith('._') || name === '.DS_Store');
+}
+
+// The name an AppleDouble twin shadows: `._agenfk.md` -> `agenfk.md`.
+function shadowedName(name) {
+  return name.startsWith('._') ? name.slice(2) : name;
+}
+
+// True for an entry uninstall should remove from a SHARED skills/commands dir:
+// one of ours, or the AppleDouble twin of one of ours. Never a third party's.
+export function isAgenfkOwnedEntry(name) {
+  return typeof name === 'string' && shadowedName(name).startsWith('agenfk');
+}
+
+// Same, restricted to a given extension (flat command files). The extension is
+// checked on the shadowed name, so `._agenfk.json` is not swept by a `.md` site.
+export function isAgenfkOwnedFile(name, ext) {
+  if (typeof name !== 'string') return false;
+  const shadowed = shadowedName(name);
+  return shadowed.startsWith('agenfk') && shadowed.endsWith(ext);
+}
+
+// True for a macOS metadata artifact that shadows one of OUR files. Commands
+// dirs can hold AppleDouble *directories* (`._agenfk-calc-tokens/`, the twin of
+// a skill dir), which carry no extension and so are not matched by
+// isAgenfkOwnedFile — they still have to go.
+export function isAgenfkOwnedArtifact(name) {
+  return isMacMetadata(name) && isAgenfkOwnedEntry(name);
+}

--- a/scripts/uninstall.mjs
+++ b/scripts/uninstall.mjs
@@ -10,6 +10,9 @@ import {
     stripAgenfkHookEntries,
     resolveConfirmation,
     summarizeResults,
+  isAgenfkOwnedEntry,
+  isAgenfkOwnedFile,
+  isAgenfkOwnedArtifact,
 } from './uninstall-helpers.mjs';
 
 const RED = '\x1b[31m';
@@ -211,8 +214,12 @@ async function run() {
         if (existsSync(claudeCommandsDir)) {
             const files = await fs.readdir(claudeCommandsDir);
             for (const file of files) {
-                if (file.startsWith('agenfk') && file.endsWith('.md')) {
-                    await fs.unlink(path.join(claudeCommandsDir, file));
+                if (isAgenfkOwnedFile(file, '.md') || isAgenfkOwnedArtifact(file)) {
+                    // rm, not unlink: an AppleDouble artifact may be a *directory*
+                    // (`._agenfk-calc-tokens/`), and unlink throws on those — which
+                    // used to abort the whole loop before the sibling files were
+                    // reached (CGLAB-94 / issue #163).
+                    await fs.rm(path.join(claudeCommandsDir, file), { recursive: true, force: true });
                     console.log(`  Removed: ${path.join(claudeCommandsDir, file)}`);
                     removed = true;
                 }
@@ -229,8 +236,12 @@ async function run() {
         if (existsSync(opencodeCommandsDir)) {
             const files = await fs.readdir(opencodeCommandsDir);
             for (const file of files) {
-                if (file.startsWith('agenfk') && file.endsWith('.md')) {
-                    await fs.unlink(path.join(opencodeCommandsDir, file));
+                if (isAgenfkOwnedFile(file, '.md') || isAgenfkOwnedArtifact(file)) {
+                    // rm, not unlink: an AppleDouble artifact may be a *directory*
+                    // (`._agenfk-calc-tokens/`), and unlink throws on those — which
+                    // used to abort the whole loop before the sibling files were
+                    // reached (CGLAB-94 / issue #163).
+                    await fs.rm(path.join(opencodeCommandsDir, file), { recursive: true, force: true });
                     console.log(`  Removed: ${path.join(opencodeCommandsDir, file)}`);
                     removed = true;
                 }
@@ -278,7 +289,7 @@ async function run() {
             if (!existsSync(dir)) continue;
             const entries = await fs.readdir(dir);
             for (const entry of entries) {
-                if (entry.startsWith('agenfk')) {
+                if (isAgenfkOwnedEntry(entry)) {
                     await fs.rm(path.join(dir, entry), { recursive: true, force: true });
                     console.log(`  Removed: ${path.join(dir, entry)}`);
                     removed = true;


### PR DESCRIPTION
## What
`agenfk ui --open <itemId>` opens the dashboard with the item highlighted — exactly like typing the id into the Kanban Search Box (pre-fill, drill-down, highlight+scroll, NOT FOUND flash).

## How
- **CLI** (`packages/cli/src/uiUrl.ts` + `ui` command): resolves the item's real project via `GET /items/:id` (cwd fallback), emits `<dashboard>?item=<id>&project=<pid>`; rejects empty `--open`.
- **UI** (`KanbanBoard.tsx`): one-shot ref-guarded deep-link effect — `?project` initializes+persists the selected project (wins over localStorage), `?item` runs the search once items/flow are ready, params stripped via replaceState after apply.
- **Docs**: command row + "show an item" guidance in clauderules/cursorrules/codexrules/geminirules, SKILL.md, commands/agenfk.md.

Also carries the v1.1.16-beta.5 lineage (merged): CGLAB-86 bug fixes + CGLAB-94 installer AppleDouble fix, so beta.6 is a strict superset of beta.1–beta.5.

## Verification
- Root suite 2311/2311 (post-merge), UI 415/415, build green
- StrykerJS 18/18 mutants killed on uiUrl.ts
- Independent adversarial review: findings #1–#5 fixed, #6 security closed, #7–#9 regression-tested
- E2E against live server: search pre-fills, card renders, params stripped

Supersedes #164. Closes CGLAB-100