### PR TITLE
feat(hub): admin model aliases — combine spellings of one model (Admin → Models)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to AgEnFK are documented here.
 
+## [1.1.17-beta.3] — 2026-09-02
+
+### Added
+- **Hub admin → Models**: a model id is free text an installation self-reports via
+  `--model <id>`, so one model reaching the hub as `qwen38-27b` and `qwen3.8:27b`
+  appeared as two rows in the PR Overview "By model" table, splitting its PR count
+  and offering two filter chips for one model. Admins can now map a reported
+  spelling to a single desired name. Resolution is a read-time overlay
+  (`model_mappings`), so `events` keeps recording what was actually reported and
+  deleting a mapping puts the dashboards back — no recompute, no migration.
+  Resolution is an exact lookup by deliberate choice: a normalization rule that
+  maps `-` to `:` and `38` to `3.8` would silently merge genuinely different
+  models. Saved links to an old spelling keep resolving, because filter values
+  go through the same mapping as stored ones.
+
 ## [1.1.17-beta.2] — 2026-09-01
 
 Hub org-boundary hardening (CGLAB-117) — after the 31 Aug 2026 incident, a clobbered

--- a/packages/hub-ui/src/App.tsx
+++ b/packages/hub-ui/src/App.tsx
@@ -13,6 +13,7 @@ import { AdminFlows } from './pages/AdminFlows';
 import { AdminUpgrades } from './pages/AdminUpgrades';
 import { AdminRepoint } from './pages/AdminRepoint';
 import { AdminIdentities } from './pages/AdminIdentities';
+import { AdminModels } from './pages/AdminModels';
 import { AdminOrg } from './pages/AdminOrg';
 import { Layout } from './components/Layout';
 
@@ -65,6 +66,7 @@ export function App() {
         <Route path="installations" element={<AdminInstallations />} />
         <Route path="repoint" element={<AdminRepoint />} />
         <Route path="identities" element={<AdminIdentities />} />
+        <Route path="models" element={<AdminModels />} />
         <Route path="org" element={<AdminOrg />} />
         <Route index element={<Navigate to="auth" replace />} />
       </Route>

--- a/packages/hub-ui/src/pages/Admin.tsx
+++ b/packages/hub-ui/src/pages/Admin.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Outlet, NavLink } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { ShieldCheck, KeyRound, Users, Trash2, Copy, Check, GitBranch, ArrowUpCircle, Server, Building2, X, EyeOff, Eye, Archive, ArchiveRestore, ArrowRightLeft } from 'lucide-react';
+import { ShieldCheck, KeyRound, Users, Trash2, Copy, Check, GitBranch, ArrowUpCircle, Server, Building2, X, EyeOff, Eye, Archive, ArchiveRestore, ArrowRightLeft, Tags } from 'lucide-react';
 import { api } from '../api';
 import { fmtDate } from '../dates';
 import { canDeleteUserRow } from './canDeleteUserRow';
