### PR TITLE
feat: exit-criteria markdown popup editor (CGLAB-109) + gatekeeper STORY authorization (CGLAB-110)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,8 @@ coverage/
 !/.claude/commands/
 tmp.*.json
 *-test-db.json
+
+# Mutation testing artifacts (StrykerJS — MUTATION_TESTS flow step)
+/reports/
+.stryker-tmp/
+stryker.log

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,8 @@
         "agenfk-hub": "bin/agenfk-hub.js"
       },
       "devDependencies": {
+        "@stryker-mutator/core": "^10.0.0",
+        "@stryker-mutator/vitest-runner": "^10.0.0",
         "@testing-library/jest-dom": "^7.0.1",
         "@testing-library/react": "^16.3.2",
         "@types/react": "^19.2.18",
@@ -230,6 +232,53 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-annotate-as-pure": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-8.0.0.tgz",
+      "integrity": "sha512-NSpMkMsvvZqzThJ0p1B02cbtA2ObEyfBvq950bmNkyxsxvcxwhvvCB036rKhlEnuBBo30bOrk13u3FzlKSoRrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-annotate-as-pure/node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-annotate-as-pure/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-annotate-as-pure/node_modules/@babel/types": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.4"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
@@ -254,6 +303,153 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-8.0.0.tgz",
+      "integrity": "sha512-xkXrMbtk87Gk7+oKBVmBc6EORg/Qwx++AHESldmHkpvG8wgccdhJJFwrzqlF382Fk8wfXhJHWE/g/43QvEGNPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^8.0.0",
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions/node_modules/@babel/code-frame": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-8.0.0.tgz",
+      "integrity": "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^8.0.0",
+        "js-tokens": "^10.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions/node_modules/@babel/generator": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0.tgz",
+      "integrity": "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^8.0.0",
+        "@babel/types": "^8.0.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "@types/jsesc": "^2.5.0",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions/node_modules/@babel/helper-globals": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-8.0.0.tgz",
+      "integrity": "sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions/node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions/node_modules/@babel/parser": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
+      "integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^8.0.4"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions/node_modules/@babel/template": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-8.0.0.tgz",
+      "integrity": "sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^8.0.0",
+        "@babel/parser": "^8.0.0",
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions/node_modules/@babel/traverse": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-8.0.4.tgz",
+      "integrity": "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^8.0.0",
+        "@babel/generator": "^8.0.0",
+        "@babel/helper-globals": "^8.0.0",
+        "@babel/parser": "^8.0.4",
+        "@babel/template": "^8.0.0",
+        "@babel/types": "^8.0.4",
+        "obug": "^2.1.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions/node_modules/@babel/types": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.4"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.29.7",
@@ -285,6 +481,53 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/@babel/helper-optimise-call-expression": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-8.0.0.tgz",
+      "integrity": "sha512-3W6satvtPuCUkUx63S2jMoW9EQNYkADgs1HTfufmL7gCmAulHMKupA/12WNz4A0GMMFn/YnWWwqOT9IZrJHQjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-optimise-call-expression/node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-optimise-call-expression/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-optimise-call-expression/node_modules/@babel/types": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.4"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
     "node_modules/@babel/helper-plugin-utils": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
@@ -293,6 +536,153 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-8.0.0.tgz",
+      "integrity": "sha512-xmCA9kP3IhySsqhzwIdWGlDN/1A4cCKNBO/uwZx/3YzmDoMePwno2Q5/Bq0q+tYaKbeF940YiKV/kaW8Mzvpjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^8.0.0",
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers/node_modules/@babel/code-frame": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-8.0.0.tgz",
+      "integrity": "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^8.0.0",
+        "js-tokens": "^10.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers/node_modules/@babel/generator": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0.tgz",
+      "integrity": "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^8.0.0",
+        "@babel/types": "^8.0.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "@types/jsesc": "^2.5.0",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers/node_modules/@babel/helper-globals": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-8.0.0.tgz",
+      "integrity": "sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers/node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers/node_modules/@babel/parser": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
+      "integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^8.0.4"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers/node_modules/@babel/template": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-8.0.0.tgz",
+      "integrity": "sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^8.0.0",
+        "@babel/parser": "^8.0.0",
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers/node_modules/@babel/traverse": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-8.0.4.tgz",
+      "integrity": "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^8.0.0",
+        "@babel/generator": "^8.0.0",
+        "@babel/helper-globals": "^8.0.0",
+        "@babel/parser": "^8.0.4",
+        "@babel/template": "^8.0.0",
+        "@babel/types": "^8.0.4",
+        "obug": "^2.1.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers/node_modules/@babel/types": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.4"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.29.7",
@@ -1298,6 +1688,199 @@
         "mlly": "^1.8.0"
       }
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
+      "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.3.tgz",
+      "integrity": "sha512-XEYX2WA8SBkLPczL6/yXPHLPCvDoptmh9v56Cy05BSV1Smk1vWy19bTC4qJBuIffw7+6l4CcaYYzGqG60RfW1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/figures": "^2.0.8",
+        "@inquirer/type": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/checkbox/node_modules/@inquirer/figures": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.8.tgz",
+      "integrity": "sha512-tApbon79GM9ry56ja/Ud3SY2CL4TQsao9fIwDQbgTeNY55025GdMzQ2+UdegV/lx51VNGUB59M0v0nMpybYY4Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.3.0.tgz",
+      "integrity": "sha512-pZHXJImFtERmSNMBHcjwuz8Ck5vEFEYNUZnwbb8aJpjHv/TwGuFErNxF2Hp8+V+pNJs2EYPMlyWscvFEqO9jOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/type": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.1.tgz",
+      "integrity": "sha512-JMD5Jy/ScL5TZE18m83Nw25HjqGFLoWXwnEkW7IdwwAhZpB9Bus55/WU7zn3UqR1MOCjjTQOIYpiD4vjWA3LPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/figures": "^2.0.8",
+        "@inquirer/type": "^4.1.0",
+        "cli-width": "^4.1.0",
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/@inquirer/figures": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.8.tgz",
+      "integrity": "sha512-tApbon79GM9ry56ja/Ud3SY2CL4TQsao9fIwDQbgTeNY55025GdMzQ2+UdegV/lx51VNGUB59M0v0nMpybYY4Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/mute-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.3.1.tgz",
+      "integrity": "sha512-y43COoyVUjPWIobn2Qep/uI1drPS78aaZZZ9kVi94Tyu/GuW2N8d8Q4rifJXGAXCEAXCPTTMjD8gC1HyvM5ukA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/external-editor": "^3.0.4",
+        "@inquirer/type": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/editor/node_modules/@inquirer/external-editor": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.4.tgz",
+      "integrity": "sha512-tZbbaK2ovq6vlrRBNQvjrypmrED/p5x2ncIHQ79cD55tei3dD96v5glMMA+6tiq7K104i/25DVYKWVPJuV6ptA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.2"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.3.tgz",
+      "integrity": "sha512-3NQJiXNJ/aj9wiAsr7pECdp5Qe9J0X9YUJCKsaFXS+ddOxfL6J4AIl3w3T4Gq3kK0WsQY5GMoDokK5X94m6lHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/type": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@inquirer/external-editor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
@@ -1326,6 +1909,210 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.4.tgz",
+      "integrity": "sha512-3xQkQrOvgOzpSN2ciTVdRDlg1FWMCA8l+0KfB6SNlILoTCGzJTzO/gc0Rwjcb3usuGyKdaGtI6OiyMdeMeLWkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/type": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.2.1.tgz",
+      "integrity": "sha512-5KaqwZNLRpUuWcoCrYghPP9TMaXL5v2Sk4xqePM7RCVegcJStoXdWibio60YIC1bec+z1fCyb67N6XPJIkZtGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/type": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.2.0.tgz",
+      "integrity": "sha512-CvVcW09emkBESEOW+4R8CjLNkP3fB3XrjeL8CDvfpjgrJN+V9oerXmJAXXM3l+4xqYPD5Yaujzy/Ph0PLOdDuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/type": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.7.0.tgz",
+      "integrity": "sha512-yQwBMYvpJ6jqrXtKiOwRD5XezjJoyt3VQvIyjsr5Arqb519nfIohOQymWVJ8/vEgg8xtZerrCsqlSaqt/LPC9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^5.2.3",
+        "@inquirer/confirm": "^6.3.0",
+        "@inquirer/editor": "^5.3.1",
+        "@inquirer/expand": "^5.1.3",
+        "@inquirer/input": "^5.1.4",
+        "@inquirer/number": "^4.2.1",
+        "@inquirer/password": "^5.2.0",
+        "@inquirer/rawlist": "^5.3.3",
+        "@inquirer/search": "^4.3.1",
+        "@inquirer/select": "^5.2.3"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.3.tgz",
+      "integrity": "sha512-Mu7WrtmDLaXBDEyrRLS70SZgX9ZSm4Up1w0ZxiH8C1OOp9oaVCn2k8q3QGgmlnhsKYUhuaU3zFWhAP6wxkVIMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/type": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.3.1.tgz",
+      "integrity": "sha512-0VWOvsHWI0rPj6CG70MoP4oXNCB6adcyN8bVFZXnh11eLDdPIK2f2XCmva78acPPDfJisfab7qNakwBh7hdBXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/figures": "^2.0.8",
+        "@inquirer/type": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search/node_modules/@inquirer/figures": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.8.tgz",
+      "integrity": "sha512-tApbon79GM9ry56ja/Ud3SY2CL4TQsao9fIwDQbgTeNY55025GdMzQ2+UdegV/lx51VNGUB59M0v0nMpybYY4Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.3.tgz",
+      "integrity": "sha512-KuRTodDa6xBXX2noIpjuitpX/QT7Sfav7dIZ/OfUY54Hxg95nrGoshSzxx6Ey7qqLbImKdiGkSDt7KjPXjQgmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/figures": "^2.0.8",
+        "@inquirer/type": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select/node_modules/@inquirer/figures": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.8.tgz",
+      "integrity": "sha512-tApbon79GM9ry56ja/Ud3SY2CL4TQsao9fIwDQbgTeNY55025GdMzQ2+UdegV/lx51VNGUB59M0v0nMpybYY4Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.1.0.tgz",
+      "integrity": "sha512-FMiJpuHUG3Dk0ex+UIXkre7i+i4OcwHWk9YdcVtZHFwb/r2rnrU2ipTCNAB7A+QOP0ryzIcqOfy76fRyyvOEAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1871,6 +2658,26 @@
         "win32"
       ]
     },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
