### PR TITLE
fix(cli): branch create --name verbatim — no forced feature/fix prefix (CGLAB-37)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ build/
 .DS_Store
 .env
 coverage/
+.reports/
 .opencode/
 *.tar.gz
 *.sqlite

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 node_modules/
 dist/
 build/
+/.stryker-tmp/
+/reports/
 .agenfk/
 *.log
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 node_modules/
 dist/
 build/
-/.stryker-tmp/
-/reports/
 .agenfk/
 *.log
 .DS_Store

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import figlet from 'figlet';
 import axios from 'axios';
-import { ItemType, Status, slugifyTitle, decideGatekeeperAuthorization, detectCrossProjectItem, findDuplicateProjectRoots, isUpgrade } from '@agenfk/core';
+import { ItemType, Status, buildBranchName, decideGatekeeperAuthorization, detectCrossProjectItem, findDuplicateProjectRoots, isUpgrade } from '@agenfk/core';
 import { TelemetryClient, getApiUrl, readServerPort, DEFAULT_API_PORT } from '@agenfk/telemetry';
 import { execSync, spawn, spawnSync } from 'child_process';
 import { randomUUID } from 'crypto';
@@ -3271,8 +3271,8 @@ const branchCmd = program
 
 branchCmd
   .command('create <itemId>')
