### PR TITLE
[Kanban UI] Project picker: Enter selects first match; whole project chip clickable (CGLAB-115)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenfk",
-  "version": "1.1.16-beta.8",
+  "version": "1.1.17-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenfk",
-      "version": "1.1.16-beta.8",
+      "version": "1.1.17-beta.1",
       "license": "ISC",
       "workspaces": [
         "packages/core",
@@ -13304,11 +13304,11 @@
     },
     "packages/cli": {
       "name": "@agenfk/cli",
-      "version": "1.1.16-beta.8",
+      "version": "1.1.17-beta.1",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.1.16-beta.8",
-        "@agenfk/telemetry": "1.1.16-beta.8",
+        "@agenfk/core": "1.1.17-beta.1",
+        "@agenfk/telemetry": "1.1.17-beta.1",
         "axios": "^1.19.0",
         "chalk": "^4.1.2",
         "commander": "^12.0.0",
@@ -13328,7 +13328,7 @@
     },
     "packages/core": {
       "name": "@agenfk/core",
-      "version": "1.1.16-beta.8",
+      "version": "1.1.17-beta.1",
       "license": "ISC",
       "devDependencies": {
         "typescript": "^5.3.3"
@@ -13336,7 +13336,7 @@
     },
     "packages/create": {
       "name": "agenfk",
-      "version": "1.1.16-beta.8",
+      "version": "1.1.17-beta.1",
       "license": "ISC",
       "bin": {
         "agenfk": "bin/agenfk.js"
@@ -13347,7 +13347,7 @@
     },
     "packages/flow-editor": {
       "name": "@agenfk/flow-editor",
-      "version": "1.1.16-beta.8",
+      "version": "1.1.17-beta.1",
       "peerDependencies": {
         "@tanstack/react-query": "^5.101.4",
         "clsx": "^2.1.1",
@@ -13361,9 +13361,9 @@
     },
     "packages/hub": {
       "name": "@agenfk/hub",
-      "version": "1.1.16-beta.8",
+      "version": "1.1.17-beta.1",
       "dependencies": {
-        "@agenfk/core": "1.1.16-beta.8",
+        "@agenfk/core": "1.1.17-beta.1",
         "axios": "^1.19.0",
         "bcryptjs": "^2.4.3",
         "cookie-parser": "^1.4.7",
@@ -13387,9 +13387,9 @@
       }
     },
     "packages/hub-ui": {
-      "version": "1.1.16-beta.8",
+      "version": "1.1.17-beta.1",
       "dependencies": {
-        "@agenfk/flow-editor": "1.1.16-beta.8",
+        "@agenfk/flow-editor": "1.1.17-beta.1",
         "@fontsource-variable/jetbrains-mono": "^5.3.0",
         "@fontsource-variable/manrope": "^5.3.0",
         "@tailwindcss/postcss": "^4.3.3",
@@ -13765,12 +13765,12 @@
     },
     "packages/server": {
       "name": "@agenfk/server",
-      "version": "1.1.16-beta.8",
+      "version": "1.1.17-beta.1",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.1.16-beta.8",
-        "@agenfk/storage-sqlite": "1.1.16-beta.8",
-        "@agenfk/telemetry": "1.1.16-beta.8",
+        "@agenfk/core": "1.1.17-beta.1",
+        "@agenfk/storage-sqlite": "1.1.17-beta.1",
+        "@agenfk/telemetry": "1.1.17-beta.1",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "axios": "^1.19.0",
         "body-parser": "^2.3.0",
@@ -13793,13 +13793,13 @@
     },
     "packages/storage-sqlite": {
       "name": "@agenfk/storage-sqlite",
-      "version": "1.1.16-beta.8",
+      "version": "1.1.17-beta.1",
       "license": "ISC",
       "dependencies": {
         "uuid": "^14.0.2"
       },
       "devDependencies": {
-        "@agenfk/core": "1.1.16-beta.8",
+        "@agenfk/core": "1.1.17-beta.1",
         "@types/node": "^22.0.0",
         "@types/uuid": "^9.0.8",
         "typescript": "^5.3.3"
@@ -13817,7 +13817,7 @@
     },
     "packages/telemetry": {
       "name": "@agenfk/telemetry",
-      "version": "1.1.16-beta.8",
+      "version": "1.1.17-beta.1",
       "license": "ISC",
       "dependencies": {
         "posthog-node": "^4.0.0"
@@ -13828,9 +13828,9 @@
       }
     },
     "packages/ui": {
-      "version": "1.1.16-beta.8",
+      "version": "1.1.17-beta.1",
       "dependencies": {
-        "@agenfk/flow-editor": "1.1.16-beta.8",
+        "@agenfk/flow-editor": "1.1.17-beta.1",
         "@fontsource-variable/jetbrains-mono": "^5.3.0",
         "@fontsource-variable/manrope": "^5.3.0",
         "@tailwindcss/postcss": "^4.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenfk",
-  "version": "1.1.16",
+  "version": "1.1.16-beta.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenfk",
-      "version": "1.1.16",
+      "version": "1.1.16-beta.8",
       "license": "ISC",
       "workspaces": [
         "packages/core",
@@ -13304,11 +13304,11 @@
     },
     "packages/cli": {
       "name": "@agenfk/cli",
-      "version": "1.1.16",
+      "version": "1.1.16-beta.8",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.1.16",
-        "@agenfk/telemetry": "1.1.16",
+        "@agenfk/core": "1.1.16-beta.8",
+        "@agenfk/telemetry": "1.1.16-beta.8",
         "axios": "^1.19.0",
         "chalk": "^4.1.2",
         "commander": "^12.0.0",
@@ -13328,7 +13328,7 @@
     },
     "packages/core": {
       "name": "@agenfk/core",
-      "version": "1.1.16",
+      "version": "1.1.16-beta.8",
       "license": "ISC",
       "devDependencies": {
         "typescript": "^5.3.3"
@@ -13336,7 +13336,7 @@
     },
     "packages/create": {
       "name": "agenfk",
-      "version": "1.1.16",
+      "version": "1.1.16-beta.8",
       "license": "ISC",
       "bin": {
         "agenfk": "bin/agenfk.js"
@@ -13347,7 +13347,7 @@
     },
     "packages/flow-editor": {
       "name": "@agenfk/flow-editor",
-      "version": "1.1.16",
+      "version": "1.1.16-beta.8",
       "peerDependencies": {
         "@tanstack/react-query": "^5.101.4",
         "clsx": "^2.1.1",
@@ -13361,9 +13361,9 @@
     },
     "packages/hub": {
       "name": "@agenfk/hub",
-      "version": "1.1.16",
+      "version": "1.1.16-beta.8",
       "dependencies": {
-        "@agenfk/core": "1.1.16",
+        "@agenfk/core": "1.1.16-beta.8",
         "axios": "^1.19.0",
         "bcryptjs": "^2.4.3",
         "cookie-parser": "^1.4.7",
@@ -13387,9 +13387,9 @@
       }
     },
     "packages/hub-ui": {
-      "version": "1.1.16",
+      "version": "1.1.16-beta.8",
       "dependencies": {
-        "@agenfk/flow-editor": "1.1.16",
+        "@agenfk/flow-editor": "1.1.16-beta.8",
         "@fontsource-variable/jetbrains-mono": "^5.3.0",
         "@fontsource-variable/manrope": "^5.3.0",
         "@tailwindcss/postcss": "^4.3.3",
@@ -13765,12 +13765,12 @@
     },
     "packages/server": {
       "name": "@agenfk/server",
-      "version": "1.1.16",
+      "version": "1.1.16-beta.8",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.1.16",
-        "@agenfk/storage-sqlite": "1.1.16",
-        "@agenfk/telemetry": "1.1.16",
+        "@agenfk/core": "1.1.16-beta.8",
+        "@agenfk/storage-sqlite": "1.1.16-beta.8",
+        "@agenfk/telemetry": "1.1.16-beta.8",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "axios": "^1.19.0",
         "body-parser": "^2.3.0",
@@ -13793,13 +13793,13 @@
     },
     "packages/storage-sqlite": {
       "name": "@agenfk/storage-sqlite",
-      "version": "1.1.16",
+      "version": "1.1.16-beta.8",
       "license": "ISC",
       "dependencies": {
         "uuid": "^14.0.2"
       },
       "devDependencies": {
-        "@agenfk/core": "1.1.16",
+        "@agenfk/core": "1.1.16-beta.8",
         "@types/node": "^22.0.0",
         "@types/uuid": "^9.0.8",
         "typescript": "^5.3.3"
@@ -13817,7 +13817,7 @@
     },
     "packages/telemetry": {
       "name": "@agenfk/telemetry",
-      "version": "1.1.16",
+      "version": "1.1.16-beta.8",
       "license": "ISC",
       "dependencies": {
         "posthog-node": "^4.0.0"
@@ -13828,9 +13828,9 @@
       }
     },
     "packages/ui": {
-      "version": "1.1.16",
+      "version": "1.1.16-beta.8",
       "dependencies": {
-        "@agenfk/flow-editor": "1.1.16",
+        "@agenfk/flow-editor": "1.1.16-beta.8",
         "@fontsource-variable/jetbrains-mono": "^5.3.0",
         "@fontsource-variable/manrope": "^5.3.0",
         "@tailwindcss/postcss": "^4.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "1.1.16",
+  "version": "1.1.16-beta.8",
   "description": "AgenFK Engineering Framework",
   "private": true,
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "1.1.16-beta.8",
+  "version": "1.1.17-beta.1",
   "description": "AgenFK Engineering Framework",
   "private": true,
   "workspaces": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/cli",
-  "version": "1.1.16",
+  "version": "1.1.16-beta.8",
   "description": "CLI for AgenFK Engineering Framework",
   "main": "dist/index.js",
   "bin": {
@@ -12,8 +12,8 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.16",
-    "@agenfk/telemetry": "1.1.16",
+    "@agenfk/core": "1.1.16-beta.8",
+    "@agenfk/telemetry": "1.1.16-beta.8",
     "axios": "^1.19.0",
     "chalk": "^4.1.2",
     "commander": "^12.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/cli",
-  "version": "1.1.16-beta.8",
+  "version": "1.1.17-beta.1",
   "description": "CLI for AgenFK Engineering Framework",
   "main": "dist/index.js",
   "bin": {
@@ -12,8 +12,8 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.16-beta.8",
-    "@agenfk/telemetry": "1.1.16-beta.8",
+    "@agenfk/core": "1.1.17-beta.1",
+    "@agenfk/telemetry": "1.1.17-beta.1",
     "axios": "^1.19.0",
     "chalk": "^4.1.2",
     "commander": "^12.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/core",
-  "version": "1.1.16",
+  "version": "1.1.16-beta.8",
   "description": "Core logic and interfaces for the AgenFK Engineering Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/core",
-  "version": "1.1.16-beta.8",
+  "version": "1.1.17-beta.1",
   "description": "Core logic and interfaces for the AgenFK Engineering Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "1.1.16",
+  "version": "1.1.16-beta.8",
   "description": "AgenFK Agentic Engineering Framework — installer",
   "bin": {
     "agenfk": "bin/agenfk.js"

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "1.1.16-beta.8",
+  "version": "1.1.17-beta.1",
   "description": "AgenFK Agentic Engineering Framework — installer",
   "bin": {
     "agenfk": "bin/agenfk.js"

--- a/packages/flow-editor/package.json
+++ b/packages/flow-editor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agenfk/flow-editor",
   "private": true,
-  "version": "1.1.16",
+  "version": "1.1.16-beta.8",
   "type": "module",
   "main": "./src/index.ts",
   "exports": {

--- a/packages/flow-editor/package.json
+++ b/packages/flow-editor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agenfk/flow-editor",
   "private": true,
-  "version": "1.1.16-beta.8",
+  "version": "1.1.17-beta.1",
   "type": "module",
   "main": "./src/index.ts",
   "exports": {

--- a/packages/hub-ui/package.json
+++ b/packages/hub-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hub-ui",
   "private": true,
-  "version": "1.1.16",
+  "version": "1.1.16-beta.8",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.1.16",
+    "@agenfk/flow-editor": "1.1.16-beta.8",
     "@fontsource-variable/jetbrains-mono": "^5.3.0",
     "@fontsource-variable/manrope": "^5.3.0",
     "@tailwindcss/postcss": "^4.3.3",

--- a/packages/hub-ui/package.json
+++ b/packages/hub-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hub-ui",
   "private": true,
-  "version": "1.1.16-beta.8",
+  "version": "1.1.17-beta.1",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.1.16-beta.8",
+    "@agenfk/flow-editor": "1.1.17-beta.1",
     "@fontsource-variable/jetbrains-mono": "^5.3.0",
     "@fontsource-variable/manrope": "^5.3.0",
     "@tailwindcss/postcss": "^4.3.3",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/hub",
-  "version": "1.1.16",
+  "version": "1.1.16-beta.8",
   "description": "Corporate Hub for AgEnFK — fleet-wide metrics + timeline server",
   "main": "dist/server.js",
   "types": "dist/server.d.ts",
@@ -20,7 +20,7 @@
     "start": "node dist/bin.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.16",
+    "@agenfk/core": "1.1.16-beta.8",
     "axios": "^1.19.0",
     "bcryptjs": "^2.4.3",
     "cookie-parser": "^1.4.7",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/hub",
-  "version": "1.1.16-beta.8",
+  "version": "1.1.17-beta.1",
   "description": "Corporate Hub for AgEnFK — fleet-wide metrics + timeline server",
   "main": "dist/server.js",
   "types": "dist/server.d.ts",
@@ -20,7 +20,7 @@
     "start": "node dist/bin.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.16-beta.8",
+    "@agenfk/core": "1.1.17-beta.1",
     "axios": "^1.19.0",
     "bcryptjs": "^2.4.3",
     "cookie-parser": "^1.4.7",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/server",
-  "version": "1.1.16-beta.8",
+  "version": "1.1.17-beta.1",
   "description": "MCP Server for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -12,9 +12,9 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.16-beta.8",
-    "@agenfk/storage-sqlite": "1.1.16-beta.8",
-    "@agenfk/telemetry": "1.1.16-beta.8",
+    "@agenfk/core": "1.1.17-beta.1",
+    "@agenfk/storage-sqlite": "1.1.17-beta.1",
+    "@agenfk/telemetry": "1.1.17-beta.1",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "axios": "^1.19.0",
     "body-parser": "^2.3.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/server",
-  "version": "1.1.16",
+  "version": "1.1.16-beta.8",
   "description": "MCP Server for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -12,9 +12,9 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.16",
-    "@agenfk/storage-sqlite": "1.1.16",
-    "@agenfk/telemetry": "1.1.16",
+    "@agenfk/core": "1.1.16-beta.8",
+    "@agenfk/storage-sqlite": "1.1.16-beta.8",
+    "@agenfk/telemetry": "1.1.16-beta.8",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "axios": "^1.19.0",
     "body-parser": "^2.3.0",

--- a/packages/storage-sqlite/package.json
+++ b/packages/storage-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/storage-sqlite",
-  "version": "1.1.16",
+  "version": "1.1.16-beta.8",
   "description": "SQLite storage implementation for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -11,7 +11,7 @@
     "uuid": "^14.0.2"
   },
   "devDependencies": {
-    "@agenfk/core": "1.1.16",
+    "@agenfk/core": "1.1.16-beta.8",
     "@types/node": "^22.0.0",
     "@types/uuid": "^9.0.8",
     "typescript": "^5.3.3"

--- a/packages/storage-sqlite/package.json
+++ b/packages/storage-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/storage-sqlite",
-  "version": "1.1.16-beta.8",
+  "version": "1.1.17-beta.1",
   "description": "SQLite storage implementation for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -11,7 +11,7 @@
     "uuid": "^14.0.2"
   },
   "devDependencies": {
-    "@agenfk/core": "1.1.16-beta.8",
+    "@agenfk/core": "1.1.17-beta.1",
     "@types/node": "^22.0.0",
     "@types/uuid": "^9.0.8",
     "typescript": "^5.3.3"

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/telemetry",
-  "version": "1.1.16",
+  "version": "1.1.16-beta.8",
   "description": "Anonymous telemetry client for AgenFK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/telemetry",
-  "version": "1.1.16-beta.8",
+  "version": "1.1.17-beta.1",
   "description": "Anonymous telemetry client for AgenFK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.1.16",
+  "version": "1.1.16-beta.8",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -12,7 +12,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.1.16",
+    "@agenfk/flow-editor": "1.1.16-beta.8",
     "@fontsource-variable/jetbrains-mono": "^5.3.0",
     "@fontsource-variable/manrope": "^5.3.0",
     "@tailwindcss/postcss": "^4.3.3",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.1.16-beta.8",
+  "version": "1.1.17-beta.1",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -12,7 +12,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.1.16-beta.8",
+    "@agenfk/flow-editor": "1.1.17-beta.1",
     "@fontsource-variable/jetbrains-mono": "^5.3.0",
     "@fontsource-variable/manrope": "^5.3.0",
     "@tailwindcss/postcss": "^4.3.3",

--- a/packages/ui/src/components/KanbanBoard.tsx
+++ b/packages/ui/src/components/KanbanBoard.tsx
@@ -918,8 +918,13 @@ export const KanbanBoard: React.FC = () => {
         e.preventDefault();
         setHighlightedProjectIndex(prev => clampIndex(prev === -1 ? 0 : prev - 1, n));
       } else if (e.key === 'Enter') {
-        if (highlightedProjectIndex >= 0 && highlightedProjectIndex < sortedFilteredProjects.length) {
-          handleSelectProject(sortedFilteredProjects[highlightedProjectIndex].id);
+        // Type-and-Enter: with no row highlighted, Enter takes the first match.
+        // A highlight is always a valid index (clampIndex) or -1, so ?? only
+        // covers the index being momentarily ahead of a shrinking list.
+        const target =
+          sortedFilteredProjects[highlightedProjectIndex] ?? sortedFilteredProjects[0];
+        if (target) {
+          handleSelectProject(target.id);
         }
       }
     };
@@ -1285,19 +1290,32 @@ export const KanbanBoard: React.FC = () => {
                   {projectSearch.trim() !== '' && sortedFilteredProjects.length === 0 ? (
                     <p className="col-span-full text-sm text-slate-400 py-4 text-center">No projects match "{projectSearch}"</p>
                   ) : (
-                    sortedFilteredProjects.map((p, index) => (
+                    sortedFilteredProjects.map((p, index) => {
+                    // While the delete confirm is armed the row is a destructive
+                    // prompt, not a project shortcut: clicking it must neither
+                    // open the project nor answer the prompt.
+                    const isConfirmingDelete = confirmDeleteProjectId === p.id;
+                    return (
                     <div
                       key={p.id}
                       role="option"
                       id={`project-option-${p.id}`}
                       aria-selected={index === highlightedProjectIndex ? 'true' : 'false'}
+                      onClick={isConfirmingDelete ? undefined : () => handleSelectProject(p.id)}
+                      // The confirm row must not still look clickable: keeping
+                      // cursor/hover styling there would advertise a click that
+                      // the guard above deliberately ignores.
                       className={`flex items-center gap-3 p-4 rounded-xl border transition-all group ${
-                        index === highlightedProjectIndex
-                          ? 'border-border-brand bg-chip'
-                          : 'border-slate-100 dark:border-slate-800 hover:border-border-brand hover:bg-chip'
+                        isConfirmingDelete
+                          ? 'border-red-200 dark:border-red-900/40'
+                          : `cursor-pointer ${
+                              index === highlightedProjectIndex
+                                ? 'border-border-brand bg-chip'
+                                : 'border-slate-100 dark:border-slate-800 hover:border-border-brand hover:bg-chip'
+                            }`
                       }`}
                     >
-                      {confirmDeleteProjectId === p.id ? (
+                      {isConfirmingDelete ? (
                         <>
                           <Trash2 className="text-red-500 shrink-0" size={20} />
                           <span className="flex-1 text-sm font-semibold text-red-600 dark:text-red-400">Delete "{p.name}"?</span>
@@ -1317,13 +1335,10 @@ export const KanbanBoard: React.FC = () => {
                         </>
                       ) : (
                         <>
-                          <button
-                            onClick={() => handleSelectProject(p.id)}
-                            className="flex flex-1 items-center gap-3 text-left"
-                          >
+                          <div className="flex flex-1 items-center gap-3 text-left">
                             <Briefcase className="text-slate-400 group-hover:text-accent-text shrink-0" size={20} />
                             <span className="font-semibold text-slate-700 dark:text-slate-200">{p.name}</span>
-                          </button>
+                          </div>
                           <button
                             onClick={(e) => { e.stopPropagation(); setConfirmDeleteProjectId(p.id); }}
                             className="opacity-0 group-hover:opacity-100 p-1 rounded-lg text-slate-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 transition-all"
@@ -1335,7 +1350,8 @@ export const KanbanBoard: React.FC = () => {
                         </>
                       )}
                     </div>
-                  ))
+                    );
+                    })
                   )}
                 </div>
               </div>

--- a/packages/ui/src/test/ProjectPickerDismiss.test.tsx
+++ b/packages/ui/src/test/ProjectPickerDismiss.test.tsx
@@ -205,4 +205,61 @@ describe('ProjectPickerDismiss', () => {
     expect(screen.getByPlaceholderText(/My Awesome App/i)).toBeDefined();
     expect(screen.getByText(/Project Name/i)).toBeDefined();
   });
+
+  // CGLAB-115 (2): selection moved from an inner button onto the whole row.
+  // These cover the switch-project path (a project is already selected, so the
+  // picker is an overlay that also closes on backdrop click) — the row must
+  // switch projects without the backdrop guard racing it.
+  it('clicking a different project row switches the project and closes the picker', async () => {
+    vi.mocked(api.listProjects).mockResolvedValue([makeProject('p1','Alpha'), makeProject('p2','Beta')]);
+    localStorage.setItem('agenfk_project_id','p1');
+    render(<KanbanBoard />, { wrapper });
+    await waitFor(() => screen.getByTitle('Switch Project'));
+    fireEvent.click(screen.getByTitle('Switch Project'));
+    await waitFor(() => screen.getByText('Beta'));
+
+    // Click the row's padding — just outside the name, where the old inner
+    // button did not reach.
+    fireEvent.click(screen.getByText('Beta').closest('[role="option"]') as HTMLElement);
+
+    await waitFor(() => expect(screen.queryByText(/Welcome to AgEnFK/i)).toBeNull());
+    expect(localStorage.getItem('agenfk_project_id')).toBe('p2');
+  });
+
+  it('clicking the row of the already-selected project keeps it selected and closes the picker', async () => {
+    vi.mocked(api.listProjects).mockResolvedValue([makeProject('p1','Alpha'), makeProject('p2','Beta')]);
+    localStorage.setItem('agenfk_project_id','p1');
+    render(<KanbanBoard />, { wrapper });
+    await waitFor(() => screen.getByTitle('Switch Project'));
+    fireEvent.click(screen.getByTitle('Switch Project'));
+    await waitFor(() => screen.getByText(/Welcome to AgEnFK/i));
+
+    // Scoped to the picker's listbox: 'Alpha' is also the board header behind
+    // the overlay.
+    const row = screen.getAllByRole('option').find(o => o.textContent?.includes('Alpha')) as HTMLElement;
+    fireEvent.click(row);
+
+    await waitFor(() => expect(screen.queryByText(/Welcome to AgEnFK/i)).toBeNull());
+    expect(localStorage.getItem('agenfk_project_id')).toBe('p1');
+  });
+
+  it('clicking a row while its delete confirm is armed neither deletes nor selects', async () => {
+    vi.mocked(api.listProjects).mockResolvedValue([makeProject('p1','Alpha'), makeProject('p2','Beta')]);
+    localStorage.setItem('agenfk_project_id','p1');
+    render(<KanbanBoard />, { wrapper });
+    await waitFor(() => screen.getByTitle('Switch Project'));
+    fireEvent.click(screen.getByTitle('Switch Project'));
+    await waitFor(() => screen.getByText('Beta'));
+
+    fireEvent.click(screen.getByLabelText('Delete project Beta'));
+    await screen.findByText(/Delete "Beta"\?/i);
+
+    // Same row element, now showing the confirm. Clicking its padding must not
+    // fall through to "open Beta".
+    fireEvent.click(screen.getByText(/Delete "Beta"\?/i).closest('[role="option"]') as HTMLElement);
+
+    expect(api.deleteProject).not.toHaveBeenCalled();
+    expect(localStorage.getItem('agenfk_project_id')).toBe('p1');
+    expect(screen.getByText(/Delete "Beta"\?/i)).toBeDefined();
+  });
 });

--- a/packages/ui/src/test/ProjectPickerKeyboardNav.test.tsx
+++ b/packages/ui/src/test/ProjectPickerKeyboardNav.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, cleanup, waitFor, act } from '@testing-library/react';
 import { KanbanBoard } from '../components/KanbanBoard';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from '../ThemeContext';
@@ -94,9 +94,14 @@ function getHighlightedRow(): HTMLElement | null {
 }
 
 describe('ProjectPickerKeyboardNav', () => {
+  // Handle on the QueryClient of the most recent render, so a test can force a
+  // projects refetch and watch the list change under the picker.
+  let queryClientRef: QueryClient | null = null;
+
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    queryClientRef = null;
   });
 
   afterEach(() => {
@@ -109,6 +114,7 @@ describe('ProjectPickerKeyboardNav', () => {
         queries: { retry: false, gcTime: 0 },
       },
     });
+    queryClientRef = queryClient;
     const wrapper = ({ children }: { children: React.ReactNode }) => (
       <QueryClientProvider client={queryClient}>
         <ThemeProvider>
@@ -136,6 +142,19 @@ describe('ProjectPickerKeyboardNav', () => {
     await waitFor(() => screen.getByText('apple'));
     const highlighted = getHighlightedRow();
     expect(highlighted).toBeNull();
+  });
+
+  // CGLAB-115 (1): the highlight is only a *visual* marker — Enter no longer
+  // depends on it. With no row highlighted, Enter falls back to the first
+  // match, so the fallback must not be smuggled into aria-selected either.
+  it('Enter with no highlight selects the first match without marking it aria-selected', async () => {
+    setup();
+    await waitFor(() => screen.getByText('apple'));
+
+    fireEvent.keyDown(document.body, { key: 'Enter' });
+
+    expect(getHighlightedRow()).toBeNull();
+    expect(localStorage.getItem('agenfk_project_id')).toBe('a-id');
   });
 
   it('ArrowDown highlights the first project (alphabetically sorted)', async () => {
@@ -308,18 +327,119 @@ describe('ProjectPickerKeyboardNav', () => {
     const mangoRow = getProjectRow('Mango');
     expect(mangoRow?.getAttribute('aria-selected')).toBe('true');
 
-    // Enter selects Mango
+    // Enter selects Mango. Note this case does not discriminate between
+    // "highlighted" and "first match" — they are the same row here. The
+    // discriminating case is 'Enter selects the highlighted row even when it
+    // is not the first match'.
     fireEvent.keyDown(searchInput, { key: 'Enter' });
     expect(localStorage.getItem('agenfk_project_id')).toBe('m-id');
   });
 
-  it('Enter with no highlight is a no-op', async () => {
+  // CGLAB-115 (1): typing in the search box resets the highlight to -1, so
+  // Enter used to fall through and do nothing — the fastest path (type a few
+  // letters, hit Enter) was dead. Enter must select the first filtered match.
+  it('Enter while typing selects the first filtered match', async () => {
     setup();
     await waitFor(() => screen.getByText('apple'));
 
-    // Press Enter without any arrow key — no item highlighted
+    const searchInput = screen.getByLabelText('Search projects');
+    fireEvent.change(searchInput, { target: { value: 'man' } });
+    await waitFor(() => {
+      expect(screen.queryByText('Zebra')).toBeNull();
+      expect(screen.queryByText('apple')).toBeNull();
+    });
+
+    fireEvent.keyDown(searchInput, { key: 'Enter' });
+
+    expect(localStorage.getItem('agenfk_project_id')).toBe('m-id');
+  });
+
+  it('Enter with no typing and no highlight still selects the first project', async () => {
+    setup();
+    await waitFor(() => screen.getByText('apple'));
+
     fireEvent.keyDown(document.body, { key: 'Enter' });
+
+    expect(localStorage.getItem('agenfk_project_id')).toBe('a-id');
+  });
+
+  // The fallback picks sortedFilteredProjects[0], so with no highlight Enter
+  // must land on 'apple' even though 'Zebra' is the first row in the raw
+  // fixture array — sort order decides, insertion order does not.
+  it('Enter with no highlight picks the alphabetically first project, not the first in the raw list', async () => {
+    setup();
+    await waitFor(() => screen.getByText('apple'));
+
+    // 'Zebra' is index 0 in the fixture array; 'apple' sorts first.
+    expect(screen.getAllByText(/^(apple|Mango|Zebra)$/)[0].textContent).toBe('apple');
+
+    fireEvent.keyDown(document.body, { key: 'Enter' });
+
+    expect(localStorage.getItem('agenfk_project_id')).toBe('a-id');
+  });
+
+  it('Enter selects the highlighted row even when it is not the first match', async () => {
+    setup();
+    await waitFor(() => screen.getByText('apple'));
+
+    const searchInput = screen.getByLabelText('Search projects');
+    fireEvent.keyDown(searchInput, { key: 'ArrowDown' }); // apple
+    fireEvent.keyDown(searchInput, { key: 'ArrowDown' }); // Mango
+
+    fireEvent.keyDown(searchInput, { key: 'Enter' });
+
+    expect(localStorage.getItem('agenfk_project_id')).toBe('m-id');
+  });
+
+  it('Enter with no matches at all is a no-op', async () => {
+    setup();
+    await waitFor(() => screen.getByText('apple'));
+
+    const searchInput = screen.getByLabelText('Search projects');
+    fireEvent.change(searchInput, { target: { value: 'zzz-no-match' } });
+    await waitFor(() => screen.getByText(/no projects match/i));
+
+    fireEvent.keyDown(searchInput, { key: 'Enter' });
 
     expect(localStorage.getItem('agenfk_project_id')).toBeNull();
   });
+
+  // The bounds check on the highlight guards a highlight that is out of range
+  // for the list it now indexes into. Typing cannot produce that (onChange
+  // resets the highlight to -1), but a background refetch of the project list
+  // can: react-query swaps in a shorter array without touching the highlight.
+  // Without this case an off-by-one in the guard survives — Stryker kept
+  // landing it, because every other Enter test leaves the index in range.
+  it('Enter with a highlight left out of range by a shrinking project list falls back to the first match', async () => {
+    const three = [
+      makeProject('z-id', 'Zebra'),
+      makeProject('a-id', 'apple'),
+      makeProject('m-id', 'Mango'),
+    ];
+    vi.mocked(api.listProjects).mockResolvedValue(three);
+    renderKanbanBoard();
+    await waitFor(() => screen.getByText('apple'));
+
+    const searchInput = screen.getByLabelText('Search projects');
+    // Highlight Mango, index 1 of apple/Mango/Zebra.
+    fireEvent.keyDown(searchInput, { key: 'ArrowDown' });
+    fireEvent.keyDown(searchInput, { key: 'ArrowDown' });
+    expect(getProjectRow('Mango')?.getAttribute('aria-selected')).toBe('true');
+
+    // The list shrinks under the highlight: only Zebra remains, so index 1 is
+    // out of range while the highlight still reads 1.
+    vi.mocked(api.listProjects).mockResolvedValue([makeProject('z-id', 'Zebra')]);
+    await act(async () => {
+      await queryClientRef!.invalidateQueries({ queryKey: ['projects'] });
+    });
+    await waitFor(() => {
+      expect(screen.queryByText('apple')).toBeNull();
+      expect(screen.queryByText('Mango')).toBeNull();
+    });
+
+    fireEvent.keyDown(searchInput, { key: 'Enter' });
+
+    expect(localStorage.getItem('agenfk_project_id')).toBe('z-id');
+  });
+
 });

--- a/packages/ui/src/test/ProjectSelection.test.tsx
+++ b/packages/ui/src/test/ProjectSelection.test.tsx
@@ -213,4 +213,98 @@ describe('ProjectSelection', () => {
     expect(screen.queryByText('Mango')).toBeNull();
     expect(screen.getByText(/no projects match/i)).toBeDefined();
   });
+
+  // ---- CGLAB-115 (2): the whole chip must be clickable, not just its name ----
+  // Each row is a padded container holding an inner button; only the icon +
+  // name were the button, so the padding ring, the gutter and the trailing
+  // dead strip swallowed clicks.
+
+  function rowOf(name: string): HTMLElement {
+    return screen.getByText(name).closest('[role="option"]') as HTMLElement;
+  }
+
+  async function renderThreeProjects() {
+    vi.mocked(api.listProjects).mockResolvedValue([
+      makeProject('z', 'Zebra'),
+      makeProject('a', 'apple'),
+      makeProject('m', 'Mango'),
+    ]);
+    renderKanbanBoard();
+    await waitFor(() => screen.getByText('apple'));
+  }
+
+  it('clicking the row padding (not the name) selects the project', async () => {
+    await renderThreeProjects();
+
+    fireEvent.click(rowOf('Zebra'));
+
+    expect(localStorage.getItem('agenfk_project_id')).toBe('z');
+  });
+
+  it('clicking the project icon selects the project', async () => {
+    await renderThreeProjects();
+
+    const row = rowOf('Mango');
+    const icon = row.querySelector('svg');
+    fireEvent.click(icon!);
+
+    expect(localStorage.getItem('agenfk_project_id')).toBe('m');
+  });
+
+  it('the whole row is the click target, not an inner sub-region', async () => {
+    await renderThreeProjects();
+
+    // The name/icon are no longer wrapped in their own button — that inner
+    // button is what left the row's padding dead. The only button left in the
+    // row is the trash action.
+    const row = rowOf('Zebra');
+    const buttons = row.querySelectorAll('button');
+    expect(buttons).toHaveLength(1);
+    expect(buttons[0].getAttribute('aria-label')).toBe('Delete project Zebra');
+
+    // And the whole row, not just the name, performs the selection.
+    fireEvent.click(row);
+    expect(localStorage.getItem('agenfk_project_id')).toBe('z');
+  });
+
+  it('a row whose delete confirmation is armed does not advertise itself as clickable', async () => {
+    await renderThreeProjects();
+
+    const row = rowOf('Zebra');
+    expect(row.className).toContain('cursor-pointer');
+
+    fireEvent.click(screen.getByLabelText('Delete project Zebra'));
+    await screen.findByText(/Delete "Zebra"\?/i);
+
+    // Same row element, now the destructive prompt. It must stop looking
+    // clickable, or it advertises a click the guard deliberately ignores.
+    const armed = rowOf('Delete "Zebra"?');
+    expect(armed.className).not.toContain('cursor-pointer');
+    expect(armed.className).not.toContain('hover:bg-chip');
+  });
+
+  it('the trash button arms the delete confirm and does NOT select the project', async () => {
+    await renderThreeProjects();
+
+    const trash = screen.getByLabelText('Delete project Zebra');
+    fireEvent.click(trash);
+
+    expect(await screen.findByText(/Delete "Zebra"\?/i)).toBeDefined();
+    expect(localStorage.getItem('agenfk_project_id')).toBeNull();
+    expect(api.deleteProject).not.toHaveBeenCalled();
+  });
+
+  it('clicking the row padding while a delete confirm is armed does not delete', async () => {
+    await renderThreeProjects();
+
+    fireEvent.click(screen.getByLabelText('Delete project Zebra'));
+    await screen.findByText(/Delete "Zebra"\?/i);
+
+    // The confirm replaces the row's contents; clicking its padding must not
+    // select the project nor confirm the deletion.
+    fireEvent.click(rowOf('Delete "Zebra"?'));
+
+    expect(api.deleteProject).not.toHaveBeenCalled();
+    expect(localStorage.getItem('agenfk_project_id')).toBeNull();
+  });
 });


### PR DESCRIPTION
## What

Two interaction fixes in the Kanban UI project selector. **CGLAB-115** · AgEnFK task `771d34b0`

### 1. Enter while typing now selects the first match
The search box reset the highlight to `-1` on every keystroke and the Enter handler only acted on a highlight, so type-a-few-letters-then-Enter did nothing.

```diff
- if (highlightedProjectIndex >= 0 && highlightedProjectIndex < sortedFilteredProjects.length) {
-   handleSelectProject(sortedFilteredProjects[highlightedProjectIndex].id);
+ const target =
+   sortedFilteredProjects[highlightedProjectIndex] ?? sortedFilteredProjects[0];
+ if (target) { handleSelectProject(target.id); }
```

### 2. The whole project chip is clickable
Selection lived on an inner `flex-1` button inside a `p-4` row, so the padding ring, the `gap-3` gutter and the trailing strip were dead surface. Selection moved onto the row; the trash button keeps its `stopPropagation`.

A row whose delete confirmation is armed loses the handler **and** the `cursor-pointer`/`hover` styling, so it no longer advertises a click that is deliberately ignored.

## Review findings that changed this code

An independent adversarial review caught two things the author missed:
- `cursor-pointer` + `hover:*` sat in the row's **base** class string, so the armed-confirm row still looked clickable while clicking it silently no-opped — reintroducing the exact dead-surface bug this PR set out to remove.
- The bounds check `>= 0 && < length` was a **tautology**: deleting it kept all 42 tests green, so the comment claimed protection no test supplied. Replaced with the `??` fallback above, which is load-bearing — removing it now fails 5 tests.

Also removed 3 tests written during this task (one asserted a Tailwind class name, one redundant, one leaning on `scrollIntoView` throwing in jsdom at ~1s/test).

## Verification

- `npx vitest run` — 219 files / 2369 tests green
- `packages/ui` (excluded by the root config, run separately) — 438 tests green
- `npm run build` clean
- StrykerJS scoped by mutation range to the changed lines: 11 mutants, 9 killed; 1 survivor proven equivalent (`>= 0` vs `> 0` — the index is only ever `-1` or `>= 0`), 1 RuntimeError that does fail the suite but crashes Stryker's reporter. 7/7 post-review hand-applied mutants killed.

## Not in scope (deliberate)

- **Pre-existing a11y gaps**: the row has no `tabIndex`/`onKeyDown` and `aria-activedescendant` can disagree with what Enter selects. The removed `<button>` had no `tabIndex` either, so keyboard reachability is unchanged here — but a pointer cursor on a non-focusable `div` is a false affordance for keyboard users. Deserves its own ticket.
- **Flaky test**: `packages/hub/src/test/admin-hidden-users.test.ts` threw `ETIMEDOUT` once mid-flow and rolled the item back a step. Unrelated to this UI-only diff (passes standalone and in the two runs after), but it will bite CI intermittently.

🤖 Generated with [pi](https://pi.dev) · model: qwen3.8:27b · harness: pi