@@ -46,6 +46,9 @@ export function AdminLayout() {
         </NavLink>
         <NavLink to="identities" className={link}>
           <span className="inline-flex items-center gap-1.5"><Users className="w-3.5 h-3.5" /> Identities</span>
+        </NavLink>
+        <NavLink to="models" className={link}>
+          <span className="inline-flex items-center gap-1.5"><Tags className="w-3.5 h-3.5" /> Models</span>
         </NavLink>
         <NavLink to="org" className={link}>
           <span className="inline-flex items-center gap-1.5"><Building2 className="w-3.5 h-3.5" /> Organization</span>

--- a/packages/hub-ui/src/pages/AdminModels.tsx
+++ b/packages/hub-ui/src/pages/AdminModels.tsx
@@ -1,0 +1,312 @@
+import { useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Trash2, AlertTriangle } from 'lucide-react';
+import { api } from '../api';
+import { fmtDate } from '../dates';
+import {
+  groupModels, validateMapping, knownCanonicalNames,
+  MappingRow, ObservedModel,
+} from './modelMappings';
+
+const inputCls = 'w-full px-3 py-2 rounded-lg border border-border-soft bg-chip text-ink dark:text-white text-sm placeholder:text-ink-tertiary focus:outline-none focus:ring-2 focus:ring-brand';
+const cardCls = 'bg-card-glass backdrop-blur border border-border-soft rounded-2xl p-5';
+const primaryBtnCls = 'px-4 py-2 rounded-lg bg-[image:var(--gradient-accent)] text-navy shadow-glow disabled:opacity-50 text-sm font-bold transition-colors';
+
+interface ModelsResponse {
+  mappings: MappingRow[];
+  observed: ObservedModel[];
+}
+
+/**
+ * Admin → Models: fold the several spellings an agent can report for one model
+ * into the single name the admin chooses.
+ *
+ * The left column is the desired name — what dashboards group and filter by.
+ * Under each, the reported spellings folded into it with their PR counts.
+ * Resolved at read time, so nothing here rewrites history and deleting a
+ * mapping puts the dashboard back the way it was.
+ */
+export function AdminModels() {
+  const qc = useQueryClient();
+  const [alias, setAlias] = useState('');
+  const [canonical, setCanonical] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const data = useQuery<ModelsResponse>({
+    queryKey: ['admin-models'],
+    queryFn: async () => (await api.get('/v1/admin/models')).data,
+  });
+
+  const invalidate = () => {
+    qc.invalidateQueries({ queryKey: ['admin-models'] });
+    // The PR Overview "By model" table and its filter options are what this
+    // actually changes, so they must refetch too.
+    qc.invalidateQueries({ queryKey: ['pr-overview'] });
+    qc.invalidateQueries({ queryKey: ['pr-overview-opts'] });
+  };
+
+  const mappings = data.data?.mappings ?? [];
+  const observed = data.data?.observed ?? [];
+  const groups = useMemo(() => groupModels(mappings, observed), [mappings, observed]);
+  const suggestions = useMemo(() => knownCanonicalNames(mappings), [mappings]);
+
+  const add = useMutation({
+    mutationFn: async (body: { aliasModel: string; canonicalModel: string }) =>
+      (await api.post('/v1/admin/models/mappings', body)).data,
+    onSuccess: () => {
+      setError(null); setAlias(''); setCanonical('');
+      invalidate();
+    },
+    onError: (e: any) => setError(e?.response?.data?.error ?? 'Could not save the mapping.'),
+  });
+
+  const remove = useMutation({
+    mutationFn: async (aliasModel: string) =>
+      (await api.delete(`/v1/admin/models/mappings/${encodeURIComponent(aliasModel)}`)).data,
+    onSuccess: () => { setError(null); invalidate(); },
+    onError: (e: any) => setError(e?.response?.data?.error ?? 'Could not delete the mapping.'),
+  });
+
+  const submit = () => {
+    const problem = validateMapping(alias, canonical, mappings);
+    if (problem) { setError(problem); return; }
+    setError(null);
+    add.mutate({ aliasModel: alias.trim(), canonicalModel: canonical.trim() });
+  };
+
+  const unmappedCount = observed.filter(o => !o.isMapped && o.model !== o.canonicalModel).length;
+  const unusedCount = groups.reduce((n, g) => n + g.unusedMappings.length, 0);
+
+  return (
+    <div className="space-y-6">
+      <section className={cardCls}>
+        <header>
+          <h3 className="text-sm font-semibold text-ink">Add a mapping</h3>
+          <p className="mt-0.5 text-xs text-ink-tertiary">
+            A model name is whatever each install reports, so one model can arrive as several spellings and
+            appear as several rows. Map a reported spelling to the single name you want shown.
+          </p>
+        </header>
+
+        <div className="mt-3 grid grid-cols-1 sm:grid-cols-[1fr_auto_1fr_auto] gap-2 items-end">
+          <label className="block">
+            <span className="block mb-1 text-[10px] uppercase tracking-[0.14em] text-ink-tertiary font-semibold">
+              Reported today as
+            </span>
+            <input
+              className={inputCls}
+              list="observed-model-ids"
+              placeholder="qwen38-27b"
+              value={alias}
+              onChange={e => setAlias(e.target.value)}
+              onKeyDown={e => { if (e.key === 'Enter') submit(); }}
+            />
+          </label>
+          <span className="hidden sm:block pb-2 text-ink-tertiary">→</span>
+          <label className="block">
+            <span className="block mb-1 text-[10px] uppercase tracking-[0.14em] text-ink-tertiary font-semibold">
+              Show as (desired name)
+            </span>
+            <input
+              className={inputCls}
+              list="known-canonical-names"
+              placeholder="qwen3.8:27b"
+              value={canonical}
+              onChange={e => setCanonical(e.target.value)}
+              onKeyDown={e => { if (e.key === 'Enter') submit(); }}
+            />
+          </label>
+          <button
+            className={primaryBtnCls}
+            disabled={add.isPending || !alias.trim() || !canonical.trim()}
+            onClick={submit}
+          >
+            {add.isPending ? 'Saving…' : 'Add'}
+          </button>
+        </div>
+
+        <datalist id="observed-model-ids">
+          {observed.map(o => <option key={o.model} value={o.model} />)}
+        </datalist>
+        <datalist id="known-canonical-names">
+          {suggestions.map(n => <option key={n} value={n} />)}
+        </datalist>
+
+        {error && (
+          <p role="alert" className="mt-2 text-xs font-semibold text-red-600 dark:text-red-400">{error}</p>
+        )}
+        {suggestions.length > 0 && !error && (
+          <p className="mt-2 text-[11px] text-ink-tertiary">
+            Pick an existing desired name to add a spelling to a group that already exists, rather than
+            starting a second one for the same model.
+          </p>
+        )}
+      </section>
+
+      <section className={cardCls}>
+        <header className="flex items-center justify-between">
+          <div>
+            <h3 className="text-sm font-semibold text-ink">
+              Models <span className="text-ink-tertiary font-normal">({groups.length})</span>
+            </h3>
+            <p className="mt-0.5 text-xs text-ink-tertiary">
+              Every model name shown on the dashboards, with the reported spellings folded into it.
+            </p>
+          </div>
+          {unmappedCount > 0 && (
+            <span
+              className="text-[11px] font-semibold text-amber-600 dark:text-amber-400 cursor-help"
+              title="These names are each their own group. Map the ones that are really the same model."
+            >
+              <AlertTriangle className="w-3.5 h-3.5 inline -mt-0.5 mr-1" />
+              {unmappedCount} unmapped
+            </span>
+          )}
+        </header>
+
+        {data.isLoading && <p className="mt-3 text-sm text-ink-tertiary">Loading…</p>}
+
+        {!data.isLoading && groups.length === 0 && (
+          <p className="mt-3 text-sm text-ink-tertiary">No PR events with a model have been reported yet.</p>
+        )}
+
+        {unusedCount > 0 && (
+          <p className="mt-2 text-[11px] text-ink-tertiary">
+            {unusedCount} {unusedCount === 1 ? 'mapping is' : 'mappings are'} listed below but that spelling
+            has not been reported yet — the mapping is waiting, not broken.
+          </p>
+        )}
+
+        <div className="mt-3 -mx-5 overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-[10px] uppercase tracking-[0.14em] text-ink-tertiary font-semibold">
+                <th className="px-5 py-2 text-left font-semibold">Desired name</th>
+                <th className="px-5 py-2 text-left font-semibold">Mapped from</th>
+                <th className="px-5 py-2 text-right font-semibold">PRs</th>
+                <th className="px-5 py-2 text-left font-semibold">Mapped by</th>
+                <th className="px-5 py-2" />
+              </tr>
+            </thead>
+            <tbody>
+              {groups.map(g => (
+                <ModelGroupRows
+                  key={g.canonicalModel}
+                  group={g}
+                  onDelete={(a) => {
+                    if (window.confirm(`Stop mapping "${a}"? Dashboards will show it as its own model again.`)) {
+                      remove.mutate(a);
+                    }
+                  }}
+                  deleting={remove.isPending}
+                />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function ModelGroupRows({ group, onDelete, deleting }: {
+  group: ReturnType<typeof groupModels>[number];
+  onDelete: (aliasModel: string) => void;
+  deleting: boolean;
+}) {
+  // Every row of the group is a spelling that folds into the desired name, so
+  // every one of them gets an unmap control. Rendering only the tail would
+  // leave a group with a single alias — the common case — with no way back.
+  const rows = [
+    ...group.aliases
+      .filter(a => a.model !== group.canonicalModel)
+      .map(a => ({
+        key: a.model,
+        reported: a.model,
+        prs: a.prs,
+        mappedAt: null as string | null,
+      })),
+    ...group.unusedMappings.map(mm => ({
+      key: mm.aliasModel,
+      reported: mm.aliasModel,
+      prs: 0,
+      mappedAt: mm.createdAt,
+    })),
+  ];
+
+  return (
+    <>
+      <tr className="border-t border-border-soft">
+        <td className="px-5 py-2 align-top" rowSpan={Math.max(rows.length, 1)}>
+          <div className="font-mono text-[12px] font-semibold text-ink">{group.canonicalModel}</div>
+          {group.createdBy && (
+            <div className="mt-0.5 text-[10px] text-ink-tertiary">by {group.createdBy}</div>
+          )}
+        </td>
+        {rows.length === 0 ? (
+          <td className="px-5 py-2 text-[11px] text-ink-tertiary italic" colSpan={2}>
+            Reported as this exact name — nothing mapped
+          </td>
+        ) : (
+          <td className="px-5 py-2 text-[11px]" colSpan={2}>
+            <AliasCell row={rows[0]} />
+          </td>
+        )}
+        <td className="px-5 py-2 text-right align-top font-mono text-[12px] text-ink-secondary">
+          {group.prs}
+        </td>
+        <td className="px-5 py-2 align-top">
+          {rows.length > 0 && (
+            <UnmapButton alias={rows[0].reported} onDelete={onDelete} deleting={deleting} />
+          )}
+        </td>
+      </tr>
+      {rows.slice(1).map(r => (
+        <tr key={r.key} className="border-t border-border-soft/50">
+          <td className="px-5 py-2 text-[11px]" colSpan={2}>
+            <AliasCell row={r} indent />
+          </td>
+          <td />
+          <td className="px-5 py-2 text-right">
+            <UnmapButton alias={r.reported} onDelete={onDelete} deleting={deleting} />
+          </td>
+        </tr>
+      ))}
+    </>
+  );
+}
+
+function AliasCell({ row, indent }: {
+  row: { reported: string; prs: number; mappedAt: string | null };
+  indent?: boolean;
+}) {
+  return (
+    <>
+      {indent && <span className="text-ink-tertiary/60 mr-1">↳</span>}
+      <span className="font-mono text-ink-secondary">{row.reported}</span>
+      {row.prs > 0
+        ? <span className="ml-1 font-mono text-ink-secondary">{row.prs}</span>
+        : <span className="ml-1 italic text-ink-tertiary">not reported yet</span>}
+      {row.mappedAt && (
+        <span className="ml-1 text-ink-tertiary">· mapped {fmtDate(row.mappedAt)}</span>
+      )}
+    </>
+  );
+}
+
+function UnmapButton({ alias, onDelete, deleting }: {
+  alias: string;
+  onDelete: (aliasModel: string) => void;
+  deleting: boolean;
+}) {
+  return (
+    <button
+      disabled={deleting}
+      onClick={() => onDelete(alias)}
+      className="text-ink-tertiary hover:text-red-500 disabled:opacity-40"
+      title={`Unmap "${alias}"`}
+    >
+      <Trash2 className="w-3.5 h-3.5" />
+    </button>
+  );
+}

--- a/packages/hub-ui/src/pages/modelMappings.ts
+++ b/packages/hub-ui/src/pages/modelMappings.ts
@@ -1,0 +1,119 @@
+/**
+ * Pure grouping/validation logic for the admin Models page, kept out of the
+ * component so it is testable without a DOM (same reasoning as hiddenPeople.ts
+ * and retiredInstallations.ts).
+ */
+
+export interface MappingRow {
+  aliasModel: string;
+  canonicalModel: string;
+  createdByUserId: string | null;
+  createdByEmail: string | null;
+  createdAt: string;
+}
+
+export interface ObservedModel {
+  model: string;
+  prs: number;
+  canonicalModel: string;
+  isMapped: boolean;
+}
+
+/** One desired model, with every reported spelling folded under it. */
+export interface ModelGroup {
+  /** The name the admin chose, shown in the "desired name" column. */
+  canonicalModel: string;
+  /** Total PRs across the canonical name and all of its aliases. */
+  prs: number;
+  /** Reported ids that resolve to this name, including the canonical itself. */
+  aliases: ObservedModel[];
+  /** True when the canonical name has been reported at least once. */
+  canonicalSeen: boolean;
+  /** Mappings that exist but whose alias has never been seen in events. */
+  unusedMappings: MappingRow[];
+  /** Who created the mappings behind this group. */
+  createdBy: string | null;
+}
+
+/**
+ * Fold observed model ids into groups keyed by desired name.
+ *
+ * A canonical name gets its own group even when it has never been reported, so
+ * the admin can see a mapping they created whose alias has not appeared (yet)
+ * rather than wondering whether it took effect.
+ */
+export function groupModels(mappings: MappingRow[], observed: ObservedModel[]): ModelGroup[] {
+  const groups = new Map<string, ModelGroup>();
+  const ensure = (canonicalModel: string): ModelGroup => {
+    let g = groups.get(canonicalModel);
+    if (!g) {
+      g = {
+        canonicalModel, prs: 0, aliases: [], canonicalSeen: false,
+        unusedMappings: [], createdBy: null,
+      };
+      groups.set(canonicalModel, g);
+    }
+    return g;
+  };
+
+  for (const o of observed) {
+    const g = ensure(o.canonicalModel);
+    g.aliases.push(o);
+    g.prs += o.prs;
+    if (o.model === o.canonicalModel) g.canonicalSeen = true;
+  }
+
+  for (const m of mappings) {
+    const g = ensure(m.canonicalModel);
+    if (!g.createdBy && m.createdByEmail) g.createdBy = m.createdByEmail;
+    // A mapping whose alias never appears in events: kept visible, because a
+    // silently-dead mapping is indistinguishable from one that never saved.
+    if (!g.aliases.some(a => a.model === m.aliasModel)) g.unusedMappings.push(m);
+  }
+
+  return [...groups.values()]
+    .map(g => ({
+      ...g,
+      aliases: [...g.aliases].sort((a, b) => b.prs - a.prs || a.model.localeCompare(b.model)),
+      unusedMappings: [...g.unusedMappings].sort((a, b) => a.aliasModel.localeCompare(b.aliasModel)),
+    }))
+    .sort((a, b) => b.prs - a.prs || a.canonicalModel.localeCompare(b.canonicalModel));
+}
+
+/**
+ * Validate a proposed mapping. Returns an error message, or null when valid.
+ *
+ * Mirrors the server's rules so the admin sees the problem before the request,
+ * but the server remains authoritative — these are not a security boundary.
+ */
+export function validateMapping(
+  aliasModel: string,
+  canonicalModel: string,
+  existing: MappingRow[],
+): string | null {
+  const alias = aliasModel.trim();
+  const canonical = canonicalModel.trim();
+  if (!alias) return 'Enter the model name as it is being reported today.';
+  if (!canonical) return 'Enter the name you want it to appear as.';
+  if (alias.length > 200 || canonical.length > 200) return 'Model names are limited to 200 characters.';
+  if (alias === canonical) return 'These are the same name — there is nothing to map.';
+
+  const clash = existing.find(m => m.aliasModel === alias);
+  if (clash && clash.canonicalModel !== canonical) {
+    return `"${alias}" is already mapped to "${clash.canonicalModel}". Delete that mapping first.`;
+  }
+  const chain = existing.find(m => m.aliasModel === canonical);
+  if (chain) {
+    return `"${canonical}" is itself mapped to "${chain.canonicalModel}". Map "${alias}" to that final name instead.`;
+  }
+  return null;
+}
+
+/**
+ * Aliases already mapped, offered as the desired name when adding another
+ * spelling — so a third spelling lands in the existing group instead of
+ * starting a second one for the same model.
+ */
+export function knownCanonicalNames(mappings: MappingRow[]): string[] {
+  return [...new Set(mappings.map(m => m.canonicalModel))].sort((a, b) => a.localeCompare(b));
+}

--- a/packages/hub-ui/src/test/adminModelsPage.test.tsx
+++ b/packages/hub-ui/src/test/adminModelsPage.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Admin → Models page. The grouping/validation rules are covered in
+ * adminModels.test.ts; what matters here is the wiring a unit test cannot see:
+ *  - the desired name is the column that groups, with spellings under it;
+ *  - adding posts the TRIMMED pair (a pasted trailing space would otherwise
+ *    make an alias that can never match);
+ *  - client-side validation blocks the request and shows why;
+ *  - a server 409 is surfaced rather than swallowed;
+ *  - deleting targets the right alias;
+ *  - the overview queries are invalidated, since that table is the thing that
+ *    actually changes.
+ */
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AdminModels } from '../pages/AdminModels';
+import { api } from '../api';
+
+vi.mock('../api', () => ({ api: { get: vi.fn(), post: vi.fn(), delete: vi.fn() } }));
+const get = api.get as unknown as ReturnType<typeof vi.fn>;
+const post = api.post as unknown as ReturnType<typeof vi.fn>;
+const del = api.delete as unknown as ReturnType<typeof vi.fn>;
+
+const RESPONSE = {
+  mappings: [
+    {
+      aliasModel: 'qwen38-27b', canonicalModel: 'qwen3.8:27b',
+      createdByUserId: 'u1', createdByEmail: 'admin@acme.com',
+      createdAt: '2026-09-01T10:00:00.000Z',
+    },
+  ],
+  observed: [
+    { model: 'glm-5.2', prs: 40, canonicalModel: 'glm-5.2', isMapped: false },
+    { model: 'qwen38-27b', prs: 2, canonicalModel: 'qwen3.8:27b', isMapped: true },
+    { model: 'qwen3.8:27b', prs: 1, canonicalModel: 'qwen3.8:27b', isMapped: false },
+  ],
+};
+
+const renderPage = () => {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter><AdminModels /></MemoryRouter>
+    </QueryClientProvider>,
+  );
+};
+
+beforeEach(() => {
+  get.mockReset().mockResolvedValue({ data: RESPONSE });
+  post.mockReset().mockResolvedValue({ data: {} });
+  del.mockReset().mockResolvedValue({ data: { removed: true } });
+});
+
+afterEach(() => { cleanup(); });
+
+describe('AdminModels', () => {
+  it('shows the desired name as the group, with the reported spelling under it', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByText('qwen3.8:27b')).toBeInTheDocument());
+    // the alias is shown as folded in, not as its own model
+    expect(screen.getByText('qwen38-27b')).toBeInTheDocument();
+    // and the group total is the sum, not either row alone
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+
+  it('leaves an unmapped model as its own row', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByText('glm-5.2')).toBeInTheDocument());
+    expect(screen.getByText('40')).toBeInTheDocument();
+  });
+
+  it('posts the trimmed pair when adding', async () => {
+    renderPage();
+    await waitFor(() => screen.getByText('glm-5.2'));
+
+    fireEvent.change(screen.getByLabelText(/reported today as/i), { target: { value: '  qwen-3.8-27b  ' } });
+    fireEvent.change(screen.getByLabelText(/show as \(desired name\)/i), { target: { value: '  qwen3.8:27b ' } });
+    fireEvent.click(screen.getByRole('button', { name: /add/i }));
+
+    await waitFor(() => expect(post).toHaveBeenCalledWith('/v1/admin/models/mappings', {
+      aliasModel: 'qwen-3.8-27b', canonicalModel: 'qwen3.8:27b',
+    }));
+  });
+
+  it('blocks a mapping of a name to itself without hitting the server', async () => {
+    renderPage();
+    await waitFor(() => screen.getByText('glm-5.2'));
+
+    fireEvent.change(screen.getByLabelText(/reported today as/i), { target: { value: 'glm-5.2' } });
+    fireEvent.change(screen.getByLabelText(/show as \(desired name\)/i), { target: { value: 'glm-5.2' } });
+    fireEvent.click(screen.getByRole('button', { name: /add/i }));
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a server conflict instead of failing silently', async () => {
+    post.mockRejectedValue({ response: { data: { error: '"qwen38-27b" is already mapped to "other".' } } });
+    renderPage();
+    await waitFor(() => screen.getByText('glm-5.2'));
+
+    fireEvent.change(screen.getByLabelText(/reported today as/i), { target: { value: 'brand-new' } });
+    fireEvent.change(screen.getByLabelText(/show as \(desired name\)/i), { target: { value: 'qwen3.8:27b' } });
+    fireEvent.click(screen.getByRole('button', { name: /add/i }));
+
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('already mapped to "other"'));
+  });
+
+  it('deletes the alias of the row it was clicked on', async () => {
+    vi.spyOn(window, 'confirm').mockImplementation(() => true);
+    renderPage();
+    await waitFor(() => screen.getByText('glm-5.2'));
+
+    fireEvent.click(screen.getByTitle(/unmap "qwen38-27b"/i));
+    await waitFor(() => expect(del).toHaveBeenCalledWith('/v1/admin/models/mappings/qwen38-27b'));
+  });
+
+  it('does not delete when the confirmation is declined', async () => {
+    vi.spyOn(window, 'confirm').mockImplementation(() => false);
+    renderPage();
+    await waitFor(() => screen.getByText('glm-5.2'));
+
+    fireEvent.click(screen.getByTitle(/unmap "qwen38-27b"/i));
+    await new Promise(r => setTimeout(r, 20));
+    expect(del).not.toHaveBeenCalled();
+  });
+
+  it('invalidates the PR Overview queries, which is what this page actually changes', async () => {
+    renderPage();
+    await waitFor(() => screen.getByText('glm-5.2'));
+
+    fireEvent.change(screen.getByLabelText(/reported today as/i), { target: { value: 'x-alias' } });
+    fireEvent.change(screen.getByLabelText(/show as \(desired name\)/i), { target: { value: 'x-name' } });
+    fireEvent.click(screen.getByRole('button', { name: /add/i }));
+
+    await waitFor(() => expect(post).toHaveBeenCalled());
+    // refetched after the mutation lands: the overview table must stop showing
+    // the split immediately, not on the next hard reload.
+    await waitFor(() => expect(get.mock.calls.filter(c => c[0] === '/v1/admin/models').length).toBeGreaterThan(1), {
+      timeout: 2000,
+    });
+  });
+
+  it('explains an empty hub rather than showing a blank table', async () => {
+    get.mockResolvedValue({ data: { mappings: [], observed: [] } });
+    renderPage();
+    await waitFor(() => expect(screen.getByText(/no PR events with a model/i)).toBeInTheDocument());
+  });
+
+  it('offers observed ids and existing desired names as suggestions', async () => {
+    renderPage();
+    await waitFor(() => screen.getByText('glm-5.2'));
+    // datalist elements are only useful if the inputs actually point at them.
+    const aliasInput = screen.getByLabelText(/reported today as/i) as HTMLInputElement;
+    const canonicalInput = screen.getByLabelText(/show as \(desired name\)/i) as HTMLInputElement;
+    expect(aliasInput.getAttribute('list')).toBe('observed-model-ids');
+    expect(canonicalInput.getAttribute('list')).toBe('known-canonical-names');
+    const options = (id: string) => Array.from(
+      document.querySelectorAll(`datalist#${id} option`),
+    ).map(o => o.getAttribute('value'));
+    expect(options('observed-model-ids')).toEqual(expect.arrayContaining(['glm-5.2', 'qwen38-27b']));
+    expect(options('known-canonical-names')).toEqual(['qwen3.8:27b']);
+  });
+});