@@ -1883,6 +2690,804 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@stryker-mutator/api": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/api/-/api-10.0.0.tgz",
+      "integrity": "sha512-ZtAJ0ZT3MVRCWJTBE2h90XB/6E+4lifHYtcTyNG6nU2nLekPgTo4gD5esjX6Okxo1b/JB4jJzyxYB54fwKAoJw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mutation-testing-metrics": "3.8.4",
+        "mutation-testing-report-schema": "3.8.4",
+        "tslib": "~2.8.0",
+        "typed-inject": "~5.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/core": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/core/-/core-10.0.0.tgz",
+      "integrity": "sha512-ZvMsRyaXQQ5e6Thcid9pkuODv6Fn9E3nrBQJUap+hcJuGJ4unm26afo3m6YKSjn8kinyxJ/3TXf0cTWRDaTxVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@inquirer/prompts": "^8.0.0",
+        "@stryker-mutator/api": "10.0.0",
+        "@stryker-mutator/instrumenter": "10.0.0",
+        "@stryker-mutator/util": "10.0.0",
+        "ajv": "~8.20.0",
+        "chalk": "~5.6.0",
+        "commander": "~14.0.0",
+        "diff-match-patch": "1.0.5",
+        "emoji-regex": "~10.6.0",
+        "execa": "~9.6.0",
+        "json-rpc-2.0": "^1.7.0",
+        "lodash.groupby": "~4.6.0",
+        "minimatch": "~10.2.4",
+        "mutation-server-protocol": "~0.4.0",
+        "mutation-testing-elements": "3.8.4",
+        "mutation-testing-metrics": "3.8.4",
+        "mutation-testing-report-schema": "3.8.4",
+        "npm-run-path": "~6.0.0",
+        "progress": "~2.0.3",
+        "rxjs": "~7.8.1",
+        "semver": "^7.6.3",
+        "source-map": "~0.7.4",
+        "tree-kill": "~1.2.2",
+        "tslib": "2.8.1",
+        "typed-inject": "~5.0.0",
+        "typed-rest-client": "~2.3.0"
+      },
+      "bin": {
+        "stryker": "bin/stryker.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@stryker-mutator/core/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@stryker-mutator/core/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/instrumenter/-/instrumenter-10.0.0.tgz",
+      "integrity": "sha512-B7Wmn1KlEWyFeOz6D6oGvQGRfi5Xw3VemG6dEKvFQp4qLvxD9Mf4kcZghfxffgnYwXd3bFgqXsJ+ZGlhdfIOrQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/core": "~8.0.0",
+        "@babel/generator": "~8.0.0",
+        "@babel/parser": "~8.0.0",
+        "@babel/plugin-proposal-decorators": "~8.0.0",
+        "@babel/plugin-transform-explicit-resource-management": "^8.0.0",
+        "@babel/preset-react": "~8.0.0",
+        "@babel/preset-typescript": "~8.0.0",
+        "@babel/traverse": "~8.0.4",
+        "@stryker-mutator/api": "10.0.0",
+        "@stryker-mutator/util": "10.0.0",
+        "angular-html-parser": "~10.11.0",
+        "semver": "~7.8.0",
+        "tslib": "2.8.1",
+        "weapon-regex": "~2.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/code-frame": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-8.0.0.tgz",
+      "integrity": "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^8.0.0",
+        "js-tokens": "^10.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/compat-data": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-8.0.0.tgz",
+      "integrity": "sha512-DOjnob/cXOUgDOozCDeq/aK2p5y8dUIVdf6tNhEV1HQRd6I8aQ4f4fbtHRVEvb6lP3BGomrKHiS8ICAASSVQSw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/core": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-8.0.1.tgz",
+      "integrity": "sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^8.0.0",
+        "@babel/generator": "^8.0.0",
+        "@babel/helper-compilation-targets": "^8.0.0",
+        "@babel/helpers": "^8.0.0",
+        "@babel/parser": "^8.0.0",
+        "@babel/template": "^8.0.0",
+        "@babel/traverse": "^8.0.0",
+        "@babel/types": "^8.0.0",
+        "@types/gensync": "^1.0.5",
+        "convert-source-map": "^2.0.0",
+        "empathic": "^2.0.1",
+        "gensync": "^1.0.0-beta.2",
+        "import-meta-resolve": "^4.2.0",
+        "json5": "^2.2.3",
+        "obug": "^2.1.1",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/generator": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0.tgz",
+      "integrity": "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^8.0.0",
+        "@babel/types": "^8.0.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "@types/jsesc": "^2.5.0",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/helper-compilation-targets": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-8.0.0.tgz",
+      "integrity": "sha512-JwculLABZvyPvyLBpwU/E/IbH2uM3mnxNtIJpxnIfb24y1PrdVxK5Dqjle4DpgqpGRnwgC7G8IkzPdSXZrO1Ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^8.0.0",
+        "@babel/helper-validator-option": "^8.0.0",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^11.0.0",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/helper-create-class-features-plugin": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-8.0.1.tgz",
+      "integrity": "sha512-++t3ZktzlLmASAxIlxeXQK9Z2YwUafYGYcvGBFevqOqt16HozVHStUoQvWD09fzAZOb/uJGpUTBuGK41AJAuOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^8.0.0",
+        "@babel/helper-member-expression-to-functions": "^8.0.0",
+        "@babel/helper-optimise-call-expression": "^8.0.0",
+        "@babel/helper-replace-supers": "^8.0.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^8.0.0",
+        "@babel/traverse": "^8.0.0",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/helper-globals": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-8.0.0.tgz",
+      "integrity": "sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/helper-module-imports": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-8.0.0.tgz",
+      "integrity": "sha512-NZ7mSS93o4ndX4KrbD7W8Sf3QT8Qe24PrnFyUcuOPDzK6faqDFKjY9RG7he7+I7FdiQ4llpnosFqzrXa+Vy3Ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^8.0.0",
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/helper-module-transforms": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-8.0.1.tgz",
+      "integrity": "sha512-UgAhl1kqiW5ciE0yCXqqvnb4H2n3IELJ7lIIQRezwDPilPEZX5i+Rvbja9MFTkwUn2biEiSMeV31aUzR4Lwakw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.0",
+        "@babel/traverse": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/helper-plugin-utils": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+      "integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/helper-replace-supers": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-8.0.1.tgz",
+      "integrity": "sha512-B1SZADIcy3tmH8CmWvj4SHi/oAPom4UL3uknTc2QRNsPVLFk/sPnZvQL/8kj7Y5omvjMqie0vklvs6XM4OLW5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^8.0.0",
+        "@babel/helper-optimise-call-expression": "^8.0.0",
+        "@babel/traverse": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/helper-validator-option": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-8.0.0.tgz",
+      "integrity": "sha512-U4Dybxh4WESWHt5XhBeExi4DrY0/DNK1aHpQbsrQXCUbFHuMweT0TpLEWKvaraV2Y6fS+ZXunsZ8zIuZIgvF2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/helpers": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-8.0.0.tgz",
+      "integrity": "sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^8.0.0",
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/parser": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
+      "integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^8.0.4"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/plugin-proposal-decorators": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-8.0.2.tgz",
+      "integrity": "sha512-+C6O6KKXU7BBq1GNaIkFJxrALUVGRcr+WeWm4OcuRl3h+l/CmNfcTLMrT2Lm3uvGBimBH/8pEBRrXJFLoO67Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^8.0.1",
+        "@babel/helper-plugin-utils": "^8.0.1",
+        "@babel/plugin-syntax-decorators": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/plugin-syntax-decorators": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-8.0.1.tgz",
+      "integrity": "sha512-NI+0S/6MvR6GlcQFwjDZ+WIc2qvG6TXN534lYs9llNldwW4b7Dh6KTtk030FA0xWdYGs4t1lWo+OEWN8wGB+Nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/plugin-syntax-jsx": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-8.0.1.tgz",
+      "integrity": "sha512-n0jtCOxEovhU7METqSQjcZO9pX53nu9uNIjMS+hEt+Nt9jA7oOZoBIgbCxhhASmF6T6rPDGge5UAvh6Z4eFz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/plugin-syntax-typescript": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-8.0.3.tgz",
+      "integrity": "sha512-jmTPwps7oSQSZaV1SxkQ3C12UWyufGysGc5OzDpZzvPAIX4mO7dJT3hoqkWVrSImvkcMiknir1iLN1SNV/CZzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/plugin-transform-destructuring": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-8.0.1.tgz",
+      "integrity": "sha512-RtR8uLDl0QcCmqMNIkM8gmDeYZ3rS0ZH+sa+I6sfc09yFoqfp9AEPgBstq9KyfVb0lFCVSRFfJXCI70FIl5ccw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/plugin-transform-explicit-resource-management": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-8.0.1.tgz",
+      "integrity": "sha512-VzDIYwBlLCpV6mJfloRdJm8HmYnMqs7O+bGha8yfg2kP7jAdxeCw6yZBVBeaKKQUThtSU52iy+3lB7DhYsbOBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^8.0.1",
+        "@babel/plugin-transform-destructuring": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/plugin-transform-modules-commonjs": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-8.0.1.tgz",
+      "integrity": "sha512-PMuzulWrrzFNmY3lXSk/tV9NRb7y0eZZLJY4UEo2TKszroxvUZHAPPi+T9FDyrQhod+TQA+t+8/QYaaMpiEuhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^8.0.1",
+        "@babel/helper-plugin-utils": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/plugin-transform-react-display-name": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-8.0.1.tgz",
+      "integrity": "sha512-soLishXlkyu6jcICPyO3HEP7A3GCzKEnn7XfvYrImuWEOwFAz93qShmWSYPf5ww0ZkO4By0zsN2bVIDF54fSdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/plugin-transform-react-jsx": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-8.0.1.tgz",
+      "integrity": "sha512-NgkoF7Uq+30TmOPDdNUimT0Nta02uVjqJRFNlVWKrbOCu/CkzfHa4aMnIs0lMpkMmZmWA1e42Va+F04i/pY1zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^8.0.0",
+        "@babel/helper-module-imports": "^8.0.0",
+        "@babel/helper-plugin-utils": "^8.0.1",
+        "@babel/plugin-syntax-jsx": "^8.0.1",
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/plugin-transform-react-jsx-development": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-8.0.1.tgz",
+      "integrity": "sha512-Hb+HUZpV9KFHjm+F+P3aLDMi8QXU9l3ROCQv20z18Me2sGyW5nNNR5YTevNlgHvCpFek3BnAwhDGq/BRndXViw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-transform-react-jsx": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/plugin-transform-react-pure-annotations": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-8.0.1.tgz",
+      "integrity": "sha512-7/8UwU8hoPBurXa9tUiTTC8aACTRy5tCqLUtqikHp2eGiWoEB57AduOdbQ71OOMTEvawKrGhv3WfzkDpI+/oSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^8.0.0",
+        "@babel/helper-plugin-utils": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/plugin-transform-typescript": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-8.0.1.tgz",
+      "integrity": "sha512-0Svqp3413Eg0GElldykF/T7SNsxQO5YVGD70fZyAdZTnX8WRgcopmbiU7GTa5xY5ZnJcEpNbfns8/GjX+/1yeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^8.0.0",
+        "@babel/helper-create-class-features-plugin": "^8.0.1",
+        "@babel/helper-plugin-utils": "^8.0.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^8.0.0",
+        "@babel/plugin-syntax-typescript": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/preset-react": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-8.0.1.tgz",
+      "integrity": "sha512-jrFuPp/pTddFZbtmWhdLNAYc6UMcpboeUPnw0BBrm4nOmcAko/1TRcFi1PzWCeOFRU+VaSiKmat87W1HvR7mIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^8.0.1",
+        "@babel/helper-validator-option": "^8.0.0",
+        "@babel/plugin-transform-react-display-name": "^8.0.1",
+        "@babel/plugin-transform-react-jsx": "^8.0.1",
+        "@babel/plugin-transform-react-jsx-development": "^8.0.1",
+        "@babel/plugin-transform-react-pure-annotations": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/preset-typescript": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-8.0.1.tgz",
+      "integrity": "sha512-qrPhQIN1NLrPmzgazF9XKQqXrOcp/WJly+K+6ReFonn24FZqRJO7clxOJo6Ni75L+2vAqI3cHVU2OJLBxoPp5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^8.0.1",
+        "@babel/helper-validator-option": "^8.0.0",
+        "@babel/plugin-transform-modules-commonjs": "^8.0.1",
+        "@babel/plugin-transform-typescript": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/template": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-8.0.0.tgz",
+      "integrity": "sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^8.0.0",
+        "@babel/parser": "^8.0.0",
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/traverse": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-8.0.4.tgz",
+      "integrity": "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^8.0.0",
+        "@babel/generator": "^8.0.0",
+        "@babel/helper-globals": "^8.0.0",
+        "@babel/parser": "^8.0.4",
+        "@babel/template": "^8.0.0",
+        "@babel/types": "^8.0.4",
+        "obug": "^2.1.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/types": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.4"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@stryker-mutator/util": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/util/-/util-10.0.0.tgz",
+      "integrity": "sha512-LzOpHiJaCp2ABQgnPMlrQQcsK43bd5Vo/2FGL78aN62yDoeRQ+4j3tzeuXxK5OAHdC3fUz6TDoy4IsoAuLAd3w==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@stryker-mutator/vitest-runner": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/vitest-runner/-/vitest-runner-10.0.0.tgz",
+      "integrity": "sha512-SHK2/vfvRUpiz7jXPnQMBnr6zLdm69DK03Mo5mPhaZWcRSygrKUqYsPqWsXsK+5ySHzlMTfCyFK5NQ/X9sJFFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stryker-mutator/api": "10.0.0",
+        "@stryker-mutator/util": "10.0.0",
+        "semver": "^7.7.4",
+        "tslib": "~2.8.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "@stryker-mutator/core": "10.0.0",
+        "vitest": ">=2.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/vitest-runner/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.3.3",
@@ -2772,6 +4377,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/gensync": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/gensync/-/gensync-1.0.5.tgz",
+      "integrity": "sha512-MbsRCT7mTikHwKZ0X+LVUTLRrZZRLipTuXEO9qOYO+zmjMVk81axyClMROf6uoPD9MRVu46bx8zoR0Ad9q3NAg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/geojson": {
       "version": "7946.0.16",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
@@ -2804,6 +4416,13 @@
         "@types/through": "*",
         "rxjs": "^7.2.0"
       }
+    },
+    "node_modules/@types/jsesc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@types/jsesc/-/jsesc-2.5.1.tgz",
+      "integrity": "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -3568,6 +5187,16 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
+    },
+    "node_modules/angular-html-parser": {
+      "version": "10.11.0",
+      "resolved": "https://registry.npmjs.org/angular-html-parser/-/angular-html-parser-10.11.0.tgz",
+      "integrity": "sha512-3vERzJ65UFDr3C7uozLJwsNcQS3FS784dSh583oDgDTTZMgXe3/pdyXgKndxiP5R2lvYRfW6gSl145Hnyf2OFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -5081,6 +6710,17 @@
         "node": ">=6"
       }
     },
