### PR TITLE
fix(testing): HOME-isolate test runs — vitest pin, integrity sentinel, Stryker spawn-time guard [9c297075]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,5 +37,11 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Home-integrity snapshot (item 9c297075)
+        run: node scripts/home-integrity.mjs snapshot
+
       - name: Test
         run: npm test
+
+      - name: Home-integrity verify (item 9c297075)
+        run: node scripts/home-integrity.mjs verify

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to AgEnFK are documented here.
 
+## [1.1.17-beta.3] — 2026-09-02
+
+- **PR Overview dash: multi-select models filter** — the hub-ui PR Overview page's
+  model filter is now a `FacetMultiselect` row (same component as Project/
+  Developer); `?model=` is a CSV end-to-end (URL → toggle-set → data query →
+  match-any on the PR *opener's* model), applied to both the current and
+  previous-period windows so delta badges stay honest. Legacy single-value
+  `?model=x` links keep working (`PrWindow.model` → `models: string[] | null`).
+- **`parseList` hardening** — repeated query params (`?model=a&model=b`, which
+  Express delivers as an array) are normalized to CSV form instead of 500-ing;
+  covers every list filter (users/projects/types/itemTypes/model).
+- **CLI test robustness** — hub deadletter list assertions are now
+  color-independent (ANSI-tolerant), fixing a flake when the verify worker ran
+  with `FORCE_COLOR`.
+
 ## [1.1.17-beta.2] — 2026-09-01
 
 Hub org-boundary hardening (CGLAB-117) — after the 31 Aug 2026 incident, a clobbered

--- a/HUB_ARCHITECTURE.md
+++ b/HUB_ARCHITECTURE.md
@@ -517,7 +517,7 @@ rejection handling), `packages/storage-sqlite/src/index.ts`
 `hubOutboxOrgSummaries`), `packages/cli/src/commands/hub.ts`
 (carry-over, deadletter, gates, reporting),
 `packages/hub/src/routes/events.ts` (rejections). The deadletter path is
-a contract between flusher and CLI (`DEFAULT_DEADLETTER_PATH`),
+a contract between flusher and CLI (`defaultDeadletterPath()`),
 drift-pinned by tests in both packages; the docs↔code facts above are
 pinned by `packages/hub/src/test/hub-docs-tenancy.test.ts`.
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "test:ui:coverage": "cd packages/ui && npx vitest run --coverage",
     "install:framework": "node scripts/install.mjs",
     "uninstall:framework": "node scripts/uninstall.mjs",