--- a/packages/hub-ui/src/test/modelMappings.test.ts
+++ b/packages/hub-ui/src/test/modelMappings.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import {
+  groupModels, validateMapping, knownCanonicalNames,
+  MappingRow, ObservedModel,
+} from '../pages/modelMappings';
+
+const m = (aliasModel: string, canonicalModel: string, over: Partial<MappingRow> = {}): MappingRow => ({
+  aliasModel, canonicalModel,
+  createdByUserId: 'u1', createdByEmail: 'admin@acme.com',
+  createdAt: '2026-09-01T10:00:00Z', ...over,
+});
+
+const o = (model: string, prs: number, canonicalModel = model): ObservedModel => ({
+  model, prs, canonicalModel, isMapped: model !== canonicalModel,
+});
+
+describe('groupModels', () => {
+  it('folds aliases into the desired name and sums their PRs', () => {
+    const groups = groupModels(
+      [m('qwen38-27b', 'qwen3.8:27b')],
+      [o('qwen3.8:27b', 1), o('qwen38-27b', 2, 'qwen3.8:27b'), o('glm-5.2', 40)],
+    );
+    const qwen = groups.find(g => g.canonicalModel === 'qwen3.8:27b')!;
+    expect(qwen.prs).toBe(3);
+    expect(qwen.aliases.map(a => a.model)).toEqual(['qwen38-27b', 'qwen3.8:27b']);
+    expect(qwen.canonicalSeen).toBe(true);
+    // unmapped models are their own group, untouched
+    expect(groups.find(g => g.canonicalModel === 'glm-5.2')!.prs).toBe(40);
+  });
+
+  it('orders by PR count so the busiest models are top of the table', () => {
+    const groups = groupModels([], [o('small', 1), o('big', 100), o('mid', 10)]);
+    expect(groups.map(g => g.canonicalModel)).toEqual(['big', 'mid', 'small']);
+  });
+
+  it('orders aliases within a group by PR count', () => {
+    const groups = groupModels(
+      [m('a-alias', 'q')],
+      [o('q', 5), o('a-alias', 1, 'q')],
+    );
+    expect(groups[0].aliases.map(a => a.model)).toEqual(['q', 'a-alias']);
+  });
+
+  it('shows a mapping whose alias has never been reported, as waiting rather than missing', () => {
+    const groups = groupModels([m('future-model', 'qwen3.8:27b')], [o('qwen3.8:27b', 3)]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].unusedMappings.map(x => x.aliasModel)).toEqual(['future-model']);
+    expect(groups[0].prs).toBe(3);
+  });
+
+  it('creates a group for a desired name that has never been reported at all', () => {
+    const groups = groupModels([m('qwen38-27b', 'brand-new-name')], [o('qwen38-27b', 7, 'brand-new-name')]);
+    expect(groups[0]).toMatchObject({ canonicalModel: 'brand-new-name', prs: 7, canonicalSeen: false });
+  });
+
+  it('handles no data at all', () => {
+    expect(groupModels([], [])).toEqual([]);
+  });
+
+  it('attributes the group to whoever created its first mapping', () => {
+    const groups = groupModels(
+      [m('a', 'q', { createdByEmail: 'first@acme.com' }), m('b', 'q', { createdByEmail: 'second@acme.com' })],
+      [],
+    );
+    expect(groups[0].createdBy).toBe('first@acme.com');
+  });
+});
+
+describe('validateMapping', () => {
+  it('accepts a plain new mapping', () => {
+    expect(validateMapping('qwen38-27b', 'qwen3.8:27b', [])).toBeNull();
+  });
+
+  it('accepts a mapping that already exists identically (the server no-ops it)', () => {
+    expect(validateMapping('qwen38-27b', 'qwen3.8:27b', [m('qwen38-27b', 'qwen3.8:27b')])).toBeNull();
+  });
+
+  it('rejects blank sides, mentioning which', () => {
+    expect(validateMapping('  ', 'qwen3.8:27b', [])).toMatch(/reported today/i);
+    expect(validateMapping('qwen38-27b', '  ', [])).toMatch(/want it to appear/i);
+  });
+
+  it('rejects mapping a name to itself', () => {
+    expect(validateMapping('qwen3.8:27b', 'qwen3.8:27b', [])).toMatch(/same name/i);
+  });
+
+  it('compares trimmed values, so trailing space is not treated as a different name', () => {
+    expect(validateMapping(' qwen3.8:27b ', 'qwen3.8:27b', [])).toMatch(/same name/i);
+  });
+
+  it('rejects an overlong name', () => {
+    expect(validateMapping('a'.repeat(201), 'q', [])).toMatch(/200/);
+  });
+
+  it('rejects re-pointing an alias that is already mapped elsewhere, naming the current target', () => {
+    const err = validateMapping('qwen38-27b', 'other-name', [m('qwen38-27b', 'qwen3.8:27b')])!;
+    expect(err).toContain('qwen3.8:27b');
+    expect(err).toMatch(/delete that mapping first/i);
+  });
+
+  it('rejects a chain and points at the final name', () => {
+    const err = validateMapping('qwen-3.8-27b', 'qwen38-27b', [m('qwen38-27b', 'qwen3.8:27b')])!;
+    expect(err).toContain('qwen3.8:27b');
+    expect(err).toMatch(/final name/i);
+  });
+});
+
+describe('knownCanonicalNames', () => {
+  it('lists distinct desired names for autocomplete', () => {
+    expect(knownCanonicalNames([m('a', 'q'), m('b', 'q'), m('c', 'g')])).toEqual(['g', 'q']);
+  });
+
+  it('is empty when nothing is mapped', () => {
+    expect(knownCanonicalNames([])).toEqual([]);
+  });
+});