+    "node_modules/des.js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
     "node_modules/destroy": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
@@ -5123,6 +6763,13 @@
         "asap": "^2.0.0",
         "wrappy": "1"
       }
+    },
+    "node_modules/diff-match-patch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/discontinuous-range": {
       "version": "1.0.0",
@@ -5188,6 +6835,16 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
+    },
+    "node_modules/empathic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.1.tgz",
+      "integrity": "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -5679,6 +7336,46 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -5783,6 +7480,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
     "node_modules/fast-uri": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
@@ -5798,6 +7512,16 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -5844,6 +7568,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/figures/node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/file-entry-cache": {
@@ -6128,6 +7881,23 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -6387,6 +8157,16 @@
       "resolved": "packages/hub-ui",
       "link": true
     },
+    "node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
@@ -6456,6 +8236,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/imurmurhash": {
@@ -6650,6 +8441,19 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -6731,6 +8535,13 @@
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
+    },
+    "node_modules/js-md4": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/js-md4/-/js-md4-0.3.2.tgz",
+      "integrity": "sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -6819,6 +8630,13 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-rpc-2.0": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/json-rpc-2.0/-/json-rpc-2.0-1.8.0.tgz",
+      "integrity": "sha512-4nw+XlJbk5XokA7BtqHGu+0PEiUPfAkRzXXd1Cgjy1c3F2UI/3Gy7yr76wyJEv3X1F1SRGGF8xPAPPhelBiGmA==",
       "dev": true,
       "license": "MIT"
     },
@@ -7307,6 +9125,13 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.groupby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+      "integrity": "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.includes": {
@@ -8491,6 +10316,13 @@
         "node": ">=4"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -8554,6 +10386,53 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/mutation-server-protocol": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/mutation-server-protocol/-/mutation-server-protocol-0.4.1.tgz",
+      "integrity": "sha512-SBGK0j8hLDne7bktgThKI8kGvGTx3rY3LAeQTmOKZ5bVnL/7TorLMvcVF7dIPJCu5RNUWhkkuF53kurygYVt3g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "zod": "^4.1.12"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/mutation-server-protocol/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/mutation-testing-elements": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/mutation-testing-elements/-/mutation-testing-elements-3.8.4.tgz",
+      "integrity": "sha512-5CF1SNa7at5ZH33vEr+21wNebTSrtNIVvnzaUlxortHajOrIPaSLczIWvg6sI/fsExekQ7jookwf2cHftkckqQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/mutation-testing-metrics": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/mutation-testing-metrics/-/mutation-testing-metrics-3.8.4.tgz",
+      "integrity": "sha512-DZcmndJBH6nrNs3tpiB3OcMVq9KkG2cHCpJSnDxSxPwi9qrafRmoec40xjhkbzOoX1n7/4UkDqg5tIj4A6nvCw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mutation-testing-report-schema": "3.8.4"
+      }
+    },
+    "node_modules/mutation-testing-report-schema": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/mutation-testing-report-schema/-/mutation-testing-report-schema-3.8.4.tgz",
+      "integrity": "sha512-s4G71R6Lt/PpZ0cqeglIcgyBdzLM8E+SeCHZAPg1wkSsPtRBa4XfPzAozYKdiJk/TLbNEEb7En9t0/bveuPuxA==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/mute-stream": {
       "version": "1.0.0",
@@ -8635,6 +10514,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/object-assign": {
@@ -8842,6 +10751,19 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
+    },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/parse5": {
       "version": "8.0.0",
@@ -9304,6 +11226,32 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.1.tgz",
+      "integrity": "sha512-HzMy3Geq23nVALD/M2LliU+F+M+gVNsvkQWWqeBZ8HDiCgzo6YPJ/Omrmtq24EFrIsk0a3EkQGEd7bDOo+IhGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/property-information": {
@@ -10104,6 +12052,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -10202,6 +12160,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/strip-indent": {
@@ -10436,6 +12407,16 @@
         "node": ">=20"
       }
     },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -10483,6 +12464,16 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -10540,6 +12531,49 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/typed-inject": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/typed-inject/-/typed-inject-5.0.0.tgz",
+      "integrity": "sha512-0Ql2ORqBORLMdAW89TQKZsb1PQkFGImFfVmncXWe7a+AA3+7dh7Se9exxZowH4kbnlvKEFkMxUYdHUpjYWFJaA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typed-rest-client": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-2.3.1.tgz",
+      "integrity": "sha512-k4kX5Up6qA68D0Cby2AK+6+vM5k3qTxe+/3FqhnHRExjY5cfbOnzjQZbP/LXleF8hVoDvDqxlgk9KK83HoBZlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "des.js": "^1.1.0",
+        "js-md4": "^0.3.2",
+        "qs": "6.15.1",
+        "tunnel": "0.0.6",
+        "underscore": "^1.13.8"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
+    },
+    "node_modules/typed-rest-client/node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -10588,6 +12622,13 @@
       "resolved": "packages/ui",
       "link": true
     },
+    "node_modules/underscore": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/undici": {
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
@@ -10603,6 +12644,19 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/unified": {
       "version": "11.0.5",
@@ -10991,6 +13045,13 @@
         "defaults": "^1.0.3"
       }
     },
+    "node_modules/weapon-regex": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/weapon-regex/-/weapon-regex-2.0.4.tgz",
+      "integrity": "sha512-ubuhY5Lo4phWcMsJqe8j62m9uhsuo/VpfK5XsSgYGRGDSt10hwVwOBTriPRd0dac+KYbGNXOrfXjM6xCp2NUKg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/web-vitals": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
@@ -11170,6 +13231,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+      "integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13354,7 +13354,9 @@
         "lucide-react": "^0.574.0",
         "mermaid": "^11.16.1",
         "react": "^19.2.8",
-        "react-dom": "^19.2.8"
+        "react-dom": "^19.2.8",
+        "react-markdown": "^10.1.0",
+        "remark-gfm": "^4.0.1"
       }
     },
     "packages/hub": {
@@ -13391,6 +13393,7 @@
         "@fontsource-variable/jetbrains-mono": "^5.3.0",
         "@fontsource-variable/manrope": "^5.3.0",
         "@tailwindcss/postcss": "^4.3.3",
+        "@tailwindcss/typography": "^0.5.20",
         "@tanstack/react-query": "^5.101.4",
         "@vitejs/plugin-react": "^5.1.1",
         "axios": "^1.19.0",
@@ -13399,7 +13402,9 @@
         "mermaid": "^11.16.1",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
+        "react-markdown": "^10.1.0",
         "react-router-dom": "^7.18.2",
+        "remark-gfm": "^4.0.1",
         "tailwindcss": "^4.2.0",
         "vite": "^7.3.1"
       },

--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
   },
   "type": "module",
   "devDependencies": {
+    "@stryker-mutator/core": "^10.0.0",
+    "@stryker-mutator/vitest-runner": "^10.0.0",
     "@testing-library/jest-dom": "^7.0.1",
     "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.18",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3113,9 +3113,10 @@ program
       }
 
       // Fetch the project's active flow so authorization is flow-aware: any