-  .description('Create a git branch for an item (BUG → fix/, others → feature/). Stores branch name on the item.')
-  .option('--name <name>', 'Override the generated branch name (prefix is still enforced)')
+  .description('Create a git branch for an item (--name is used verbatim; generated as feature/<slug>, fix/<slug> for BUG when omitted). Stores branch name on the item.')
+  .option('--name <name>', 'Branch name to use verbatim (no prefix is added or stripped)')
   .action(async (itemId, options) => {
     try {
       const { data: item } = await axios.get(`${API_URL}/items/${itemId}`);
@@ -3280,9 +3280,14 @@ branchCmd
         console.error(chalk.red(`❌ Branches are tracked on top-level items only. Item [${itemId.substring(0, 8)}] is a child of [${item.parentId.substring(0, 8)}]. Run this command on the parent item instead.`));
         process.exit(1);
       }
-      const prefix = item.type === 'BUG' ? 'fix' : 'feature';
-      const slug = options.name ? options.name.replace(/^(feature|fix)\//, '') : slugifyTitle(item.title);
-      const branchName = `${prefix}/${slug}`;
+      const explicitName = options.name;
+      if (explicitName !== undefined && explicitName.trim() === '') {
+        console.error(chalk.red('❌ --name must not be empty or whitespace.'));
+        process.exit(1);
+      }
+      const branchName = explicitName !== undefined
+        ? explicitName
+        : buildBranchName(item.type, item.title);
 
       console.log(chalk.blue(`Creating branch: ${branchName}`));
       try {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,7 +4,7 @@ import figlet from 'figlet';
 import axios from 'axios';
 import { ItemType, Status, buildBranchName, decideGatekeeperAuthorization, detectCrossProjectItem, findDuplicateProjectRoots, isUpgrade } from '@agenfk/core';
 import { TelemetryClient, getApiUrl, readServerPort, DEFAULT_API_PORT } from '@agenfk/telemetry';
-import { execSync, spawn, spawnSync } from 'child_process';
+import { execSync, execFileSync, spawn, spawnSync } from 'child_process';
 import { randomUUID } from 'crypto';
 import fs from 'fs';
 import path from 'path';
@@ -3272,7 +3272,7 @@ const branchCmd = program
 branchCmd
   .command('create <itemId>')
   .description('Create a git branch for an item (--name is used verbatim; generated as feature/<slug>, fix/<slug> for BUG when omitted). Stores branch name on the item.')
-  .option('--name <name>', 'Branch name to use verbatim (no prefix is added or stripped)')
+  .option('--name <name>', 'Branch name to use verbatim (no prefix is added or stripped; surrounding whitespace is trimmed)')
   .action(async (itemId, options) => {
     try {
       const { data: item } = await axios.get(`${API_URL}/items/${itemId}`);
@@ -3280,8 +3280,9 @@ branchCmd
         console.error(chalk.red(`❌ Branches are tracked on top-level items only. Item [${itemId.substring(0, 8)}] is a child of [${item.parentId.substring(0, 8)}]. Run this command on the parent item instead.`));
         process.exit(1);
       }
-      const explicitName = options.name;
-      if (explicitName !== undefined && explicitName.trim() === '') {
+      const explicitName = options.name !== undefined ? options.name.trim() : undefined;
+      // trimmed above: '' here catches empty and whitespace-only; undefined falls through to generation
+      if (explicitName === '') {
         console.error(chalk.red('❌ --name must not be empty or whitespace.'));
         process.exit(1);
       }
@@ -3291,7 +3292,10 @@ branchCmd
 
       console.log(chalk.blue(`Creating branch: ${branchName}`));
       try {
-        execSync(`git checkout -b ${branchName}`, { stdio: 'inherit' });
+        // No shell: the name must reach git as exactly one argument (no word-splitting,
+        // no shell injection). Git validates the refname itself and rejects invalid names
+        // (leading dash, embedded space) with a clean error.
+        execFileSync('git', ['checkout', '-b', branchName], { stdio: 'inherit' });
       } catch {
         console.error(chalk.red(`Failed to create branch. Does it already exist? Try: git checkout ${branchName}`));
         process.exit(1);

--- a/packages/cli/src/test/branch-command.test.ts
+++ b/packages/cli/src/test/branch-command.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { program } from '../index';
+import axios from 'axios';
+import * as child_process from 'child_process';
+
+vi.mock('axios');
+vi.mock('child_process');
+const mockedAxios = vi.mocked(axios, true);
+const mockedChildProcess = vi.mocked(child_process, true);
+
+const ITEM_ID = '11111111-2222-3333-4444-555555555555';
+const PARENT_ID = '99999999-8888-7777-6666-555544443333';
+
+class ExitError extends Error {
+  code?: number;
+  constructor(code?: number) {
+    super(`process.exit(${code})`);
+    this.code = code;
+  }
+}
+
+function mockItem(partial: Record<string, unknown> = {}) {
+  mockedAxios.get.mockResolvedValue({
+    data: { id: ITEM_ID, type: 'STORY', title: 'Fix the thing', ...partial },
+  });
+  mockedAxios.put.mockResolvedValue({ data: { id: ITEM_ID } });
+}
+
+describe('branch create', () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset Commander options (recursively — nested subcommand options, like
+    // `branch create`'s --name, are not reset by a fresh parse)
+    const resetCommandOptions = (cmd: any) => {
+      (cmd.options || []).forEach((opt: any) => {
+        cmd.setOptionValue(opt.attributeName(), undefined);
+      });
+      (cmd.commands || []).forEach((sub: any) => resetCommandOptions(sub));
+    };
+    resetCommandOptions(program);
+    exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(((code?: number) => {
+        throw new ExitError(code);
+      }) as never);
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+  });
+
+  it('uses --name verbatim for non-BUG items — no auto feature/ prefix (the CGLAB-37 bug)', async () => {
+    mockItem({ type: 'STORY' });
+    await program.parseAsync([
+      'node', 'agenfk', 'branch', 'create', ITEM_ID,
+      '--name', 'feat/CGLAB-37_no-auto-branch-prefix',
+    ]);
+
+    expect(mockedChildProcess.execSync).toHaveBeenCalledWith(
+      'git checkout -b feat/CGLAB-37_no-auto-branch-prefix',
+      { stdio: 'inherit' },
+    );
+    expect(mockedAxios.put).toHaveBeenCalledWith(
+      expect.stringContaining(`/items/${ITEM_ID}`),
+      { branchName: 'feat/CGLAB-37_no-auto-branch-prefix' },
+    );
+  });
+
+  it('uses --name verbatim for BUG items even when it does not start with fix/', async () => {
+    mockItem({ type: 'BUG' });
+    await program.parseAsync([
+      'node', 'agenfk', 'branch', 'create', ITEM_ID,
+      '--name', 'hotfix/CGLAB-37_emergency',
+    ]);
+
+    expect(mockedChildProcess.execSync).toHaveBeenCalledWith(
+      'git checkout -b hotfix/CGLAB-37_emergency',
+      { stdio: 'inherit' },
+    );
+    expect(mockedAxios.put).toHaveBeenCalledWith(
+      expect.stringContaining(`/items/${ITEM_ID}`),
+      { branchName: 'hotfix/CGLAB-37_emergency' },
+    );
+  });
+
+  it('still honours an explicit feature/-prefixed --name (no double prefix, no stripping)', async () => {
+    mockItem({ type: 'STORY' });
+    await program.parseAsync([
+      'node', 'agenfk', 'branch', 'create', ITEM_ID,
+      '--name', 'feature/legacy-override',
+    ]);
+
+    expect(mockedChildProcess.execSync).toHaveBeenCalledWith(
+      'git checkout -b feature/legacy-override',
+      { stdio: 'inherit' },
+    );
+  });
+
+  it('does not re-prefix an explicit fix/ --name on a non-BUG item (discriminates from the old strip-then-re-prefix code)', async () => {
+    mockItem({ type: 'STORY' });
+    await program.parseAsync([
+      'node', 'agenfk', 'branch', 'create', ITEM_ID,
+      '--name', 'fix/CGLAB-37_strip-check',
+    ]);
+
+    expect(mockedChildProcess.execSync).toHaveBeenCalledWith(
+      'git checkout -b fix/CGLAB-37_strip-check',
+      { stdio: 'inherit' },
+    );
+    expect(mockedAxios.put).toHaveBeenCalledWith(
+      expect.stringContaining(`/items/${ITEM_ID}`),
+      { branchName: 'fix/CGLAB-37_strip-check' },
+    );
+  });
+
+  it('does not re-prefix an explicit feature/ --name on a BUG item (discriminates from the old strip-then-re-prefix code)', async () => {
+    mockItem({ type: 'BUG' });
+    await program.parseAsync([
+      'node', 'agenfk', 'branch', 'create', ITEM_ID,
+      '--name', 'feature/CGLAB-37_strip-check',
+    ]);
+
+    expect(mockedChildProcess.execSync).toHaveBeenCalledWith(
+      'git checkout -b feature/CGLAB-37_strip-check',
+      { stdio: 'inherit' },
+    );
+  });
+
+  it('rejects an empty --name with an explicit error instead of silently auto-generating', async () => {
+    mockItem({ type: 'STORY' });
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await expect(
+      program.parseAsync(['node', 'agenfk', 'branch', 'create', ITEM_ID, '--name', '']),
+    ).rejects.toThrow(ExitError);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('--name must not be empty or whitespace'));
+    expect(mockedChildProcess.execSync).not.toHaveBeenCalled();
+    expect(mockedAxios.put).not.toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  it('rejects a whitespace-only --name with an explicit error', async () => {
+    mockItem({ type: 'STORY' });
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await expect(
+      program.parseAsync(['node', 'agenfk', 'branch', 'create', ITEM_ID, '--name', '   ']),
+    ).rejects.toThrow(ExitError);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('--name must not be empty or whitespace'));
+    expect(mockedChildProcess.execSync).not.toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  it('auto-generates feature/<slug> from the title when --name is omitted (non-BUG)', async () => {
+    mockItem({ type: 'STORY', title: 'Fix the thing, now!' });
+    await program.parseAsync(['node', 'agenfk', 'branch', 'create', ITEM_ID]);
+
+    expect(mockedChildProcess.execSync).toHaveBeenCalledWith(
+      'git checkout -b feature/fix-the-thing-now',
+      { stdio: 'inherit' },
+    );
+    expect(mockedAxios.put).toHaveBeenCalledWith(
+      expect.stringContaining(`/items/${ITEM_ID}`),
+      { branchName: 'feature/fix-the-thing-now' },
+    );
+  });
+
+  it('auto-generates fix/<slug> from the title when --name is omitted (BUG)', async () => {
+    mockItem({ type: 'BUG', title: 'Fix the thing, now!' });
+    await program.parseAsync(['node', 'agenfk', 'branch', 'create', ITEM_ID]);
+
+    expect(mockedChildProcess.execSync).toHaveBeenCalledWith(
+      'git checkout -b fix/fix-the-thing-now',
+      { stdio: 'inherit' },
+    );
+  });
+
+  it('refuses child items and never creates a branch or links one', async () => {
+    mockItem({ parentId: PARENT_ID });
+    await expect(
+      program.parseAsync(['node', 'agenfk', 'branch', 'create', ITEM_ID]),
+    ).rejects.toThrow(ExitError);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(mockedChildProcess.execSync).not.toHaveBeenCalled();
+    expect(mockedAxios.put).not.toHaveBeenCalled();
+  });
+
+  it('does not link the branch when git checkout -b fails', async () => {
+    mockItem({ type: 'STORY' });
+    mockedChildProcess.execSync.mockImplementation(() => {
+      throw new Error('branch already exists');
+    });
+    await expect(
+      program.parseAsync(['node', 'agenfk', 'branch', 'create', ITEM_ID]),
+    ).rejects.toThrow(ExitError);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(mockedAxios.put).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/test/branch-command.test.ts
+++ b/packages/cli/src/test/branch-command.test.ts
@@ -26,6 +26,15 @@ function mockItem(partial: Record<string, unknown> = {}) {
   mockedAxios.put.mockResolvedValue({ data: { id: ITEM_ID } });
 }
 
+/** The action must reach git as exactly one argument, no shell. */
+function expectCheckout(branch: string) {
+  expect(mockedChildProcess.execFileSync).toHaveBeenCalledWith(
+    'git',
+    ['checkout', '-b', branch],
+    { stdio: 'inherit' },
+  );
+}
+
 describe('branch create', () => {
   let exitSpy: ReturnType<typeof vi.spyOn>;
 
@@ -58,10 +67,7 @@ describe('branch create', () => {
       '--name', 'feat/CGLAB-37_no-auto-branch-prefix',
     ]);
 
-    expect(mockedChildProcess.execSync).toHaveBeenCalledWith(
-      'git checkout -b feat/CGLAB-37_no-auto-branch-prefix',
-      { stdio: 'inherit' },
-    );
+    expectCheckout('feat/CGLAB-37_no-auto-branch-prefix');
     expect(mockedAxios.put).toHaveBeenCalledWith(
       expect.stringContaining(`/items/${ITEM_ID}`),
       { branchName: 'feat/CGLAB-37_no-auto-branch-prefix' },
@@ -75,10 +81,7 @@ describe('branch create', () => {
       '--name', 'hotfix/CGLAB-37_emergency',
     ]);
 
-    expect(mockedChildProcess.execSync).toHaveBeenCalledWith(
-      'git checkout -b hotfix/CGLAB-37_emergency',
-      { stdio: 'inherit' },
-    );
+    expectCheckout('hotfix/CGLAB-37_emergency');
     expect(mockedAxios.put).toHaveBeenCalledWith(
       expect.stringContaining(`/items/${ITEM_ID}`),
       { branchName: 'hotfix/CGLAB-37_emergency' },
@@ -92,10 +95,7 @@ describe('branch create', () => {
       '--name', 'feature/legacy-override',
     ]);
 
-    expect(mockedChildProcess.execSync).toHaveBeenCalledWith(
-      'git checkout -b feature/legacy-override',
-      { stdio: 'inherit' },
-    );
+    expectCheckout('feature/legacy-override');
   });
 
   it('does not re-prefix an explicit fix/ --name on a non-BUG item (discriminates from the old strip-then-re-prefix code)', async () => {
@@ -105,10 +105,7 @@ describe('branch create', () => {
       '--name', 'fix/CGLAB-37_strip-check',
     ]);
 
-    expect(mockedChildProcess.execSync).toHaveBeenCalledWith(
-      'git checkout -b fix/CGLAB-37_strip-check',
-      { stdio: 'inherit' },
-    );
+    expectCheckout('fix/CGLAB-37_strip-check');
     expect(mockedAxios.put).toHaveBeenCalledWith(
       expect.stringContaining(`/items/${ITEM_ID}`),
       { branchName: 'fix/CGLAB-37_strip-check' },
@@ -122,10 +119,39 @@ describe('branch create', () => {
       '--name', 'feature/CGLAB-37_strip-check',
     ]);
 
-    expect(mockedChildProcess.execSync).toHaveBeenCalledWith(
-      'git checkout -b feature/CGLAB-37_strip-check',
-      { stdio: 'inherit' },
+    expectCheckout('feature/CGLAB-37_strip-check');
+  });
+
+  it('trims surrounding whitespace so the recorded name matches the real git branch', async () => {
+    mockItem({ type: 'STORY' });
+    await program.parseAsync([
+      'node', 'agenfk', 'branch', 'create', ITEM_ID,
+      '--name', '   feat/CGLAB-37_trim-check   ',
+    ]);
+
+    expectCheckout('feat/CGLAB-37_trim-check');
+    expect(mockedAxios.put).toHaveBeenCalledWith(
+      expect.stringContaining(`/items/${ITEM_ID}`),
+      { branchName: 'feat/CGLAB-37_trim-check' },
     );
+  });
+
+  it('auto-generates feature/<slug> from the title when --name is omitted (non-BUG)', async () => {
+    mockItem({ type: 'STORY', title: 'Fix the thing, now!' });
+    await program.parseAsync(['node', 'agenfk', 'branch', 'create', ITEM_ID]);
+
+    expectCheckout('feature/fix-the-thing-now');
+    expect(mockedAxios.put).toHaveBeenCalledWith(
+      expect.stringContaining(`/items/${ITEM_ID}`),
+      { branchName: 'feature/fix-the-thing-now' },
+    );
+  });
+
+  it('auto-generates fix/<slug> from the title when --name is omitted (BUG)', async () => {
+    mockItem({ type: 'BUG', title: 'Fix the thing, now!' });
+    await program.parseAsync(['node', 'agenfk', 'branch', 'create', ITEM_ID]);
+
+    expectCheckout('fix/fix-the-thing-now');
   });
 
   it('rejects an empty --name with an explicit error instead of silently auto-generating', async () => {
@@ -136,7 +162,7 @@ describe('branch create', () => {
     ).rejects.toThrow(ExitError);
     expect(exitSpy).toHaveBeenCalledWith(1);
     expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('--name must not be empty or whitespace'));
-    expect(mockedChildProcess.execSync).not.toHaveBeenCalled();
+    expect(mockedChildProcess.execFileSync).not.toHaveBeenCalled();
     expect(mockedAxios.put).not.toHaveBeenCalled();
     errSpy.mockRestore();
   });
@@ -149,32 +175,8 @@ describe('branch create', () => {
     ).rejects.toThrow(ExitError);
     expect(exitSpy).toHaveBeenCalledWith(1);
     expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('--name must not be empty or whitespace'));
-    expect(mockedChildProcess.execSync).not.toHaveBeenCalled();
+    expect(mockedChildProcess.execFileSync).not.toHaveBeenCalled();
     errSpy.mockRestore();
-  });
-
-  it('auto-generates feature/<slug> from the title when --name is omitted (non-BUG)', async () => {
-    mockItem({ type: 'STORY', title: 'Fix the thing, now!' });
-    await program.parseAsync(['node', 'agenfk', 'branch', 'create', ITEM_ID]);
-
-    expect(mockedChildProcess.execSync).toHaveBeenCalledWith(
-      'git checkout -b feature/fix-the-thing-now',
-      { stdio: 'inherit' },
-    );
-    expect(mockedAxios.put).toHaveBeenCalledWith(
-      expect.stringContaining(`/items/${ITEM_ID}`),
-      { branchName: 'feature/fix-the-thing-now' },
-    );
-  });
-
-  it('auto-generates fix/<slug> from the title when --name is omitted (BUG)', async () => {
-    mockItem({ type: 'BUG', title: 'Fix the thing, now!' });
-    await program.parseAsync(['node', 'agenfk', 'branch', 'create', ITEM_ID]);
-
-    expect(mockedChildProcess.execSync).toHaveBeenCalledWith(
-      'git checkout -b fix/fix-the-thing-now',
-      { stdio: 'inherit' },
-    );
   });
 
   it('refuses child items and never creates a branch or links one', async () => {
@@ -183,13 +185,13 @@ describe('branch create', () => {
       program.parseAsync(['node', 'agenfk', 'branch', 'create', ITEM_ID]),
     ).rejects.toThrow(ExitError);
     expect(exitSpy).toHaveBeenCalledWith(1);
-    expect(mockedChildProcess.execSync).not.toHaveBeenCalled();
+    expect(mockedChildProcess.execFileSync).not.toHaveBeenCalled();
     expect(mockedAxios.put).not.toHaveBeenCalled();
   });
 
   it('does not link the branch when git checkout -b fails', async () => {
     mockItem({ type: 'STORY' });
-    mockedChildProcess.execSync.mockImplementation(() => {
+    mockedChildProcess.execFileSync.mockImplementation(() => {
       throw new Error('branch already exists');
     });
     await expect(

--- a/packages/core/src/test/utils.test.ts
+++ b/packages/core/src/test/utils.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { ItemType } from '../types';
+import { buildBranchName, slugifyTitle } from '../utils';
+
+describe('slugifyTitle', () => {
+  it('lowercases, strips punctuation, and joins with dashes', () => {
+    expect(slugifyTitle('Fix the thing, now!')).toBe('fix-the-thing-now');
+  });
+
+  it('collapses repeated dashes and trims the trailing one', () => {
+    expect(slugifyTitle('  A  --  B --  ')).toBe('a-b');
+  });
+
+  it('caps the slug at 50 chars', () => {
+    const slug = slugifyTitle('a'.repeat(80));
+    expect(slug.length).toBeLessThanOrEqual(50);
+  });
+});
+
+describe('buildBranchName', () => {
+  it('prefixes BUG with fix/<slug>', () => {
+    expect(buildBranchName(ItemType.BUG, 'Fix the login bug')).toBe('fix/fix-the-login-bug');
+  });
+
+  it('prefixes STORY with feature/<slug>', () => {
+    expect(buildBranchName(ItemType.STORY, 'Add the export feature')).toBe('feature/add-the-export-feature');
+  });
+
+  it('prefixes TASK with feature/<slug>', () => {
+    expect(buildBranchName(ItemType.TASK, 'Refactor the parser')).toBe('feature/refactor-the-parser');
+  });
+
+  it('prefixes EPIC with feature/<slug>', () => {
+    expect(buildBranchName(ItemType.EPIC, 'Ship the dashboard')).toBe('feature/ship-the-dashboard');
+  });
+});


### PR DESCRIPTION
Fixes CGLAB-37: 'agenfk branch create <id> --name <name>' always re-prefixed the name (feature/ or fix/ per item type) and stripped a leading feature/|fix/, so the flow-mandated feat/JIRAKEY_<desc> format came out as feature/feat/JIRAKEY_<desc>.

Changes:
- --name is used verbatim (surrounding whitespace trimmed); feature/<slug> / fix/<slug> generation only when --name is omitted, now delegated to the existing core buildBranchName (was dead code, now live)
- empty/whitespace --name rejected with an explicit error
- git invoked via execFileSync (no shell; single-argument refname, git validates the name)

Verification: 12 CLI tests + 7 core utils tests (two cases fail against the unfixed code); StrykerJS 14/14 mutants killed (100%) on the changed lines; E2E on the built CLI; full suite 2314/2314 at final verify; two independent adversarial reviews (separate agent), both SHIP.