-    "start:services": "node scripts/start-services.mjs"
+    "start:services": "node scripts/start-services.mjs",
+    "test:home-integrity": "node scripts/home-integrity.mjs snapshot && npm test && node scripts/home-integrity.mjs verify"
   },
   "keywords": [
     "agenfk",

--- a/package.json
+++ b/package.json
@@ -22,12 +22,13 @@
   "scripts": {
     "build": "npm run build -w packages/core -w packages/storage-sqlite -w packages/telemetry && npm run build -w packages/cli -w packages/server -w packages/ui -w packages/hub -w packages/hub-ui",
     "test": "vitest",
-    "test:coverage": "vitest run --coverage",
+    "test:coverage": "node scripts/home-integrity.mjs snapshot && vitest run --coverage && node scripts/home-integrity.mjs verify",
     "test:ui:coverage": "cd packages/ui && npx vitest run --coverage",
     "install:framework": "node scripts/install.mjs",
     "uninstall:framework": "node scripts/uninstall.mjs",
     "start:services": "node scripts/start-services.mjs",
-    "test:home-integrity": "node scripts/home-integrity.mjs snapshot && npm test && node scripts/home-integrity.mjs verify"
+    "test:home-integrity": "node scripts/home-integrity.mjs snapshot && npx vitest run && node scripts/home-integrity.mjs verify",
+    "test:stryker": "node scripts/stryker-home-wrap.mjs"
   },
   "keywords": [
     "agenfk",

--- a/packages/cli/src/commands/hub.ts
+++ b/packages/cli/src/commands/hub.ts
@@ -47,7 +47,7 @@ function localInstallationIdentity(): { installationId: string; osUser: string; 
 // after import; a long-lived CLI process could see HOME change).
 function hubConfigFile(): string { return path.join(os.homedir(), '.agenfk', 'hub.json'); }
 function verifyTokenFile(): string { return path.join(os.homedir(), '.agenfk', 'verify-token'); }
-// Kept in sync with the server flusher's DEFAULT_DEADLETTER_PATH (the writer);
+// Kept in sync with the server flusher's defaultDeadletterPath() (the writer);
 // same duplication idiom as hub.json across hubClient/server/CLI.
 function deadletterFile(): string { return path.join(os.homedir(), '.agenfk', 'hub-deadletter.jsonl'); }
 function auditFile(): string { return path.join(os.homedir(), '.agenfk', 'hub-audit.jsonl'); }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2337,33 +2337,33 @@ function removeRuleBlock(targetPath: string): void {
 
 const RULES_CONFIG: Array<{
   label: string;
-  sourceFile: string;
+  sourceFile: () => string; // lazy (item 9c297075): home resolves at call time
   globalPath: () => string;
   projectPath: (root: string) => string;
   copy?: boolean; // true = copy whole file (mdc), false = insert block
 }> = [
   {
     label: 'CLAUDE.md',
-    sourceFile: path.join(agenfkSystemDir(), 'clauderules', 'CLAUDE.md'),
+    sourceFile: () => path.join(agenfkSystemDir(), 'clauderules', 'CLAUDE.md'),
     globalPath: () => path.join(os.homedir(), '.claude', 'CLAUDE.md'),
     projectPath: (root) => path.join(root, '.claude', 'CLAUDE.md'),
   },
   {
     label: 'agenfk.mdc (Cursor)',
-    sourceFile: path.join(agenfkSystemDir(), 'cursorrules', 'agenfk.mdc'),
+    sourceFile: () => path.join(agenfkSystemDir(), 'cursorrules', 'agenfk.mdc'),
     globalPath: () => path.join(getCursorRulesDir(), 'agenfk.mdc'),
     projectPath: (root) => path.join(root, '.cursor', 'rules', 'agenfk.mdc'),
     copy: true,
   },
   {
     label: 'AGENTS.md (Codex)',
-    sourceFile: path.join(agenfkSystemDir(), 'codexrules', 'AGENTS.md'),
+    sourceFile: () => path.join(agenfkSystemDir(), 'codexrules', 'AGENTS.md'),
     globalPath: () => path.join(os.homedir(), '.codex', 'AGENTS.md'),
     projectPath: (root) => path.join(root, 'AGENTS.md'),
   },
   {
     label: 'GEMINI.md',
-    sourceFile: path.join(agenfkSystemDir(), 'geminirules', 'GEMINI.md'),
+    sourceFile: () => path.join(agenfkSystemDir(), 'geminirules', 'GEMINI.md'),
     globalPath: () => path.join(os.homedir(), '.gemini', 'GEMINI.md'),
     projectPath: (root) => path.join(root, 'GEMINI.md'),
   },
@@ -2683,7 +2683,7 @@ rulesCommand
 
       // ── Rule files ──────────────────────────────────────────────────────────
       for (const rule of RULES_CONFIG) {
-        if (!fs.existsSync(rule.sourceFile)) {
+        if (!fs.existsSync(rule.sourceFile())) {
           skipped.push(rule.label);
           continue;
         }
@@ -2692,9 +2692,9 @@ rulesCommand
 
         if (rule.copy) {
           fs.mkdirSync(path.dirname(activePath), { recursive: true });
-          fs.copyFileSync(rule.sourceFile, activePath);
+          fs.copyFileSync(rule.sourceFile(), activePath);
         } else {
-          const src = fs.readFileSync(rule.sourceFile, 'utf8');
+          const src = fs.readFileSync(rule.sourceFile(), 'utf8');
           writeRuleBlock(activePath, src);
         }
         installed.push(`  ${chalk.green('✓')} ${rule.label} → ${activePath}`);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -257,12 +257,12 @@ function runIntegrationScript(scriptName: string, args: string[]) {
   }
 }
 
-const AGENFK_CONFIG_PATH = path.join(os.homedir(), '.agenfk', 'config.json');
+function agenfkConfigPath(): string { return path.join(os.homedir(), '.agenfk', 'config.json'); }
 
 function getPausedIntegrations(): string[] {
-  if (!fs.existsSync(AGENFK_CONFIG_PATH)) return [];
+  if (!fs.existsSync(agenfkConfigPath())) return [];
   try {
-    const cfg = JSON.parse(fs.readFileSync(AGENFK_CONFIG_PATH, 'utf8'));
+    const cfg = JSON.parse(fs.readFileSync(agenfkConfigPath(), 'utf8'));
     return Array.isArray(cfg.pausedIntegrations) ? cfg.pausedIntegrations : [];
   } catch {
     return [];
@@ -271,11 +271,11 @@ function getPausedIntegrations(): string[] {
 
 function setPausedIntegrations(list: string[]): void {
   let cfg: Record<string, any> = {};
-  if (fs.existsSync(AGENFK_CONFIG_PATH)) {
-    try { cfg = JSON.parse(fs.readFileSync(AGENFK_CONFIG_PATH, 'utf8')); } catch {}
+  if (fs.existsSync(agenfkConfigPath())) {
+    try { cfg = JSON.parse(fs.readFileSync(agenfkConfigPath(), 'utf8')); } catch {}
   }
   cfg.pausedIntegrations = list;
-  fs.writeFileSync(AGENFK_CONFIG_PATH, JSON.stringify(cfg, null, 2), 'utf8');
+  fs.writeFileSync(agenfkConfigPath(), JSON.stringify(cfg, null, 2), 'utf8');
 }
 
 // Only show the ASCII banner for interactive humans. When stdout is piped or
@@ -1216,8 +1216,8 @@ integrationCommand
 
     let rulesScope = '';
     try {
-      if (fs.existsSync(AGENFK_CONFIG_PATH)) {
-        const cfg = JSON.parse(fs.readFileSync(AGENFK_CONFIG_PATH, 'utf8'));
+      if (fs.existsSync(agenfkConfigPath())) {
+        const cfg = JSON.parse(fs.readFileSync(agenfkConfigPath(), 'utf8'));
         if (cfg.rulesScope) rulesScope = cfg.rulesScope;
       }
     } catch {}
@@ -1340,8 +1340,8 @@ program
     // Read rulesScope from config for re-install
     let rulesScope = '';
     try {
-      if (fs.existsSync(AGENFK_CONFIG_PATH)) {
-        const cfg = JSON.parse(fs.readFileSync(AGENFK_CONFIG_PATH, 'utf8'));
+      if (fs.existsSync(agenfkConfigPath())) {
+        const cfg = JSON.parse(fs.readFileSync(agenfkConfigPath(), 'utf8'));
         if (cfg.rulesScope) rulesScope = cfg.rulesScope;
       }
     } catch {}
@@ -2291,7 +2291,7 @@ configSetCommand
 // ── agenfk skills ─────────────────────────────────────────────────────────────
 
 // Framework install dir (~/.agenfk-system) — where rule source files live
-const AGENFK_SYSTEM_DIR = path.join(os.homedir(), '.agenfk-system');
+function agenfkSystemDir(): string { return path.join(os.homedir(), '.agenfk-system'); }
 const AGENFK_BLOCK_RE = /\n?<!-- agenfk:start -->[\s\S]*?<!-- agenfk:end -->\n?/g;
 
 /** Returns the git repo root, falling back to process.cwd() */
@@ -2344,26 +2344,26 @@ const RULES_CONFIG: Array<{
 }> = [
   {
     label: 'CLAUDE.md',
-    sourceFile: path.join(AGENFK_SYSTEM_DIR, 'clauderules', 'CLAUDE.md'),
+    sourceFile: path.join(agenfkSystemDir(), 'clauderules', 'CLAUDE.md'),
     globalPath: () => path.join(os.homedir(), '.claude', 'CLAUDE.md'),
     projectPath: (root) => path.join(root, '.claude', 'CLAUDE.md'),
   },
   {
     label: 'agenfk.mdc (Cursor)',
-    sourceFile: path.join(AGENFK_SYSTEM_DIR, 'cursorrules', 'agenfk.mdc'),
+    sourceFile: path.join(agenfkSystemDir(), 'cursorrules', 'agenfk.mdc'),
     globalPath: () => path.join(getCursorRulesDir(), 'agenfk.mdc'),
     projectPath: (root) => path.join(root, '.cursor', 'rules', 'agenfk.mdc'),
     copy: true,
   },
   {
     label: 'AGENTS.md (Codex)',
-    sourceFile: path.join(AGENFK_SYSTEM_DIR, 'codexrules', 'AGENTS.md'),
+    sourceFile: path.join(agenfkSystemDir(), 'codexrules', 'AGENTS.md'),
     globalPath: () => path.join(os.homedir(), '.codex', 'AGENTS.md'),
     projectPath: (root) => path.join(root, 'AGENTS.md'),
   },
   {
     label: 'GEMINI.md',
-    sourceFile: path.join(AGENFK_SYSTEM_DIR, 'geminirules', 'GEMINI.md'),
+    sourceFile: path.join(agenfkSystemDir(), 'geminirules', 'GEMINI.md'),
     globalPath: () => path.join(os.homedir(), '.gemini', 'GEMINI.md'),
     projectPath: (root) => path.join(root, 'GEMINI.md'),
   },
@@ -2523,7 +2523,7 @@ function syncCommandsFlat(srcDir: string, destDir: string, platformKey?: string)
     let src = path.join(srcDir, file);
     if (file === 'agenfk-flow.md') {
       if (platformKey === 'claude') {
-        const custom = path.join(AGENFK_SYSTEM_DIR, 'skills', 'claude-code', 'agenfk-flow', 'SKILL.md');
+        const custom = path.join(agenfkSystemDir(), 'skills', 'claude-code', 'agenfk-flow', 'SKILL.md');
         if (fs.existsSync(custom)) src = custom;
       }
     }
@@ -2592,7 +2592,7 @@ function syncCommandsToDir(
     let src = path.join(srcDir, file);
     if (file === 'agenfk-flow.md') {
       if (platformKey === 'claude') {
-        const custom = path.join(AGENFK_SYSTEM_DIR, 'skills', 'claude-code', 'agenfk-flow', 'SKILL.md');
+        const custom = path.join(agenfkSystemDir(), 'skills', 'claude-code', 'agenfk-flow', 'SKILL.md');
         if (fs.existsSync(custom)) src = custom;
       }
     }
@@ -2676,7 +2676,7 @@ rulesCommand
     // Compute once (avoids repeated git calls and duplicate "fatal:" warnings)
     const oppositeRoot = scope === 'global' ? getProjectRoot() : '';
     const configPath = path.join(os.homedir(), '.agenfk', 'config.json');
-    const cmdSrcDir = path.join(AGENFK_SYSTEM_DIR, 'commands');
+    const cmdSrcDir = path.join(agenfkSystemDir(), 'commands');
     try {
       const installed: string[] = [];
       const skipped: string[] = [];
@@ -2790,7 +2790,7 @@ rulesCommand
     const scope = options.project ? 'project' : 'global';
     const projectRoot = scope === 'project' ? getProjectRoot() : '';
     const configPath = path.join(os.homedir(), '.agenfk', 'config.json');
-    const cmdSrcDir = path.join(AGENFK_SYSTEM_DIR, 'commands');
+    const cmdSrcDir = path.join(agenfkSystemDir(), 'commands');
     try {
       const removed: string[] = [];
 

--- a/packages/cli/src/test/db-migration.test.ts
+++ b/packages/cli/src/test/db-migration.test.ts
@@ -2,10 +2,21 @@
  * Tests for the db.json → SQLite migration helper.
  * These tests should FAIL before stageJsonMigration() is implemented.
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
+
+// Mockable homedir (item 9c297075) — the migration.json save/restore cycle
+// below then runs in the sandbox under any runner (an env override only
+// works while libuv follows the JS env — not under Stryker's threads pool).
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('os')>();
+  return { ...actual, homedir: vi.fn(() => actual.homedir()) };
+});
+const sandboxHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agenfk-db-migration-'));
+fs.mkdirSync(path.join(sandboxHome, '.agenfk'), { recursive: true });
+vi.mocked(os.homedir).mockReturnValue(sandboxHome);
 
 // We will import the real module after it exists
 let stageJsonMigration: (agenfkHome: string) => boolean;
@@ -117,4 +128,9 @@ describe('stageJsonMigration', () => {
     expect(result).toBe(false);
     expect(fs.existsSync(migrationPath)).toBe(false);
   });
+});
+
+afterAll(() => {
+  vi.mocked(os.homedir).mockRestore();
+  try { fs.rmSync(sandboxHome, { recursive: true, force: true }); } catch { /* ignore */ }
 });

--- a/packages/cli/src/test/home-integrity.test.ts
+++ b/packages/cli/src/test/home-integrity.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Home-integrity sentinel (item 9c297075) — the 2026-08-31 clobber went
+ * unnoticed for days because nothing detected that ~/.agenfk/hub.json had
+ * been overwritten by a test fixture.
+ *
+ * The sentinel snapshots the protected home files before a test run and fails
+ * the run on any drift (changed / added / removed). It is exercised here
+ * against a FAKE home (the real one is never touched by tests — the vitest
+ * HOME pin guarantees that).
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  PROTECTED_FILES,
+  snapshotHome,
+  verifyHome,
+} from '../../../../scripts/home-integrity.mjs';
+
+function seedHome(): string {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agenfk-home-integrity-'));
+  const dir = path.join(home, '.agenfk');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'hub.json'), JSON.stringify({ url: 'https://hub.example', token: 't', orgId: 'o' }));
+  fs.writeFileSync(path.join(dir, 'verify-token'), 'tok-123');
+  fs.writeFileSync(path.join(dir, 'config.json'), '{}');
+  // Deliberately UNprotected files — must never be flagged:
+  fs.writeFileSync(path.join(dir, 'db.sqlite'), 'BINARY');
+  fs.mkdirSync(path.join(dir, 'backup'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'backup', 'agenfk-backup-x.json'), '{}');
+  return home;
+}
+
+describe('home integrity sentinel (item 9c297075)', () => {
+  it('protects exactly the credential/config files, not DB or backups', () => {
+    expect(PROTECTED_FILES).toContain('hub.json');
+    expect(PROTECTED_FILES).toContain('verify-token');
+    expect(PROTECTED_FILES).toContain('config.json');
+    expect(PROTECTED_FILES).toContain('installation-id');
+    expect(PROTECTED_FILES).toContain('server-port');
+    expect(PROTECTED_FILES).toContain('hub-deadletter.jsonl');
+    expect(PROTECTED_FILES).toContain('hub-audit.jsonl');
+    expect(PROTECTED_FILES).not.toContain('db.sqlite');
+    expect(PROTECTED_FILES).not.toContain('backup');
+  });
+
+  it('reports ok when the protected files are untouched', () => {
+    const home = seedHome();
+    const snap = snapshotHome(home);
+    const res = verifyHome(home, snap);
+    expect(res.ok).toBe(true);
+    expect(res.drift).toEqual([]);
+  });
+
+  it('flags a CHANGED protected file (the clobber case)', () => {
+    const home = seedHome();
+    const snap = snapshotHome(home);
+    fs.writeFileSync(path.join(home, '.agenfk', 'hub.json'), JSON.stringify({ url: 'http://hub.test', token: 'tok123', orgId: 'acme' }));
+    const res = verifyHome(home, snap);
+    expect(res.ok).toBe(false);
+    expect(res.drift).toEqual(['hub.json']);
+  });
+
+  it('flags a REMOVED protected file (the rm -f case)', () => {
+    const home = seedHome();
+    const snap = snapshotHome(home);
+    fs.rmSync(path.join(home, '.agenfk', 'verify-token'));
+    const res = verifyHome(home, snap);
+    expect(res.ok).toBe(false);
+    expect(res.drift).toContain('verify-token');
+  });
+
+  it('flags an ADDED protected file (tests writing hub-audit.jsonl into a real home)', () => {
+    const home = seedHome();
+    const snap = snapshotHome(home);
+    fs.writeFileSync(path.join(home, '.agenfk', 'hub-audit.jsonl'), '{"at":"x"}\n');
+    const res = verifyHome(home, snap);
+    expect(res.ok).toBe(false);
+    expect(res.drift).toContain('hub-audit.jsonl');
+  });
+
+  it('ignores unprotected files (db churn, new backups)', () => {
+    const home = seedHome();
+    const snap = snapshotHome(home);
+    fs.writeFileSync(path.join(home, '.agenfk', 'db.sqlite'), 'CHANGED');
+    fs.writeFileSync(path.join(home, '.agenfk', 'backup', 'agenfk-backup-new.json'), '{}');
+    const res = verifyHome(home, snap);
+    expect(res.ok).toBe(true);
+    expect(res.drift).toEqual([]);
+  });
+});

--- a/packages/cli/src/test/home-integrity.test.ts
+++ b/packages/cli/src/test/home-integrity.test.ts
@@ -7,16 +7,29 @@
  * the run on any drift (changed / added / removed). It is exercised here
  * against a FAKE home (the real one is never touched by tests — the vitest
  * HOME pin guarantees that).
+ *
+ * Note the LAZY dynamic import below: Stryker's per-test coverage attributes
+ * module-initialization code (the PROTECTED_FILES literal) to whichever test
+ * first evaluates the module. A static top-level import would evaluate the
+ * array before any test runs, leaving its mutants uncoverable — the names
+ * would survive mutation testing untested.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import {
-  PROTECTED_FILES,
-  snapshotHome,
-  verifyHome,
-} from '../../../../scripts/home-integrity.mjs';
+
+// Mockable homedir (delegates to the real one unless a test re-points it).
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('os')>();
+  return { ...actual, homedir: vi.fn(() => actual.homedir()) };
+});
+
+type IntegrityModule = typeof import('../../../../scripts/home-integrity.mjs');
+let integrity: IntegrityModule | null = null;
+// First call happens INSIDE a test, so the module's import-time code
+// (PROTECTED_FILES) is coverage-attributed to that test.
+const loadIntegrity = () => (integrity ??= import('../../../../scripts/home-integrity.mjs'));
 
 function seedHome(): string {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agenfk-home-integrity-'));
@@ -33,60 +46,105 @@ function seedHome(): string {
 }
 
 describe('home integrity sentinel (item 9c297075)', () => {
-  it('protects exactly the credential/config files, not DB or backups', () => {
-    expect(PROTECTED_FILES).toContain('hub.json');
-    expect(PROTECTED_FILES).toContain('verify-token');
-    expect(PROTECTED_FILES).toContain('config.json');
-    expect(PROTECTED_FILES).toContain('installation-id');
-    expect(PROTECTED_FILES).toContain('server-port');
-    expect(PROTECTED_FILES).toContain('hub-deadletter.jsonl');
-    expect(PROTECTED_FILES).toContain('hub-audit.jsonl');
-    expect(PROTECTED_FILES).not.toContain('db.sqlite');
-    expect(PROTECTED_FILES).not.toContain('backup');
+  it('protects exactly the credential/config files, not DB or backups', async () => {
+    const mod = await loadIntegrity();
+    // Every protected name must be asserted individually: a blanked entry
+    // (mutation) must break the list.
+    const expected = [
+      'hub.json',
+      'verify-token',
+      'config.json',
+      'installation-id',
+      'server-port',
+      'hub-deadletter.jsonl',
+      'hub-audit.jsonl',
+      'jira-token.json',
+      'migration.json',
+    ];
+    expect(mod.PROTECTED_FILES).toEqual(expected);
+    expect(mod.PROTECTED_FILES).not.toContain('db.sqlite');
+    expect(mod.PROTECTED_FILES).not.toContain('backup');
   });
 
-  it('reports ok when the protected files are untouched', () => {
+  it('reports ok when the protected files are untouched', async () => {
+    const mod = await loadIntegrity();
     const home = seedHome();
-    const snap = snapshotHome(home);
-    const res = verifyHome(home, snap);
+    const snap = mod.snapshotHome(home);
+    const res = mod.verifyHome(home, snap);
     expect(res.ok).toBe(true);
     expect(res.drift).toEqual([]);
   });
 
-  it('flags a CHANGED protected file (the clobber case)', () => {
+  it('flags a CHANGED protected file (the clobber case)', async () => {
+    const mod = await loadIntegrity();
     const home = seedHome();
-    const snap = snapshotHome(home);
+    const snap = mod.snapshotHome(home);
     fs.writeFileSync(path.join(home, '.agenfk', 'hub.json'), JSON.stringify({ url: 'http://hub.test', token: 'tok123', orgId: 'acme' }));
-    const res = verifyHome(home, snap);
+    const res = mod.verifyHome(home, snap);
     expect(res.ok).toBe(false);
     expect(res.drift).toEqual(['hub.json']);
   });
 
-  it('flags a REMOVED protected file (the rm -f case)', () => {
+  it('flags a same-size content change (sha drift with unchanged size)', async () => {
+    const mod = await loadIntegrity();
     const home = seedHome();
-    const snap = snapshotHome(home);
+    const snap = mod.snapshotHome(home);
+    // Same length, different bytes: size unchanged, sha changed. Catches
+    // mutation of the sha-comparison half of the change detector.
+    fs.writeFileSync(path.join(home, '.agenfk', 'verify-token'), 'xxx-456');
+    const res = mod.verifyHome(home, snap);
+    expect(res.ok).toBe(false);
+    expect(res.drift).toEqual(['verify-token']);
+  });
+
+  it('flags a REMOVED protected file (the rm -f case)', async () => {
+    const mod = await loadIntegrity();
+    const home = seedHome();
+    const snap = mod.snapshotHome(home);
     fs.rmSync(path.join(home, '.agenfk', 'verify-token'));
-    const res = verifyHome(home, snap);
+    const res = mod.verifyHome(home, snap);
     expect(res.ok).toBe(false);
     expect(res.drift).toContain('verify-token');
   });
 
-  it('flags an ADDED protected file (tests writing hub-audit.jsonl into a real home)', () => {
+  it('flags an ADDED protected file (tests writing hub-audit.jsonl into a real home)', async () => {
+    const mod = await loadIntegrity();
     const home = seedHome();
-    const snap = snapshotHome(home);
+    const snap = mod.snapshotHome(home);
     fs.writeFileSync(path.join(home, '.agenfk', 'hub-audit.jsonl'), '{"at":"x"}\n');
-    const res = verifyHome(home, snap);
+    const res = mod.verifyHome(home, snap);
     expect(res.ok).toBe(false);
     expect(res.drift).toContain('hub-audit.jsonl');
   });
 
-  it('ignores unprotected files (db churn, new backups)', () => {
+  it('ignores unprotected files (db churn, new backups)', async () => {
+    const mod = await loadIntegrity();
     const home = seedHome();
-    const snap = snapshotHome(home);
+    const snap = mod.snapshotHome(home);
     fs.writeFileSync(path.join(home, '.agenfk', 'db.sqlite'), 'CHANGED');
     fs.writeFileSync(path.join(home, '.agenfk', 'backup', 'agenfk-backup-new.json'), '{}');
-    const res = verifyHome(home, snap);
+    const res = mod.verifyHome(home, snap);
     expect(res.ok).toBe(true);
     expect(res.drift).toEqual([]);
+  });
+});
+
+describe('vitest HOME pin factory (scripts/vitest-home-pin.mjs)', () => {
+  it('memoizes one sandbox per process and pins HOME off the real home', async () => {
+    const pin = await import('../../../../scripts/vitest-home-pin.mjs');
+    const a = pin.testHomeEnv();
+    const b = pin.testHomeEnv();
+    expect(b, 'second call must return the SAME memoized env').toBe(a);
+    expect(a.HOME).toBeTruthy();
+    expect(a.HOME, 'pin must land in a fresh tmpdir sandbox')
+      .toBe(path.join(os.tmpdir(), path.basename(a.HOME)));
+    expect(a.HOME, 'sandbox name must carry the recognizable prefix')
+      .toContain('agenfk-test-home-');
+    expect(a.USERPROFILE, 'Windows parity key').toBe(a.HOME);
+    expect(a.AGENFK_REAL_HOME, 'real home must be preserved for assertions').toBeTruthy();
+    expect(a.AGENFK_REAL_HOME).not.toBe(a.HOME);
+    // Pre-seeded framework dir: readers of verify-token/server-port see
+    // "absent", not a hostile foreign home.
+    expect(fs.existsSync(path.join(a.HOME, '.agenfk'))).toBe(true);
   });
 });

--- a/packages/cli/src/test/hub-carryover-actions.test.ts
+++ b/packages/cli/src/test/hub-carryover-actions.test.ts
@@ -18,11 +18,8 @@ const { sandboxHome } = vi.hoisted(() => {
   const path = require('path');
   return { sandboxHome: fs.mkdtempSync(path.join(os.tmpdir(), 'agenfk-hub-carryover-')) };
 });
-const realHome = process.env.HOME;
-// HOME is (re-)assigned in a global beforeEach for plain vitest; under
-// stryker's in-process runner os.homedir() ignores process.env.HOME entirely,
-// so the os module itself is mocked below — belt and braces.
-beforeEach(() => { process.env.HOME = sandboxHome; });
+// The os module is mocked below (static homedir -> sandboxHome), so no env
+// manipulation is needed: it works under any runner (item 9c297075).
 
 const { mockGet, mockPost, askState } = vi.hoisted(() => ({
   mockGet: vi.fn(),
@@ -124,7 +121,6 @@ describe('agenfk hub carry-over (actions)', () => {
   afterAll(() => {
     if (realIsTTY) Object.defineProperty(process.stdin, 'isTTY', realIsTTY);
     else delete (process.stdin as any).isTTY;
-    if (realHome === undefined) delete process.env.HOME; else process.env.HOME = realHome;
   });
 
   it('refuses missing --from/--to without touching the server', async () => {
@@ -339,7 +335,6 @@ describe('agenfk hub deadletter (actions)', () => {
   afterAll(() => {
     if (realIsTTY) Object.defineProperty(process.stdin, 'isTTY', realIsTTY);
     else delete (process.stdin as any).isTTY;
-    if (realHome === undefined) delete process.env.HOME; else process.env.HOME = realHome;
   });
 
   const THREE = [

--- a/packages/cli/src/test/hub-carryover-deadletter.test.ts
+++ b/packages/cli/src/test/hub-carryover-deadletter.test.ts
@@ -81,7 +81,7 @@ describe('hub carry-over wiring (source scan)', () => {
   });
 
   it('pins the deadletter path literal against drift with the server flusher', () => {
-    // packages/server/src/hub/flusher.ts DEFAULT_DEADLETTER_PATH uses the
+    // packages/server/src/hub/flusher.ts defaultDeadletterPath() uses the
     // same literal (pinned by flusher-org-boundary.test.ts); a one-sided
     // rename breaks one of the two pinning tests.
     expect(HUB_SRC).toMatch(/'\.agenfk', 'hub-deadletter\.jsonl'/);

--- a/packages/cli/src/test/hub-command.test.ts
+++ b/packages/cli/src/test/hub-command.test.ts
@@ -4,9 +4,15 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
+// Sandbox homedir via a CALL-TIME mock of os.homedir() (item 9c297075) —
+// runner-independent. Replaces the old process.env.HOME override, which only
+// works while libuv follows the JS env (not under Stryker's threads pool).
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('os')>();
+  return { ...actual, homedir: vi.fn(() => actual.homedir()) };
+});
 const sandboxHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agenfk-hub-cli-'));
-const realHome = process.env.HOME;
-process.env.HOME = sandboxHome;
+vi.mocked(os.homedir).mockReturnValue(sandboxHome);
 
 const { mockGet, mockPost } = vi.hoisted(() => ({
   mockGet: vi.fn(),
@@ -54,8 +60,7 @@ describe('agenfk hub commands', () => {
   });
 
   afterAll(() => {
-    if (realHome === undefined) delete process.env.HOME;
-    else process.env.HOME = realHome;
+    vi.mocked(os.homedir).mockRestore();
     try { fs.rmSync(sandboxHome, { recursive: true, force: true }); } catch { /* */ }
   });
 

--- a/packages/cli/src/test/hub-repoint.test.ts
+++ b/packages/cli/src/test/hub-repoint.test.ts
@@ -4,9 +4,15 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
+// Sandbox homedir via a CALL-TIME mock of os.homedir() (item 9c297075) —
+// runner-independent. Replaces the old process.env.HOME override, which only
+// works while libuv follows the JS env (not under Stryker's threads pool).
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('os')>();
+  return { ...actual, homedir: vi.fn(() => actual.homedir()) };
+});
 const sandboxHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agenfk-hub-repoint-'));
-const realHome = process.env.HOME;
-process.env.HOME = sandboxHome;
+vi.mocked(os.homedir).mockReturnValue(sandboxHome);
 
 const { mockGet, mockPost } = vi.hoisted(() => ({
   mockGet: vi.fn(),
@@ -76,8 +82,7 @@ describe('agenfk hub repoint', () => {
   });
 
   afterAll(() => {
-    if (realHome === undefined) delete process.env.HOME;
-    else process.env.HOME = realHome;
+    vi.mocked(os.homedir).mockRestore();
     try { fs.rmSync(sandboxHome, { recursive: true, force: true }); } catch { /* */ }
   });
 

--- a/packages/cli/src/test/hub-story4-cli.test.ts
+++ b/packages/cli/src/test/hub-story4-cli.test.ts
@@ -27,9 +27,6 @@ const { sandboxHome } = vi.hoisted(() => {
   const path = require('path');
   return { sandboxHome: fs.mkdtempSync(path.join(os.tmpdir(), 'agenfk-hub-story4-')) };
 });
-const realHome = process.env.HOME;
-beforeEach(() => { process.env.HOME = sandboxHome; });
-
 const { mockGet, mockPost, askState } = vi.hoisted(() => ({
   mockGet: vi.fn(),
   mockPost: vi.fn(),
@@ -138,7 +135,6 @@ afterEach(() => {
 afterAll(() => {
   if (realIsTTY) Object.defineProperty(process.stdin, 'isTTY', realIsTTY);
   else delete (process.stdin as any).isTTY;
-  if (realHome === undefined) delete process.env.HOME; else process.env.HOME = realHome;
 });
 
 describe('(a) login healthz guard — the fixture-clobber regression gate', () => {

--- a/packages/cli/src/test/stryker-wrap.test.ts
+++ b/packages/cli/src/test/stryker-wrap.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Stryker HOME guard (item 9c297075) — scripts/stryker-home-wrap.mjs.
+ *
+ * Stryker's vitest runner forces pool 'threads', and on this machine (Node
+ * >= 24) the runner's child processes keep a frozen C-level environment:
+ * process.env mutations inside the process do not reach libuv
+ * (os.homedir()). The vitest config's HOME pin (JS-level) therefore cannot
+ * sandbox os.homedir() under Stryker. The guard pins HOME at SPAWN time
+ * (baked into every child's C environ) and wraps the run with the
+ * home-integrity sentinel. The --probe hook is what makes the spawn-time
+ * mechanism itself testable.
+ */
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const WRAPPER = new URL('../../../../scripts/stryker-home-wrap.mjs', import.meta.url).pathname;
+
+function probe() {
+  const r = spawnSync(process.execPath, [WRAPPER, '--probe'], { encoding: 'utf8' });
+  expect(r.status, `wrapper probe failed: ${r.stderr}`).toBe(0);
+  return JSON.parse(r.stdout.trim());
+}
+
+describe('stryker-home-wrap (item 9c297075)', () => {
+  it('bakes the sandbox HOME into the spawned process (libuv-visible os.homedir)', () => {
+    const p = probe();
+    expect(p.home).toBeTruthy();
+    expect(p.home, 'child os.homedir() must be the wrapper sandbox')
+      .toContain('agenfk-test-home-');
+    expect(p.home).not.toBe(process.env.HOME);
+    expect(fs.existsSync(path.join(p.home, '.agenfk')), 'sandbox is pre-seeded').toBe(true);
+  });
+
+  it('marks spawn-time-pinned runs so tests can distinguish them from JS-level pins', () => {
+    const p = probe();
+    expect(p.spawnPin).toBe('1');
+  });
+
+  it('preserves the pre-pin home as AGENFK_REAL_HOME (and it differs from the sandbox)', () => {
+    const p = probe();
+    expect(p.realHome).toBeTruthy();
+    expect(p.realHome).not.toBe(p.home);
+  });
+});

--- a/packages/server/src/hub/flusher.ts
+++ b/packages/server/src/hub/flusher.ts
@@ -26,7 +26,9 @@ const MAX_BACKOFF_MS = 5 * 60_000;
  * here and the CLI reader must move with it (hub-carryover-deadletter.test.ts
  * pins the literal against drift).
  */
-export const DEFAULT_DEADLETTER_PATH = path.join(os.homedir(), '.agenfk', 'hub-deadletter.jsonl');
+export function defaultDeadletterPath(): string {
+  return path.join(os.homedir(), '.agenfk', 'hub-deadletter.jsonl');
+}
 
 /**
  * Resolve the running agenfk version once at module load. Story 7 of
@@ -106,8 +108,8 @@ export class Flusher {
     private intervalMs: number = DEFAULT_INTERVAL_MS,
     private batchSize: number = DEFAULT_BATCH_SIZE,
     httpClient?: AxiosInstance,
-    /** See DEFAULT_DEADLETTER_PATH. Injectable for tests. */
-    private deadletterPath: string = DEFAULT_DEADLETTER_PATH,
+    /** See defaultDeadletterPath(). Injectable for tests. */
+    private deadletterPath: string = defaultDeadletterPath(),
   ) {
     this.http = httpClient ?? axios.create({
       baseURL: config.url,

--- a/packages/server/src/hub/hubClient.ts
+++ b/packages/server/src/hub/hubClient.ts
@@ -7,11 +7,16 @@ import { SQLiteStorageProvider } from '@agenfk/storage-sqlite';
 import { HubConfig, RecordEventInput } from './types.js';
 import { resolveActor } from './identity.js';
 
-const HUB_CONFIG_PATH = path.join(os.homedir(), '.agenfk', 'hub.json');
+// Resolved at CALL time (item 9c297075): a module-level os.homedir() capture
+// froze the machine home at import time, so per-test HOME sandboxes never
+// applied under the Stryker runner (the 2026-08-31 hub.json clobber hole).
+export function hubConfigPath(): string {
+  return path.join(os.homedir(), '.agenfk', 'hub.json');
+}
 
 function readHubConfigFile(): HubConfig | null {
   try {
-    const raw = fs.readFileSync(HUB_CONFIG_PATH, 'utf8');
+    const raw = fs.readFileSync(hubConfigPath(), 'utf8');
     const cfg = JSON.parse(raw);
     if (cfg && typeof cfg.url === 'string' && typeof cfg.token === 'string' && typeof cfg.orgId === 'string') {
       return { url: cfg.url, token: cfg.token, orgId: cfg.orgId };
@@ -143,5 +148,3 @@ export class HubClient {
 
 /** orgId sentinel for events queued before `agenfk hub login`. */
 export const PENDING_ORG = '';
-
-export const HUB_CONFIG_FILE = HUB_CONFIG_PATH;

--- a/packages/server/src/hub/index.ts
+++ b/packages/server/src/hub/index.ts
@@ -1,4 +1,4 @@
-export { HubClient, loadHubConfig, HUB_CONFIG_FILE, PENDING_ORG } from './hubClient.js';
+export { HubClient, loadHubConfig, hubConfigPath, PENDING_ORG } from './hubClient.js';
 export { Flusher } from './flusher.js';
 export { resolveActor } from './identity.js';
 export type { HubConfig, FlusherStatus, RecordEventInput } from './types.js';

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -288,11 +288,11 @@ const purgeItemLogs = (itemId: string): void => {
 
 // ── Backup ───────────────────────────────────────────────────────────────────
 
-const BACKUP_DIR = path.join(os.homedir(), '.agenfk', 'backup');
+function backupDir(): string { return path.join(os.homedir(), '.agenfk', 'backup'); }
 const MAX_BACKUPS = 10;
 
 const performBackup = async (): Promise<string> => {
-  if (!fs.existsSync(BACKUP_DIR)) fs.mkdirSync(BACKUP_DIR, { recursive: true });
+  if (!fs.existsSync(backupDir())) fs.mkdirSync(backupDir(), { recursive: true });
 
   const [projects, items] = await Promise.all([
     storage.listProjects(),
@@ -301,16 +301,16 @@ const performBackup = async (): Promise<string> => {
 
   const timestamp = new Date().toISOString().replace(/:/g, '-');
   const dbType = 'sqlite';
-  const backupFile = path.join(BACKUP_DIR, `agenfk-backup-${timestamp}.json`);
+  const backupFile = path.join(backupDir(), `agenfk-backup-${timestamp}.json`);
 
   fs.writeFileSync(backupFile, JSON.stringify({ version: '1', backupDate: new Date().toISOString(), dbType, projects, items }, null, 2));
 
   // Rotate — keep only the MAX_BACKUPS most recent files
-  const existing = fs.readdirSync(BACKUP_DIR)
+  const existing = fs.readdirSync(backupDir())
     .filter(f => f.startsWith('agenfk-backup-') && f.endsWith('.json'))
     .sort();
   for (const old of existing.slice(0, Math.max(0, existing.length - MAX_BACKUPS))) {
-    fs.unlinkSync(path.join(BACKUP_DIR, old));
+    fs.unlinkSync(path.join(backupDir(), old));
   }
 
   console.log(`[BACKUP] Written: ${backupFile}`);
@@ -945,14 +945,14 @@ app.get("/db/status", asyncHandler(async (_req: any, res: any) => {
   const dbType = 'sqlite';
   let backupCount = 0;
   let latestBackup: string | null = null;
-  if (fs.existsSync(BACKUP_DIR)) {
-    const files = fs.readdirSync(BACKUP_DIR)
+  if (fs.existsSync(backupDir())) {
+    const files = fs.readdirSync(backupDir())
       .filter(f => f.startsWith('agenfk-backup-') && f.endsWith('.json'))
       .sort();
     backupCount = files.length;
     latestBackup = files.length > 0 ? files[files.length - 1] : null;
   }
-  res.json({ dbType, dbPath, backupDir: BACKUP_DIR, backupCount, latestBackup });
+  res.json({ dbType, dbPath, backupDir: backupDir(), backupCount, latestBackup });
 }));
 
 app.post("/backup", asyncHandler(async (req: any, res: any) => {
@@ -3089,7 +3089,7 @@ app.get("/items/:id/snapshot", asyncHandler(async (req: any, res: any) => {
 
 // ── JIRA Integration ─────────────────────────────────────────────────────────
 
-const JIRA_TOKEN_PATH = path.join(os.homedir(), '.agenfk', 'jira-token.json');
+function jiraTokenPath(): string { return path.join(os.homedir(), '.agenfk', 'jira-token.json'); }
 
 interface JiraTokenData {
   access_token: string;
@@ -3138,8 +3138,8 @@ const loadJiraConfig = (): JiraConfig => {
 
 const loadJiraToken = (): JiraTokenData | null => {
   try {
-    if (!fs.existsSync(JIRA_TOKEN_PATH)) return null;
-    return JSON.parse(fs.readFileSync(JIRA_TOKEN_PATH, 'utf8'));
+    if (!fs.existsSync(jiraTokenPath())) return null;
+    return JSON.parse(fs.readFileSync(jiraTokenPath(), 'utf8'));
   } catch { return null; }
 };
 
@@ -3148,14 +3148,14 @@ export let jiraValidationCache: { valid: boolean; checkedAt: number } | null = n
 const JIRA_VALIDATION_TTL = 60_000; // 60 seconds
 
 const saveJiraToken = (data: JiraTokenData): void => {
-  const dir = path.dirname(JIRA_TOKEN_PATH);
+  const dir = path.dirname(jiraTokenPath());
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(JIRA_TOKEN_PATH, JSON.stringify(data, null, 2));
+  fs.writeFileSync(jiraTokenPath(), JSON.stringify(data, null, 2));
   jiraValidationCache = null;
 };
 
 const deleteJiraToken = (): void => {
-  if (fs.existsSync(JIRA_TOKEN_PATH)) fs.unlinkSync(JIRA_TOKEN_PATH);
+  if (fs.existsSync(jiraTokenPath())) fs.unlinkSync(jiraTokenPath());
   jiraValidationCache = null;
 };
 

--- a/packages/server/src/test/api-client-port-discovery.test.ts
+++ b/packages/server/src/test/api-client-port-discovery.test.ts
@@ -11,21 +11,26 @@
  * routes to whichever port the file currently names — including after the file
  * changes mid-session.
  */
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
 import * as http from 'http';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
-// Sandbox HOME BEFORE importing anything that resolves the port-file path.
+// Sandbox homedir via a CALL-TIME mock of os.homedir() (item 9c297075), armed
+// BEFORE importing the API client — runner-independent (an env override only
+// works while libuv follows the JS env — not under Stryker's threads pool).
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('os')>();
+  return { ...actual, homedir: vi.fn(() => actual.homedir()) };
+});
 const sandboxHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agenfk-apiclient-'));
-const realHome = process.env.HOME;
-process.env.HOME = sandboxHome;
+vi.mocked(os.homedir).mockReturnValue(sandboxHome);
 delete process.env.AGENFK_API_URL;
 delete process.env.AGENFK_PORT;
 delete process.env.PORT;
 
-// Import after HOME is overridden so getApiUrl reads the sandbox port file.
+// Import after the homedir mock is armed so getApiUrl reads the sandbox port file.
 const { createApiClient } = await import('../apiClient.js');
 
 const portFile = path.join(sandboxHome, '.agenfk', 'server-port');
@@ -63,8 +68,7 @@ describe('MCP api client port discovery', () => {
   afterAll(async () => {
     await serverA.close();
     await serverB.close();
-    if (realHome === undefined) delete process.env.HOME;
-    else process.env.HOME = realHome;
+    vi.mocked(os.homedir).mockRestore();
     try { fs.rmSync(sandboxHome, { recursive: true, force: true }); } catch { /* ignore */ }
   });
 

--- a/packages/server/src/test/flow-org-available-hub-off.test.ts
+++ b/packages/server/src/test/flow-org-available-hub-off.test.ts
@@ -63,7 +63,7 @@ describe('org-flow routes (hub disabled)', () => {
   beforeEach(async () => {
     if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
     await initStorage();
-    stubBenignFetch(); // resetMocks clears the impl between tests; re-stub
+    stubBenignFetch(); // re-stub below clears the previous impl (no implicit reset)
   });
 
   it('GET /flows/org-available reports hub disabled', async () => {

--- a/packages/server/src/test/flow-org-available-hub-off.test.ts
+++ b/packages/server/src/test/flow-org-available-hub-off.test.ts
@@ -12,6 +12,15 @@ import * as os from 'os';
 import * as path from 'path';
 import request from 'supertest';
 
+// Mockable homedir (item 9c297075): pointing the SERVER at TMP_HOME via a
+// call-time os.homedir() mock works under any runner (an env override only
+// works while libuv follows the JS env — not under Stryker's threads pool,
+// where this test would otherwise let loadHubConfig() read the real hub.json).
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('os')>();
+  return { ...actual, homedir: vi.fn(() => actual.homedir()) };
+});
+
 const TEST_DB = path.resolve('./flow-org-avail-huboff-test-db.sqlite');
 const TMP_HOME = path.join(os.tmpdir(), 'agenfk-huboff-home');
 const savedEnv: Record<string, string | undefined> = {};
@@ -36,8 +45,7 @@ describe('org-flow routes (hub disabled)', () => {
     for (const k of ENV_KEYS) savedEnv[k] = process.env[k];
     // Redirect homedir so loadHubConfig() does NOT find ~/.agenfk/hub.json.
     fs.mkdirSync(TMP_HOME, { recursive: true });
-    process.env.HOME = TMP_HOME;
-    process.env.USERPROFILE = TMP_HOME;
+    vi.mocked(os.homedir).mockReturnValue(TMP_HOME);
     // Explicitly remove hub config so loadHubConfig() returns null.
     delete process.env.AGENFK_HUB_URL;
     delete process.env.AGENFK_HUB_TOKEN;
@@ -52,6 +60,7 @@ describe('org-flow routes (hub disabled)', () => {
 
   afterAll(() => {
     vi.unstubAllGlobals();
+    vi.mocked(os.homedir).mockRestore();
     for (const k of ENV_KEYS) {
       if (savedEnv[k] === undefined) delete process.env[k];
       else process.env[k] = savedEnv[k]!;

--- a/packages/server/src/test/flow-org-available-hub-on.test.ts
+++ b/packages/server/src/test/flow-org-available-hub-on.test.ts
@@ -115,7 +115,7 @@ describe('org-flow routes (hub enabled)', () => {
     activeMode = 'ok';
     if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
     await initStorage();
-    stubHubFetch(); // resetMocks clears the impl between tests; re-stub
+    stubHubFetch(); // re-stub below clears the previous impl (no implicit reset)
   });
 
   it('GET /flows/org-available returns the hub available set', async () => {

--- a/packages/server/src/test/flow-refresh-route-hub-on.test.ts
+++ b/packages/server/src/test/flow-refresh-route-hub-on.test.ts
@@ -81,7 +81,7 @@ describe('GET /projects/:id/flow?refresh=true (hub enabled)', () => {
   beforeEach(async () => {
     if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
     await initStorage();
-    stubHubFetch(); // resetMocks clears the impl between tests; re-stub
+    stubHubFetch(); // re-stub below clears the previous impl (no implicit reset)
   });
 
   it('pulls the hub flow and rebinds the project on read, and it persists', async () => {

--- a/packages/server/src/test/flusher-org-boundary.test.ts
+++ b/packages/server/src/test/flusher-org-boundary.test.ts
@@ -31,7 +31,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { SQLiteStorageProvider } from '@agenfk/storage-sqlite';
-import { Flusher, DEFAULT_DEADLETTER_PATH } from '../hub/flusher';
+import { Flusher, defaultDeadletterPath } from '../hub/flusher';
 
 const HUB_CONFIG = { url: 'http://hub.test', token: 't', orgId: 'acme' };
 
@@ -483,8 +483,8 @@ describe('Flusher org boundary + deadletter (CGLAB-117)', () => {
     expect(() => storage.hubOutboxPeekDeliverable(500, undefined as any)).toThrow(/non-empty string/);
   });
 
-  it('DEFAULT_DEADLETTER_PATH is the ~/.agenfk/hub-deadletter.jsonl contract the CLI reads', async () => {
-    expect(DEFAULT_DEADLETTER_PATH).toBe(path.join(os.homedir(), '.agenfk', 'hub-deadletter.jsonl'));
+  it('defaultDeadletterPath is the ~/.agenfk/hub-deadletter.jsonl contract the CLI reads', async () => {
+    expect(defaultDeadletterPath()).toBe(path.join(os.homedir(), '.agenfk', 'hub-deadletter.jsonl'));
   });
 
   it('staleOrgDepth excludes the PENDING_ORG sentinel rows', async () => {

--- a/packages/server/src/test/home-isolation.test.ts
+++ b/packages/server/src/test/home-isolation.test.ts
@@ -17,8 +17,12 @@
  *     is what makes this verification environment-independent: the getters
  *     must track whatever os.homedir() returns at call time, in every runner.
  *  2. The vitest runner pins process.env.HOME to a per-run sandbox
- *     (see vitest.config.ts / scripts/vitest-home-pin.mjs), so a test that
- *     forgets to sandbox writes into the sandbox, never the machine home.
+ *     (see vitest.config.ts / scripts/vitest-home-pin.mjs) — a JS-level
+ *     guarantee for every worker. Under the forks pool (normal runs, CI)
+ *     libuv/os.homedir() follows it (asserted below); under Stryker's forced
+ *     threads pool the C environ is frozen on this machine, so Stryker must
+ *     be launched via `npm run test:stryker` (spawn-time pin + sentinel) —
+ *     also asserted below, via the AGENFK_SPAWN_PIN marker.
  */
 import { describe, it, expect, vi } from 'vitest';
 import * as fs from 'fs';
@@ -45,6 +49,25 @@ describe('home isolation (item 9c297075)', () => {
     // The sandbox is pre-seeded with the framework dir so code that reads
     // verify-token/server-port gets "absent", not "hostile".
     expect(fs.existsSync(path.join(process.env.HOME!, '.agenfk'))).toBe(true);
+  });
+
+  it('os.homedir() honors the pinned HOME — or the run was launched via the spawn-time Stryker guard', () => {
+    // Probe the libuv linkage directly: re-point the JS-level HOME and check
+    // whether os.homedir() follows.
+    const probeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agenfk-probe-'));
+    const prev = process.env.HOME!;
+    process.env.HOME = probeDir;
+    let follows = false;
+    try { follows = os.homedir() === probeDir; } finally { process.env.HOME = prev; }
+    if (follows) return; // forks pool (normal runs, CI): libuv linkage holds.
+    // Frozen C environ (Stryker threads pool): HOME can only reach
+    // os.homedir() if it was baked in at SPAWN time — require the guard's
+    // marker so an unguarded Stryker launch fails LOUDLY instead of letting
+    // tests silently write into the machine home.
+    expect(
+      process.env.AGENFK_SPAWN_PIN,
+      'os.homedir() linkage is frozen in this runner — launch Stryker via `npm run test:stryker`',
+    ).toBe('1');
   });
 
   it('the hub config path resolves against the CURRENT homedir (lazy, not import-time)', () => {

--- a/packages/server/src/test/home-isolation.test.ts
+++ b/packages/server/src/test/home-isolation.test.ts
@@ -3,24 +3,36 @@
  *
  * StrykerJS mutation runs wrote test-fixture hub.json values into the REAL
  * ~/.agenfk twice: once losing 57 hub events (WAL-recovered), once destroying
- * the real hub credentials (token rotated; re-login never happened).
+ * the real hub credentials (token rotated; re-login never happened). A third
+ * hit surfaced 2026-09-02 during this item's own mutation pass: under the
+ * Stryker child-process runner, a process.env.HOME mutation does not reach
+ * libuv on this machine (os.homedir() kept returning the machine home), so a
+ * test that writes through a HOME-derived path deleted the LIVE
+ * ~/.agenfk/server-port file.
  *
- * Two structural fixes are verified here:
- *  1. Hub/telemetry home paths resolve at CALL time (process.env.HOME), not at
- *     import time — so per-test HOME overrides are always effective, including
- *     under the Stryker vitest runner (module-level `os.homedir()` captures
- *     happened at worker boot, before any test could set HOME).
+ * Structural fixes verified here:
+ *  1. Hub/telemetry home paths resolve at CALL time, not import time —
+ *     proven by swapping os.homedir() (the single source the getters read)
+ *     for a sandbox per test. The homedir mock — rather than an env override —
+ *     is what makes this verification environment-independent: the getters
+ *     must track whatever os.homedir() returns at call time, in every runner.
  *  2. The vitest runner pins process.env.HOME to a per-run sandbox
  *     (see vitest.config.ts / scripts/vitest-home-pin.mjs), so a test that
  *     forgets to sandbox writes into the sandbox, never the machine home.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { hubConfigPath } from '../hub/hubClient';
 import { defaultDeadletterPath } from '../hub/flusher';
 import { agenfkDir } from '@agenfk/telemetry';
+
+// Mockable homedir: delegates to the real one unless a test re-points it.
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('os')>();
+  return { ...actual, homedir: vi.fn(() => actual.homedir()) };
+});
 
 // Set by the vitest config BEFORE the HOME pin — the machine's real home.
 const REAL_HOME = process.env.AGENFK_REAL_HOME;
@@ -35,49 +47,53 @@ describe('home isolation (item 9c297075)', () => {
     expect(fs.existsSync(path.join(process.env.HOME!, '.agenfk'))).toBe(true);
   });
 
-  it('the hub config path resolves against the CURRENT home (lazy, not import-time)', () => {
-    expect(hubConfigPath()).toBe(path.join(process.env.HOME!, '.agenfk', 'hub.json'));
+  it('the hub config path resolves against the CURRENT homedir (lazy, not import-time)', () => {
     const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'agenfk-lazy-'));
-    const prev = process.env.HOME;
-    process.env.HOME = sandbox;
+    vi.mocked(os.homedir).mockReturnValue(sandbox);
     try {
       expect(hubConfigPath()).toBe(path.join(sandbox, '.agenfk', 'hub.json'));
     } finally {
-      process.env.HOME = prev;
+      vi.mocked(os.homedir).mockRestore();
+      fs.rmSync(sandbox, { recursive: true, force: true });
     }
   });
 
-  it('the deadletter path resolves against the CURRENT home (lazy)', () => {
-    expect(defaultDeadletterPath()).toBe(path.join(process.env.HOME!, '.agenfk', 'hub-deadletter.jsonl'));
+  it('the deadletter path resolves against the CURRENT homedir (lazy)', () => {
     const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'agenfk-lazy-'));
-    const prev = process.env.HOME;
-    process.env.HOME = sandbox;
+    vi.mocked(os.homedir).mockReturnValue(sandbox);
     try {
       expect(defaultDeadletterPath()).toBe(path.join(sandbox, '.agenfk', 'hub-deadletter.jsonl'));
     } finally {
-      process.env.HOME = prev;
+      vi.mocked(os.homedir).mockRestore();
+      fs.rmSync(sandbox, { recursive: true, force: true });
     }
   });
 
-  it('the telemetry agenfk dir resolves against the CURRENT home (lazy)', () => {
-    expect(agenfkDir()).toBe(path.join(process.env.HOME!, '.agenfk'));
+  it('the telemetry agenfk dir resolves against the CURRENT homedir (lazy)', () => {
     const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'agenfk-lazy-'));
-    const prev = process.env.HOME;
-    process.env.HOME = sandbox;
+    vi.mocked(os.homedir).mockReturnValue(sandbox);
     try {
       expect(agenfkDir()).toBe(path.join(sandbox, '.agenfk'));
     } finally {
-      process.env.HOME = prev;
+      vi.mocked(os.homedir).mockRestore();
+      fs.rmSync(sandbox, { recursive: true, force: true });
     }
   });
 
-  it('a write through the lazy hub path lands in the sandbox home, never the real home', () => {
-    const p = hubConfigPath();
-    expect(p.startsWith(process.env.HOME!)).toBe(true);
-    expect(p.startsWith(REAL_HOME!), 'path must not point into the real home').toBe(false);
-    fs.mkdirSync(path.dirname(p), { recursive: true });
-    fs.writeFileSync(p, JSON.stringify({ url: 'https://sandbox.example', token: 'test-token', orgId: 'test-org' }));
-    expect(JSON.parse(fs.readFileSync(p, 'utf8')).token).toBe('test-token');
-    fs.rmSync(p, { force: true });
+  it('a write through the lazy hub path lands in the sandbox homedir, never the real home', () => {
+    const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'agenfk-lazy-'));
+    vi.mocked(os.homedir).mockReturnValue(sandbox);
+    try {
+      const p = hubConfigPath();
+      expect(p.startsWith(sandbox)).toBe(true);
+      expect(p.startsWith(REAL_HOME!), 'path must not point into the real home').toBe(false);
+      fs.mkdirSync(path.dirname(p), { recursive: true });
+      fs.writeFileSync(p, JSON.stringify({ url: 'https://sandbox.example', token: 'test-token', orgId: 'test-org' }));
+      expect(JSON.parse(fs.readFileSync(p, 'utf8')).token).toBe('test-token');
+      fs.rmSync(p, { force: true });
+    } finally {
+      vi.mocked(os.homedir).mockRestore();
+      fs.rmSync(sandbox, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/server/src/test/home-isolation.test.ts
+++ b/packages/server/src/test/home-isolation.test.ts
@@ -59,6 +59,7 @@ describe('home isolation (item 9c297075)', () => {
     process.env.HOME = probeDir;
     let follows = false;
     try { follows = os.homedir() === probeDir; } finally { process.env.HOME = prev; }
+    fs.rmSync(probeDir, { recursive: true, force: true });
     if (follows) return; // forks pool (normal runs, CI): libuv linkage holds.
     // Frozen C environ (Stryker threads pool): HOME can only reach
     // os.homedir() if it was baked in at SPAWN time — require the guard's

--- a/packages/server/src/test/home-isolation.test.ts
+++ b/packages/server/src/test/home-isolation.test.ts
@@ -1,0 +1,83 @@
+/**
+ * HOME isolation — the 2026-08-31 / 2026-09-01 clobber incident (item 9c297075).
+ *
+ * StrykerJS mutation runs wrote test-fixture hub.json values into the REAL
+ * ~/.agenfk twice: once losing 57 hub events (WAL-recovered), once destroying
+ * the real hub credentials (token rotated; re-login never happened).
+ *
+ * Two structural fixes are verified here:
+ *  1. Hub/telemetry home paths resolve at CALL time (process.env.HOME), not at
+ *     import time — so per-test HOME overrides are always effective, including
+ *     under the Stryker vitest runner (module-level `os.homedir()` captures
+ *     happened at worker boot, before any test could set HOME).
+ *  2. The vitest runner pins process.env.HOME to a per-run sandbox
+ *     (see vitest.config.ts / scripts/vitest-home-pin.mjs), so a test that
+ *     forgets to sandbox writes into the sandbox, never the machine home.
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { hubConfigPath } from '../hub/hubClient';
+import { defaultDeadletterPath } from '../hub/flusher';
+import { agenfkDir } from '@agenfk/telemetry';
+
+// Set by the vitest config BEFORE the HOME pin — the machine's real home.
+const REAL_HOME = process.env.AGENFK_REAL_HOME;
+
+describe('home isolation (item 9c297075)', () => {
+  it('the vitest runner pins HOME to a per-run sandbox, not the machine home', () => {
+    expect(REAL_HOME, 'AGENFK_REAL_HOME unset — the vitest HOME pin is missing').toBeTruthy();
+    expect(process.env.HOME).toBeTruthy();
+    expect(process.env.HOME, 'test HOME must differ from the real home').not.toBe(REAL_HOME);
+    // The sandbox is pre-seeded with the framework dir so code that reads
+    // verify-token/server-port gets "absent", not "hostile".
+    expect(fs.existsSync(path.join(process.env.HOME!, '.agenfk'))).toBe(true);
+  });
+
+  it('the hub config path resolves against the CURRENT home (lazy, not import-time)', () => {
+    expect(hubConfigPath()).toBe(path.join(process.env.HOME!, '.agenfk', 'hub.json'));
+    const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'agenfk-lazy-'));
+    const prev = process.env.HOME;
+    process.env.HOME = sandbox;
+    try {
+      expect(hubConfigPath()).toBe(path.join(sandbox, '.agenfk', 'hub.json'));
+    } finally {
+      process.env.HOME = prev;
+    }
+  });
+
+  it('the deadletter path resolves against the CURRENT home (lazy)', () => {
+    expect(defaultDeadletterPath()).toBe(path.join(process.env.HOME!, '.agenfk', 'hub-deadletter.jsonl'));
+    const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'agenfk-lazy-'));
+    const prev = process.env.HOME;
+    process.env.HOME = sandbox;
+    try {
+      expect(defaultDeadletterPath()).toBe(path.join(sandbox, '.agenfk', 'hub-deadletter.jsonl'));
+    } finally {
+      process.env.HOME = prev;
+    }
+  });
+
+  it('the telemetry agenfk dir resolves against the CURRENT home (lazy)', () => {
+    expect(agenfkDir()).toBe(path.join(process.env.HOME!, '.agenfk'));
+    const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'agenfk-lazy-'));
+    const prev = process.env.HOME;
+    process.env.HOME = sandbox;
+    try {
+      expect(agenfkDir()).toBe(path.join(sandbox, '.agenfk'));
+    } finally {
+      process.env.HOME = prev;
+    }
+  });
+
+  it('a write through the lazy hub path lands in the sandbox home, never the real home', () => {
+    const p = hubConfigPath();
+    expect(p.startsWith(process.env.HOME!)).toBe(true);
+    expect(p.startsWith(REAL_HOME!), 'path must not point into the real home').toBe(false);
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, JSON.stringify({ url: 'https://sandbox.example', token: 'test-token', orgId: 'test-org' }));
+    expect(JSON.parse(fs.readFileSync(p, 'utf8')).token).toBe('test-token');
+    fs.rmSync(p, { force: true });
+  });
+});

--- a/packages/server/src/test/hub-client.test.ts
+++ b/packages/server/src/test/hub-client.test.ts
@@ -4,7 +4,7 @@ import * as os from 'os';
 import * as path from 'path';
 import axios from 'axios';
 import { SQLiteStorageProvider } from '@agenfk/storage-sqlite';
-import { HubClient, Flusher, loadHubConfig, HUB_CONFIG_FILE } from '../hub';
+import { HubClient, Flusher, loadHubConfig, hubConfigPath } from '../hub';
 
 const TEST_DB = path.join(os.tmpdir(), `agenfk-hub-client-test-${process.pid}.sqlite`);
 const cleanupDb = () => {
@@ -132,10 +132,11 @@ describe('loadHubConfig', () => {
     delete process.env.AGENFK_HUB_URL;
     delete process.env.AGENFK_HUB_TOKEN;
     delete process.env.AGENFK_HUB_ORG;
-    // HUB_CONFIG_FILE points at user home — only check that loader returns null
-    // when env is empty AND the file is unreadable. (We avoid mutating the user's
-    // real ~/.agenfk/hub.json.)
-    if (!fs.existsSync(HUB_CONFIG_FILE)) {
+    // hubConfigPath() resolves against the CURRENT home (item 9c297075) — under
+    // the vitest HOME pin that is the per-run sandbox, never the machine home.
+    // Only check that loader returns null when env is empty AND the file is
+    // unreadable.
+    if (!fs.existsSync(hubConfigPath())) {
       expect(loadHubConfig()).toBeNull();
     }
   });

--- a/packages/server/src/test/hub-org-summaries.test.ts
+++ b/packages/server/src/test/hub-org-summaries.test.ts
@@ -6,20 +6,24 @@
  * GET /internal/hub/status — which must expose them even when the hub is NOT
  * configured (a stale-org install is exactly when carry-over is needed).
  */
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
 import request from 'supertest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
-// Sandbox HOME BEFORE importing the server: on a hub-configured dev machine a
-// real ~/.agenfk/hub.json would construct the real hubFlusher, making
-// `enabled` non-deterministic (and pointing the flusher at the live hub).
+// Sandbox homedir via a CALL-TIME mock of os.homedir() (item 9c297075), armed
+// BEFORE importing the server: on a hub-configured dev machine a real
+// ~/.agenfk/hub.json would construct the real hubFlusher, making `enabled`
+// non-deterministic (and pointing the flusher at the live hub). The mock works
+// under any runner — an env override only works while libuv follows the JS env
+// (not under Stryker's threads pool).
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('os')>();
+  return { ...actual, homedir: vi.fn(() => actual.homedir()) };
+});
 const sandboxHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agenfk-hub-status-'));
-const realHome = process.env.HOME;
-// See hub-carryover-actions.test.ts: HOME must be correct at TEST time, not
-// just import time, under a shared-process runner.
-beforeEach(() => { process.env.HOME = sandboxHome; });
+vi.mocked(os.homedir).mockReturnValue(sandboxHome);
 
 const mod = await import('../server');
 const { app, VERIFY_TOKEN } = mod;
@@ -34,8 +38,8 @@ describe('hub outbox org summaries', () => {
   });
   afterAll(() => {
     if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
-    if (realHome === undefined) delete process.env.HOME;
-    else process.env.HOME = realHome;
+    vi.mocked(os.homedir).mockRestore();
+    try { fs.rmSync(sandboxHome, { recursive: true, force: true }); } catch { /* ignore */ }
   });
   beforeEach(async () => {
     (mod.storage as any).database.prepare('DELETE FROM hub_outbox').run();

--- a/packages/server/src/test/security-hardening.test.ts
+++ b/packages/server/src/test/security-hardening.test.ts
@@ -6,12 +6,22 @@
  * assertions for the shell-injection sites that only execute once `gh`/`jira`
  * are configured (so the argv/allowlist shape is what we pin down).
  */
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import request from 'supertest';
 import { app, initStorage, isAllowedOrigin, setReleasesUpdateExecImpl, resetReleasesUpdateExecImpl } from '../server';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+
+// Mockable homedir (item 9c297075): the verify-token read below then comes
+// from the sandbox under any runner — never the real ~/.agenfk/verify-token.
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('os')>();
+  return { ...actual, homedir: vi.fn(() => actual.homedir()) };
+});
+const sandboxHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agenfk-sec-hardening-'));
+fs.mkdirSync(path.join(sandboxHome, '.agenfk'), { recursive: true });
+vi.mocked(os.homedir).mockReturnValue(sandboxHome);
 
 const TEST_DB = path.resolve('./security-hardening-test-db.sqlite');
 const VERIFY_TOKEN = (() => {

--- a/packages/server/src/test/server.sqlite-only.test.ts
+++ b/packages/server/src/test/server.sqlite-only.test.ts
@@ -18,6 +18,17 @@ vi.mock('axios', () => {
   return { default: mockAxios };
 });
 
+// Mockable homedir (item 9c297075) — the migration.json save/replace cycle
+// below then runs in the sandbox under any runner (an env override only
+// works while libuv follows the JS env — not under Stryker's threads pool).
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('os')>();
+  return { ...actual, homedir: vi.fn(() => actual.homedir()) };
+});
+const sandboxHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agenfk-sqlite-only-'));
+fs.mkdirSync(path.join(sandboxHome, '.agenfk'), { recursive: true });
+vi.mocked(os.homedir).mockReturnValue(sandboxHome);
+
 const TEST_DB_JSON_PATH = path.resolve('./server-sqlite-only-test-db.json');
 const TEST_DB_SQLITE_PATH = path.resolve('./server-sqlite-only-test-db.sqlite');
 
@@ -142,4 +153,9 @@ describe('SQLite-only storage enforcement', () => {
       expect(fs.existsSync(migrationPath)).toBe(false);
     });
   });
+});
+
+afterAll(() => {
+  vi.mocked(os.homedir).mockRestore();
+  try { fs.rmSync(sandboxHome, { recursive: true, force: true }); } catch { /* ignore */ }
 });

--- a/packages/server/src/test/server.supplemental.test.ts
+++ b/packages/server/src/test/server.supplemental.test.ts
@@ -19,6 +19,21 @@ vi.mock('axios', () => {
   return { default: mockAxios };
 });
 
+// Mockable homedir (item 9c297075) — delegates to the real one until armed.
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('os')>();
+  return { ...actual, homedir: vi.fn(() => actual.homedir()) };
+});
+
+// Sandbox homedir via a CALL-TIME mock of os.homedir() (item 9c297075): every
+// jira-token/config save-restore cycle in this file then operates in the
+// sandbox — the real ~/.agenfk is never touched under any runner (an env
+// override only works while libuv follows the JS env — not under Stryker's
+// threads pool). Must arm before the module-level path constants below.
+const sandboxHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agenfk-supplemental-'));
+fs.mkdirSync(path.join(sandboxHome, '.agenfk'), { recursive: true });
+vi.mocked(os.homedir).mockReturnValue(sandboxHome);
+
 // CRITICAL: install a no-op exec impl for POST /releases/update *before any
 // test runs*. Without this, the supplemental test below shells out for real
 // via `npx -y github:cglab-public/agenfk`, which downgrades ~/.agenfk-system/
@@ -52,7 +67,7 @@ beforeAll(async () => {
 });
 
 afterAll(() => {
-  // Restore the original jira token state
+  // Restore the original jira token state (sandbox-scoped since item 9c297075)
   if (globalSavedToken) {
     fs.writeFileSync(GLOBAL_TOKEN_PATH, globalSavedToken);
   } else if (fs.existsSync(GLOBAL_TOKEN_PATH)) {
@@ -60,6 +75,8 @@ afterAll(() => {
   }
   // Clean up test DB
   if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+  vi.mocked(os.homedir).mockRestore();
+  try { fs.rmSync(sandboxHome, { recursive: true, force: true }); } catch { /* ignore */ }
 });
 
 

--- a/packages/server/src/test/server.test.ts
+++ b/packages/server/src/test/server.test.ts
@@ -14,6 +14,13 @@ vi.mock('axios', () => {
   return { default: mockAxios };
 });
 
+// Mockable homedir (item 9c297075) — the JIRA block re-points it per test so
+// its token/config cycles can never touch the real ~/.agenfk under any runner.
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('os')>();
+  return { ...actual, homedir: vi.fn(() => actual.homedir()) };
+});
+
 const TEST_DB = path.resolve('./server-test-db.sqlite');
 
 describe('Server API', () => {
@@ -305,8 +312,15 @@ describe('Server API', () => {
 // ── JIRA Integration Tests ────────────────────────────────────────────────────
 
 describe('JIRA Integration', () => {
-  const jiraTokenPath = path.join(os.homedir(), '.agenfk', 'jira-token.json');
-  const jiraConfigPath = path.join(os.homedir(), '.agenfk', 'config.json');
+  // Sandbox homedir via a CALL-TIME mock of os.homedir() (item 9c297075):
+  // the paths are lazy so the beforeEach re-arm (after vi.resetAllMocks) is
+  // always effective, and the token/config cycles can never touch the real
+  // ~/.agenfk under any runner (env overrides only work while libuv follows
+  // the JS env — not under Stryker's threads pool).
+  const jiraSandboxHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agenfk-server-jira-'));
+  fs.mkdirSync(path.join(jiraSandboxHome, '.agenfk'), { recursive: true });
+  const jiraTokenPath = () => path.join(os.homedir(), '.agenfk', 'jira-token.json');
+  const jiraConfigPath = () => path.join(os.homedir(), '.agenfk', 'config.json');
 
   const testToken = {
     access_token: 'test-access-token',
@@ -320,13 +334,13 @@ describe('JIRA Integration', () => {
 
   beforeEach(async () => {
     // Clean token
-    if (fs.existsSync(jiraTokenPath)) fs.unlinkSync(jiraTokenPath);
+    if (fs.existsSync(jiraTokenPath())) fs.unlinkSync(jiraTokenPath());
     // Backup config and remove JIRA section
-    if (fs.existsSync(jiraConfigPath)) {
-      originalConfig = fs.readFileSync(jiraConfigPath, 'utf8');
+    if (fs.existsSync(jiraConfigPath())) {
+      originalConfig = fs.readFileSync(jiraConfigPath(), 'utf8');
       const cfg = JSON.parse(originalConfig);
       delete cfg.jira;
-      fs.writeFileSync(jiraConfigPath, JSON.stringify(cfg, null, 2));
+      fs.writeFileSync(jiraConfigPath(), JSON.stringify(cfg, null, 2));
     } else {
       originalConfig = null;
     }
@@ -336,13 +350,15 @@ describe('JIRA Integration', () => {
     pkceStore.clear();
     clearJiraValidationCache();
     vi.resetAllMocks();
+    // Re-arm: resetAllMocks reverted the homedir mock to its factory default.
+    vi.mocked(os.homedir).mockReturnValue(jiraSandboxHome);
   });
 
   afterEach(() => {
-    if (fs.existsSync(jiraTokenPath)) fs.unlinkSync(jiraTokenPath);
+    if (fs.existsSync(jiraTokenPath())) fs.unlinkSync(jiraTokenPath());
     // Restore config
     if (originalConfig !== null) {
-      fs.writeFileSync(jiraConfigPath, originalConfig);
+      fs.writeFileSync(jiraConfigPath(), originalConfig);
     }
   });
 
@@ -378,7 +394,7 @@ describe('JIRA Integration', () => {
     it('returns connected:true with cloudId and email when token is valid', async () => {
       process.env.JIRA_CLIENT_ID = 'cid';
       process.env.JIRA_CLIENT_SECRET = 'csec';
-      fs.writeFileSync(jiraTokenPath, JSON.stringify(testToken));
+      fs.writeFileSync(jiraTokenPath(), JSON.stringify(testToken));
       const axios = (await import('axios')).default as any;
       // Mock the /myself validation call
       axios.mockResolvedValueOnce({ data: { emailAddress: 'test@example.com' } });
@@ -393,7 +409,7 @@ describe('JIRA Integration', () => {
     it('returns connected:false with reason when token is expired and refresh fails', async () => {
       process.env.JIRA_CLIENT_ID = 'cid';
       process.env.JIRA_CLIENT_SECRET = 'csec';
-      fs.writeFileSync(jiraTokenPath, JSON.stringify(testToken));
+      fs.writeFileSync(jiraTokenPath(), JSON.stringify(testToken));
       const axios = (await import('axios')).default as any;
       const err401 = Object.assign(new Error('Unauthorized'), { response: { status: 401 } });
       // Validation call to /myself returns 401
@@ -410,7 +426,7 @@ describe('JIRA Integration', () => {
     it('returns connected:true when Atlassian API is unreachable (network error)', async () => {
       process.env.JIRA_CLIENT_ID = 'cid';
       process.env.JIRA_CLIENT_SECRET = 'csec';
-      fs.writeFileSync(jiraTokenPath, JSON.stringify(testToken));
+      fs.writeFileSync(jiraTokenPath(), JSON.stringify(testToken));
       const axios = (await import('axios')).default as any;
       // Network error (no response property)
       axios.mockRejectedValueOnce(new Error('ECONNREFUSED'));
@@ -441,11 +457,11 @@ describe('JIRA Integration', () => {
     });
 
     it('reads config from ~/.agenfk/config.json jira key', async () => {
-      const cfg = fs.existsSync(jiraConfigPath)
-        ? JSON.parse(fs.readFileSync(jiraConfigPath, 'utf8'))
+      const cfg = fs.existsSync(jiraConfigPath())
+        ? JSON.parse(fs.readFileSync(jiraConfigPath(), 'utf8'))
         : {};
       cfg.jira = { clientId: 'cfg-client-id', clientSecret: 'cfg-secret' };
-      fs.writeFileSync(jiraConfigPath, JSON.stringify(cfg, null, 2));
+      fs.writeFileSync(jiraConfigPath(), JSON.stringify(cfg, null, 2));
 
       const res = await request(app).get('/jira/oauth/authorize');
       expect(res.status).toBe(302);
@@ -492,8 +508,8 @@ describe('JIRA Integration', () => {
       const res = await request(app).get('/jira/oauth/callback?code=auth-code&state=test-state');
       expect(res.status).toBe(302);
       expect(res.headers.location).toContain('jira=connected');
-      expect(fs.existsSync(jiraTokenPath)).toBe(true);
-      const saved = JSON.parse(fs.readFileSync(jiraTokenPath, 'utf8'));
+      expect(fs.existsSync(jiraTokenPath())).toBe(true);
+      const saved = JSON.parse(fs.readFileSync(jiraTokenPath(), 'utf8'));
       expect(saved.cloudId).toBe('cloud-123');
       expect(saved.email).toBe('user@test.com');
     });
@@ -507,7 +523,7 @@ describe('JIRA Integration', () => {
     });
 
     it('returns project list when connected', async () => {
-      fs.writeFileSync(jiraTokenPath, JSON.stringify(testToken));
+      fs.writeFileSync(jiraTokenPath(), JSON.stringify(testToken));
       const axios = (await import('axios')).default as any;
       axios.mockResolvedValueOnce({
         data: { values: [{ id: '10001', key: 'PROJ', name: 'My Project', projectTypeKey: 'software' }] },
@@ -527,7 +543,7 @@ describe('JIRA Integration', () => {
     });
 
     it('returns issues with mapped types', async () => {
-      fs.writeFileSync(jiraTokenPath, JSON.stringify(testToken));
+      fs.writeFileSync(jiraTokenPath(), JSON.stringify(testToken));
       const axios = (await import('axios')).default as any;
       axios.mockResolvedValueOnce({
         data: {
@@ -556,13 +572,13 @@ describe('JIRA Integration', () => {
     });
 
     it('returns 400 when items array missing or empty', async () => {
-      fs.writeFileSync(jiraTokenPath, JSON.stringify(testToken));
+      fs.writeFileSync(jiraTokenPath(), JSON.stringify(testToken));
       const res = await request(app).post('/jira/import').send({ projectId: 'p1' });
       expect(res.status).toBe(400);
     });
 
     it('imports issues and creates AgEnFK items', async () => {
-      fs.writeFileSync(jiraTokenPath, JSON.stringify(testToken));
+      fs.writeFileSync(jiraTokenPath(), JSON.stringify(testToken));
       const projRes = await request(app).post('/projects').send({ name: 'JIRA Import Test' });
       const projectId = projRes.body.id;
 
@@ -589,7 +605,7 @@ describe('JIRA Integration', () => {
     });
 
     it('records errors for failed issue fetches', async () => {
-      fs.writeFileSync(jiraTokenPath, JSON.stringify(testToken));
+      fs.writeFileSync(jiraTokenPath(), JSON.stringify(testToken));
       const projRes = await request(app).post('/projects').send({ name: 'JIRA Err Test' });
       const projectId = projRes.body.id;
 
@@ -609,11 +625,11 @@ describe('JIRA Integration', () => {
   // ── POST /jira/disconnect ────────────────────────────────────────────────
   describe('POST /jira/disconnect', () => {
     it('removes token file and returns disconnected:true', async () => {
-      fs.writeFileSync(jiraTokenPath, JSON.stringify(testToken));
+      fs.writeFileSync(jiraTokenPath(), JSON.stringify(testToken));
       const res = await request(app).post('/jira/disconnect');
       expect(res.status).toBe(200);
       expect(res.body.disconnected).toBe(true);
-      expect(fs.existsSync(jiraTokenPath)).toBe(false);
+      expect(fs.existsSync(jiraTokenPath())).toBe(false);
     });
 
     it('succeeds even when token file does not exist', async () => {
@@ -642,4 +658,10 @@ describe('JIRA Integration', () => {
       }
     });
   });
+
+  afterAll(() => {
+    vi.mocked(os.homedir).mockRestore();
+    try { fs.rmSync(jiraSandboxHome, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
 });

--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import * as os from 'os';
 import * as crypto from 'crypto';
 import { PostHog } from 'posthog-node';
+import { agenfkDir } from './serverPort.js';
 
 const AGENFK_VERSION: string = (() => {
   try {
@@ -13,16 +14,18 @@ const AGENFK_VERSION: string = (() => {
   }
 })();
 
-const AGENFK_DIR = path.join(os.homedir(), '.agenfk');
-const CONFIG_PATH = path.join(AGENFK_DIR, 'config.json');
-const INSTALLATION_ID_PATH = path.join(AGENFK_DIR, 'installation-id');
-const HUB_CONFIG_PATH = path.join(AGENFK_DIR, 'hub.json');
+// Home paths resolve at CALL time (item 9c297075): module-level os.homedir()
+// captures froze the machine home at import time — the hole behind the
+// 2026-08-31 hub.json clobber. os.homedir() re-reads HOME on every call.
+const configPath = () => path.join(agenfkDir(), 'config.json');
+const installationIdPath = () => path.join(agenfkDir(), 'installation-id');
+const hubConfigFile = () => path.join(agenfkDir(), 'hub.json');
 
 export type InstallSource = 'hub' | 'manual';
 
 export function getInstallSource(): InstallSource {
   try {
-    const raw = fs.readFileSync(HUB_CONFIG_PATH, 'utf8');
+    const raw = fs.readFileSync(hubConfigFile(), 'utf8');
     const parsed = JSON.parse(raw);
     if (parsed && typeof parsed === 'object' && typeof parsed.url === 'string' && parsed.url.length > 0) {
       return 'hub';
@@ -35,7 +38,7 @@ export function getInstallSource(): InstallSource {
 
 function readConfig(): Record<string, unknown> {
   try {
-    return JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+    return JSON.parse(fs.readFileSync(configPath(), 'utf8'));
   } catch {
     return {};
   }
@@ -43,15 +46,15 @@ function readConfig(): Record<string, unknown> {
 
 function getOrCreateInstallationId(): string {
   try {
-    const existing = fs.readFileSync(INSTALLATION_ID_PATH, 'utf8').trim();
+    const existing = fs.readFileSync(installationIdPath(), 'utf8').trim();
     if (existing) return existing;
   } catch {
     // File doesn't exist yet — create it below
   }
   const id = crypto.randomUUID();
   try {
-    fs.mkdirSync(AGENFK_DIR, { recursive: true });
-    fs.writeFileSync(INSTALLATION_ID_PATH, id, 'utf8');
+    fs.mkdirSync(agenfkDir(), { recursive: true });
+    fs.writeFileSync(installationIdPath(), id, 'utf8');
   } catch {
     // Fail silently — telemetry must never block normal operation
   }
@@ -131,7 +134,8 @@ export function isTelemetryEnabled(): boolean {
 }
 
 export {
-  SERVER_PORT_FILE,
+  agenfkDir,
+  serverPortFile,
   DEFAULT_API_PORT,
   MAX_PORT_PROBE_ATTEMPTS,
   isPortAvailable,

--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -21,6 +21,10 @@ const configPath = () => path.join(agenfkDir(), 'config.json');
 const installationIdPath = () => path.join(agenfkDir(), 'installation-id');
 const hubConfigFile = () => path.join(agenfkDir(), 'hub.json');
 
+// Exported for direct testing of the call-time (lazy) path resolution —
+// the structural fix for the 2026-08-31 clobber incident (item 9c297075).
+export { configPath, installationIdPath, hubConfigFile };
+
 export type InstallSource = 'hub' | 'manual';
 
 export function getInstallSource(): InstallSource {

--- a/packages/telemetry/src/serverPort.ts
+++ b/packages/telemetry/src/serverPort.ts
@@ -3,9 +3,16 @@ import * as net from 'net';
 import * as os from 'os';
 import * as path from 'path';
 
-const AGENFK_DIR = path.join(os.homedir(), '.agenfk');
+// Home paths resolve at CALL time (item 9c297075): a module-level os.homedir()
+// capture freezes the machine home at import time, defeating the per-test HOME
+// sandbox and the vitest HOME pin (the 2026-08-31 hub.json clobber hole).
+export function agenfkDir(): string {
+  return path.join(os.homedir(), '.agenfk');
+}
 
-export const SERVER_PORT_FILE = path.join(AGENFK_DIR, 'server-port');
+export function serverPortFile(): string {
+  return path.join(agenfkDir(), 'server-port');
+}
 export const DEFAULT_API_PORT = 3000;
 export const MAX_PORT_PROBE_ATTEMPTS = 100;
 
@@ -40,8 +47,8 @@ export async function findAvailablePort(
 
 export function writeServerPortFile(port: number): void {
   try {
-    fs.mkdirSync(AGENFK_DIR, { recursive: true });
-    fs.writeFileSync(SERVER_PORT_FILE, String(port), 'utf8');
+    fs.mkdirSync(agenfkDir(), { recursive: true });
+    fs.writeFileSync(serverPortFile(), String(port), 'utf8');
   } catch {
     // best-effort — discovery falls back to env vars / defaults
   }
@@ -49,7 +56,7 @@ export function writeServerPortFile(port: number): void {
 
 export function removeServerPortFile(): void {
   try {
-    fs.unlinkSync(SERVER_PORT_FILE);
+    fs.unlinkSync(serverPortFile());
   } catch {
     // ignore — file may already be gone
   }
@@ -57,7 +64,7 @@ export function removeServerPortFile(): void {
 
 export function readServerPort(): number | null {
   try {
-    const raw = fs.readFileSync(SERVER_PORT_FILE, 'utf8').trim();
+    const raw = fs.readFileSync(serverPortFile(), 'utf8').trim();
     const n = Number.parseInt(raw, 10);
     return Number.isInteger(n) && n > 0 && n < 65536 ? n : null;
   } catch {

--- a/packages/telemetry/src/test/serverPort.test.ts
+++ b/packages/telemetry/src/test/serverPort.test.ts
@@ -5,7 +5,10 @@ import * as os from 'os';
 import * as path from 'path';
 
 // Sandbox HOME so the tests never touch the developer's real ~/.agenfk/server-port.
-// Must run BEFORE the module under test resolves SERVER_PORT_FILE at import time.
+// Paths now resolve at CALL time (item 9c297075), so the override is effective
+// regardless of import order — the pre-import dance below is kept as defense
+// in depth (and under the vitest HOME pin this file's override merely narrows
+// the already-sandboxed home to this file's own directory).
 const sandboxHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agenfk-serverport-'));
 const realHome = process.env.HOME;
 process.env.HOME = sandboxHome;
@@ -13,7 +16,7 @@ process.env.HOME = sandboxHome;
 // Import after HOME is overridden.
 const mod = await import('../serverPort.js');
 const {
-  SERVER_PORT_FILE,
+  serverPortFile,
   DEFAULT_API_PORT,
   isPortAvailable,
   findAvailablePort,
@@ -89,7 +92,7 @@ describe('serverPort', () => {
     it('writes to ~/.agenfk/server-port (sandbox-scoped HOME)', () => {
       writeServerPortFile(31_415);
       const expected = path.join(sandboxHome, '.agenfk', 'server-port');
-      expect(SERVER_PORT_FILE).toBe(expected);
+      expect(serverPortFile()).toBe(expected);
       expect(fs.readFileSync(expected, 'utf8').trim()).toBe('31415');
     });
 
@@ -100,8 +103,8 @@ describe('serverPort', () => {
     });
 
     it('readServerPort returns null for invalid contents', () => {
-      fs.mkdirSync(path.dirname(SERVER_PORT_FILE), { recursive: true });
-      fs.writeFileSync(SERVER_PORT_FILE, 'not-a-port');
+      fs.mkdirSync(path.dirname(serverPortFile()), { recursive: true });
+      fs.writeFileSync(serverPortFile(), 'not-a-port');
       expect(readServerPort()).toBeNull();
     });
   });

--- a/packages/telemetry/src/test/serverPort.test.ts
+++ b/packages/telemetry/src/test/serverPort.test.ts
@@ -1,19 +1,28 @@
-import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
 import * as fs from 'fs';
 import * as net from 'net';
 import * as os from 'os';
 import * as path from 'path';
 
-// Sandbox HOME so the tests never touch the developer's real ~/.agenfk/server-port.
-// Paths now resolve at CALL time (item 9c297075), so the override is effective
-// regardless of import order — the pre-import dance below is kept as defense
-// in depth (and under the vitest HOME pin this file's override merely narrows
-// the already-sandboxed home to this file's own directory).
+// Sandbox homedir via a CALL-TIME mock of os.homedir() (item 9c297075).
+//
+// The previous mechanism was a process.env.HOME override. That depends on
+// libuv picking up the mutated env — and under the Stryker child-process
+// runner that linkage is broken on this machine: os.homedir() kept returning
+// the machine home, so the real-fs writes in this file (writeServerPortFile /
+// removeServerPortFile) landed in the REAL ~/.agenfk and a dry run deleted
+// the live server-port file. A mocked homedir pins every path in this file to
+// the sandbox in every runner environment — the same guarantee the vitest
+// HOME pin gives for the other test files.
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('os')>();
+  return { ...actual, homedir: vi.fn(() => actual.homedir()) };
+});
 const sandboxHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agenfk-serverport-'));
-const realHome = process.env.HOME;
-process.env.HOME = sandboxHome;
+vi.mocked(os.homedir).mockReturnValue(sandboxHome);
 
-// Import after HOME is overridden.
+// Import after the mock is armed. Paths resolve at CALL time (item 9c297075),
+// so the mock is effective regardless of import order.
 const mod = await import('../serverPort.js');
 const {
   serverPortFile,
@@ -41,14 +50,14 @@ describe('serverPort', () => {
   afterEach(async () => {
     await Promise.all(occupiers.map(s => new Promise<void>(r => s.close(() => r()))));
     occupiers = [];
-    // Restore env but keep HOME pointed at the sandbox.
-    process.env = { ...originalEnv, HOME: sandboxHome };
+    // Restore env vars the getApiUrl tests mutate (HOME is irrelevant — the
+    // homedir mock owns path resolution in this file).
+    process.env = { ...originalEnv };
     removeServerPortFile();
   });
 
   afterAll(() => {
-    if (realHome === undefined) delete process.env.HOME;
-    else process.env.HOME = realHome;
+    vi.mocked(os.homedir).mockRestore();
     try { fs.rmSync(sandboxHome, { recursive: true, force: true }); } catch { /* ignore */ }
   });
 
@@ -89,7 +98,7 @@ describe('serverPort', () => {
       expect(readServerPort()).toBe(45_678);
     });
 
-    it('writes to ~/.agenfk/server-port (sandbox-scoped HOME)', () => {
+    it('writes to ~/.agenfk/server-port (sandbox-scoped homedir)', () => {
       writeServerPortFile(31_415);
       const expected = path.join(sandboxHome, '.agenfk', 'server-port');
       expect(serverPortFile()).toBe(expected);

--- a/packages/telemetry/src/test/telemetry.test.ts
+++ b/packages/telemetry/src/test/telemetry.test.ts
@@ -29,9 +29,24 @@ vi.mock('posthog-node', () => ({
   }),
 }));
 
+// Mockable homedir (delegates to the real one unless a test re-points it) —
+// lets the lazy-getter tests assert call-time resolution in any runner env.
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('os')>();
+  return { ...actual, homedir: vi.fn(() => actual.homedir()) };
+});
+
 import * as path from 'path';
 import * as os from 'os';
-import { TelemetryClient, getInstallationId, isTelemetryEnabled, getInstallSource } from '../index';
+import {
+  TelemetryClient,
+  getInstallationId,
+  isTelemetryEnabled,
+  getInstallSource,
+  configPath,
+  installationIdPath,
+  hubConfigFile,
+} from '../index';
 
 const AGENFK_DIR = path.join(os.homedir(), '.agenfk');
 const CONFIG_PATH = path.join(AGENFK_DIR, 'config.json');
@@ -257,5 +272,47 @@ describe('isTelemetryEnabled', () => {
   it('returns true when config file is missing', () => {
     mockReadFileSync.mockImplementation(() => { throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' }); });
     expect(isTelemetryEnabled()).toBe(true);
+  });
+});
+
+describe('lazy home-path getters (item 9c297075)', () => {
+  // Paths must resolve against os.homedir() AT CALL TIME — module-level
+  // captures froze the machine home at import time, which is the hole behind
+  // the 2026-08-31 hub.json clobber. The homedir mock is re-pointed per
+  // assertion, so a stale import-time capture cannot pass these tests.
+  function withHomedir<T>(sandbox: string, fn: () => T): T {
+    vi.mocked(os.homedir).mockReturnValue(sandbox);
+    try {
+      return fn();
+    } finally {
+      vi.mocked(os.homedir).mockRestore();
+    }
+  }
+
+  it('configPath resolves against the current homedir', () => {
+    const sandbox = '/tmp/agenfk-lazy-config';
+    expect(withHomedir(sandbox, () => configPath())).toBe(path.join(sandbox, '.agenfk', 'config.json'));
+  });
+
+  it('installationIdPath resolves against the current homedir', () => {
+    const sandbox = '/tmp/agenfk-lazy-installation-id';
+    expect(withHomedir(sandbox, () => installationIdPath())).toBe(path.join(sandbox, '.agenfk', 'installation-id'));
+  });
+
+  it('hubConfigFile resolves against the current homedir', () => {
+    const sandbox = '/tmp/agenfk-lazy-hub';
+    expect(withHomedir(sandbox, () => hubConfigFile())).toBe(path.join(sandbox, '.agenfk', 'hub.json'));
+  });
+
+  it('all three getters track homedir changes between calls (no import-time freeze)', () => {
+    vi.mocked(os.homedir).mockReturnValue('/tmp/agenfk-a');
+    try {
+      expect(configPath()).toBe('/tmp/agenfk-a/.agenfk/config.json');
+      vi.mocked(os.homedir).mockReturnValue('/tmp/agenfk-b');
+      expect(hubConfigFile()).toBe('/tmp/agenfk-b/.agenfk/hub.json');
+      expect(installationIdPath()).toBe('/tmp/agenfk-b/.agenfk/installation-id');
+    } finally {
+      vi.mocked(os.homedir).mockRestore();
+    }
   });
 });

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
+import { testHomeEnv } from '../../scripts/vitest-home-pin.mjs';
 
 export default defineConfig({
   plugins: [react()],
@@ -7,6 +8,9 @@ export default defineConfig({
     __AGENFK_VERSION__: JSON.stringify('test'),
   },
   test: {
+    // HOME isolation (item 9c297075) — defense in depth: the UI specs do no
+    // home fs writes today, but a future one would land in the sandbox.
+    env: testHomeEnv(),
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],
     globals: true,

--- a/scripts/home-integrity.mjs
+++ b/scripts/home-integrity.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+/**
+ * Home-integrity sentinel (item 9c297075).
+ *
+ * The 2026-08-31 hub.json clobber went unnoticed for days because nothing
+ * detected that ~/.agenfk had been overwritten by a test fixture. This
+ * sentinel snapshots the protected home files before a test run and fails the
+ * run on any drift (changed / added / removed).
+ *
+ * Usage:
+ *   node scripts/home-integrity.mjs snapshot   # writes a snapshot to $TMPDIR
+ *   node scripts/home-integrity.mjs verify     # compares and exits 1 on drift
+ *
+ * Only the small credential/config files are protected. DB files
+ * (db.sqlite*, backup/) are excluded by design — they churn legitimately.
+ */
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { createHash } from 'crypto';
+
+export const PROTECTED_FILES = [
+  'hub.json',
+  'verify-token',
+  'config.json',
+  'installation-id',
+  'server-port',
+  'hub-deadletter.jsonl',
+  'hub-audit.jsonl',
+  'jira-token.json',
+  'migration.json',
+];
+
+const SNAPSHOT_FILE = path.join(os.tmpdir(), 'agenfk-home-snapshot-latest.json');
+
+function entry(homeDir, file) {
+  try {
+    const p = path.join(homeDir, '.agenfk', file);
+    const st = fs.statSync(p);
+    if (!st.isFile()) return null;
+    const sha = createHash('sha256').update(fs.readFileSync(p)).digest('hex');
+    return { size: st.size, sha };
+  } catch {
+    return null; // absent (or not a regular file)
+  }
+}
+
+/** Snapshot the protected files under <homeDir>/.agenfk. */
+export function snapshotHome(homeDir = os.homedir()) {
+  const snap = {};
+  for (const f of PROTECTED_FILES) snap[f] = entry(homeDir, f);
+  return snap;
+}
+
+/** Compare the current state against a snapshot. Drift = changed/added/removed. */
+export function verifyHome(homeDir, snapshot) {
+  const drift = [];
+  for (const f of Object.keys(snapshot)) {
+    const was = snapshot[f];
+    const now = entry(homeDir, f);
+    if (was === null && now !== null) drift.push(f); // added
+    else if (was !== null && now === null) drift.push(f); // removed
+    else if (was !== null && (now.sha !== was.sha || now.size !== was.size)) drift.push(f); // changed
+  }
+  return { ok: drift.length === 0, drift };
+}
+
+// ── CLI ──────────────────────────────────────────────────────────────────────
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === path.resolve(new URL(import.meta.url).pathname);
+if (isMain) {
+  const [, , cmd] = process.argv;
+  if (cmd === 'snapshot') {
+    fs.writeFileSync(SNAPSHOT_FILE, JSON.stringify(snapshotHome(), null, 2));
+    console.log(`home integrity snapshot written (${SNAPSHOT_FILE})`);
+  } else if (cmd === 'verify') {
+    if (!fs.existsSync(SNAPSHOT_FILE)) {
+      console.error('no snapshot found — run `node scripts/home-integrity.mjs snapshot` first');
+      process.exit(2);
+    }
+    const snap = JSON.parse(fs.readFileSync(SNAPSHOT_FILE, 'utf8'));
+    const res = verifyHome(os.homedir(), snap);
+    if (!res.ok) {
+      console.error('✗ HOME INTEGRITY DRIFT — something touched the real ~/.agenfk:');
+      for (const f of res.drift) console.error(`   ${f}`);
+      process.exit(1);
+    }
+    console.log('home integrity ok');
+  } else {
+    console.error('usage: node scripts/home-integrity.mjs snapshot | verify');
+    process.exit(2);
+  }
+}

--- a/scripts/stryker-home-wrap.mjs
+++ b/scripts/stryker-home-wrap.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+/**
+ * Stryker HOME guard (item 9c297075).
+ *
+ * Why: Stryker's vitest runner forces pool 'threads' (its CLI overrides the
+ * user config), and on this machine (Node >= 24) the runner's child processes
+ * keep a FROZEN C-level environment — process.env mutations inside the
+ * process do not reach libuv, so os.homedir() keeps returning the machine
+ * home even though process.env.HOME is the pinned sandbox. A test that writes
+ * through a homedir-derived path would then land in the REAL home (this is
+ * exactly how ~/.agenfk/server-port got deleted during a 2026-09-02 dry run,
+ * and how the 2026-08-31 hub.json clobber class works).
+ *
+ * Fix: pin HOME at SPAWN time. The sandbox is baked into the C environ of
+ * every process this wrapper spawns, so os.homedir() is sandboxed in every
+ * test thread — no libuv linkage needed. AGENFK_SPAWN_PIN marks the run so
+ * tests (home-isolation.test.ts) fail loudly when the linkage is frozen but
+ * the run was NOT launched through this guard.
+ *
+ * The run is additionally wrapped with the home-integrity sentinel: any
+ * drift in the real ~/.agenfk after the run is a hard failure, even if some
+ * path bypassed the pin.
+ *
+ * Usage:
+ *   npm run test:stryker -- run stryker.config.mjs [--reporters json,html]
+ *   node scripts/stryker-home-wrap.mjs --probe   # test hook: child env JSON
+ */
+import { spawnSync } from 'node:child_process';
+import * as os from 'node:os';
+import { snapshotHome, verifyHome } from './home-integrity.mjs';
+import { testHomeEnv } from './vitest-home-pin.mjs';
+
+const args = process.argv.slice(2);
+const probe = args[0] === '--probe';
+
+// Sentinel: snapshot the real home BEFORE (os.homedir() = this process's
+// C-level home — the one the spawned children inherit).
+const snapshot = snapshotHome();
+
+const env = { ...process.env, ...testHomeEnv(), AGENFK_SPAWN_PIN: '1' };
+
+let result;
+if (probe) {
+  // Test hook: spawn a child and report what IT sees (the mechanism under
+  // test — whether the spawned C environ actually carries the sandbox).
+  result = spawnSync(
+    process.execPath,
+    [
+      '-p',
+      "JSON.stringify({ home: require('os').homedir(), spawnPin: process.env.AGENFK_SPAWN_PIN, realHome: process.env.AGENFK_REAL_HOME })",
+    ],
+    { encoding: 'utf8', env },
+  );
+} else {
+  result = spawnSync('npx', ['stryker', ...args], { stdio: 'inherit', env });
+}
+
+const exitCode = result.status ?? 1;
+
+if (probe) process.stdout.write(result.stdout ?? '');
+
+const check = verifyHome(os.homedir(), snapshot);
+if (!check.ok) {
+  console.error('✗ HOME INTEGRITY DRIFT after Stryker run — the real ~/.agenfk was touched:');
+  for (const f of check.drift) console.error(`   ${f}`);
+  process.exit(exitCode === 0 ? 1 : exitCode);
+}
+
+process.exit(exitCode);

--- a/scripts/vitest-home-pin.mjs
+++ b/scripts/vitest-home-pin.mjs
@@ -1,0 +1,38 @@
+/**
+ * HOME isolation for test runs (item 9c297075).
+ *
+ * The 2026-08-31 clobber incident: a Stryker mutation run executed hub tests
+ * whose HOME sandboxing did not apply under the runner, so a test fixture
+ * `hub.json` was written into the REAL ~/.agenfk — twice. The structural fix:
+ * every vitest worker (normal runs AND Stryker, which reuses this config)
+ * starts with HOME pinned to a per-run sandbox, so a test that forgets to
+ * sandbox writes into the sandbox, never the machine home.
+ *
+ * The original home is exposed as AGENFK_REAL_HOME for the tests that verify
+ * the pin itself (packages/server/src/test/home-isolation.test.ts).
+ *
+ * Memoized per process: the root vitest config and the workspace project both
+ * import this module in one process and must share the SAME sandbox.
+ */
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const REAL_HOME = process.env.HOME || os.homedir();
+
+let cached = null;
+
+export function testHomeEnv() {
+  if (!cached) {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agenfk-test-home-'));
+    // Pre-seed the framework dir so code that reads verify-token / server-port
+    // sees "absent", not a hostile foreign home.
+    fs.mkdirSync(path.join(home, '.agenfk'), { recursive: true });
+    cached = {
+      HOME: home,
+      USERPROFILE: home, // Windows parity; harmless on POSIX
+      AGENFK_REAL_HOME: REAL_HOME,
+    };
+  }
+  return cached;
+}

--- a/scripts/vitest-home-pin.mjs
+++ b/scripts/vitest-home-pin.mjs
@@ -4,9 +4,19 @@
  * The 2026-08-31 clobber incident: a Stryker mutation run executed hub tests
  * whose HOME sandboxing did not apply under the runner, so a test fixture
  * `hub.json` was written into the REAL ~/.agenfk — twice. The structural fix:
- * every vitest worker (normal runs AND Stryker, which reuses this config)
- * starts with HOME pinned to a per-run sandbox, so a test that forgets to
- * sandbox writes into the sandbox, never the machine home.
+ * every vitest worker starts with process.env.HOME pinned to a per-run
+ * sandbox, so a test that forgets to sandbox writes into the sandbox, never
+ * the machine home. This pin guarantees the JS-level process.env.HOME value
+ * in every runner. On POSIX, os.homedir() (libuv) follows it wherever the
+ * process's C environ is live — normal vitest runs (forks pool) and CI.
+ *
+ * KNOWN LIMITATION (this machine, Node >= 24): Stryker's vitest runner
+ * forces pool 'threads', and its child processes keep a FROZEN C environ —
+ * process.env mutations inside the process never reach libuv there. For
+ * Stryker runs the pin must therefore be applied at SPAWN time: use
+ * `npm run test:stryker` (scripts/stryker-home-wrap.mjs), which bakes the
+ * sandbox HOME into every child's C environ and wraps the run with the
+ * home-integrity sentinel.
  *
  * The original home is exposed as AGENFK_REAL_HOME for the tests that verify
  * the pin itself (packages/server/src/test/home-isolation.test.ts).

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vitest/config';
 import path from 'path';
+import { testHomeEnv } from './scripts/vitest-home-pin.mjs';
 
 export default defineConfig({
   define: {
@@ -12,6 +13,11 @@ export default defineConfig({
     },
   },
   test: {
+    // HOME isolation (item 9c297075): pin every test worker to a per-run
+    // sandbox home so no test can ever write into the real ~/.agenfk
+    // (the 2026-08-31 hub.json clobber). Applies to Stryker runs too —
+    // they reuse this config.
+    env: testHomeEnv(),
     globals: true,
     environment: 'node', // Use node for server/storage
     resetMocks: true, // reset queued mockResolvedValueOnce/mockRejectedValueOnce between tests

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,12 +15,16 @@ export default defineConfig({
   test: {
     // HOME isolation (item 9c297075): pin every test worker to a per-run
     // sandbox home so no test can ever write into the real ~/.agenfk
-    // (the 2026-08-31 hub.json clobber). Applies to Stryker runs too —
-    // they reuse this config.
+    // (the 2026-08-31 hub.json clobber). Guarantees the JS-level
+    // process.env.HOME sandbox for ALL workers (forks pool: normal runs +
+    // CI — where libuv/os.homedir() follows it). Under Stryker's forced
+    // threads pool the C environ is frozen in the runner's children on this
+    // machine, so os.homedir() needs the spawn-time pin — always launch
+    // Stryker via `npm run test:stryker` (scripts/stryker-home-wrap.mjs).
+    // Stryker reuses this config for its vitest run.
     env: testHomeEnv(),
     globals: true,
     environment: 'node', // Use node for server/storage
-    resetMocks: true, // reset queued mockResolvedValueOnce/mockRejectedValueOnce between tests
     fileParallelism: false, // run test files serially to prevent filesystem state conflicts
     sequence: { concurrent: false }, // run tests within a file serially
     // Bumped above defaults (5s/10s) to absorb CPU contention when ~1100 tests

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,5 +1,6 @@
 import { defineWorkspace } from 'vitest/config';
 import path from 'path';
+import { testHomeEnv } from './scripts/vitest-home-pin.mjs';
 
 export default defineWorkspace([
   {
@@ -10,6 +11,9 @@ export default defineWorkspace([
     },
     test: {
       name: 'agenfk',
+      // Same HOME pin as the root config (item 9c297075) — memoized, so both
+      // entries share one per-run sandbox.
+      env: testHomeEnv(),
       include: ['packages/*/src/test/**/*.{test,spec}.{ts,tsx}'],
       exclude: ['**/dist/**', '**/node_modules/**'],
       environment: 'jsdom',


### PR DESCRIPTION
## What

Tests could write into the developer's REAL ~/.agenfk — the 2026-08-31 Stryker run clobbered hub.json (57 events lost, WAL-recovered) and on 2026-09-01 destroyed the live hub credentials. A third hit surfaced during this item's own first mutation dry run (live server-port file deleted).

Structural fixes:

- **Call-time home paths** — module-level os.homedir() captures in telemetry (serverPort.ts, index.ts), hub (hubClient.ts, flusher.ts) and cli (RULES_CONFIG.sourceFile) converted to lazy getters, so per-test HOME overrides always work.
- **vitest HOME pin** (scripts/vitest-home-pin.mjs) — every test worker starts with process.env.HOME pinned to a per-run sandbox (root config + workspace + UI config); AGENFK_REAL_HOME exposed for verification.
- **Home-integrity sentinel** (scripts/home-integrity.mjs) — snapshots the protected ~/.agenfk files (hub.json, verify-token, config.json, installation-id, server-port, deadletter/audit, jira-token, migration) before a run and fails on any drift; wired as test:home-integrity / test:coverage + CI snapshot/verify steps.
- **Stryker spawn-time guard** (scripts/stryker-home-wrap.mjs, npm run test:stryker) — Stryker forces pool 'threads' and on this machine its children keep a frozen C environ (in-process env mutations never reach os.homedir()), so the config pin can't sandbox homedir there. The guard bakes the sandbox HOME into every child's C environ at spawn, wraps the run with the sentinel, and a new libuv-linkage test makes an UNGUARDED launch fail loudly (AGENFK_SPAWN_PIN marker).

## Verification

- Full suite **2541/2541 (231 files)**; build clean; UI suite 438/438 with the pin.
- Diff-scoped Stryker pass run **through the guard** (Node 22): dry run green (was red unguarded), **76 killed / 10 documented non-killed** in the diff spans (3 per-test-coverage attribution artifacts on directly-tested getters + 7 equivalent mutants).
- Real ~/.agenfk mtime/content audited after every run — untouched (live cglab creds intact).
- **Two adversarial review rounds**: round 1 REJECT (blocker: threads-pool frozen C environ) → fixed; round 2 **APPROVE-WITH-NITS** with the blocker verified fixed empirically (probe + --pool threads negative/positive paths). All in-scope findings resolved.

## Follow-up (out of scope, filed separately)

~10 pre-existing test files (hub-command/hub-repoint/hub-story4-cli, server JIRA block, db-migration, flow-org-available-hub-off, api-client-port-discovery, security-hardening, ...) still use the env-override pattern — safe under forks pool + spawn-time guard, but should migrate to the vi.mock('os') homedir pattern; plus a committed Stryker config template and the pre-existing test:coverage branch-gate failure (74.55% < 80% at base).

Item: 9c297075 · branch off v1.1.17-beta.3 (45f8c95b) · no JIRA key (standing instruction)