-      // TASK/BUG in a non-anchor working step is authorizable, regardless of
-      // whether the step is literally named IN_PROGRESS. Falls back to default
-      // TODO/DONE anchors when no flow is resolvable.
+      // STORY/TASK/BUG in a non-anchor working step is authorizable (an EPIC is
+      // never worked directly — CGLAB-110), regardless of whether the step is
+      // literally named IN_PROGRESS. Falls back to default TODO/DONE anchors
+      // when no flow is resolvable.
       let activeFlow: any = null;
       let flowFetchFailed = false;
       if (projectId) {

--- a/packages/core/src/gatekeeper.ts
+++ b/packages/core/src/gatekeeper.ts
@@ -205,9 +205,12 @@ export interface GatekeeperDecisionOptions {
 
 /**
  * Decide whether work is authorized, mirroring the server's workflow_gatekeeper
- * semantics: work may only proceed on a TASK or BUG that sits in an active
- * working step of the project's active flow. The `role` is advisory — it never
- * gates on a hardcoded status, so custom flows are honored.
+ * semantics: work may proceed on a TASK, BUG, or STORY that sits in an active
+ * working step of the project's active flow. Only an EPIC is never worked
+ * directly (CGLAB-110: the shipped protocol decomposes EPICs into stories but
+ * explicitly waives story→task decomposition — "A small story goes straight to
+ * its first working step"). The `role` is advisory — it never gates on a
+ * hardcoded status, so custom flows are honored.
  */
 export function decideGatekeeperAuthorization(
   items: GatekeeperItem[],
@@ -218,17 +221,17 @@ export function decideGatekeeperAuthorization(
   const role = (opts.role || 'coding').toLowerCase();
 
   const workingItems = getActiveStepItems(items, flow);
-  const actionable = workingItems.filter(i => i.type === 'TASK' || i.type === 'BUG');
+  const actionable = workingItems.filter(i => i.type === 'TASK' || i.type === 'BUG' || i.type === 'STORY');
 
   if (actionable.length === 0) {
-    const stuck = workingItems.find(i => i.type === 'STORY' || i.type === 'EPIC');
+    const stuck = workingItems.find(i => i.type === 'EPIC');
     const hint = stuck
-      ? ` "${stuck.title}" (${stuck.type}) is at step ${stuck.status}, but work must be authorized on a TASK or BUG. Create or advance a TASK or BUG within that ${stuck.type} to an active step first.`
-      : ' Create or advance a TASK or BUG to an active step first.';
+      ? ` "${stuck.title}" (${stuck.type}) is at step ${stuck.status}, but an EPIC is never worked directly. Create or advance a STORY, TASK or BUG within that EPIC to an active step first.`
+      : ' Create or advance a STORY, TASK or BUG to an active step first.';
     return {
       authorized: false,
       task: null,
-      message: `❌ WORKFLOW BREACH: No TASK or BUG is in an active working step.${hint}`,
+      message: `❌ WORKFLOW BREACH: No STORY, TASK or BUG is in an active working step.${hint}`,
     };
   }
 
@@ -242,11 +245,11 @@ export function decideGatekeeperAuthorization(
         message: `❌ WORKFLOW BREACH: Item [${opts.itemId}] is not in an active working step.`,
       };
     }
-    if (task.type === 'EPIC' || task.type === 'STORY') {
+    if (task.type === 'EPIC') {
       return {
         authorized: false,
         task: null,
-        message: `❌ WORKFLOW BREACH: Cannot authorize work directly on a ${task.type} [${task.id.substring(0, 8)}] "${task.title}". Create or advance a TASK or BUG within this ${task.type} to an active step first.`,
+        message: `❌ WORKFLOW BREACH: Cannot authorize work directly on an EPIC [${task.id.substring(0, 8)}] "${task.title}". An EPIC is never worked directly — create or advance a STORY, TASK or BUG within it to an active step first.`,
       };
     }
   } else if (actionable.length > 1) {
@@ -257,7 +260,7 @@ export function decideGatekeeperAuthorization(
       authorized: false,
       ambiguous: true,
       task: null,
-      message: `⚠️ AMBIGUOUS: Multiple tasks are in an active step. Provide --item-id to disambiguate:\n${list}`,
+      message: `⚠️ AMBIGUOUS: Multiple items are in an active step. Provide --item-id to disambiguate:\n${list}`,
     };
   } else {
     task = actionable[0];

--- a/packages/core/src/test/gatekeeper.test.ts
+++ b/packages/core/src/test/gatekeeper.test.ts
@@ -4,6 +4,7 @@ import {
   decideGatekeeperAuthorization,
   findItemAcrossProjects,
   detectCrossProjectItem,
+  INACTIVE_STATUSES,
   type GatekeeperFlow,
   type GatekeeperItem,
 } from '../gatekeeper';
@@ -77,11 +78,13 @@ describe('decideGatekeeperAuthorization', () => {
     expect(d.message).toContain('WORKFLOW BREACH');
   });
 
-  it('hints to advance a TASK/BUG when only a STORY/EPIC is active', () => {
-    const d = decideGatekeeperAuthorization([item('s1', 'IN_PROGRESS', 'STORY', 'My Story')], tddFlow, {});
+  it('still hints to create a child item when only an EPIC is active', () => {
+    // CGLAB-110: a lone STORY is directly actionable, so this refusal now only
+    // fires for an EPIC — and the advice must name the child types.
+    const d = decideGatekeeperAuthorization([item('e1', 'IN_PROGRESS', 'EPIC', 'My Epic')], tddFlow, {});
     expect(d.authorized).toBe(false);
-    expect(d.message).toContain('My Story');
-    expect(d.message).toMatch(/TASK or BUG/);
+    expect(d.message).toContain('My Epic');
+    expect(d.message).toMatch(/STORY, TASK or BUG/);
   });
 
   it('is AMBIGUOUS when multiple tasks are active and no item id is given', () => {
@@ -107,10 +110,72 @@ describe('decideGatekeeperAuthorization', () => {
     expect(d.message).toContain('t2');
   });
 
-  it('refuses to authorize work directly on an EPIC/STORY even when targeted by id', () => {
+  it('refuses to authorize work directly on an EPIC even when targeted by id', () => {
+    // CGLAB-110: only EPICs refuse direct work. A STORY targeted by id is
+    // authorized — pinned in the CGLAB-110 block below.
     const d = decideGatekeeperAuthorization([item('e1', 'IN_PROGRESS', 'EPIC', 'Epic X')], tddFlow, { itemId: 'e1' });
     expect(d.authorized).toBe(false);
     expect(d.message).toContain('EPIC');
+  });
+});
+
+// ── CGLAB-110: a STORY is directly actionable; only an EPIC refuses ──────────
+// The shipped Standard Mode protocol decomposes EPICs into stories but says
+// "Decomposing a story into tasks is not mandatory ... A small story goes
+// straight to its first working step." The gatekeeper nonetheless deadlocked
+// every STORY with a WORKFLOW BREACH (observed 2026-08-28 on CGLAB-109),
+// forcing the decomposition the protocol waived. Fix: STORY joins the
+// actionable set; EPIC alone still refuses direct authorization.
+describe('a STORY is directly actionable, only an EPIC refuses (CGLAB-110)', () => {
+  it('authorizes a STORY in an active step when targeted by id', () => {
+    const d = decideGatekeeperAuthorization([item('s1', 'IN_PROGRESS', 'STORY', 'My Story')], tddFlow, { itemId: 's1' });
+    expect(d.authorized).toBe(true);
+    expect(d.task?.id).toBe('s1');
+    expect(d.message).toContain('AUTHORIZED');
+  });
+
+  it('authorizes a STORY in a custom coding step (the observed CGLAB-109 deadlock)', () => {
+    const d = decideGatekeeperAuthorization([item('a1f428b9', 'CREATE_UNIT_TESTS', 'STORY')], tddFlow, { itemId: 'a1f428b9' });
+    expect(d.authorized).toBe(true);
+    expect(d.task?.id).toBe('a1f428b9');
+    expect(d.message).toContain('CREATE_UNIT_TESTS');
+  });
+
+  it('picks up a lone STORY as the actionable item when no TASK/BUG is active', () => {
+    const d = decideGatekeeperAuthorization([item('s1', 'IN_PROGRESS', 'STORY', 'My Story')], tddFlow, {});
+    expect(d.authorized).toBe(true);
+    expect(d.task?.id).toBe('s1');
+  });
+
+  it('resolves a STORY by id prefix when a TASK is also active', () => {
+    const items = [item('t1', 'IN_PROGRESS'), item('bbbbbbbb-2', 'CREATE_UNIT_TESTS', 'STORY', 'Story S')];
+    const d = decideGatekeeperAuthorization(items, tddFlow, { itemId: 'bbbbbbbb' });
+    expect(d.authorized).toBe(true);
+    expect(d.task?.id).toBe('bbbbbbbb-2');
+  });
+
+  it('lists a STORY among the ambiguous active items', () => {
+    const items = [item('t1', 'IN_PROGRESS'), item('s1', 'CREATE_UNIT_TESTS', 'STORY', 'Story S')];
+    const d = decideGatekeeperAuthorization(items, tddFlow, {});
+    expect(d.authorized).toBe(false);
+    expect(d.ambiguous).toBe(true);
+    expect(d.message).toContain('Story S');
+  });
+
+  it('still refuses when only an EPIC is active', () => {
+    const d = decideGatekeeperAuthorization([item('e1', 'IN_PROGRESS', 'EPIC', 'Epic X')], tddFlow, {});
+    expect(d.authorized).toBe(false);
+    expect(d.message).toMatch(/WORKFLOW BREACH/);
+    expect(d.message).toContain('Epic X');
+  });
+
+  it('carries the step contract onto an authorized STORY, not a refused EPIC', () => {
+    const ok = decideGatekeeperAuthorization([item('s1', 'DISCOVERY', 'STORY')], criteriaFlow, { itemId: 's1' });
+    expect(ok.authorized).toBe(true);
+    expect(ok.exitCriteria).toBe('Cards created and the user gave the go-ahead.');
+    const no = decideGatekeeperAuthorization([item('e1', 'DISCOVERY', 'EPIC')], criteriaFlow, { itemId: 'e1' });
+    expect(no.authorized).toBe(false);
+    expect(no.exitCriteria).toBeUndefined();
   });
 });
 
@@ -376,5 +441,189 @@ describe('the shipped default flow states its exit criteria (CGLAB-82)', () => {
     const { DEFAULT_FLOW } = await import('../defaultFlow');
     const anchors = DEFAULT_FLOW.steps.filter((s: any) => s.isAnchor);
     for (const a of anchors) expect((a as any).exitCriteria ?? '').toBe('');
+  });
+});
+
+// ── Mutation hardening (CGLAB-110 MUTATION_TESTS step) ──────────────────────
+// StrykerJS over packages/core/src/gatekeeper.ts reported 44 surviving mutants
+// against the original suite. These tests pin the behaviours those mutants
+// slipped through: the inactive-status set and its null-flow anchor fallback,
+// the cross-project match's projectId requirement, order-field sorting, the
+// whitespace-only criteria trim, and the exact refusal/fallback message copy.
+describe('mutation hardening for the gatekeeper (CGLAB-110)', () => {
+  it('excludes every INACTIVE_STATUSES entry, each name individually', () => {
+    for (const status of ['BLOCKED', 'PAUSED', 'TRASHED', 'ARCHIVED', 'IDEAS']) {
+      expect(INACTIVE_STATUSES).toContain(status);
+      const d = decideGatekeeperAuthorization([item('a', status)], tddFlow, {});
+      expect(d.authorized, `${status} must never be an active working step`).toBe(false);
+    }
+  });
+
+  it('falls back to TODO/DONE anchors when the flow is null', () => {
+    const items = [item('a', 'TODO'), item('b', 'DONE'), item('c', 'IN_PROGRESS')];
+    const active = getActiveStepItems(items, null);
+    expect(active.map(i => i.id)).toEqual(['c']);
+  });
+
+  it('never treats a cross-project match lacking a projectId as the match', () => {
+    const all = [
+      { id: 'ffff0000-1111', title: 'no-project match' } as any, // projectId undefined
+    ];
+    expect(detectCrossProjectItem(all, 'ffff0000', 'projC')).toBeNull();
+  });
+
+  it('prefers an in-project PREFIX-only match over an out-of-project exact match', () => {
+    // Kills the inner ||→&& mutant: the original accepts the in-project item on
+    // the id-prefix alone, so it must short-circuit the cross-project return.
+    const all = [
+      { id: 'abcdef12-other', projectId: 'projX', title: 'other' },
+      { id: 'abcdef12-mine', projectId: 'projY', title: 'mine' },
+    ];
+    expect(detectCrossProjectItem(all, 'abcdef12', 'projY')).toBeNull();
+  });
+
+  it('resolves coding/final steps by the order field, not array position', () => {
+    const shuffled: GatekeeperFlow = {
+      name: 'Shuffled',
+      steps: [
+        { name: 'IN_PROGRESS', order: 2 },
+        { name: 'DONE', order: 3, isAnchor: true },
+        { name: 'DISCOVERY', order: 1 },
+        { name: 'TODO', order: 0, isAnchor: true },
+      ],
+    } as GatekeeperFlow;
+    const d = decideGatekeeperAuthorization([item('a', 'IN_PROGRESS')], shuffled, {});
+    expect(d.codingStep).toBe('DISCOVERY');
+    expect(d.finalStep).toBe('IN_PROGRESS');
+  });
+
+  it('survives a flow whose every step is an anchor (no coding step, no throw)', () => {
+    const anchorsOnly: GatekeeperFlow = {
+      name: 'Anchors',
+      steps: [
+        { name: 'TODO', order: 0, isAnchor: true },
+        { name: 'DONE', order: 1, isAnchor: true },
+      ],
+    } as GatekeeperFlow;
+    const d = decideGatekeeperAuthorization([item('a', 'IN_PROGRESS')], anchorsOnly, {});
+    expect(d.authorized).toBe(true);
+    expect(d.codingStep).toBeUndefined();
+    // Degenerate flow with no working steps: only DONE is filtered out of the
+    // "non-terminal" set, so the leftover anchor (TODO) is what finalStep pins.
+    expect(d.finalStep).toBe('TODO');
+  });
+
+  it('treats whitespace-only exit criteria as none-defined', () => {
+    const wsFlow: GatekeeperFlow = {
+      steps: [
+        { name: 'TODO', order: 0, isAnchor: true },
+        { name: 'IN_PROGRESS', order: 1, exitCriteria: '   ' },
+        { name: 'DONE', order: 2, isAnchor: true },
+      ],
+    } as GatekeeperFlow;
+    const d = decideGatekeeperAuthorization([item('a', 'IN_PROGRESS')], wsFlow, {});
+    expect(d.criteriaState).toBe('none-defined');
+    expect(d.exitCriteria).toBeUndefined();
+  });
+
+  it('says "Could not resolve this project\'s flow" when the flow is unresolved', () => {
+    const d = decideGatekeeperAuthorization([item('a', 'IN_PROGRESS')], null as any, {});
+    expect(d.message).toContain("Could not resolve this project's flow");
+  });
+
+  it('joins the active flow steps with the arrow separator', () => {
+    const d = decideGatekeeperAuthorization([item('a', 'IN_PROGRESS')], anchoredFlow, {});
+    expect(d.message).toContain('TODO → DISCOVERY → IN_PROGRESS → DONE');
+    expect(d.message).toContain('Final step (omit the command on this one): IN_PROGRESS');
+  });
+
+  it('renders a nameless flow without a quoted name', () => {
+    const d = decideGatekeeperAuthorization([item('a', 'IN_PROGRESS')], anchoredFlow, {});
+    expect(d.message).toContain('Active flow "TDD Flow"');
+    const anonymous = { steps: anchoredFlow.steps } as GatekeeperFlow;
+    const d2 = decideGatekeeperAuthorization([item('a', 'IN_PROGRESS')], anonymous, {});
+    expect(d2.message).toContain('Active flow: TODO → DISCOVERY → IN_PROGRESS → DONE');
+    expect(d2.message).not.toContain('Active flow ""');
+  });
+
+  it('echoes the no-intent fallback and the default role in the message', () => {
+    const d = decideGatekeeperAuthorization([item('a', 'IN_PROGRESS')], tddFlow, {});
+    expect(d.message).toContain('Intent: "(no intent provided)"');
+    expect(d.message).toContain('AUTHORIZED (CODING)');
+  });
+
+  it('pins the generic no-actionable refusal copy', () => {
+    const d = decideGatekeeperAuthorization([item('a', 'TODO')], tddFlow, {});
+    expect(d.message).toContain('No STORY, TASK or BUG is in an active working step');
+    expect(d.message).toContain('Create or advance a STORY, TASK or BUG to an active step first');
+  });
+
+  it('pins the EPIC refusal copy when a STORY is also actionable', () => {
+    // The by-id refusal branch only runs when SOME actionable item exists —
+    // with an EPIC as the sole active item the no-actionable refusal fires first.
+    const items = [item('s1', 'IN_PROGRESS', 'STORY'), item('e1', 'IN_PROGRESS', 'EPIC', 'Epic X')];
+    const d = decideGatekeeperAuthorization(items, tddFlow, { itemId: 'e1' });
+    expect(d.authorized).toBe(false);
+    expect(d.message).toContain('Cannot authorize work directly on an EPIC [e1] "Epic X"');
+    expect(d.message).toContain('An EPIC is never worked directly — create or advance a STORY, TASK or BUG within it');
+  });
+
+  it('pins the EPIC-stuck hint copy', () => {
+    const d = decideGatekeeperAuthorization([item('e1', 'IN_PROGRESS', 'EPIC', 'My Epic')], tddFlow, {});
+    expect(d.message).toContain('"My Epic" (EPIC) is at step IN_PROGRESS, but an EPIC is never worked directly');
+  });
+
+  it('embeds the 8-char id prefix, not the full id, in the EPIC refusal', () => {
+    const longId = 'a1b2c3d4-ef56-abcd-ef01-23456789abcd';
+    const items = [item('s1', 'IN_PROGRESS', 'STORY'), { ...item(longId, 'IN_PROGRESS', 'EPIC', 'Long Epic') }];
+    const d = decideGatekeeperAuthorization(items, tddFlow, { itemId: 'a1b2c3d4-ef56' });
+    expect(d.authorized).toBe(false);
+    expect(d.message).toContain('EPIC [a1b2c3d4] "Long Epic"');
+  });
+
+  it('pins the ambiguity listing line format', () => {
+    const items = [item('aaaaaaaa-1', 'IN_PROGRESS'), item('bbbbbbbb-2', 'CREATE_UNIT_TESTS', 'STORY', 'Story S')];
+    const d = decideGatekeeperAuthorization(items, tddFlow, {});
+    expect(d.message).toContain('Multiple items are in an active step. Provide --item-id to disambiguate');
+    expect(d.message).toContain('• [aaaaaaaa] t-aaaaaaaa-1 (IN_PROGRESS)');
+    expect(d.message).toContain('• [bbbbbbbb] Story S (CREATE_UNIT_TESTS)');
+    // The listing is newline-separated — pin the separator itself.
+    expect(d.message).toContain('(IN_PROGRESS)\n  • [bbbbbbbb] Story S');
+  });
+
+  it('pins the exact coding-step and final-step lines, and omits the coding line when there is none', () => {
+    const d = decideGatekeeperAuthorization([item('a', 'IN_PROGRESS')], anchoredFlow, {});
+    expect(d.message).toContain('Coding step: DISCOVERY\nFinal step (omit the command on this one): IN_PROGRESS');
+    const anchorsOnly: GatekeeperFlow = {
+      steps: [
+        { name: 'TODO', order: 0, isAnchor: true },
+        { name: 'DONE', order: 1, isAnchor: true },
+      ],
+    } as GatekeeperFlow;
+    const d2 = decideGatekeeperAuthorization([item('a', 'IN_PROGRESS')], anchorsOnly, {});
+    expect(d2.message).not.toContain('Coding step:');
+    // Exact adjacency: with no coding step, the final-step line follows the
+    // flow line directly — nothing may be injected in between.
+    expect(d2.message).toContain('Active flow: TODO → DONE\nFinal step (omit the command on this one): TODO');
+  });
+
+  it('leaks no step-shape copy when the flow could not be resolved', () => {
+    const d = decideGatekeeperAuthorization([item('a', 'IN_PROGRESS')], null as any, {});
+    expect(d.message).not.toContain('Active flow');
+    expect(d.message).not.toContain('Coding step');
+    // With no flow there is no step-shape block at all: the message must end
+    // exactly where the advice ends — nothing appended after it.
+    expect(d.message).toMatch(/before advancing\.$/);
+  });
+
+  it('embeds the item id prefix in the advance hint', () => {
+    const d = decideGatekeeperAuthorization([item('a1b2c3d4-9999', 'IN_PROGRESS')], tddFlow, {});
+    expect(d.message).toContain('agenfk verify a1b2c3d4 --evidence');
+  });
+
+  it('embeds the step status and title in the authorized message', () => {
+    const d = decideGatekeeperAuthorization([item('a1b2c3d4-9999', 'IN_PROGRESS', 'STORY', 'My Story')], tddFlow, {});
+    expect(d.message).toContain('STORY: [a1b2c3d4] My Story');
+    expect(d.message).toContain('Current step: IN_PROGRESS');
   });
 });

--- a/packages/flow-editor/package.json
+++ b/packages/flow-editor/package.json
@@ -13,6 +13,8 @@
     "lucide-react": "^0.574.0",
     "mermaid": "^11.16.1",
     "react": "^19.2.8",
-    "react-dom": "^19.2.8"
+    "react-dom": "^19.2.8",
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1"
   }
 }

--- a/packages/flow-editor/src/ExitCriteriaEditorModal.tsx
+++ b/packages/flow-editor/src/ExitCriteriaEditorModal.tsx
@@ -1,0 +1,158 @@
+/**
+ * Exit criteria editor — the "popped up view" for a flow step's exit criteria
+ * (CGLAB-109).
+ *
+ * Exit criteria were designed to show short text (a plain inline textarea in
+ * the step column) but grew into long markdown. This popup gives the full
+ * surface: a markdown source editor, a rendered preview beside it, and a
+ * token count estimate under the editor so the author sees the context cost
+ * before saving. It is a nested modal (z-index above FlowEditorModal's z-50)
+ * with local edit state: Save commits via onSave, Cancel/Escape/overlay-click
+ * discard.
+ *
+ * Markdown rendering uses react-markdown + remark-gfm (peer deps) with the
+ * same `prose` styling the host apps already use for rendered markdown (the
+ * host's Tailwind build must include the typography plugin — ui and hub-ui
+ * both do).
+ */
+import React, { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { X, ScrollText } from 'lucide-react';
+import { estimateTokenCount } from './estimateTokens';
+
+export interface ExitCriteriaEditorModalProps {
+  /** Step label (display name) shown in the header. */
+  stepLabel: string;
+  /** Current criteria (markdown source) — seeds the editor. */
+  initialValue: string;
+  /** Committed on Save with the editor's final value. */
+  onSave: (value: string) => void;
+  /** Called on Cancel / Escape / overlay click. */
+  onClose: () => void;
+}
+
+export const ExitCriteriaEditorModal: React.FC<ExitCriteriaEditorModalProps> = ({
+  stepLabel,
+  initialValue,
+  onSave,
+  onClose,
+}) => {
+  const [value, setValue] = useState(initialValue);
+
+  // Escape closes without saving — and ONLY this popup. The parent flow
+  // editor has its own bubble-phase window Escape listener (which hard-
+  // unmounts it in the hosts, discarding every unsaved step edit), so this
+  // one registers in the CAPTURE phase and stops propagation: capture on
+  // window runs before the parent's bubble listener, and stopPropagation
+  // here means the parent's handler never sees the keypress. (A bubble-phase
+  // stopPropagation would not work — both listeners sit on window.)
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', onKey, true);
+    return () => window.removeEventListener('keydown', onKey, true);
+  }, [onClose]);
+
+  const tokens = estimateTokenCount(value);
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50 backdrop-blur-sm p-4"
+      data-testid="exit-criteria-editor-modal"
+      onClick={e => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="bg-white dark:bg-slate-900 rounded-2xl shadow-2xl w-[calc(100vw-2rem)] max-w-4xl h-[85vh] flex flex-col overflow-hidden">
+        {/* Header */}
+        <div className="px-5 py-3.5 border-b border-slate-200 dark:border-slate-700 flex items-center gap-2.5 shrink-0">
+          <ScrollText size={16} className="text-accent-text shrink-0" />
+          <div className="min-w-0">
+            <h3 className="text-sm font-bold text-slate-800 dark:text-slate-100 truncate">
+              Exit Criteria
+            </h3>
+            <p className="text-xs text-slate-400 dark:text-slate-500 truncate">{stepLabel}</p>
+          </div>
+          <button
+            data-testid="exit-criteria-close"
+            onClick={onClose}
+            aria-label="Close"
+            className="ml-auto p-1 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-800 text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 transition-colors"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        {/* Body: editor | preview */}
+        <div className="flex-1 min-h-0 grid grid-cols-2">
+          {/* Editor column */}
+          <div className="flex flex-col min-h-0 border-r border-slate-200 dark:border-slate-700">
+            <label className="text-xs font-semibold uppercase tracking-wide text-slate-400 dark:text-slate-500 px-4 pt-3 shrink-0">
+              Markdown
+            </label>
+            <textarea
+              data-testid="exit-criteria-editor"
+              value={value}
+              onChange={e => setValue(e.target.value)}
+              rows={14}
+              placeholder={'What must be true before leaving this step?\n\nMarkdown is supported:\n- lists, **bold**, `code`, [links](…)'}
+              className="flex-1 min-h-0 mx-4 my-2 px-3 py-2 rounded-lg border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-800 text-slate-800 dark:text-slate-100 text-sm font-mono focus:outline-none focus:ring-1 focus:ring-brand resize-none leading-relaxed"
+            />
+            {/* Token estimate — under the editor, as specified */}
+            <div
+              data-testid="exit-criteria-token-count"
+              className="px-4 pb-3 shrink-0 text-xs text-slate-400 dark:text-slate-500 tabular-nums"
+            >
+              ~{tokens} {tokens === 1 ? 'token' : 'tokens'} (estimate)
+            </div>
+          </div>
+          {/* Preview column */}
+          <div className="flex flex-col min-h-0">
+            <span className="text-xs font-semibold uppercase tracking-wide text-slate-400 dark:text-slate-500 px-4 pt-3 shrink-0">
+              Preview
+            </span>
+            <div
+              data-testid="exit-criteria-preview"
+              className="flex-1 min-h-0 overflow-y-auto px-4 py-3 prose prose-slate dark:prose-invert prose-sm max-w-none"
+            >
+              {value.trim() ? (
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>{value}</ReactMarkdown>
+              ) : (
+                <span className="not-prose text-sm italic text-slate-400 dark:text-slate-600">
+                  Nothing to preview yet.
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="px-5 py-3.5 border-t border-slate-200 dark:border-slate-700 flex items-center justify-end gap-2 shrink-0">
+          <button
+            data-testid="exit-criteria-cancel"
+            type="button"
+            onClick={onClose}
+            className="px-3.5 py-1.5 rounded-lg text-sm font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            data-testid="exit-criteria-save"
+            type="button"
+            onClick={() => onSave(value)}
+            className="px-3.5 py-1.5 rounded-lg text-sm font-semibold text-white bg-brand hover:opacity-90 transition-opacity"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+};

--- a/packages/flow-editor/src/FlowEditorModal.tsx
+++ b/packages/flow-editor/src/FlowEditorModal.tsx
@@ -4,6 +4,8 @@ import mermaid from 'mermaid';
 import type { Flow, FlowStep, RegistryFlow, FlowClient, RegistryClient } from './types';
 import { extractApiError } from './apiError';
 import { flowDefinitionIssues, stepIssue, withStepIds } from './flowDefinition';
+import { ExitCriteriaEditorModal } from './ExitCriteriaEditorModal';
+import { estimateTokenCount } from './estimateTokens';
 
 // ── Host injection ─────────────────────────────────────────────────────────
 // The editor accepts its data layer (server REST + community registry) and
@@ -137,6 +139,45 @@ function makeBlankStep(order: number): FlowStep {
   };
 }
 
+// ── Exit criteria summary trigger (CGLAB-109) ─────────────────────────────────
+// The inline field that used to be a short-text textarea is now a compact,
+// read-only summary: first line of the criteria (or an empty state) plus the
+// token estimate. Clicking it opens the full popup editor
+// (ExitCriteriaEditorModal) — the only place criteria are edited.
+interface ExitCriteriaSummaryProps {
+  index: number;
+  value: string;
+  disabled: boolean;
+  onEdit: () => void;
+}
+
+const ExitCriteriaSummary: React.FC<ExitCriteriaSummaryProps> = ({ index, value, disabled, onEdit }) => {
+  const trimmed = value.trim();
+  const firstLine = trimmed.split('\n').find(l => l.trim()) ?? '';
+  const tokens = estimateTokenCount(trimmed);
+  return (
+    <button
+      data-testid={`step-exit-criteria-${index}`}
+      type="button"
+      disabled={disabled}
+      onClick={onEdit}
+      title={disabled ? undefined : 'Edit exit criteria (markdown)'}
+      className="w-full text-left px-2 py-1.5 rounded-md border border-slate-200 dark:border-slate-600 bg-slate-50 dark:bg-slate-700/50 hover:border-slate-300 dark:hover:border-slate-500 transition-colors disabled:opacity-60 disabled:cursor-not-allowed min-h-[52px]"
+    >
+      {firstLine ? (
+        <span className="block text-xs text-slate-600 dark:text-slate-300 truncate">{firstLine}</span>
+      ) : (
+        <span className="block text-xs italic text-slate-400 dark:text-slate-500">
+          No exit criteria — click to add
+        </span>
+      )}
+      <span className="block text-[10px] tabular-nums text-slate-400 dark:text-slate-500 mt-0.5">
+        ~{tokens} {tokens === 1 ? 'token' : 'tokens'} (estimate){disabled ? '' : ' · edit'}
+      </span>
+    </button>
+  );
+};
+
 // ── Inner editor component (right panel) ──────────────────────────────────────
 
 interface EditorPanelProps {
@@ -178,6 +219,8 @@ const EditorPanel: React.FC<EditorPanelProps> = ({
   const [steps, setSteps] = useState<FlowStep[]>([]);
   const [saved, setSaved] = useState(false);
   const [openIconPickerIndex, setOpenIconPickerIndex] = useState<number | null>(null);
+  // CGLAB-109: which step's exit criteria are open in the popup editor.
+  const [exitCriteriaEditIndex, setExitCriteriaEditIndex] = useState<number | null>(null);
 
   useEffect(() => {
     if (flow) {
@@ -621,14 +664,11 @@ const EditorPanel: React.FC<EditorPanelProps> = ({
                         <label className="block text-xs text-slate-400 dark:text-slate-500 mb-0.5">
                           Exit Criteria
                         </label>
-                        <textarea
-                          data-testid={`step-exit-criteria-${index}`}
+                        <ExitCriteriaSummary
+                          index={index}
                           value={step.exitCriteria ?? ''}
-                          onChange={e => updateStep(index, { exitCriteria: e.target.value })}
-                          rows={5}
-                          placeholder="What must be true before leaving this step?"
                           disabled={isReadOnly}
-                          className="w-full px-2 py-1 rounded-md border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-800 dark:text-slate-100 text-xs focus:outline-none focus:ring-1 focus:ring-brand resize-none disabled:opacity-60 min-h-[80px]"
+                          onEdit={() => setExitCriteriaEditIndex(index)}
                         />
                       </div>
                     )}
@@ -679,19 +719,17 @@ const EditorPanel: React.FC<EditorPanelProps> = ({
                             className="w-full px-2 py-1 rounded-md border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-800 dark:text-slate-100 text-xs focus:outline-none focus:ring-1 focus:ring-brand disabled:opacity-60"
                           />
                         </div>
-                        {/* Exit criteria */}
+                        {/* Exit criteria (CGLAB-109): compact summary — the
+                            popup is the full markdown editor. */}
                         <div>
                           <label className="block text-xs text-slate-400 dark:text-slate-500 mb-0.5">
                             Exit Criteria
                           </label>
-                          <textarea
-                            data-testid={`step-exit-criteria-${index}`}
+                          <ExitCriteriaSummary
+                            index={index}
                             value={step.exitCriteria ?? ''}
-                            onChange={e => updateStep(index, { exitCriteria: e.target.value })}
-                            rows={5}
-                            placeholder="What must be true before leaving this step?"
                             disabled={isStepLocked}
-                            className="w-full px-2 py-1 rounded-md border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-800 dark:text-slate-100 text-xs focus:outline-none focus:ring-1 focus:ring-brand resize-none disabled:opacity-60 min-h-[80px]"
+                            onEdit={() => setExitCriteriaEditIndex(index)}
                           />
                         </div>
                       </>
@@ -824,6 +862,23 @@ const EditorPanel: React.FC<EditorPanelProps> = ({
 
           {publishFeedback}
         </div>
+      )}
+
+      {/* Exit criteria popup (CGLAB-109) — nested above this modal's z-50. */}
+      {exitCriteriaEditIndex !== null && steps[exitCriteriaEditIndex] && (
+        <ExitCriteriaEditorModal
+          stepLabel={steps[exitCriteriaEditIndex].label || steps[exitCriteriaEditIndex].name}
+          initialValue={steps[exitCriteriaEditIndex].exitCriteria ?? ''}
+          onSave={v => {
+            // The popup's Save commits a step field — mark the panel dirty so
+            // the footer's "Saved" badge doesn't claim a clean state (F2,
+            // CGLAB-109 review: the popup button is literally labelled Save).
+            updateStep(exitCriteriaEditIndex, { exitCriteria: v });
+            setSaved(false);
+            setExitCriteriaEditIndex(null);
+          }}
+          onClose={() => setExitCriteriaEditIndex(null)}
+        />
       )}
     </div>
   );

--- a/packages/flow-editor/src/estimateTokens.ts
+++ b/packages/flow-editor/src/estimateTokens.ts
@@ -1,0 +1,15 @@
+/**
+ * Client-side token count estimate for exit-criteria markdown (CGLAB-109).
+ *
+ * Shown under the popup editor so an author can see the context cost of their
+ * criteria before saving. The estimate is a heuristic — chars/4 on the
+ * trimmed text, the standard GPT-family approximation — not an encoder
+ * count: criteria are short text and the purpose is a budget signal, not a
+ * billing figure. Pure function, no dependencies. Empty/whitespace input
+ * yields 0 naturally (ceil(0/4)); there is no special-casing branch because
+ * the expression already covers it (mutation-testing confirmed the branch
+ * was an equivalent-mutant trap).
+ */
+export function estimateTokenCount(text: string): number {
+  return Math.ceil(text.trim().length / 4);
+}

--- a/packages/flow-editor/src/index.ts
+++ b/packages/flow-editor/src/index.ts
@@ -1,3 +1,5 @@
 export { FlowEditorModal, type FlowEditorModalPublicProps } from './FlowEditorModal';
+export { ExitCriteriaEditorModal, type ExitCriteriaEditorModalProps } from './ExitCriteriaEditorModal';
+export { estimateTokenCount } from './estimateTokens';
 export { renderStepIcon } from './FlowEditorModal';
 export type { Flow, FlowStep, RegistryFlow, FlowClient, RegistryClient } from './types';

--- a/packages/flow-editor/src/test/estimateTokens.test.ts
+++ b/packages/flow-editor/src/test/estimateTokens.test.ts
@@ -1,0 +1,63 @@
+/**
+ * CGLAB-109: token count estimate for the exit-criteria markdown editor.
+ *
+ * The estimate is a client-side heuristic (chars/4 — the standard
+ * GPT-family approximation), shown under the editor so authors can see the
+ * context cost of their criteria before saving. It is a pure function, so it
+ * is pinned exhaustively and is the prime mutation-testing target for this
+ * story's MUTATION_TESTS step.
+ */
+import { describe, it, expect } from 'vitest';
+import { estimateTokenCount } from '../estimateTokens';
+
+describe('estimateTokenCount', () => {
+  it('returns 0 for empty input', () => {
+    expect(estimateTokenCount('')).toBe(0);
+  });
+
+  it('returns 0 for whitespace-only input', () => {
+    expect(estimateTokenCount('   \n\t  ')).toBe(0);
+  });
+
+  it('estimates 4 characters as one token', () => {
+    expect(estimateTokenCount('abcd')).toBe(1);
+    expect(estimateTokenCount('a')).toBe(1);
+    expect(estimateTokenCount('ab')).toBe(1);
+    expect(estimateTokenCount('abc')).toBe(1);
+  });
+
+  it('scales linearly: 400 chars is 100 tokens, 404 is 101', () => {
+    expect(estimateTokenCount('a'.repeat(400))).toBe(100);
+    expect(estimateTokenCount('a'.repeat(401))).toBe(101);
+    expect(estimateTokenCount('a'.repeat(404))).toBe(101);
+    expect(estimateTokenCount('a'.repeat(405))).toBe(102);
+  });
+
+  it('ignores surrounding whitespace in the count', () => {
+    expect(estimateTokenCount('  hello world  ')).toBe(estimateTokenCount('hello world'));
+    expect(estimateTokenCount('  hello world  ')).toBe(3); // 11 chars -> ceil(11/4)
+  });
+
+  it('counts markdown syntax as characters (it costs context too)', () => {
+    const plain = 'all tests passing';
+    const md = '**all tests passing**';
+    expect(estimateTokenCount(md)).toBeGreaterThan(estimateTokenCount(plain));
+  });
+
+  it('always returns a non-negative integer', () => {
+    for (const s of ['', 'a', 'hello', 'a'.repeat(12345), 'émoji 🚀 test']) {
+      const n = estimateTokenCount(s);
+      expect(Number.isInteger(n)).toBe(true);
+      expect(n).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it('is monotonic in trimmed length', () => {
+    let max = 0;
+    for (let len = 0; len <= 200; len += 7) {
+      const n = estimateTokenCount('x'.repeat(len));
+      expect(n).toBeGreaterThanOrEqual(max);
+      max = n;
+    }
+  });
+});

--- a/packages/hub-ui/package.json
+++ b/packages/hub-ui/package.json
@@ -13,6 +13,7 @@
     "@fontsource-variable/jetbrains-mono": "^5.3.0",
     "@fontsource-variable/manrope": "^5.3.0",
     "@tailwindcss/postcss": "^4.3.3",
+    "@tailwindcss/typography": "^0.5.20",
     "@tanstack/react-query": "^5.101.4",
     "@vitejs/plugin-react": "^5.1.1",
     "axios": "^1.19.0",
@@ -21,7 +22,9 @@
     "mermaid": "^11.16.1",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
+    "react-markdown": "^10.1.0",
     "react-router-dom": "^7.18.2",
+    "remark-gfm": "^4.0.1",
     "tailwindcss": "^4.2.0",
     "vite": "^7.3.1"
   },

--- a/packages/hub-ui/src/index.css
+++ b/packages/hub-ui/src/index.css
@@ -8,6 +8,13 @@
  * packages/ui/src/index.css. Edit values only in packages/brand/tokens.css. */
 @import "../../brand/tokens.css";
 
+/* @import statements must precede all other statements (besides @charset or
+ * an empty @layer) per the CSS spec — @plugin/@source below silently broke
+ * every @import that followed them (PostCSS dropped fonts + design tokens
+ * from the compiled CSS without erroring at runtime). Keep all @import lines
+ * first. */
+@plugin "@tailwindcss/typography";
+
 /* Tailwind v4 only auto-scans the importing package's source by default.
  * The shared @agenfk/flow-editor workspace package contains JIT utilities
  * (w-[calc(100vw-2rem)], h-[90vh], w-64, flex-1, etc.) that need to land in

--- a/packages/hub-ui/src/test/darkVariantWiring.test.ts
+++ b/packages/hub-ui/src/test/darkVariantWiring.test.ts
@@ -21,6 +21,17 @@ const UI_INDEX_CSS = path.resolve(HUB_UI_SRC, '../../ui/src/index.css');
 const readCss = () => fs.readFileSync(INDEX_CSS, 'utf8');
 
 describe('hub-ui dark variant wiring', () => {
+  it('loads the Tailwind typography plugin for rendered markdown (CGLAB-109)', () => {
+    // The shared flow-editor popup renders markdown with `prose` utilities;
+    // without this plugin line the hub preview would fall back to browser-
+    // default styling while the ui app looks correct. Static-source
+    // assertion, same style as the @variant checks below.
+    const css = readCss();
+    expect(css, 'expected @plugin "@tailwindcss/typography" in hub-ui/src/index.css').toContain(
+      '@plugin "@tailwindcss/typography"'
+    );
+  });
+
   it('declares an @variant dark override so `dark:` follows the explicit class', () => {
     const css = readCss();
     const variantLine = css

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -765,14 +765,16 @@ async function callToolHandler(request: any): Promise<any> {
 
         // Find all items in any active working step (any non-anchor, non-BLOCKED/PAUSED step)
         const workingItems = getActiveStepItems(allItems, activeFlow);
-        const actionableItems = workingItems.filter((i: any) => i.type === 'TASK' || i.type === 'BUG');
+        // CGLAB-110: a STORY is directly actionable — mirrors the core
+        // decider; only an EPIC is never worked directly.
+        const actionableItems = workingItems.filter((i: any) => i.type === 'TASK' || i.type === 'BUG' || i.type === 'STORY');
 
         if (actionableItems.length === 0) {
-          const storyOrEpicInProgress = workingItems.find((i: any) => i.type === 'STORY' || i.type === 'EPIC');
-          const hint = storyOrEpicInProgress
-            ? `\n\n"${storyOrEpicInProgress.title}" (${storyOrEpicInProgress.type}) is at step ${storyOrEpicInProgress.status}, but work must be authorized on a TASK or BUG. Create or advance a TASK/BUG within that ${storyOrEpicInProgress.type} to an active step first.`
-            : ' Create or advance a TASK or BUG to an active step first.';
-          return { isError: true, content: [{ type: "text", text: `❌ WORKFLOW BREACH: No TASK or BUG is currently active in project [${effectiveProjectId}].${hint}${flowStepsSummary}` }] };
+          const epicInProgress = workingItems.find((i: any) => i.type === 'EPIC');
+          const hint = epicInProgress
+            ? `\n\n"${epicInProgress.title}" (${epicInProgress.type}) is at step ${epicInProgress.status}, but an EPIC is never worked directly. Create or advance a STORY, TASK or BUG within that EPIC to an active step first.`
+            : ' Create or advance a STORY, TASK or BUG to an active step first.';
+          return { isError: true, content: [{ type: "text", text: `❌ WORKFLOW BREACH: No STORY, TASK or BUG is currently active in project [${effectiveProjectId}].${hint}${flowStepsSummary}` }] };
         }
 
         // Resolve which task to authorize
@@ -782,13 +784,13 @@ async function callToolHandler(request: any): Promise<any> {
           // 8-char id shown in gatekeeper output) — matches the CLI/core decider.
           task = workingItems.find((i: any) => i.id === itemId || i.id.startsWith(itemId));
           if (!task) return { isError: true, content: [{ type: "text", text: `❌ WORKFLOW BREACH: Item [${itemId}] is not in an active working step or does not belong to project [${effectiveProjectId}].` }] };
-          if (task.type === 'EPIC' || task.type === 'STORY') {
-            return { isError: true, content: [{ type: "text", text: `❌ WORKFLOW BREACH: Cannot authorize work directly on a ${task.type} [${task.id.substring(0,8)}] "${task.title}". Create or advance a TASK or BUG within this ${task.type} to an active step first, then call workflow_gatekeeper with that TASK/BUG's itemId.` }] };
+          if (task.type === 'EPIC') {
+            return { isError: true, content: [{ type: "text", text: `❌ WORKFLOW BREACH: Cannot authorize work directly on an EPIC [${task.id.substring(0,8)}] "${task.title}". An EPIC is never worked directly — create or advance a STORY, TASK or BUG within it to an active step first, then call workflow_gatekeeper with that item's id.` }] };
           }
         } else {
           if (actionableItems.length > 1) {
             const list = actionableItems.map((i: any) => `  • [${i.id.substring(0,8)}] ${i.title} (${i.status})`).join('\n');
-            return { isError: true, content: [{ type: "text", text: `⚠️ AMBIGUOUS WORKFLOW: Multiple tasks are active in project [${effectiveProjectId}]. Provide 'itemId' to disambiguate:\n${list}` }] };
+            return { isError: true, content: [{ type: "text", text: `⚠️ AMBIGUOUS WORKFLOW: Multiple items are active in project [${effectiveProjectId}]. Provide 'itemId' to disambiguate:\n${list}` }] };
           }
           task = actionableItems[0];
         }

--- a/packages/server/src/test/mcp-gatekeeper.test.ts
+++ b/packages/server/src/test/mcp-gatekeeper.test.ts
@@ -1,0 +1,144 @@
+/**
+ * CGLAB-110 regression protection for the server-side workflow_gatekeeper
+ * MCP handler.
+ *
+ * That handler carries a HAND-WRITTEN MIRROR of the core
+ * decideGatekeeperAuthorization (packages/core/src/gatekeeper.ts) — and this
+ * mirror is exactly where the STORY deadlock lived: it drifted from the core
+ * and refused to authorize work directly on a STORY. The core is unit-tested
+ * exhaustively; nothing exercised the mirror. These tests round-trip the real
+ * MCP surface (in-memory client → live CallTool handler → self-REST via the
+ * proxied axios mock) and pin the CGLAB-110 behaviour on both sides of the
+ * type gate: a STORY in an active step authorizes, an EPIC still refuses.
+ */
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import request from 'supertest';
+import { app, initStorage } from '../server';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { connectMcpClient, type ConnectedMcpClient } from './helpers/mcpClient';
+
+// The MCP handler reaches the REST layer through an axios client
+// (createApiClient). Other MCP test files mock axios as a no-op because the
+// tools they exercise never self-REST. workflow_gatekeeper DOES — so this
+// file's mock proxies every axios call to the real in-memory express app and
+// answers in axios shape ({ data, status }). The dynamic imports run at call
+// time, by which point the module graph is fully loaded.
+vi.mock('axios', () => {
+  const proxy = (method: 'get' | 'post' | 'put' | 'patch') => async (url: string, config?: any) => {
+    const { default: supertest } = await import('supertest');
+    const { app: liveApp } = await import('../server');
+    const req = supertest(liveApp)[method](url);
+    if (method !== 'get' && config?.data !== undefined) req.send(config.data);
+    const r = await req;
+    return { data: r.body, status: r.status, headers: r.headers };
+  };
+  const mockAxios: any = {
+    get: proxy('get'),
+    post: proxy('post'),
+    put: proxy('put'),
+    patch: proxy('patch'),
+    interceptors: {
+      request: { use: vi.fn() },
+      response: { use: vi.fn() },
+    },
+    create: vi.fn(() => mockAxios),
+  };
+  return { default: mockAxios };
+});
+
+const TEST_DB = path.resolve('./mcp-gatekeeper-test-db.sqlite');
+// The no-item-id path resolves the project by walking up from process.cwd()
+// to the nearest .agenfk/project.json (findProjectId, re-read per call). Point
+// the cwd at a scratch dir whose project.json names the TEST project, so the
+// handler binds to the test DB instead of the repo's live project.
+const SCRATCH_CWD = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-gatekeeper-'));
+const ORIGINAL_CWD = process.cwd();
+
+const toolText = (result: any): string =>
+  String(Array.isArray(result.content) ? (result.content as any[]).map(c => c.text).join('\n') : '');
+
+describe('workflow_gatekeeper MCP handler: a STORY is directly actionable (CGLAB-110)', () => {
+  let mcp: ConnectedMcpClient;
+  let projectId: string;
+  let storyId: string;
+  let epicId: string;
+
+  beforeAll(async () => {
+    process.env.AGENFK_DB_PATH = TEST_DB;
+    if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+    await initStorage();
+    mcp = await connectMcpClient();
+
+    const proj = await request(app).post('/projects').send({ name: 'gatekeeper-mirror' });
+    projectId = proj.body.id;
+
+    const story = await request(app).post('/items').send({ type: 'STORY', title: 'mirror story', projectId });
+    storyId = story.body.id;
+    await request(app).put(`/items/${storyId}`).send({ status: 'IN_PROGRESS' });
+
+    const epic = await request(app).post('/items').send({ type: 'EPIC', title: 'mirror epic', projectId });
+    epicId = epic.body.id;
+    await request(app).put(`/items/${epicId}`).send({ status: 'IN_PROGRESS' });
+  });
+
+  afterAll(async () => {
+    await mcp.close();
+    process.chdir(ORIGINAL_CWD);
+    if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+    fs.rmSync(SCRATCH_CWD, { recursive: true, force: true });
+  });
+
+  it('authorizes a STORY in an active step when targeted by id', async () => {
+    const result = await mcp.client.callTool({
+      name: 'workflow_gatekeeper',
+      arguments: { intent: 'mirror parity check', itemId: storyId },
+    } as any);
+    const text = toolText(result);
+    expect(result.isError).not.toBe(true);
+    expect(text).toContain('AUTHORIZED');
+    expect(text).toContain('STORY');
+    expect(text).not.toContain('WORKFLOW BREACH');
+  });
+
+  it('still refuses an EPIC targeted by id, and names the child-item route', async () => {
+    const result = await mcp.client.callTool({
+      name: 'workflow_gatekeeper',
+      arguments: { intent: 'mirror parity check', itemId: epicId },
+    } as any);
+    const text = toolText(result);
+    expect(result.isError).toBe(true);
+    expect(text).toContain('Cannot authorize work directly on an EPIC');
+    expect(text).toContain('STORY, TASK or BUG');
+  });
+
+  it('lists the active STORY when no item id is given and no TASK/BUG exists', async () => {
+    // With a STORY + EPIC both active and no TASK/BUG, the lone actionable
+    // item is the STORY — the handler must pick it up, not report a breach.
+    // findProjectRoot prefers AGENFK_DB_PATH over the cwd walk, so the env var
+    // is unset for the duration of this call to make the handler bind to the
+    // scratch cwd (storage is already initialised; nothing re-reads it).
+    fs.mkdirSync(path.join(SCRATCH_CWD, '.agenfk'), { recursive: true });
+    fs.writeFileSync(path.join(SCRATCH_CWD, '.agenfk', 'project.json'), JSON.stringify({ projectId }));
+    const savedDbPath = process.env.AGENFK_DB_PATH;
+    const savedRoot = process.env.AGENFK_PROJECT_ROOT;
+    delete process.env.AGENFK_DB_PATH;
+    delete process.env.AGENFK_PROJECT_ROOT;
+    process.chdir(SCRATCH_CWD);
+    try {
+      const result = await mcp.client.callTool({
+        name: 'workflow_gatekeeper',
+        arguments: { intent: 'mirror parity check' },
+      } as any);
+      const text = toolText(result);
+      expect(result.isError).not.toBe(true);
+      expect(text).toContain('AUTHORIZED');
+      expect(text).toContain('mirror story');
+    } finally {
+      process.chdir(ORIGINAL_CWD);
+      if (savedDbPath !== undefined) process.env.AGENFK_DB_PATH = savedDbPath;
+      if (savedRoot !== undefined) process.env.AGENFK_PROJECT_ROOT = savedRoot;
+    }
+  });
+});

--- a/packages/ui/src/test/FlowEditorModal.test.tsx
+++ b/packages/ui/src/test/FlowEditorModal.test.tsx
@@ -343,7 +343,10 @@ describe('FlowEditorModal', () => {
     await waitFor(() => screen.getByTestId('step-name-1'));
     expect((screen.getByTestId('step-name-1') as HTMLInputElement).value).toBe('in_review');
     expect((screen.getByTestId('step-label-1') as HTMLInputElement).value).toBe('In Review');
-    expect((screen.getByTestId('step-exit-criteria-1') as HTMLTextAreaElement).value).toBe('Ticket refined');
+    // CGLAB-109: the inline field is now a summary trigger (button) showing the
+    // current criteria; the popup is the only editor. The value check moved to
+    // the popup block below.
+    expect(screen.getByTestId('step-exit-criteria-1').textContent).toContain('Ticket refined');
   });
 
   it('adds a blank step when Add Step is clicked', async () => {
@@ -601,7 +604,7 @@ describe('FlowEditorModal', () => {
     expect(container.className).toMatch(/scrollbar-none|scrollbar-hide|\[&::-webkit-scrollbar\]/);
   });
 
-  it('exit criteria textarea has enough rows for comfortable editing (>= 5)', async () => {
+  it('exit criteria popup editor is a full-height markdown surface (>= 14 rows)', async () => {
     render(
       <FlowEditorModal isOpen={true} onClose={() => {}} projectId={PROJECT_ID} />,
       { wrapper: wrapper(makeQueryClient()) }
@@ -609,8 +612,12 @@ describe('FlowEditorModal', () => {
     await waitFor(() => screen.getByTestId('flow-item-flow-1'));
     fireEvent.click(screen.getByTestId('flow-item-flow-1'));
     await waitFor(() => screen.getByTestId('step-exit-criteria-1'));
-    const textarea = screen.getByTestId('step-exit-criteria-1') as HTMLTextAreaElement;
-    expect(Number(textarea.rows)).toBeGreaterThanOrEqual(5);
+    // The inline field is a compact summary; the comfortable-editing surface is
+    // the popup's markdown editor (CGLAB-109 replaced the inline textarea).
+    fireEvent.click(screen.getByTestId('step-exit-criteria-1'));
+    await waitFor(() => screen.getByTestId('exit-criteria-editor'));
+    const textarea = screen.getByTestId('exit-criteria-editor') as HTMLTextAreaElement;
+    expect(Number(textarea.rows)).toBeGreaterThanOrEqual(14);
   });
 
   // ── Anchor color swatch ────────────────────────────────────────────────────
@@ -1527,5 +1534,176 @@ describe('FlowEditorModal — save failures surface the reason (BUG 269eeec8)', 
 
     await waitFor(() => expect((screen.getByTestId('save-flow-btn') as HTMLButtonElement).disabled).toBe(true));
     expect(api.updateFlow).not.toHaveBeenCalled();
+  });
+});
+
+// ── CGLAB-109: Exit Criteria popup editor (markdown + preview + tokens) ─────
+// The flow builder's exit criteria were a short inline textarea. The new
+// contract: the inline field is a compact summary + trigger; clicking it opens
+// a popped-up editor with a full markdown source field, a rendered preview,
+// and a token count estimate under the editor. Save commits; Cancel/Escape
+// discard. Both the middle steps and the TODO anchor column open the popup.
+describe('Exit criteria popup editor (CGLAB-109)', () => {
+  const HUB_FLOW: Flow = {
+    id: 'flow-hub',
+    name: 'Hub Flow',
+    description: 'owned by the hub',
+    source: 'hub',
+    steps: [
+      { id: 'h1', name: 'TODO', label: 'To Do', order: 0, exitCriteria: '', isAnchor: true },
+      { id: 'h2', name: 'in_progress', label: 'In Progress', order: 1, exitCriteria: 'hub criteria' },
+      { id: 'h3', name: 'DONE', label: 'Done', order: 2, exitCriteria: '', isAnchor: true },
+    ],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+
+  const openStep1Popup = async () => {
+    await waitFor(() => screen.getByTestId('flow-item-flow-1'));
+    fireEvent.click(screen.getByTestId('flow-item-flow-1'));
+    await waitFor(() => screen.getByTestId('step-exit-criteria-1'));
+    fireEvent.click(screen.getByTestId('step-exit-criteria-1'));
+    await waitFor(() => screen.getByTestId('exit-criteria-editor'));
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(api.listFlows).mockResolvedValue([SAMPLE_FLOW, HUB_FLOW]);
+    vi.mocked(api.getDefaultFlow).mockResolvedValue(DEFAULT_FLOW);
+    vi.mocked(api.getOrgAvailableFlows).mockResolvedValue({ flows: [], defaultFlowId: null, hubEnabled: false });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  const renderEditor = (onClose: () => void = () => {}) =>
+    render(
+      <FlowEditorModal isOpen={true} onClose={onClose} projectId={PROJECT_ID} />,
+      { wrapper: wrapper(makeQueryClient()) }
+    );
+
+  it('opens the popup from the summary field with the current criteria loaded', async () => {
+    renderEditor();
+    await openStep1Popup();
+    const editor = screen.getByTestId('exit-criteria-editor') as HTMLTextAreaElement;
+    expect(editor.value).toBe('Ticket refined');
+    // The preview shows the current criteria as rendered markdown.
+    expect(screen.getByTestId('exit-criteria-preview').textContent).toContain('Ticket refined');
+    // A token estimate is shown under the editor.
+    expect(screen.getByTestId('exit-criteria-token-count').textContent).toMatch(/tokens?/i);
+  });
+
+  it('renders markdown in the preview and updates the token count live', async () => {
+    renderEditor();
+    await openStep1Popup();
+    const before = screen.getByTestId('exit-criteria-token-count').textContent ?? '';
+    fireEvent.change(screen.getByTestId('exit-criteria-editor'), {
+      target: { value: 'All tests passing:\n\n- **fast** and *fresh*\n- [proof](https://example.com)' },
+    });
+    const preview = screen.getByTestId('exit-criteria-preview');
+    expect(preview.querySelector('strong')?.textContent).toBe('fast');
+    expect(preview.querySelector('em')?.textContent).toBe('fresh');
+    expect(preview.querySelector('a')?.getAttribute('href')).toBe('https://example.com');
+    const after = screen.getByTestId('exit-criteria-token-count').textContent ?? '';
+    expect(after).not.toBe(before);
+    expect(Number((after.match(/~?(\d+)/) ?? [])[1])).toBeGreaterThan(
+      Number((before.match(/~?(\d+)/) ?? [])[1])
+    );
+  });
+
+  it('Save commits the edited criteria and the summary reflects it', async () => {
+    renderEditor();
+    await openStep1Popup();
+    fireEvent.change(screen.getByTestId('exit-criteria-editor'), {
+      target: { value: 'All tests green\n\n- evidence attached' },
+    });
+    fireEvent.click(screen.getByTestId('exit-criteria-save'));
+    // Popup closes and the inline summary shows the new first line.
+    await waitFor(() => expect(screen.queryByTestId('exit-criteria-editor')).toBeNull());
+    expect(screen.getByTestId('step-exit-criteria-1').textContent).toContain('All tests green');
+    // Reopening shows the committed value — the popup edits local state until Save.
+    fireEvent.click(screen.getByTestId('step-exit-criteria-1'));
+    await waitFor(() => screen.getByTestId('exit-criteria-editor'));
+    expect((screen.getByTestId('exit-criteria-editor') as HTMLTextAreaElement).value).toBe(
+      'All tests green\n\n- evidence attached'
+    );
+  });
+
+  it('Cancel discards the edit — the summary keeps the original criteria', async () => {
+    renderEditor();
+    await openStep1Popup();
+    fireEvent.change(screen.getByTestId('exit-criteria-editor'), {
+      target: { value: 'should not stick around' },
+    });
+    fireEvent.click(screen.getByTestId('exit-criteria-cancel'));
+    await waitFor(() => expect(screen.queryByTestId('exit-criteria-editor')).toBeNull());
+    expect(screen.getByTestId('step-exit-criteria-1').textContent).toContain('Ticket refined');
+    fireEvent.click(screen.getByTestId('step-exit-criteria-1'));
+    await waitFor(() => screen.getByTestId('exit-criteria-editor'));
+    expect((screen.getByTestId('exit-criteria-editor') as HTMLTextAreaElement).value).toBe('Ticket refined');
+  });
+
+  it('Escape closes the popup without saving — and does NOT close the flow editor', async () => {
+    const hostClose = vi.fn();
+    renderEditor(hostClose);
+    await openStep1Popup();
+    fireEvent.change(screen.getByTestId('exit-criteria-editor'), {
+      target: { value: 'escaped' },
+    });
+    fireEvent.keyDown(screen.getByTestId('exit-criteria-editor'), { key: 'Escape' });
+    await waitFor(() => expect(screen.queryByTestId('exit-criteria-editor')).toBeNull());
+    // CGLAB-109 review F1: the parent modal has its own window Escape
+    // listener; the popup must own the keypress (capture + stopPropagation)
+    // or Escape would unmount the whole flow editor and silently discard
+    // every unsaved step edit. The host onClose staying uncalled is the
+    // production contract (KanbanBoard/AdminFlows close on it).
+    expect(screen.getByTestId('flow-editor-modal')).toBeDefined();
+    expect(hostClose).not.toHaveBeenCalled();
+    expect(screen.getByTestId('step-exit-criteria-1').textContent).toContain('Ticket refined');
+  });
+
+  it('the preview never executes raw HTML (rendered markdown, not raw)', async () => {
+    // CGLAB-109 review F3: pins the sanitisation contract — no rehype-raw,
+    // so HTML in the source stays literal text. Keeps a future 'realism'
+    // change from silently enabling a (self-)XSS vector.
+    renderEditor();
+    await openStep1Popup();
+    fireEvent.change(screen.getByTestId('exit-criteria-editor'), {
+      target: { value: 'plain <img src=x onerror=alert(1)> and <script>evil()</script> text' },
+    });
+    const preview = screen.getByTestId('exit-criteria-preview');
+    expect(preview.querySelector('img')).toBeNull();
+    expect(preview.querySelector('script')).toBeNull();
+    expect(preview.textContent).toContain('<img');
+  });
+
+  it('the TODO anchor column opens the same popup and saves from it', async () => {
+    renderEditor();
+    await waitFor(() => screen.getByTestId('flow-item-flow-1'));
+    fireEvent.click(screen.getByTestId('flow-item-flow-1'));
+    await waitFor(() => screen.getByTestId('step-exit-criteria-0'));
+    // TODO anchor starts with no criteria — the trigger shows the empty state.
+    expect(screen.getByTestId('step-exit-criteria-0').textContent).toMatch(/no exit criteria/i);
+    fireEvent.click(screen.getByTestId('step-exit-criteria-0'));
+    await waitFor(() => screen.getByTestId('exit-criteria-editor'));
+    expect((screen.getByTestId('exit-criteria-editor') as HTMLTextAreaElement).value).toBe('');
+    fireEvent.change(screen.getByTestId('exit-criteria-editor'), {
+      target: { value: 'Cards created and the user gave the go-ahead.' },
+    });
+    fireEvent.click(screen.getByTestId('exit-criteria-save'));
+    await waitFor(() => expect(screen.queryByTestId('exit-criteria-editor')).toBeNull());
+    expect(screen.getByTestId('step-exit-criteria-0').textContent).toContain('Cards created');
+  });
+
+  it('a hub-owned (read-only) flow cannot open the editor', async () => {
+    renderEditor();
+    await waitFor(() => screen.getByTestId('flow-item-flow-hub'));
+    fireEvent.click(screen.getByTestId('flow-item-flow-hub'));
+    await waitFor(() => screen.getByTestId('step-exit-criteria-1'));
+    const trigger = screen.getByTestId('step-exit-criteria-1') as HTMLButtonElement;
+    expect(trigger.disabled).toBe(true);
+    fireEvent.click(trigger);
+    expect(screen.queryByTestId('exit-criteria-editor')).toBeNull();
   });
 });


### PR DESCRIPTION
Two items on one branch by developer decision (deviation logged in item comments):

**CGLAB-109 (STORY a1f428b9)** — Flow builder Exit Criteria becomes a popped-up view: nested modal with a full markdown source editor, a rendered GFM preview (react-markdown + remark-gfm, prose styling), and a token count estimate under the editor. Built once in the shared packages/flow-editor, so the agenfk UI and the hub admin both get it; hub-ui gains react-markdown/remark-gfm + @tailwindcss/typography (+ plugin line, asserted by test). The inline field becomes a compact summary + trigger; the popup is the only editor. Independent adversarial review: 1 HIGH (Escape in the popup unmounted the whole editor via the parent's own Escape listener) fixed and regression-pinned (test proven red against the old code); 3 LOW findings fixed; second independent pass: SHIP.

**CGLAB-110 (BUG 4c098eef)** — The workflow gatekeeper refused to authorize work directly on a STORY, contradicting the shipped Standard Mode protocol. Stories are now directly actionable; only EPICs refuse direct work. Mirrored in the core decider (CLI path) and the server MCP handler.

Tests: root 2295/2295, ui 100/100, hub-ui 7/7, estimateTokens 8/8, gatekeeper 90/90 (incl. new MCP round-trip test). StrykerJS mutation: gatekeeper module 204/220 killed (16 survivors triaged: 6 instrumentation artifacts proven killed in fresh-process runs, 10 documented equivalents); estimateTokens 3/3 killed. npm run build clean.