--- a/packages/hub/src/db/postgres.ts
+++ b/packages/hub/src/db/postgres.ts
@@ -273,6 +273,20 @@ const SCHEMA_PG = `
     created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     PRIMARY KEY (org_id, user_key)
   );
+
+  -- Admin-curated model identity; see the SQLite schema for the reasoning
+  -- (literal canonical name by choice, read-time only, events untouched).
+  CREATE TABLE IF NOT EXISTS model_mappings (
+    org_id TEXT NOT NULL,
+    alias_model TEXT NOT NULL,
+    canonical_model TEXT NOT NULL,
+    created_by_user_id TEXT,
+    created_by_email TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (org_id, alias_model)
+  );
+  CREATE INDEX IF NOT EXISTS idx_model_mappings_canonical
+    ON model_mappings(org_id, canonical_model);
 `;
 
 /**

--- a/packages/hub/src/db/sqlite.ts
+++ b/packages/hub/src/db/sqlite.ts
@@ -293,6 +293,34 @@ const SCHEMA_SQLITE = `
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
     PRIMARY KEY (org_id, user_key)
   );
+
+  -- Admin-curated model identity, the "model" axis of user_key_aliases.
+  -- A model id is free text the agent self-reports (--model <id>), so one
+  -- model arrives as qwen3.8:27b, qwen38-27b, ... and the dashboards group
+  -- by the raw string and show them as separate models.
+  --
+  -- The canonical name is the admin's literal string, deliberately NOT derived
+  -- by a normalization rule: a rule that maps "-" to ":" and "38" to "3.8"
+  -- eventually merges two genuinely different models, and the admin cannot see
+  -- why it happened. Here the desired name is exactly what was typed, and only
+  -- the listed aliases fold into it.
+  --
+  -- Applied at read time only. The events table keeps recording what was actually
+  -- reported — this is append-only telemetry of what an agent claimed, and
+  -- rewriting it would destroy that fact and be undone by the next event
+  -- anyway. Deleting a row here reverts the dashboards, which is why no
+  -- recompute job is needed.
+  CREATE TABLE IF NOT EXISTS model_mappings (
+    org_id TEXT NOT NULL,
+    alias_model TEXT NOT NULL,
+    canonical_model TEXT NOT NULL,
+    created_by_user_id TEXT,
+    created_by_email TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (org_id, alias_model)
+  );
+  CREATE INDEX IF NOT EXISTS idx_model_mappings_canonical
+    ON model_mappings(org_id, canonical_model);
 `;
 
 class SqliteAdapter implements HubDb {

--- a/packages/hub/src/queries/pr-overview-aggregate.ts
+++ b/packages/hub/src/queries/pr-overview-aggregate.ts
@@ -1,4 +1,5 @@
 import { prSizePoints, prSizeBucket, SIZE_BUCKETS, SizeBucket } from '@agenfk/core';
+import { resolveModelId, ModelMapping, EMPTY_MODEL_MAPPING } from '../util/modelMapping';
 
 // One json_extract-shaped row per pr.opened / pr.updated event. Sizing fields are
 // read from the server-computed shadow (the only source that knows leaf stories).
@@ -44,7 +45,7 @@ const toNum = (v: unknown): number => {
   return Number.isFinite(n) ? n : 0;
 };
 
-function normaliseRow(r: PrEventRow): NormRow {
+function normaliseRow(r: PrEventRow, mapping: ModelMapping): NormRow {
   return {
     user_key: r.user_key,
     occurred_at: toIso(r.occurred_at),
@@ -54,7 +55,9 @@ function normaliseRow(r: PrEventRow): NormRow {
     leafStory: toNum(r.leaf_story),
     task: toNum(r.task),
     bug: toNum(r.bug),
-    model: r.model,
+    // Resolved here, at the single funnel both the grouping and the filter read
+    // through, so the two can never disagree about a PR's model.
+    model: resolveModelId(r.model, mapping),
     harness: r.harness,
   };
 }
@@ -97,6 +100,12 @@ export interface PrWindow {
   to?: string | null;
   models?: string[] | null;
   developers?: string[] | null;
+  /**
+   * Admin alias -> canonical model name. Applied to stored ids AND to `models`
+   * above, so both sides of the filter compare canonical names. Callers pass
+   * already-resolved `models` if they resolved them themselves.
+   */
+  modelMapping?: ModelMapping | null;
 }
 
 interface ResolvedPr {
@@ -114,10 +123,10 @@ interface ResolvedPr {
 // Collapse the raw event stream into one record per PR. A pr.updated never adds a
 // new PR — it re-sizes the existing one. The PR is counted once, placed on its
 // OPEN day at its LATEST size, and attributed to whoever OPENED it.
-function resolvePrs(rows: ReadonlyArray<PrEventRow>): ResolvedPr[] {
+function resolvePrs(rows: ReadonlyArray<PrEventRow>, mapping: ModelMapping): ResolvedPr[] {
   const groups = new Map<string, NormRow[]>();
   for (const raw of rows) {
-    const r = normaliseRow(raw);
+    const r = normaliseRow(raw, mapping);
     if (!r.repo || r.pr_number == null) continue; // not a sizeable PR event
     const key = `${r.repo}#${r.pr_number}`;
     const g = groups.get(key);
@@ -149,9 +158,12 @@ function resolvePrs(rows: ReadonlyArray<PrEventRow>): ResolvedPr[] {
 export function aggregatePrOverview(rows: ReadonlyArray<PrEventRow>, window?: PrWindow): PrOverviewResult {
   const from = window?.from ?? null;
   const to = window?.to ?? null;
-  const modelFilter = window?.models && window.models.length ? new Set(window.models) : null;
+  const mapping = window?.modelMapping ?? EMPTY_MODEL_MAPPING;
+  const modelFilter = window?.models && window.models.length
+    ? new Set(window.models.map(m => resolveModelId(m, mapping) as string))
+    : null;
   const devFilter = window?.developers && window.developers.length ? new Set(window.developers) : null;
-  const prs = resolvePrs(rows).filter(pr =>
+  const prs = resolvePrs(rows, mapping).filter(pr =>
     (!from || pr.openerAt >= from)
     && (!to || pr.openerAt <= to)
     && (!modelFilter || modelFilter.has(pr.model))

--- a/packages/hub/src/routes/admin.ts
+++ b/packages/hub/src/routes/admin.ts
@@ -13,6 +13,7 @@ import { recomputeRollups } from '../rollup.js';
 import { liveIdentityBlockers, blockersFor } from '../util/mergeLiveness.js';
 import { loadAliasMap, resolveAliasKey, canonicaliseSourceKey } from '../util/userKeyAlias.js';
 import { rateLimit } from '../util/rateLimit.js';
+import { loadModelMappings } from '../util/modelMapping.js';
 
 /**
  * Hosts a repoint campaign may never target. Every installation in the org
@@ -239,6 +240,146 @@ export function adminRouter(ctx: HubServerContext): Router {
     // Note: api_key revocation is permanent — unhiding does NOT restore
     // revoked tokens (the person must re-register their installation).
     res.json({ userKey, unhidden: r.changes > 0 });
+  });
+
+  // ── Model mappings ───────────────────────────────────────────────────────
+  // Admin-curated model identity: an alias reported by an installation folds
+  // into a canonical name the admin chose. Read-time overlay only — `events`
+  // keeps what was actually reported, so DELETE reverts the dashboards and no
+  // recompute job is involved. See util/modelMapping.ts for why resolution is
+  // an exact lookup rather than a normalization rule.
+  //
+  // Ids are stored EXACTLY as typed, not lowercased or trimmed beyond the outer
+  // whitespace: the canonical name is the admin's literal string and the UI
+  // shows it verbatim. Trimming is applied because a trailing space is invisible
+  // in a table cell and would otherwise make an alias unmatchable.
+  const MODEL_ID_MAX_LENGTH = 200;
+
+  function validModelId(value: unknown): string | null {
+    if (typeof value !== 'string') return null;
+    const v = value.trim();
+    if (!v || v.length > MODEL_ID_MAX_LENGTH) return null;
+    // Control characters cannot be typed deliberately but arrive via paste, and
+    // would make an alias that can never be matched or read.
+    // eslint-disable-next-line no-control-regex
+    if (/[\u0000-\u001f\u007f]/.test(v)) return null;
+    return v;
+  }
+
+  // The table the admin edits, plus every model id actually seen in events so
+  // the UI can offer real values instead of free typing. The DISTINCT scan is
+  // over an append-only table and reads a JSON field, so it is bounded by total
+  // event volume rather than by the window — acceptable at current scale, and
+  // the reason this is an admin page rather than something on every dashboard
+  // load. A materialized model column would replace it if that ever bites.
+  router.get('/models', guard, async (req: Request, res: Response) => {
+    const orgId = req.session!.orgId;
+    const [mappings, seen] = await Promise.all([
+      ctx.db.all<Record<string, unknown>>(
+        `SELECT alias_model, canonical_model, created_by_user_id, created_by_email, created_at
+           FROM model_mappings WHERE org_id = ? ORDER BY canonical_model, alias_model`,
+        [orgId],
+      ),
+      ctx.db.all<{ model: string | null; prs: number }>(
+        `SELECT json_extract(payload, '$.payload.model') AS model,
+                COUNT(*) AS prs
+           FROM events
+          WHERE org_id = ? AND type IN ('pr.opened', 'pr.updated')
+          GROUP BY model`,
+        [orgId],
+      ),
+    ]);
+
+    const mapped = new Map(mappings.map((m: any) => [m.alias_model as string, m.canonical_model as string]));
+    const observed = seen
+      .filter(r => r.model)
+      .map(r => ({
+        model: r.model as string,
+        prs: Number(r.prs),
+        // A reported id already folded into a canonical name: shown grouped
+        // under that name rather than as its own row.
+        canonicalModel: mapped.get(r.model as string) ?? (r.model as string),
+        isMapped: mapped.has(r.model as string),
+      }))
+      .sort((a, b) => b.prs - a.prs || a.model.localeCompare(b.model));
+
+    res.json({
+      mappings: mappings.map((m: any) => ({
+        aliasModel: m.alias_model,
+        canonicalModel: m.canonical_model,
+        createdByUserId: m.created_by_user_id ?? null,
+        createdByEmail: m.created_by_email ?? null,
+        createdAt: m.created_at,
+      })),
+      observed,
+    });
+  });
+
+  router.post('/models/mappings', guard, async (req: Request, res: Response) => {
+    const orgId = req.session!.orgId;
+    const aliasModel = validModelId(req.body?.aliasModel);
+    const canonicalModel = validModelId(req.body?.canonicalModel);
+    if (!aliasModel || !canonicalModel) {
+      return res.status(400).json({
+      error: `Body must be { aliasModel: string, canonicalModel: string }, each non-empty and at most ${MODEL_ID_MAX_LENGTH} characters.`,
+      });
+    }
+    if (aliasModel === canonicalModel) {
+      return res.status(400).json({ error: 'An alias must differ from the canonical name it maps to.' });
+    }
+
+    // Reject an alias that would resolve to a different canonical name than the
+    // one already on file. Overwriting silently would re-file every PR behind
+    // that alias under a new model with no audit trail, so the admin has to
+    // delete the existing row first and say so deliberately.
+    const existing = await ctx.db.get<{ canonical_model: string }>(
+      'SELECT canonical_model FROM model_mappings WHERE org_id = ? AND alias_model = ?',
+      [orgId, aliasModel],
+    );
+    if (existing && existing.canonical_model !== canonicalModel) {
+      return res.status(409).json({
+        error: `"${aliasModel}" is already mapped to "${existing.canonical_model}". Delete that mapping first.`,
+        canonicalModel: existing.canonical_model,
+      });
+    }
+
+    // A chain (A→B where B is itself an alias of C) would resolve A→B while the
+    // dashboard shows B grouped under C, so A's PRs land in a group that looks
+    // empty. Reject rather than resolve transitively: the admin's intent when
+    // mapping A is to name it, and pointing A at the final name is one edit.
+    const aliasIsAlsoAlias = await ctx.db.get<{ canonical_model: string }>(
+      'SELECT canonical_model FROM model_mappings WHERE org_id = ? AND alias_model = ?',
+      [orgId, canonicalModel],
+    );
+    if (aliasIsAlsoAlias) {
+      return res.status(409).json({
+        error: `"${canonicalModel}" is itself mapped to "${aliasIsAlsoAlias.canonical_model}". Map "${aliasModel}" to that final name instead.`,
+      });
+    }
+
+    let createdByEmail: string | null = null;
+    if (req.session?.userId) {
+      const u = await ctx.db.get<{ email: string }>('SELECT email FROM users WHERE id = ?', [req.session.userId]);
+      createdByEmail = u?.email ?? null;
+    }
+
+    await ctx.db.run(
+      `INSERT INTO model_mappings (org_id, alias_model, canonical_model, created_by_user_id, created_by_email)
+       VALUES (?, ?, ?, ?, ?)
+       ON CONFLICT(org_id, alias_model) DO NOTHING`,
+      [orgId, aliasModel, canonicalModel, req.session!.userId, createdByEmail],
+    );
+    res.status(201).json({ aliasModel, canonicalModel });
+  });
+
+  router.delete('/models/mappings/:aliasModel', guard, async (req: Request, res: Response) => {
+    const aliasModel = validModelId(decodeURIComponent(req.params.aliasModel));
+    if (!aliasModel) return res.status(400).json({ error: 'Invalid alias model id.' });
+    const r = await ctx.db.run(
+      'DELETE FROM model_mappings WHERE org_id = ? AND alias_model = ?',
+      [req.session!.orgId, aliasModel],
+    );
+    res.json({ aliasModel, removed: r.changes > 0 });
   });
 
   // ── Users ────────────────────────────────────────────────────────────────

--- a/packages/hub/src/routes/orgRename.ts
+++ b/packages/hub/src/routes/orgRename.ts
@@ -19,6 +19,7 @@ export const ORG_ID_CHILD_TABLES: readonly string[] = [
   'flows',
   'hidden_users',
   'installations',
+  'model_mappings',
   'repoint_campaigns',
   'rollups_daily',
   'upgrade_directives',

--- a/packages/hub/src/routes/queries.ts
+++ b/packages/hub/src/routes/queries.ts
@@ -7,6 +7,7 @@ import { coerceMetricsRow } from '../queries/metrics-coerce.js';
 import { aggregatePrOverview, PrEventRow } from '../queries/pr-overview-aggregate.js';
 import { sanitizeRemoteUrl } from './events.js';
 import { rateLimit } from '../util/rateLimit.js';
+import { loadModelMappings } from '../util/modelMapping.js';
 
 function parseList(s: string | undefined): string[] | null {
   // Repeated params (?model=a&model=b) arrive as an array — normalize to the
@@ -224,6 +225,10 @@ export function queriesRouter(ctx: HubServerContext): Router {
     // Multi-select: a CSV of models, same parseList semantics as users/projects.
     // A single-value ?model=x link keeps working (one-element list).
     const models = parseList(req.query.model as string | undefined);
+    // Admin alias -> canonical. Resolved inside the aggregator for the rows, and
+    // the filter values go through the same mapping so a saved link to
+    // `?model=qwen38-27b` still finds the group now filed under `qwen3.8:27b`.
+    const modelMapping = await loadModelMappings(ctx.db, orgId);
 
     // Fetch PR events with only the UPPER time bound applied in SQL (`upTo`). The
     // lower bound (`from`) and the model filter are intentionally NOT pushed down:
@@ -253,7 +258,7 @@ export function queriesRouter(ctx: HubServerContext): Router {
       );
     };
 
-    const result = aggregatePrOverview(await fetchRows(f.to), { from: f.from, to: f.to, models, developers: f.users });
+    const result = aggregatePrOverview(await fetchRows(f.to), { from: f.from, to: f.to, models, developers: f.users, modelMapping });
 
     // Previous equal-length window for deltas — only when a lower bound is set.
     // The previous window's upper bound is EXCLUSIVE of `from` so a PR opened
@@ -266,7 +271,7 @@ export function queriesRouter(ctx: HubServerContext): Router {
         const span = toMs - fromMs;
         const prevFrom = new Date(fromMs - span).toISOString();
         const prevTo = new Date(fromMs - 1).toISOString();
-        const prev = aggregatePrOverview(await fetchRows(prevTo), { from: prevFrom, to: prevTo, models, developers: f.users });
+        const prev = aggregatePrOverview(await fetchRows(prevTo), { from: prevFrom, to: prevTo, models, developers: f.users, modelMapping });
         previous = { prs: prev.totals.prs, sizePoints: prev.totals.sizePoints };
       }
     }

--- a/packages/hub/src/test/admin-model-mappings.test.ts
+++ b/packages/hub/src/test/admin-model-mappings.test.ts
@@ -1,0 +1,222 @@
+// Admin model mappings:
+//   GET    /v1/admin/models                    — mappings + every model id seen in events
+//   POST   /v1/admin/models/mappings           — map an alias to a canonical name
+//   DELETE /v1/admin/models/mappings/:alias    — remove a mapping (reverts the dashboards)
+//
+// The bug these exist for: one model reported as `qwen38-27b` and `qwen3.8:27b`
+// appeared as two rows in the PR Overview "By model" table, splitting its PR
+// count. Resolution is a read-time overlay, so `events` keeps what was reported.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import supertest from 'supertest';
+import { createHubApp } from '../server';
+import { createPasswordUser } from '../auth/password';
+import { issueApiKey } from '../auth/apiKey';
+
+const TEST_DB = path.join(os.tmpdir(), `agenfk-hub-model-mappings-${process.pid}.sqlite`);
+const SECRET = 'a'.repeat(64);
+
+const cleanup = () => {
+  for (const suffix of ['', '-wal', '-shm']) {
+    const f = TEST_DB + suffix;
+    if (fs.existsSync(f)) fs.unlinkSync(f);
+  }
+};
+
+describe('admin model mappings', () => {
+  let app: any;
+  let ctx: any;
+  let cookie: string;
+  let send: (events: any[]) => Promise<any>;
+
+  const pr = (over: any) => ({
+    eventId: 'e-' + Math.random().toString(36).slice(2),
+    installationId: 'inst-1',
+    orgId: 'org',
+    occurredAt: '2026-05-03T10:00:00Z',
+    actor: { osUser: 'alice', gitName: 'A', gitEmail: 'alice@acme.com' },
+    type: 'pr.opened',
+    remoteUrl: 'git@github.com:acme/api.git',
+    payload: {
+      prNumber: over.prNumber,
+      repo: 'acme/api',
+      model: over.model,
+      harness: 'pi',
+      sizing: { epic: 0, story: 0, task: 1, bug: 0 },
+      sizingShadow: { epic: 0, story: 0, task: 1, bug: 0 },
+      leafStory: 0,
+    },
+  });
+
+  const overview = async (qs = '') =>
+    (await supertest(app).get(`/v1/prs/overview${qs}`).set('Cookie', cookie)).body;
+
+  beforeEach(async () => {
+    cleanup();
+    const out = await createHubApp({
+      dbPath: TEST_DB, secretKey: SECRET, sessionSecret: 'test-session-secret', defaultOrgId: 'org',
+    });
+    app = out.app; ctx = out.ctx;
+    await createPasswordUser(ctx.db, 'org', 'admin@x', 'longenough1', 'admin');
+    const login = await supertest(app).post('/auth/login').send({ email: 'admin@x', password: 'longenough1' });
+    cookie = login.headers['set-cookie']?.[0] ?? '';
+    const token = await issueApiKey(ctx.db, 'org', 'test');
+    send = (events: any[]) =>
+      supertest(app).post('/v1/events').set('Authorization', `Bearer ${token}`).send({ events });
+
+    // The same model under three spellings, plus one genuinely different model.
+    await send([
+      pr({ prNumber: 1, model: 'qwen3.8:27b' }),
+      pr({ prNumber: 2, model: 'qwen38-27b' }),
+      pr({ prNumber: 3, model: 'qwen38-27b' }),
+      pr({ prNumber: 4, model: 'glm-5.2' }),
+    ]);
+  });
+
+  afterEach(async () => { await ctx.db.close(); cleanup(); });
+
+  describe('the bug', () => {
+    it('splits one model across rows before any mapping exists', async () => {
+      const r = await overview();
+      expect(r.byModel.map((m: any) => m.model)).toContain('qwen38-27b');
+      expect(r.byModel.map((m: any) => m.model)).toContain('qwen3.8:27b');
+      expect(r.byModel.find((m: any) => m.model === 'qwen38-27b').prs).toBe(2);
+    });
+  });
+
+  describe('GET /v1/admin/models', () => {
+    it('lists observed model ids with their PR counts, unmapped by default', async () => {
+      const r = await supertest(app).get('/v1/admin/models').set('Cookie', cookie);
+      expect(r.status).toBe(200);
+      expect(r.body.mappings).toEqual([]);
+      const q = r.body.observed.find((o: any) => o.model === 'qwen38-27b');
+      expect(q).toMatchObject({ prs: 2, canonicalModel: 'qwen38-27b', isMapped: false });
+    });
+
+    it('requires admin', async () => {
+      const r = await supertest(app).get('/v1/admin/models');
+      expect(r.status).toBe(401);
+    });
+  });
+
+  describe('POST /v1/admin/models/mappings', () => {
+    const post = (body: any) =>
+      supertest(app).post('/v1/admin/models/mappings').set('Cookie', cookie).send(body);
+
+    it('creates a mapping and records who made it', async () => {
+      const r = await post({ aliasModel: 'qwen38-27b', canonicalModel: 'qwen3.8:27b' });
+      expect(r.status).toBe(201);
+      const list = await supertest(app).get('/v1/admin/models').set('Cookie', cookie);
+      expect(list.body.mappings).toHaveLength(1);
+      expect(list.body.mappings[0]).toMatchObject({
+        aliasModel: 'qwen38-27b', canonicalModel: 'qwen3.8:27b', createdByEmail: 'admin@x',
+      });
+    });
+
+    it('trims surrounding whitespace, which is invisible in a table cell', async () => {
+      const r = await post({ aliasModel: '  qwen38-27b  ', canonicalModel: '  qwen3.8:27b ' });
+      expect(r.status).toBe(201);
+      expect(r.body).toEqual({ aliasModel: 'qwen38-27b', canonicalModel: 'qwen3.8:27b' });
+    });
+
+    it.each([
+      ['missing alias', { canonicalModel: 'qwen3.8:27b' }],
+      ['missing canonical', { aliasModel: 'qwen38-27b' }],
+      ['empty alias', { aliasModel: '   ', canonicalModel: 'qwen3.8:27b' }],
+      ['alias identical to canonical', { aliasModel: 'x', canonicalModel: 'x' }],
+      ['non-string alias', { aliasModel: 42, canonicalModel: 'qwen3.8:27b' }],
+      ['control characters', { aliasModel: 'qwen\u000038', canonicalModel: 'qwen3.8:27b' }],
+      ['overlong id', { aliasModel: 'a'.repeat(201), canonicalModel: 'qwen3.8:27b' }],
+    ])('rejects %s', async (_name, body) => {
+      const r = await post(body);
+      expect(r.status).toBe(400);
+      expect(r.body.error).toBeTruthy();
+    });
+
+    it('refuses to silently re-point an alias already mapped elsewhere', async () => {
+      await post({ aliasModel: 'qwen38-27b', canonicalModel: 'qwen3.8:27b' });
+      const r = await post({ aliasModel: 'qwen38-27b', canonicalModel: 'qwen-3.8' });
+      expect(r.status).toBe(409);
+      expect(r.body.error).toContain('qwen3.8:27b');
+      // unchanged
+      const list = await supertest(app).get('/v1/admin/models').set('Cookie', cookie);
+      expect(list.body.mappings[0].canonicalModel).toBe('qwen3.8:27b');
+    });
+
+    it('accepts a repeat of the identical mapping', async () => {
+      await post({ aliasModel: 'qwen38-27b', canonicalModel: 'qwen3.8:27b' });
+      const r = await post({ aliasModel: 'qwen38-27b', canonicalModel: 'qwen3.8:27b' });
+      expect(r.status).toBe(201);
+      const list = await supertest(app).get('/v1/admin/models').set('Cookie', cookie);
+      expect(list.body.mappings).toHaveLength(1);
+    });
+
+    it('refuses to create a chain, which would leave a group that looks empty', async () => {
+      await post({ aliasModel: 'qwen38-27b', canonicalModel: 'qwen3.8:27b' });
+      const r = await post({ aliasModel: 'qwen-3.8-27b', canonicalModel: 'qwen38-27b' });
+      expect(r.status).toBe(409);
+      expect(r.body.error).toContain('qwen3.8:27b');
+    });
+  });
+
+  describe('effect on PR Overview', () => {
+    beforeEach(async () => {
+      await supertest(app).post('/v1/admin/models/mappings').set('Cookie', cookie)
+        .send({ aliasModel: 'qwen38-27b', canonicalModel: 'qwen3.8:27b' });
+    });
+
+    it('combines the spellings into one row with the summed count', async () => {
+      const r = await overview();
+      const models = r.byModel.map((m: any) => m.model);
+      expect(models).not.toContain('qwen38-27b');
+      const qwen = r.byModel.find((m: any) => m.model === 'qwen3.8:27b');
+      expect(qwen.prs).toBe(3); // 1 + 2, one row
+      expect(r.totals.prs).toBe(4); // total unaffected — only grouping changed
+    });
+
+    it('still filters correctly by the OLD spelling (saved links keep working)', async () => {
+      const r = await overview('?model=qwen38-27b');
+      expect(r.totals.prs).toBe(3);
+      expect(r.byModel).toHaveLength(1);
+      expect(r.byModel[0].model).toBe('qwen3.8:27b');
+    });
+
+    it('filters by the new spelling too', async () => {
+      const r = await overview('?model=qwen3.8:27b');
+      expect(r.totals.prs).toBe(3);
+    });
+
+    it('leaves unmapped models alone', async () => {
+      const r = await overview();
+      expect(r.byModel.find((m: any) => m.model === 'glm-5.2').prs).toBe(1);
+    });
+
+    it('reverts when the mapping is deleted', async () => {
+      const d = await supertest(app)
+        .delete('/v1/admin/models/mappings/qwen38-27b').set('Cookie', cookie);
+      expect(d.status).toBe(200);
+      expect(d.body.removed).toBe(true);
+      const r = await overview();
+      expect(r.byModel.find((m: any) => m.model === 'qwen38-27b').prs).toBe(2);
+    });
+  });
+
+  it('is org-scoped: another org sees neither the mapping nor its effect', async () => {
+    await ctx.db.run(`INSERT INTO orgs (id, name) VALUES ('org-b', 'org-b')`);
+    await createPasswordUser(ctx.db, 'org-b', 'adminb@x', 'longenough1', 'admin');
+    const loginB = await supertest(app).post('/auth/login').send({ email: 'adminb@x', password: 'longenough1' });
+    const cookieB = loginB.headers['set-cookie']?.[0] ?? '';
+
+    await supertest(app).post('/v1/admin/models/mappings').set('Cookie', cookie)
+      .send({ aliasModel: 'qwen38-27b', canonicalModel: 'qwen3.8:27b' });
+
+    const listB = await supertest(app).get('/v1/admin/models').set('Cookie', cookieB);
+    expect(listB.body.mappings).toEqual([]);
+    // org-b has no events at all, so the overview is empty rather than shared.
+    const overviewB = await (await supertest(app).get('/v1/prs/overview').set('Cookie', cookieB)).body;
+    expect(overviewB.totals.prs).toBe(0);
+  });
+});

--- a/packages/hub/src/test/hub-pg-parity.test.ts
+++ b/packages/hub/src/test/hub-pg-parity.test.ts
@@ -673,3 +673,67 @@ describe('PG parity: hub endpoint lifecycle (CGLAB-62)', () => {
     expect(board.body.counts.succeeded).toBe(1);
   });
 });
+
+describe('PG parity: admin model mappings', () => {
+  let fx: Fixture;
+  beforeEach(async () => { fx = await bootHubOnPg(); });
+  afterEach(async () => { await fx.db.close(); });
+
+  const pr = (n: number, model: string) => ({
+    eventId: `pr-${n}`, installationId: 'inst-1', orgId: 'org',
+    occurredAt: '2026-05-03T10:00:00Z',
+    actor: { osUser: 'alice', gitName: 'A', gitEmail: 'alice@acme.com' },
+    type: 'pr.opened',
+    remoteUrl: 'git@github.com:acme/api.git',
+    payload: {
+      prNumber: n, repo: 'acme/api', model, harness: 'pi',
+      sizing: { epic: 0, story: 0, task: 1, bug: 0 },
+      sizingShadow: { epic: 0, story: 0, task: 1, bug: 0 },
+      leafStory: 0,
+    },
+  });
+
+  it('lists observed models, creates a mapping, and folds the PR Overview rows', async () => {
+    await supertest(fx.app).post('/v1/events').set('Authorization', `Bearer ${fx.token}`).send({
+      events: [pr(1, 'qwen3.8:27b'), pr(2, 'qwen38-27b'), pr(3, 'qwen38-27b')],
+    });
+
+    // The DISTINCT + json_extract scan must survive the dialect rewrite: on PG
+    // json_extract becomes jsonb_extract_path_text and the count comes back as a
+    // string, which is why the route coerces with Number().
+    const before = await supertest(fx.app).get('/v1/admin/models').set('Cookie', fx.cookie);
+    expect(before.status).toBe(200);
+    const q = before.body.observed.find((o: any) => o.model === 'qwen38-27b');
+    expect(q.prs).toBe(2);
+
+    const created = await supertest(fx.app).post('/v1/admin/models/mappings')
+      .set('Cookie', fx.cookie)
+      .send({ aliasModel: 'qwen38-27b', canonicalModel: 'qwen3.8:27b' });
+    expect(created.status).toBe(201);
+
+    const list = await supertest(fx.app).get('/v1/admin/models').set('Cookie', fx.cookie);
+    expect(list.body.mappings).toHaveLength(1);
+    expect(list.body.mappings[0]).toMatchObject({
+      aliasModel: 'qwen38-27b', canonicalModel: 'qwen3.8:27b', createdByEmail: 'admin@x',
+    });
+
+    const overview = await (await supertest(fx.app).get('/v1/prs/overview').set('Cookie', fx.cookie)).body;
+    expect(overview.byModel).toHaveLength(1);
+    expect(overview.byModel[0]).toMatchObject({ model: 'qwen3.8:27b', prs: 3 });
+
+    // The ON CONFLICT path: identical repeat is a no-op, a different target 409s.
+    await supertest(fx.app).post('/v1/admin/models/mappings')
+      .set('Cookie', fx.cookie)
+      .send({ aliasModel: 'qwen38-27b', canonicalModel: 'qwen3.8:27b' }).expect(201);
+    expect((await supertest(fx.app).get('/v1/admin/models').set('Cookie', fx.cookie)).body.mappings).toHaveLength(1);
+    await supertest(fx.app).post('/v1/admin/models/mappings')
+      .set('Cookie', fx.cookie)
+      .send({ aliasModel: 'qwen38-27b', canonicalModel: 'other' }).expect(409);
+
+    const removed = await supertest(fx.app)
+      .delete('/v1/admin/models/mappings/qwen38-27b').set('Cookie', fx.cookie);
+    expect(removed.body.removed).toBe(true);
+    const reverted = await (await supertest(fx.app).get('/v1/prs/overview').set('Cookie', fx.cookie)).body;
+    expect(reverted.byModel).toHaveLength(2);
+  });
+});

--- a/packages/hub/src/test/model-mapping.test.ts
+++ b/packages/hub/src/test/model-mapping.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveModelId,
+  resolveModelFilter,
+  loadModelMappings,
+  EMPTY_MODEL_MAPPING,
+} from '../util/modelMapping';
+
+const map = new Map([
+  ['qwen38-27b', 'qwen3.8:27b'],
+  ['qwen-3.8-27b', 'qwen3.8:27b'],
+]);
+
+describe('resolveModelId', () => {
+  it('maps a listed alias to the canonical name', () => {
+    expect(resolveModelId('qwen38-27b', map)).toBe('qwen3.8:27b');
+    expect(resolveModelId('qwen-3.8-27b', map)).toBe('qwen3.8:27b');
+  });
+
+  it('leaves an unmapped id untouched — it is its own group', () => {
+    expect(resolveModelId('glm-5.2', map)).toBe('glm-5.2');
+  });
+
+  it('is exact, not fuzzy: a near-miss does NOT fold in', () => {
+    // The whole point of option A. A normalization rule would merge these and
+    // the admin could not see why.
+    expect(resolveModelId('qwen3.8:14b', map)).toBe('qwen3.8:14b');
+    expect(resolveModelId('qwen38-7b', map)).toBe('qwen38-7b');
+    expect(resolveModelId('Qwen38-27b', map)).toBe('Qwen38-27b'); // case is part of the id
+    expect(resolveModelId('qwen38-27b ', map)).toBe('qwen38-27b '); // and so is whitespace
+  });
+
+  it('passes null/empty through so the row still renders', () => {
+    expect(resolveModelId(null, map)).toBeNull();
+    expect(resolveModelId('', map)).toBe('');
+  });
+
+  it('is identity with no mappings configured', () => {
+    expect(resolveModelId('qwen38-27b', EMPTY_MODEL_MAPPING)).toBe('qwen38-27b');
+  });
+});
+
+describe('resolveModelFilter', () => {
+  it('resolves filter values so saved links to an alias still match', () => {
+    expect(resolveModelFilter(['qwen38-27b'], map)).toEqual(['qwen3.8:27b']);
+  });
+
+  it('collapses aliases that resolve to the same canonical name', () => {
+    expect(resolveModelFilter(['qwen38-27b', 'qwen-3.8-27b'], map)).toEqual(['qwen3.8:27b']);
+  });
+
+  it('keeps unmapped values so filtering by an unmapped model still works', () => {
+    expect(resolveModelFilter(['qwen38-27b', 'glm-5.2'], map))
+      .toEqual(['qwen3.8:27b', 'glm-5.2']);
+  });
+
+  it('passes empty/null through unchanged (no filter)', () => {
+    expect(resolveModelFilter(null, map)).toBeNull();
+    expect(resolveModelFilter([], map)).toEqual([]);
+  });
+});
+
+describe('loadModelMappings', () => {
+  it('reads an org\'s rows into a lookup map', async () => {
+    const calls: any[] = [];
+    const db = {
+      all: async (sql: string, params?: unknown[]) => {
+        calls.push({ sql, params });
+        return [{ alias_model: 'qwen38-27b', canonical_model: 'qwen3.8:27b' }];
+      },
+    };
+    const m = await loadModelMappings(db, 'org-a');
+    expect(m.get('qwen38-27b')).toBe('qwen3.8:27b');
+    // org-scoped: a mapping from another org must never leak in.
+    expect(calls[0].params).toEqual(['org-a']);
+  });
+
+  it('returns the empty map when nothing is configured', async () => {
+    const m = await loadModelMappings({ all: async () => [] }, 'org-a');
+    expect(m.size).toBe(0);
+  });
+});

--- a/packages/hub/src/util/modelMapping.ts
+++ b/packages/hub/src/util/modelMapping.ts
@@ -1,0 +1,72 @@
+/**
+ * Admin-curated model identity (the `model` axis of user_key aliases).
+ *
+ * A model id is free text an agent self-reports via `--model <id>`, so one
+ * model reaches the hub as several spellings and every dashboard that groups by
+ * the raw string shows them as separate models.
+ *
+ * The mapping is an overlay resolved at READ time. `events` keeps whatever was
+ * actually reported: it is append-only telemetry of what an agent claimed, and
+ * rewriting it would destroy that fact and be undone by the next event anyway.
+ *
+ * Resolution is a single exact lookup — no fuzzy matching, no normalization
+ * rule. A rule that maps `-` to `:` and `38` to `3.8` would merge models that
+ * are genuinely different, silently and invisibly to the admin. Here the
+ * canonical name is exactly the string the admin typed and only the aliases
+ * they listed fold into it.
+ */
+
+/** alias -> canonical, for one org. Empty map means no mappings configured. */
+export type ModelMapping = ReadonlyMap<string, string>;
+
+export const EMPTY_MODEL_MAPPING: ModelMapping = new Map();
+
+/**
+ * The name a reported model id should be displayed and grouped under.
+ *
+ * Returns the input unchanged when nothing is mapped. Unknown and empty ids
+ * pass through so the dashboard still shows the raw value rather than dropping
+ * the PR or showing a blank row.
+ */
+export function resolveModelId(model: string | null, mapping: ModelMapping): string | null {
+  if (!model) return model;
+  return mapping.get(model) ?? model;
+}
+
+/**
+ * Resolve a filter value instead of a stored one.
+ *
+ * A filter must be resolved through the mapping too: once rows are grouped
+ * under the canonical name, a saved link or bookmark to `?model=qwen38-27b`
+ * would otherwise match nothing and the dashboard would silently report zero
+ * PRs for a model that has plenty. Both sides of the comparison land on the
+ * canonical name, so any spelling the admin has mapped resolves to the same
+ * group.
+ *
+ * Values with no mapping are left as-is, which is correct: an unmapped id is
+ * its own group, and filtering by it must still return it.
+ */
+export function resolveModelFilter(models: string[] | null, mapping: ModelMapping): string[] | null {
+  if (!models || !models.length) return models;
+  return [...new Set(models.map(m => resolveModelId(m, mapping) as string))];
+}
+
+/**
+ * Load an org's mappings.
+ *
+ * Called per request by the surfaces that group by model. The table is small by
+ * construction — one row per alias an admin has chosen to fold — so a fresh
+ * read is cheaper than a cache that has to be invalidated on every admin edit,
+ * and it means an edit is visible on the next page load rather than after a TTL.
+ */
+export async function loadModelMappings(
+  db: { all<T = unknown>(sql: string, params?: unknown[]): Promise<T[]> },
+  orgId: string,
+): Promise<ModelMapping> {
+  const rows = await db.all<{ alias_model: string; canonical_model: string }>(
+    'SELECT alias_model, canonical_model FROM model_mappings WHERE org_id = ?',
+    [orgId],
+  );
+  if (!rows.length) return EMPTY_MODEL_MAPPING;
+  return new Map(rows.map(r => [r.alias_model, r.canonical_model]));
+}


### PR DESCRIPTION
## What

Admin → Models: a page (in the Admin tab, `/admin/models`) where the admin creates model aliases — a column with the **desired model name**, and the reported spellings mapped into it.

Fixes the hub DB showing `qwen38-27b` and `qwen3.8:27b` as two separate models.

## Why it happened

`model` is free text an installation self-reports via `--model <id>`. The hub stored it verbatim and grouped by the raw string, so one model became N rows, splitting its PR count and offering N filter chips.

## How

`model_mappings` (org-scoped, SQLite + Postgres) resolved at **read time** in `normaliseRow` — the single funnel both the grouping and the `?model=` filter already pass through, so they can't disagree about a PR's model.

- **`events` is untouched.** It is append-only telemetry of what an agent claimed; rewriting it would destroy that fact and be undone by the next event anyway. Deleting a mapping reverts the dashboards — no recompute job, no migration.
- **Exact lookup, deliberately.** A normalization rule that maps `-`→`:` and `38`→`3.8` would silently merge genuinely different models, invisibly to the admin. The canonical name is exactly the string the admin typed.
- **Filter values resolve through the same mapping**, so a saved link to `?model=qwen38-27b` still finds the group now filed under `qwen3.8:27b` instead of silently reporting zero.

## Verified live

Seeded a hub with the exact reported spellings:

```
BY MODEL (before):   qwen38-27b 3 PRs   qwen3.8:27b 2 PRs   →  two rows
POST /v1/admin/models/mappings {"aliasModel":"qwen38-27b","canonicalModel":"qwen3.8:27b"} → 201
BY MODEL (after):    qwen3.8:27b 5 PRs                      →  one row, total PRs unchanged (11)
?model=qwen38-27b  → 5 PRs   (old spelling still resolves)
?model=qwen3.8:27b → 5 PRs
```

Rejections: re-pointing a mapped alias → `409` naming the current target; alias == canonical → `400`.

## Bugs found and fixed during the build

1. **`./adminModels` resolved to the wrong file.** `adminModels.ts` sat next to `AdminModels.tsx`; macOS is case-insensitive and Vite tries `.ts` before `.tsx`, so the component imported as `undefined`. This would have **crashed the page at runtime**, not merely failed an import in a test. Renamed to `modelMappings.ts`.
2. **No unmap button in the common case** — the control rendered only for rows after the first, leaving a single-alias group with no way back. Caught by its own test.
3. **Wrong invalidation key** (`prs-overview` vs the real `pr-overview`/`pr-overview-opts`) — edits wouldn't have refreshed the table.
4. **Chain-rejection message echoed the wrong value** (selected `alias_model`, compared to itself). Caught by its own test.
5. **Missed `ORG_ID_CHILD_TABLES`** — the org-rename regression pin failed until the table was registered, exactly as that test's comment predicts.

## Tests

| Suite | Result |
|---|---|
| `packages/hub` | **849 passed / 67 files**, 0 failures |
| pg-mem parity (new spec) | `DISTINCT` + `json_extract` scan and `ON CONFLICT` insert survive the dialect rewrite — prod is Postgres, this was the risky path |
| hub-ui (new + adjacent) | 33 passed |
| `tsc --noEmit` (hub, hub-ui) | clean |
| `vite build` | succeeds |

**Pre-existing failures, not caused by this branch:** `ThemeContext`/`ThemeToggle` (25 failures, identical with this work stashed). One more, `hub-docs-tenancy`, *was* fixed here: the `1.1.17-beta.3` bump shipped without a CHANGELOG entry, leaving that spec red on the branch.

## Scope notes

- `GET /v1/admin/models` does a full-table JSON scan on an append-only table — fine at current volume, bounded by total event count, commented as such. A materialized `model` column replaces it if that ever bites.
- Three other model surfaces stay unswept: `AgentRun.model`, `TokenEvent.model`, and `getModelPrice()` in `packages/ui/src/utils.ts` (which already hand-rolls the same class of alias list). Worth converging on one helper later.

## Base

Opened against `feat/CGLAB-117_hub-per-event-rejections`, **not** `main` — see the discussion in the PR thread. The `v1.1.17-beta.x` line, including the `1.1.17-beta.3` currently in production, lives on that branch and is not on `main` yet.
