### PR TITLE
Fix PR Overview heatmap tooltip placement and add per-cell PR drill-down with GitHub links (CGLAB-131)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ tmp.*.json
 /reports/
 .stryker-tmp/
 stryker.log
+mutation-testing/

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ tmp.*.json
 .stryker-tmp/
 stryker.log
 mutation-testing/
+
+# pi coding-agent local session artifacts (subagent transcripts, clipboard)
+.pi/

--- a/packages/hub-ui/src/pages/PrOverview.tsx
+++ b/packages/hub-ui/src/pages/PrOverview.tsx
@@ -8,7 +8,7 @@ import { shortRemote } from '../components/facetSearch';
 import { useToggleSet } from '../hooks/useToggleSet';
 import { fromIsoForRange, type RangeKey } from '../components/timelineAxis';
 import { SIZE_META, type SizeKey, buildDayAxis, pctDelta } from '../prOverview';
-import { buildMonthBands, dayHeaderInfo, contributionPcts, cellTooltip } from '../prPerDay';
+import { buildMonthBands, dayHeaderInfo, contributionPcts, cellTooltip, placeTooltip } from '../prPerDay';
 
 const RANGES: Array<{ key: RangeKey; label: string }> = [
   { key: 'today', label: 'today' },
@@ -31,6 +31,20 @@ interface PrOverviewResponse {
   }>;
   byDeveloper: Array<{ user_key: string; prs: number; sizePoints: number; sizes: SizeDist; daily: Record<string, number> }>;
   byModel: Array<{ model: string; harnesses: string[]; prs: number; sizePoints: number; sizes: SizeDist }>;
+  // CGLAB-131 drill-down: the resolved PR set behind the heatmap cells
+  // (opener attribution, latest sizing — same aggregation pass as the totals).
+  prs: Array<{
+    repo: string;
+    prNumber: number;
+    url: string | null;
+    user_key: string;
+    model: string;
+    harness: string | null;
+    openedAt: string;
+    day: string;
+    points: number;
+    bucket: SizeKey;
+  }>;
   previous: { prs: number; sizePoints: number } | null;
 }
 interface ProjectsResponse { projects: string[] }
@@ -101,6 +115,82 @@ function Sparkline({ daily, axis }: { daily: Record<string, number>; axis: strin
     <svg width={w} height={h} viewBox={`0 0 ${w} ${h}`} aria-hidden className="overflow-visible">
       <polyline points={pts} fill="none" stroke="#04cc98" strokeWidth="1.6" strokeLinejoin="round" strokeLinecap="round" />
     </svg>
+  );
+}
+
+/** CGLAB-131 — the per-cell drill-down: the PRs one developer opened on one
+ *  day, with a GitHub link where the server could derive one. Rendered at the
+ *  page root (fixed positioning — same containing-block rule as the tooltip). */
+function PrDrilldownModal({ dev, day, prs, onClose }: {
+  dev: string;
+  day: string;
+  prs: NonNullable<PrOverviewResponse['prs']>;
+  onClose: () => void;
+}) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+  const { weekday } = dayHeaderInfo(day);
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4" role="dialog" aria-modal="true" aria-label={`PRs by ${dev} on ${day}`}>
+      <div className="absolute inset-0 bg-black/50" onClick={onClose} />
+      <div className="relative z-50 w-full max-w-xl max-h-[70vh] overflow-y-auto rounded-2xl border border-border-soft bg-surface shadow-2xl">
+        <div className="sticky top-0 flex items-center justify-between gap-3 border-b border-border-soft bg-surface px-5 py-3.5">
+          <div className="min-w-0">
+            <h3 className="truncate text-sm font-semibold text-ink">{dev}</h3>
+            <p className="font-mono text-[11px] text-ink-tertiary">{weekday} {day} · {prs.length} PR{prs.length === 1 ? '' : 's'}</p>
+          </div>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="rounded-lg border border-border-soft px-2 py-1 text-[12px] text-ink-tertiary hover:text-ink hover:bg-chip transition-colors"
+          >
+            ✕
+          </button>
+        </div>
+        <ul className="divide-y divide-border-soft">
+          {prs.map(p => {
+            const size = SIZE_META.find(s => s.key === p.bucket);
+            const openedAt = new Date(p.openedAt);
+            return (
+              <li key={`${p.repo}#${p.prNumber}`} className="flex items-center gap-3 px-5 py-2.5">
+                {p.url ? (
+                  <a
+                    href={p.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="font-mono text-[13px] font-bold text-accent-text hover:underline shrink-0"
+                    title="Open on GitHub"
+                  >
+                    #{p.prNumber}
+                  </a>
+                ) : (
+                  <span className="font-mono text-[13px] font-bold text-ink-secondary shrink-0" title={`${p.repo} — no GitHub link (non-GitHub host)`}>
+                    #{p.prNumber}
+                  </span>
+                )}
+                <div className="min-w-0 flex-1">
+                  <div className="truncate font-mono text-[12px] text-ink-secondary">{p.repo}</div>
+                  <div className="text-[11px] text-ink-tertiary truncate">{p.model}{p.harness ? ` · via ${p.harness}` : ''}</div>
+                </div>
+                <div className="text-right shrink-0">
+                  {size && (
+                    <span className="inline-block rounded-md px-1.5 py-0.5 font-mono text-[10px] font-bold text-white" style={{ background: size.color }}>
+                      {size.label}
+                    </span>
+                  )}
+                  <div className="mt-0.5 font-mono text-[10px] text-ink-tertiary tabular-nums">
+                    {Number.isNaN(openedAt.getTime()) ? '' : openedAt.toISOString().slice(11, 19)} UTC
+                  </div>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </div>
   );
 }
 
@@ -196,13 +286,25 @@ export function PrOverviewPage() {
   const dayInfos = useMemo(() => axis.map(day => dayHeaderInfo(day, todayIso)), [axis, todayIso]);
   // One shared, fixed-position tooltip for the whole heatmap: per-cell hidden
   // spans would add tens of thousands of DOM nodes on a 90d × many-devs grid,
-  // and anything absolutely positioned inside the overflow-x-auto scroller
-  // gets clipped at its edges. Fixed positioning escapes the scroller.
-  const [heatTip, setHeatTip] = useState<{ text: string; x: number; y: number } | null>(null);
+  // and anything positioned inside the overflow-x-auto scroller gets clipped
+  // at its edges. Fixed positioning escapes the scroller — BUT only when the
+  // tooltip is NOT a descendant of a backdrop-filter/transform element (those
+  // create a containing block that silently re-roots the fixed coordinates and
+  // a stacking context that swallows the z-index — the CGLAB-131 defect). So it
+  // renders at the page root, below, in viewport coordinates from placeTooltip.
+  const [heatTip, setHeatTip] = useState<{ text: string; x: number; y: number; below: boolean } | null>(null);
   const showHeatTip = (text: string) => (e: React.MouseEvent<HTMLDivElement>) => {
     const r = e.currentTarget.getBoundingClientRect();
-    setHeatTip({ text, x: Math.max(8, Math.min(r.left + r.width / 2, window.innerWidth - 8)), y: r.top - 6 });
+    setHeatTip({ text, ...placeTooltip({ left: r.left, top: r.top, width: r.width, height: r.height }, text, window.innerWidth) });
   };
+  // CGLAB-131 — the cell being drilled into (developer × day), or null.
+  const [drill, setDrill] = useState<{ dev: string; day: string } | null>(null);
+  const drillPrs = useMemo(() => {
+    if (!drill || !d?.prs) return [];
+    // The server already orders by open time, then repo#number, and applied the
+    // same window/model/developer filters as the heatmap itself.
+    return d.prs.filter(p => p.user_key === drill.dev && p.day === drill.day);
+  }, [drill, d?.prs]);
   const maxDayTotal = Math.max(1, ...(d?.byDay.map(x => x.total) ?? [1]));
   const byDayMap = useMemo(() => new Map((d?.byDay ?? []).map(x => [x.day, x])), [d]);
 
@@ -517,11 +619,14 @@ export function PrOverviewPage() {
                             key={day}
                             onMouseEnter={showHeatTip(cellTooltip(dev.user_key, day, c))}
                             onMouseLeave={() => setHeatTip(null)}
+                            // CGLAB-131 — non-empty cells are drillable: open the PR list.
+                            // (Clear the tooltip so it cannot peek out from the modal.)
+                            onClick={c > 0 ? () => { setHeatTip(null); setDrill({ dev: dev.user_key, day }); } : undefined}
                             className={`aspect-square rounded-[3px] ${c === 0
                               ? h.isWeekend
                                 ? 'bg-chip border border-dashed border-border-soft'
                                 : 'bg-chip'
-                              : ''}`}
+                              : 'cursor-pointer hover:opacity-75 transition-opacity'}`}
                             style={{ background: c === 0 ? undefined : `rgba(99,102,241,${intensity.toFixed(2)})` }}
                           />
                         );
@@ -531,15 +636,21 @@ export function PrOverviewPage() {
                 })}
               </div>
             </div>
-            {heatTip && (
-              <div
-                className="pointer-events-none fixed z-50 -translate-x-1/2 -translate-y-full whitespace-nowrap rounded-md bg-card-glass text-white font-mono text-[10px] px-2 py-1 shadow-lg"
-                style={{ left: heatTip.x, top: heatTip.y }}
-              >
-                {heatTip.text}
-              </div>
-            )}
           </section>
+
+          {/* CGLAB-131 — deliberately OUTSIDE the heatmap section above: a
+              backdrop-filter ancestor would re-root these fixed coordinates
+              (the "tooltip far away" defect) and swallow the z-50 (the z-order
+              defect). Coordinates are viewport-relative, from placeTooltip. */}
+          {heatTip && (
+            <div
+              className={`pointer-events-none fixed z-50 -translate-x-1/2 whitespace-nowrap rounded-md bg-card-glass text-white font-mono text-[10px] px-2 py-1 shadow-lg ${heatTip.below ? '' : '-translate-y-full'}`}
+              style={{ left: heatTip.x, top: heatTip.y }}
+            >
+              {heatTip.text}
+            </div>
+          )}
+          {drill && <PrDrilldownModal dev={drill.dev} day={drill.day} prs={drillPrs} onClose={() => setDrill(null)} />}
 
           {/* Size model explainer */}
           <section className="bg-card-glass backdrop-blur border border-border-soft rounded-2xl p-5">

--- a/packages/hub-ui/src/pages/PrOverview.tsx
+++ b/packages/hub-ui/src/pages/PrOverview.tsx
@@ -193,20 +193,17 @@ function PrDrilldownModal({ dev, day, prs, onClose }: {
           {prs.map(p => {
             const size = SIZE_META.find(s => s.key === p.bucket);
             const openedAt = new Date(p.openedAt);
-            return (
-              <li key={`${p.repo}#${p.prNumber}`} className="flex items-center gap-3 px-5 py-2.5">
+            const rowBody = (
+              <>
                 {p.url ? (
-                  <a
-                    href={p.url}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="font-mono text-[13px] font-bold text-accent-text hover:underline shrink-0"
-                    title="Open on GitHub"
-                  >
+                  <span className="font-mono text-[13px] font-bold text-accent-text shrink-0">
                     #{p.prNumber}
-                  </a>
+                  </span>
                 ) : (
-                  <span className="font-mono text-[13px] font-bold text-ink-secondary shrink-0" title={`${p.repo} — no GitHub link (non-GitHub host)`}>
+                  <span
+                    className="font-mono text-[13px] font-bold text-ink-secondary shrink-0"
+                    title={`${p.repo} — no GitHub link (non-GitHub host)`}
+                  >
                     #{p.prNumber}
                   </span>
                 )}
@@ -216,7 +213,9 @@ function PrDrilldownModal({ dev, day, prs, onClose }: {
                 </div>
                 <div className="text-right shrink-0">
                   {size && (
-                    <span className="inline-block rounded-md px-1.5 py-0.5 font-mono text-[10px] font-bold text-white" style={{ background: size.color }}>
+                    // size.text (not a fixed text-white): the ramp's light end
+                    // is near-white, so white-on-XS reads as a blank box.
+                    <span className="inline-block rounded-md px-1.5 py-0.5 font-mono text-[10px] font-bold" style={{ background: size.color, color: size.text }}>
                       {size.label}
                     </span>
                   )}
@@ -224,6 +223,26 @@ function PrDrilldownModal({ dev, day, prs, onClose }: {
                     {Number.isNaN(openedAt.getTime()) ? '' : openedAt.toISOString().slice(11, 19)} UTC
                   </div>
                 </div>
+              </>
+            );
+            // Whole row is the GitHub link (no nested anchors): the <a> IS the
+            // row container, so repo / model / badge / time all open the PR.
+            // Rows without a derived link stay inert.
+            return p.url ? (
+              <li key={`${p.repo}#${p.prNumber}`}>
+                <a
+                  href={p.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  title="Open on GitHub"
+                  className="flex items-center gap-3 px-5 py-2.5 hover:bg-chip/40 transition-colors"
+                >
+                  {rowBody}
+                </a>
+              </li>
+            ) : (
+              <li key={`${p.repo}#${p.prNumber}`} className="flex items-center gap-3 px-5 py-2.5">
+                {rowBody}
               </li>
             );
           })}

--- a/packages/hub-ui/src/pages/PrOverview.tsx
+++ b/packages/hub-ui/src/pages/PrOverview.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useMemo, useState } from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { GitPullRequest, RefreshCw, TrendingUp, TrendingDown } from 'lucide-react';
@@ -120,29 +120,68 @@ function Sparkline({ daily, axis }: { daily: Record<string, number>; axis: strin
 
 /** CGLAB-131 — the per-cell drill-down: the PRs one developer opened on one
  *  day, with a GitHub link where the server could derive one. Rendered at the
- *  page root (fixed positioning — same containing-block rule as the tooltip). */
+ *  page root (fixed positioning — same containing-block rule as the tooltip).
+ *  Focus management (aria-modal contract): focus moves into the dialog on
+ *  open and Tab cycles inside it; focus returns to the triggering cell on
+ *  close; background scrolling is locked while open. */
 function PrDrilldownModal({ dev, day, prs, onClose }: {
   dev: string;
   day: string;
   prs: NonNullable<PrOverviewResponse['prs']>;
   onClose: () => void;
 }) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const closeRef = useRef<HTMLButtonElement>(null);
+
+  // Initial focus + focus restore (runs once per open).
+  useEffect(() => {
+    const prev = document.activeElement as HTMLElement | null;
+    closeRef.current?.focus();
+    return () => { prev?.focus?.(); };
+  }, []);
+
+  // Escape to close (window-level: works no matter where focus sits inside).
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
   }, [onClose]);
+
+  // Scroll lock while the overlay is up.
+  useEffect(() => {
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => { document.body.style.overflow = prev; };
+  }, []);
+
+  // Minimal focus trap: wrap Tab / Shift+Tab at the dialog edges.
+  const trapTab = (e: React.KeyboardEvent) => {
+    if (e.key !== 'Tab') return;
+    const nodes = panelRef.current?.querySelectorAll<HTMLElement>('a[href], button:not([disabled])');
+    if (!nodes || nodes.length === 0) return;
+    const list = Array.from(nodes);
+    const first = list[0];
+    const last = list[list.length - 1];
+    const active = document.activeElement;
+    if (e.shiftKey && (active === first || active === panelRef.current)) {
+      e.preventDefault(); last.focus();
+    } else if (!e.shiftKey && active === last) {
+      e.preventDefault(); first.focus();
+    }
+  };
+
   const { weekday } = dayHeaderInfo(day);
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4" role="dialog" aria-modal="true" aria-label={`PRs by ${dev} on ${day}`}>
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4" role="dialog" aria-modal="true" aria-label={`PRs by ${dev} on ${day}`} onKeyDown={trapTab}>
       <div className="absolute inset-0 bg-black/50" onClick={onClose} />
-      <div className="relative z-50 w-full max-w-xl max-h-[70vh] overflow-y-auto rounded-2xl border border-border-soft bg-surface shadow-2xl">
+      <div ref={panelRef} className="relative z-50 w-full max-w-xl max-h-[70vh] overflow-y-auto rounded-2xl border border-border-soft bg-surface shadow-2xl">
         <div className="sticky top-0 flex items-center justify-between gap-3 border-b border-border-soft bg-surface px-5 py-3.5">
           <div className="min-w-0">
             <h3 className="truncate text-sm font-semibold text-ink">{dev}</h3>
             <p className="font-mono text-[11px] text-ink-tertiary">{weekday} {day} · {prs.length} PR{prs.length === 1 ? '' : 's'}</p>
           </div>
           <button
+            ref={closeRef}
             onClick={onClose}
             aria-label="Close"
             className="rounded-lg border border-border-soft px-2 py-1 text-[12px] text-ink-tertiary hover:text-ink hover:bg-chip transition-colors"
@@ -299,6 +338,14 @@ export function PrOverviewPage() {
   };
   // CGLAB-131 — the cell being drilled into (developer × day), or null.
   const [drill, setDrill] = useState<{ dev: string; day: string } | null>(null);
+  const closeDrill = useCallback(() => setDrill(null), []);
+  const openDrill = useCallback((devKey: string, dayKey: string) => {
+    setHeatTip(null);
+    setDrill({ dev: devKey, day: dayKey });
+  }, []);
+  // A refetch replaces the data the open drill was built from — close it
+  // rather than show a stale (or emptied) list against the new window.
+  useEffect(() => { setDrill(null); }, [d]);
   const drillPrs = useMemo(() => {
     if (!drill || !d?.prs) return [];
     // The server already orders by open time, then repo#number, and applied the
@@ -621,7 +668,14 @@ export function PrOverviewPage() {
                             onMouseLeave={() => setHeatTip(null)}
                             // CGLAB-131 — non-empty cells are drillable: open the PR list.
                             // (Clear the tooltip so it cannot peek out from the modal.)
-                            onClick={c > 0 ? () => { setHeatTip(null); setDrill({ dev: dev.user_key, day }); } : undefined}
+                            // role/tabIndex/keydown keep the drill reachable by keyboard.
+                            onClick={c > 0 ? () => openDrill(dev.user_key, day) : undefined}
+                            role={c > 0 ? 'button' : undefined}
+                            tabIndex={c > 0 ? 0 : undefined}
+                            aria-label={c > 0 ? `${c} PR${c === 1 ? '' : 's'} by ${dev.user_key} on ${day} — open list` : undefined}
+                            onKeyDown={c > 0 ? (e) => {
+                              if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDrill(dev.user_key, day); }
+                            } : undefined}
                             className={`aspect-square rounded-[3px] ${c === 0
                               ? h.isWeekend
                                 ? 'bg-chip border border-dashed border-border-soft'
@@ -650,7 +704,7 @@ export function PrOverviewPage() {
               {heatTip.text}
             </div>
           )}
-          {drill && <PrDrilldownModal dev={drill.dev} day={drill.day} prs={drillPrs} onClose={() => setDrill(null)} />}
+          {drill && <PrDrilldownModal dev={drill.dev} day={drill.day} prs={drillPrs} onClose={closeDrill} />}
 
           {/* Size model explainer */}
           <section className="bg-card-glass backdrop-blur border border-border-soft rounded-2xl p-5">

--- a/packages/hub-ui/src/prOverview.ts
+++ b/packages/hub-ui/src/prOverview.ts
@@ -3,12 +3,17 @@
 
 /** Ordinal PR-size ramp (XS→XL): a single teal hue climbing in weight, so a
  *  bigger PR reads as a denser colour. Separate from status colours on purpose. */
+/** Size ramp: light → dark on the dark canvas. `color` is the fill; `text`
+ *  is the label color when text is rendered ON the fill (the drill-down modal
+ *  badge, CGLAB-131) — the ramp's light end is near-white, so one fixed
+ *  `text-white` reads as a blank white box there; light steps take the dark
+ *  primary ink, dark steps take white. */
 export const SIZE_META = [
-  { key: 'xs', label: 'XS', color: '#dbf7f0' },
-  { key: 's', label: 'S', color: '#7fe5ca' },
-  { key: 'm', label: 'M', color: '#04cc98' },
-  { key: 'l', label: 'L', color: '#056f71' },
-  { key: 'xl', label: 'XL', color: '#00332f' },
+  { key: 'xs', label: 'XS', color: '#dbf7f0', text: '#000f3b' },
+  { key: 's', label: 'S', color: '#7fe5ca', text: '#000f3b' },
+  { key: 'm', label: 'M', color: '#04cc98', text: '#000f3b' },
+  { key: 'l', label: 'L', color: '#056f71', text: '#ffffff' },
+  { key: 'xl', label: 'XL', color: '#00332f', text: '#ffffff' },
 ] as const;
 
 export type SizeKey = typeof SIZE_META[number]['key'];

--- a/packages/hub-ui/src/prPerDay.ts
+++ b/packages/hub-ui/src/prPerDay.ts
@@ -67,3 +67,56 @@ export function cellTooltip(userKey: string, day: string, count: number): string
   const { weekday } = dayHeaderInfo(day);
   return `${userKey} · ${weekday} ${day}: ${count} PR${count === 1 ? '' : 's'}`;
 }
+
+// CGLAB-131 — tooltip placement. The tooltip is position:fixed and must be
+// rendered OUTSIDE any backdrop-filter/transform ancestor (the card sections
+// create containing blocks + stacking contexts that offset the placement and
+// swallow its z-index). The returned {x, y} are therefore VIEWPORT
+// coordinates: x is the horizontal centre of the box, and the box occupies
+// [y - height, y] when `below` is false (anchored above the cell) or
+// [y, y + height] when true (flipped below, no room above).
+//
+// The box size is estimated from the single-line mono text rather than
+// measured from the DOM: the tooltip only appears on hover, a layout pass to
+// measure it would flash it at the wrong spot for one frame, and the mono
+// character width is exact enough for clamping.
+const TIP_CHAR_WIDTH = 6;   // 10px font-mono ≈ 6px per glyph
+const TIP_PADDING = 18;     // px-2 padding + border slack
+const TIP_HEIGHT = 26;       // single line: py-1 + 10px text
+const TIP_GAP = 6;           // distance from the cell edge
+const TIP_MARGIN = 8;        // minimum distance from the viewport edges
+
+export interface TooltipSize { width: number; height: number }
+
+/** Estimated on-screen box for a single-line tooltip with this text. */
+export function estimateTooltipSize(text: string): TooltipSize {
+  return { width: Math.max(1, text.length) * TIP_CHAR_WIDTH + TIP_PADDING, height: TIP_HEIGHT };
+}
+
+export interface CellRect { left: number; top: number; width: number; height: number }
+
+export interface TooltipPlacement { x: number; y: number; below: boolean }
+
+/**
+ * Place the tooltip for one cell in VIEWPORT coordinates. Centred horizontally
+ * on the cell, anchored `TIP_GAP` above it — flipping below when the box would
+ * cross the top margin — with the box clamped to the viewport on both
+ * horizontal edges. Degenerate case (box wider than the viewport): centre on
+ * the viewport rather than producing an infinite/negative coordinate.
+ */
+export function placeTooltip(cell: CellRect, text: string, viewportWidth: number): TooltipPlacement {
+  const { width, height } = estimateTooltipSize(text);
+  const halfW = width / 2;
+  const centreX = cell.left + cell.width / 2;
+  const minX = TIP_MARGIN + halfW;
+  const maxX = viewportWidth - TIP_MARGIN - halfW;
+  const x = maxX < minX
+    ? viewportWidth / 2
+    : Math.min(maxX, Math.max(minX, centreX));
+  const roomAbove = cell.top - TIP_GAP - height >= TIP_MARGIN;
+  return {
+    x,
+    y: roomAbove ? cell.top - TIP_GAP : cell.top + cell.height + TIP_GAP,
+    below: !roomAbove,
+  };
+}

--- a/packages/hub-ui/src/test/prOverview.test.ts
+++ b/packages/hub-ui/src/test/prOverview.test.ts
@@ -41,4 +41,17 @@ describe('SIZE_META', () => {
       expect(s.color).toMatch(/^#/);
     }
   });
+
+  it('gives each step a badge text color with legible contrast on its own fill (CGLAB-131 drill-down)', () => {
+    // The ramp is light → dark on the dark canvas. Text rendered ON a fill
+    // (the drill-down modal badge) must not use one fixed color: white on the
+    // near-white light end reads as a blank white box. Light steps take the
+    // dark primary ink, dark steps take white.
+    for (const s of ['xs', 's', 'm'] as const) {
+      expect(SIZE_META.find(x => x.key === s)!.text).toBe('#000f3b');
+    }
+    for (const s of ['l', 'xl'] as const) {
+      expect(SIZE_META.find(x => x.key === s)!.text).toBe('#ffffff');
+    }
+  });
 });

--- a/packages/hub-ui/src/test/prOverviewDrilldown.test.tsx
+++ b/packages/hub-ui/src/test/prOverviewDrilldown.test.tsx
@@ -1,0 +1,176 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * PR Overview — per-cell drill-down modal (CGLAB-131).
+ *
+ * Page-level contract for the modal opened from a non-zero heatmap cell:
+ *  - clicking the cell opens a dialog listing that developer's PRs for that day;
+ *  - rows with a derived GitHub link are WHOLE-ROW links (no nested anchors):
+ *    clicking anywhere on the row (repo, model, badge…) hits the PR href;
+ *  - rows without a link (non-GitHub host / unparseable) are inert — no anchor;
+ *  - size badges are legible: dark ink on the light ramp end (xs/s/m), white
+ *    on the dark end (l/xl) — the "white box" defect was white text on the
+ *    near-white XS fill.
+ */
+import { render, screen, fireEvent, cleanup, within } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { PrOverviewPage } from '../pages/PrOverview';
+import { api } from '../api';
+
+vi.mock('../api', () => ({ api: { get: vi.fn() } }));
+const get = api.get as unknown as ReturnType<typeof vi.fn>;
+
+const overview = {
+  period: { from: '2026-08-10T00:00:00.000Z', to: '2026-08-22T23:59:59.999Z' },
+  buckets: ['xs', 's', 'm', 'l', 'xl'],
+  totals: { prs: 2, sizePoints: 8, developers: 1, medianBucket: 'xs' },
+  resized: { count: 0, grew: 0, shrank: 0 },
+  byDay: [
+    {
+      day: '2026-08-13',
+      sizes: { xs: 1, s: 0, m: 0, l: 1, xl: 0 },
+      total: 2,
+      devBySize: {
+        xs: [{ user_key: 'alice@acme.com', count: 1 }],
+        s: [], m: [], l: [{ user_key: 'alice@acme.com', count: 1 }], xl: [],
+      },
+    },
+  ],
+  byDeveloper: [
+    {
+      user_key: 'alice@acme.com',
+      prs: 2,
+      sizePoints: 8,
+      sizes: { xs: 1, s: 0, m: 0, l: 1, xl: 0 },
+      daily: { '2026-08-13': 2 },
+    },
+  ],
+  byModel: [
+    { model: 'claude-opus-5', harnesses: ['claude-code'], prs: 2, sizePoints: 8, sizes: { xs: 1, s: 0, m: 0, l: 1, xl: 0 } },
+  ],
+  prs: [
+    {
+      repo: 'cglab-PRIVATE/smartshot',
+      prNumber: 202,
+      url: 'https://github.com/cglab-PRIVATE/smartshot/pull/202',
+      user_key: 'alice@acme.com',
+      model: 'claude-opus-5',
+      harness: 'claude-code',
+      openedAt: '2026-08-13T16:50:18Z',
+      day: '2026-08-13',
+      points: 2,
+      bucket: 'xs',
+    },
+    {
+      repo: 'cglab-PRIVATE/smartshot',
+      prNumber: 203,
+      url: null, // non-GitHub host — the hub deliberately derives no link
+      user_key: 'alice@acme.com',
+      model: 'claude-opus-5',
+      harness: 'claude-code',
+      openedAt: '2026-08-13T18:12:13Z',
+      day: '2026-08-13',
+      points: 16,
+      bucket: 'l',
+    },
+  ],
+  previous: { prs: 1, sizePoints: 4 },
+};
+
+const renderPage = () => {
+  get.mockImplementation(async (url: string) => {
+    if (url.startsWith('/v1/projects')) return { data: { projects: ['cglab-PRIVATE/smartshot'] } };
+    return { data: overview };
+  });
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={['/prs']}>
+        <PrOverviewPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+};
+
+const openModal = async () => {
+  renderPage();
+  // Await the data load (the heatmap cells only exist once the overview
+  // query has resolved) — then click the non-zero cell (the a11y fix made
+  // drillable cells real buttons).
+  const cell = await screen.findByRole('button', { name: '2 PRs by alice@acme.com on 2026-08-13 — open list' });
+  fireEvent.click(cell);
+  return screen.findByRole('dialog');
+};
+
+beforeEach(() => {
+  get.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+  get.mockReset();
+});
+
+describe('PrOverviewPage drill-down modal (CGLAB-131)', () => {
+  it('opens from a non-zero cell and lists that developer’s PRs for that day', async () => {
+    const dialog = await openModal();
+    const scope = within(dialog);
+    expect(scope.getByText('#202')).toBeInTheDocument();
+    expect(scope.getByText('#203')).toBeInTheDocument();
+    // Exactly the PRs for this cell — nothing from other days/developers.
+    expect(scope.queryByText('#999')).not.toBeInTheDocument();
+  });
+
+  it('makes the WHOLE row the GitHub link (no nested anchors) when a link was derived', async () => {
+    const dialog = await openModal();
+    const scope = within(dialog);
+    // Both fixture PRs are in the same repo — scope to the #202 row.
+    const rows = dialog.querySelectorAll('li');
+    const row202 = Array.from(rows).find(li => li.textContent?.includes('#202'))!;
+    // Clicking the repo text (not the #N) must land on the PR href.
+    const repo = within(row202).getByText('cglab-PRIVATE/smartshot');
+    const anchor = repo.closest('a');
+    expect(anchor).not.toBeNull();
+    expect(anchor!.getAttribute('href')).toBe('https://github.com/cglab-PRIVATE/smartshot/pull/202');
+    expect(anchor!.getAttribute('target')).toBe('_blank');
+    // No anchor nested inside the row anchor (invalid HTML + double-link UX).
+    expect(anchor!.querySelector('a')).toBeNull();
+    // The #N itself is no longer a separate link — it is part of the row link.
+    expect(within(row202).getByText('#202').closest('a')).toBe(anchor);
+  });
+
+  it('keeps rows without a derived link inert (no anchor anywhere in the row)', async () => {
+    const dialog = await openModal();
+    const scope = within(dialog);
+    const num203 = scope.getByText('#203');
+    expect(num203.closest('a')).toBeNull();
+    // Its repo text is inert too.
+    const rows = dialog.querySelectorAll('li');
+    const row203 = Array.from(rows).find(li => li.textContent?.includes('#203'))!;
+    expect(row203.querySelector('a')).toBeNull();
+  });
+
+  it('renders size badges with legible text color per ramp step (no white-on-white)', async () => {
+    const dialog = await openModal();
+    const scope = within(dialog);
+    const badge = (label: string) =>
+      Array.from(scope.getAllByText(label)).find(el => (el as HTMLElement).style.background) as HTMLElement;
+
+    // XS: near-white fill #dbf7f0 → dark ink, NOT white.
+    const xs = badge('XS');
+    expect(xs).toBeTruthy();
+    expect(xs.style.background).toContain('219, 247, 240'); // #dbf7f0
+    expect(xs.style.color).not.toContain('255, 255, 255');
+    expect(xs.style.color).toContain('0, 15, 59'); // #000f3b
+
+    // L: dark fill #056f71 → white.
+    const l = badge('L');
+    expect(l).toBeTruthy();
+    expect(l.style.background).toContain('5, 111, 113'); // #056f71
+    expect(l.style.color).toContain('255, 255, 255');
+  });
+});

--- a/packages/hub-ui/src/test/prPerDay.test.ts
+++ b/packages/hub-ui/src/test/prPerDay.test.ts
@@ -63,6 +63,20 @@ describe('dayHeaderInfo', () => {
     expect(dayHeaderInfo('2026-07-14', '2026-07-14').isToday).toBe(true);
     expect(dayHeaderInfo('2026-07-13', '2026-07-14').isToday).toBe(false);
   });
+
+  it('normalises a full ISO timestamp input to its UTC calendar day', () => {
+    // The slice(0,10) + T00:00:00Z normalisation means a timestamp that leaked
+    // in (e.g. '2026-06-29T12:00:00Z') is read as its UTC day, not the
+    // embedded hour — 2026-06-29 is a Monday.
+    expect(dayHeaderInfo('2026-06-29T12:00:00Z')).toMatchObject({ weekday: 'Mon', dayNum: 29 });
+  });
+
+  it('rejects a non-10-char day instead of letting the engine misparse it', () => {
+    // '2026-06-2' (9 chars): with the T00:00:00Z suffix the string is invalid
+    // ISO and dayNum is NaN; without it, V8 leniently misparses it as a local
+    // date. The strict normalisation is the contract.
+    expect(dayHeaderInfo('2026-06-2').dayNum).toBeNaN();
+  });
 });
 
 describe('contributionPcts', () => {
@@ -108,6 +122,16 @@ describe('estimateTooltipSize', () => {
     // single-line tooltip: height does not depend on the text
     expect(b.height).toBe(a.height);
   });
+
+  // Exact-size contract (6px per mono glyph + 18px padding, 26px line): the
+  // clamping in placeTooltip is only as good as this estimate, so pin the
+  // formula rather than merely its monotonicity.
+  it('pins the documented size formula', () => {
+    expect(estimateTooltipSize('abc').width).toBe(3 * 6 + 18);
+    // empty text still gets a non-zero minimum box (Math.max(1, length))
+    expect(estimateTooltipSize('').width).toBe(1 * 6 + 18);
+    expect(estimateTooltipSize('abc').height).toBe(26);
+  });
 });
 
 // CGLAB-131 — the tooltip was rendered INSIDE the backdrop-blur card section,
@@ -150,6 +174,16 @@ describe('placeTooltip', () => {
     expect(p.y).toBe(36); // 10 + 20 + 6
   });
 
+  it('flips below at the top of the no-room band (top < height + gap + margin)', () => {
+    // top=30: room above = 30 - 6 - 26 = -2 < 8 → below (y = 30 + 20 + 6 = 56).
+    // Guards the sign of the gap term in the room-above comparison: a +/-
+    // flip in that comparison moves the flip threshold by 2*gap and this
+    // input sits inside the band where the two branches disagree.
+    const p = placeTooltip({ ...cell, top: 30 }, text, 1200);
+    expect(p.below).toBe(true);
+    expect(p.y).toBe(56);
+  });
+
   it('clamps to the left edge when the cell sits near it', () => {
     const long = 'x'.repeat(100);
     const { width: w } = estimateTooltipSize(long);
@@ -172,7 +206,10 @@ describe('placeTooltip', () => {
   it('does not blow up when the tooltip is wider than the viewport', () => {
     const huge = 'x'.repeat(5000);
     const p = placeTooltip({ left: 500, top: 300, width: 20, height: 20 }, huge, 800);
-    expect(Number.isFinite(p.x)).toBe(true);
+    // the degenerate branch centres the tooltip on the VIEWPORT (not the cell):
+    // pin the exact value, not just finiteness — a clamped coordinate here
+    // would be far off-screen.
+    expect(p.x).toBe(400); // viewportWidth / 2
     expect(Number.isFinite(p.y)).toBe(true);
   });
 });

--- a/packages/hub-ui/src/test/prPerDay.test.ts
+++ b/packages/hub-ui/src/test/prPerDay.test.ts
@@ -9,7 +9,7 @@
  * mirroring ../prOverview.
  */
 import { describe, it, expect } from 'vitest';
-import { buildMonthBands, dayHeaderInfo, contributionPcts, cellTooltip } from '../prPerDay';
+import { buildMonthBands, dayHeaderInfo, contributionPcts, cellTooltip, placeTooltip, estimateTooltipSize } from '../prPerDay';
 
 describe('buildMonthBands', () => {
   it('spans each month name across exactly its day columns', () => {
@@ -96,5 +96,83 @@ describe('cellTooltip', () => {
   it('still produces a tooltip for empty cells (0 PRs) — the bug being fixed', () => {
     expect(cellTooltip('danielp@cglab.com', '2026-06-28', 0))
       .toBe('danielp@cglab.com · Sun 2026-06-28: 0 PRs');
+  });
+});
+
+describe('estimateTooltipSize', () => {
+  it('estimates a single-line box that grows with the text', () => {
+    const a = estimateTooltipSize('alice · Mon 2026-06-29: 2 PRs');
+    const b = estimateTooltipSize('a@long-org.example.com · Mon 2026-06-29: 2 PRs');
+    expect(a.width).toBeGreaterThan(0);
+    expect(b.width).toBeGreaterThan(a.width);
+    // single-line tooltip: height does not depend on the text
+    expect(b.height).toBe(a.height);
+  });
+});
+
+// CGLAB-131 — the tooltip was rendered INSIDE the backdrop-blur card section,
+// so its viewport coordinates were interpreted against the section's box
+// (offset = "far away") and its z-50 lost to the later cards (z-order).
+// placeTooltip() is the pure placement contract the component must honour:
+// the returned {x, y} are VIEWPORT coordinates for a tooltip rendered outside
+// any filtered/stacking ancestor, centred horizontally on x, and occupying
+// [y - h, y] when `below` is false (anchored above) or [y, y + h] when true.
+describe('placeTooltip', () => {
+  const cell = { left: 500, top: 300, width: 20, height: 20 };
+  const text = 'alice@acme.com · Mon 2026-06-29: 2 PRs';
+
+  it('anchors above the cell, centred on it, when there is room', () => {
+    const p = placeTooltip(cell, text, 1200);
+    const { width: w, height: h } = estimateTooltipSize(text);
+    expect(p.below).toBe(false);
+    expect(p.x).toBe(510); // cell centre (500 + 20/2)
+    expect(p.y).toBe(294); // 6px gap above the cell top
+    // the tooltip box [y-h, y] × [x-w/2, x+w/2] must fit the viewport
+    expect(p.y - h).toBeGreaterThanOrEqual(0);
+    expect(p.x - w / 2).toBeGreaterThanOrEqual(0);
+    expect(p.x + w / 2).toBeLessThanOrEqual(1200);
+  });
+
+  it('stays above when the box would land exactly on the margin', () => {
+    // top of the box = cell.top - gap - h must equal the margin, not go past it
+    const { height: h } = estimateTooltipSize(text);
+    const c = { ...cell, top: h + 6 + 8 };
+    const p = placeTooltip(c, text, 1200);
+    expect(p.below).toBe(false);
+    expect(p.y - h).toBe(8);
+  });
+
+  it('flips below the cell when there is no room above', () => {
+    const p = placeTooltip({ ...cell, top: 10 }, text, 1200);
+    expect(p.below).toBe(true);
+    // anchored 6px below the cell bottom, centred unchanged
+    expect(p.x).toBe(510);
+    expect(p.y).toBe(36); // 10 + 20 + 6
+  });
+
+  it('clamps to the left edge when the cell sits near it', () => {
+    const long = 'x'.repeat(100);
+    const { width: w } = estimateTooltipSize(long);
+    const p = placeTooltip({ left: 2, top: 300, width: 20, height: 20 }, long, 1200);
+    expect(p.below).toBe(false);
+    // tooltip left edge stays at least the margin inside the viewport
+    expect(p.x - w / 2).toBeGreaterThanOrEqual(8);
+    expect(p.x - w / 2).toBe(8); // pinned, not centred
+  });
+
+  it('clamps to the right edge when the cell sits near it', () => {
+    const long = 'x'.repeat(100);
+    const { width: w } = estimateTooltipSize(long);
+    const p = placeTooltip({ left: 1195, top: 300, width: 20, height: 20 }, long, 1200);
+    // tooltip right edge stays at least the margin inside the viewport
+    expect(p.x + w / 2).toBeLessThanOrEqual(1192);
+    expect(p.x + w / 2).toBe(1192); // pinned, not centred
+  });
+
+  it('does not blow up when the tooltip is wider than the viewport', () => {
+    const huge = 'x'.repeat(5000);
+    const p = placeTooltip({ left: 500, top: 300, width: 20, height: 20 }, huge, 800);
+    expect(Number.isFinite(p.x)).toBe(true);
+    expect(Number.isFinite(p.y)).toBe(true);
   });
 });

--- a/packages/hub/src/queries/pr-overview-aggregate.ts
+++ b/packages/hub/src/queries/pr-overview-aggregate.ts
@@ -1,4 +1,5 @@
 import { prSizePoints, prSizeBucket, SIZE_BUCKETS, SizeBucket } from '@agenfk/core';
+import { prUrlFor } from '../util/remoteUrl.js';
 
 // One json_extract-shaped row per pr.opened / pr.updated event. Sizing fields are
 // read from the server-computed shadow (the only source that knows leaf stories).
@@ -18,6 +19,9 @@ export interface PrEventRow {
   bug: number | string | null;
   model: string | null;
   harness: string | null;
+  // CGLAB-131: the event's canonical git remote (written at ingest). The
+  // drill-down link is derived from the OPENER's row, not the latest one.
+  remote_url: string | null;
 }
 
 // Normalised, backend-agnostic event used internally.
@@ -32,6 +36,7 @@ interface NormRow {
   bug: number;
   model: string | null;
   harness: string | null;
+  remoteUrl: string | null;
 }
 
 const toIso = (v: unknown): string =>
@@ -56,6 +61,7 @@ function normaliseRow(r: PrEventRow): NormRow {
     bug: toNum(r.bug),
     model: r.model,
     harness: r.harness,
+    remoteUrl: r.remote_url ?? null,
   };
 }
 
@@ -75,6 +81,23 @@ export interface PrOverviewResult {
   }>;
   byDeveloper: Array<{ user_key: string; prs: number; sizePoints: number; sizes: SizeDist; daily: Record<string, number> }>;
   byModel: Array<{ model: string; harnesses: string[]; prs: number; sizePoints: number; sizes: SizeDist }>;
+  // CGLAB-131 drill-down: the resolved PR set itself — one entry per PR with
+  // opener attribution and the LATEST sizing, exactly the set the heatmap
+  // cells and the totals count. Ordered by open time, then repo#number.
+  // `url` is a GitHub link or null (non-GitHub host / unparseable — the UI
+  // then shows "repo #N" without a link rather than a guess).
+  prs: Array<{
+    repo: string;
+    prNumber: number;
+    url: string | null;
+    user_key: string;
+    model: string;
+    harness: string | null;
+    openedAt: string;
+    day: string;
+    points: number;
+    bucket: SizeBucket;
+  }>;
 }
 
 const emptyDist = (): SizeDist => ({ xs: 0, s: 0, m: 0, l: 0, xl: 0 });
@@ -107,6 +130,10 @@ interface ResolvedPr {
   bucket: SizeBucket;   // from latest sizing
   openerPoints: number; // first sizing
   events: number;
+  // CGLAB-131 drill-down fields (opener-identified, for the link + list).
+  repo: string;
+  prNumber: number;
+  url: string | null;   // GitHub link or null (non-GitHub host / unparseable)
 }
 
 // Collapse the raw event stream into one record per PR. A pr.updated never adds a
@@ -129,6 +156,8 @@ function resolvePrs(rows: ReadonlyArray<PrEventRow>): ResolvedPr[] {
     const opener = sorted.find(e => e.type === 'pr.opened') ?? sorted[0];
     const latest = sorted[sorted.length - 1];
     const points = pointsOf(latest);
+    // The link follows the OPENER (same attribution rule as user/model/day):
+    // a later re-size from another machine must not re-home the PR's repo host.
     resolved.push({
       user_key: opener.user_key,
       model: opener.model ?? 'unknown',
@@ -139,6 +168,9 @@ function resolvePrs(rows: ReadonlyArray<PrEventRow>): ResolvedPr[] {
       bucket: prSizeBucket(points),
       openerPoints: pointsOf(opener),
       events: sorted.length,
+      repo: opener.repo!,
+      prNumber: Number(opener.pr_number),
+      url: prUrlFor(opener.remoteUrl, opener.repo, Number(opener.pr_number)),
     });
   }
   return resolved;
@@ -228,6 +260,25 @@ export function aggregatePrOverview(rows: ReadonlyArray<PrEventRow>, window?: Pr
     .map(([model, v]) => ({ model, prs: v.prs, sizePoints: v.sizePoints, sizes: v.sizes, harnesses: [...v.harnesses].sort() }))
     .sort((a, b) => b.prs - a.prs || a.model.localeCompare(b.model));
 
+  // The drill-down list: the same resolved PRs (already window/model/dev-
+  // filtered), in a stable order for the modal — open time, then repo#number.
+  const prsDetail = [...prs]
+    .sort((a, b) =>
+      a.openerAt.localeCompare(b.openerAt)
+      || `${a.repo}#${a.prNumber}`.localeCompare(`${b.repo}#${b.prNumber}`))
+    .map(p => ({
+      repo: p.repo,
+      prNumber: p.prNumber,
+      url: p.url,
+      user_key: p.user_key,
+      model: p.model,
+      harness: p.harness,
+      openedAt: p.openerAt,
+      day: p.day,
+      points: p.points,
+      bucket: p.bucket,
+    }));
+
   return {
     buckets: SIZE_BUCKETS,
     totals: { prs: prs.length, sizePoints, developers: developers.size, medianBucket },
@@ -235,5 +286,6 @@ export function aggregatePrOverview(rows: ReadonlyArray<PrEventRow>, window?: Pr
     byDay,
     byDeveloper,
     byModel,
+    prs: prsDetail,
   };
 }

--- a/packages/hub/src/routes/queries.ts
+++ b/packages/hub/src/routes/queries.ts
@@ -241,7 +241,8 @@ export function queriesRouter(ctx: HubServerContext): Router {
                 json_extract(payload, '$.payload.sizingShadow.task') AS task,
                 json_extract(payload, '$.payload.sizingShadow.bug') AS bug,
                 json_extract(payload, '$.payload.model') AS model,
-                json_extract(payload, '$.payload.harness') AS harness
+                json_extract(payload, '$.payload.harness') AS harness,
+                remote_url
          FROM events WHERE ${where.join(' AND ')}
          ORDER BY occurred_at ASC`,
         base.params,

--- a/packages/hub/src/test/hub-pg-smoke.test.ts
+++ b/packages/hub/src/test/hub-pg-smoke.test.ts
@@ -102,4 +102,80 @@ describe('hub server end-to-end on Postgres (pg-mem)', () => {
     expect(types.status).toBe(200);
     expect(types.body.types).toContain('item.created');
   });
+
+  it('serves /v1/prs/overview with the per-PR drill-down list (CGLAB-131 — jsonb sizing path)', async () => {
+    // The only changed call path with no end-to-end PG coverage: this SELECT
+    // mixes bare columns (remote_url) with eight json_extract(payload, …) forms
+    // the dialect rewriter must translate to jsonb_extract_path_text — and the
+    // aggregator must normalise PG's Date/jsonb-text rows onto the same shape
+    // as SQLite (opener attribution, latest sizing, GitHub links).
+    await createPasswordUser(db, 'org', 'admin@x', 'longenough1', 'admin');
+    const login = await supertest(app).post('/auth/login').send({ email: 'admin@x', password: 'longenough1' });
+    const cookie = login.headers['set-cookie']?.[0] ?? '';
+    expect(login.status).toBe(200);
+
+    const token = await issueApiKey(db, 'org', 'pg-test');
+    const send = (events: any[]) =>
+      supertest(app).post('/v1/events').set('Authorization', `Bearer ${token}`).send({ events });
+
+    const pr = (over: any) => ({
+      eventId: over.eventId,
+      installationId: 'inst-pg',
+      orgId: 'org',
+      occurredAt: over.occurredAt,
+      actor: { osUser: over.osUser, gitName: over.osUser[0].toUpperCase(), gitEmail: `${over.osUser}@acme.com` },
+      type: over.type ?? 'pr.opened',
+      projectId: 'p1',
+      itemId: 'i1',
+      remoteUrl: over.remoteUrl ?? null,
+      payload: {
+        prNumber: over.prNumber,
+        repo: over.repo ?? 'acme/api',
+        model: over.model,
+        harness: 'claude-code',
+        sizing: over.sizing,
+        sizingShadow: over.sizing,
+        leafStory: over.leafStory ?? 0,
+      },
+    });
+
+    await send([
+      // alice opens #1 (task 1 → 2pts → xs) with an authoritative GitHub remote.
+      pr({ eventId: 'pg-pr-1', occurredAt: '2026-05-03T10:00:00Z', osUser: 'alice', prNumber: 1,
+           model: 'claude-opus-4-8', sizing: { epic: 0, story: 0, task: 1, bug: 0 },
+           remoteUrl: 'git@github.com:acme/api.git' }),
+      // bob opens #2 WITHOUT a remote — the link must fall back to the slug.
+      pr({ eventId: 'pg-pr-2', occurredAt: '2026-05-03T11:00:00Z', osUser: 'bob', prNumber: 2,
+           model: 'glm-5.2', sizing: { epic: 0, story: 1, task: 0, bug: 0 }, leafStory: 1 }),
+      // alice re-sizes #1 later (task 4 → 6pts → s) — latest sizing must win
+      // while the attribution (and the link) stays with the OPENER.
+      pr({ eventId: 'pg-pr-3', type: 'pr.updated', occurredAt: '2026-05-04T09:00:00Z', osUser: 'alice', prNumber: 1,
+           model: 'claude-opus-4-8', sizing: { epic: 0, story: 0, task: 4, bug: 0 } }),
+    ]);
+
+    const r = await supertest(app).get('/v1/prs/overview').set('Cookie', cookie);
+    expect(r.status).toBe(200);
+    expect(r.body.totals.prs).toBe(2);
+    expect(r.body.prs).toHaveLength(2);
+    const p1 = r.body.prs.find((p: any) => p.prNumber === 1);
+    expect(p1).toMatchObject({
+      repo: 'acme/api',
+      user_key: 'alice@acme.com',
+      model: 'claude-opus-4-8',
+      day: '2026-05-03',
+      bucket: 'm', // latest sizing (task 4 → 8pts) wins, attribution stays with the opener
+      url: 'https://github.com/acme/api/pull/1',
+    });
+    const p2 = r.body.prs.find((p: any) => p.prNumber === 2);
+    expect(p2).toMatchObject({
+      user_key: 'bob@acme.com',
+      bucket: 's', // leafStory 1 → 4pts
+      url: 'https://github.com/acme/api/pull/2', // slug fallback, same github.com assumption
+    });
+
+    // The developer filter is opener-based on PG too.
+    const filtered = await supertest(app).get('/v1/prs/overview?users=bob@acme.com').set('Cookie', cookie);
+    expect(filtered.status).toBe(200);
+    expect(filtered.body.prs.map((p: any) => p.prNumber)).toEqual([2]);
+  });
 });

--- a/packages/hub/src/test/pr-event-remote-url.test.ts
+++ b/packages/hub/src/test/pr-event-remote-url.test.ts
@@ -73,6 +73,26 @@ describe('remoteUrlFromRepo (unit)', () => {
   });
 });
 
+describe('sanitizeRemoteUrl (unit)', () => {
+  // The chip-collapse function: canonical ssh form wins, noise is stripped
+  // first, and anything unparseable is returned cleaned (never a guess).
+  it('canonicalises an https remote onto the canonical ssh form', () => {
+    expect(sanitizeRemoteUrl('https://github.com/acme/api'))
+      .toBe('git@github.com:acme/api.git');
+  });
+
+  it('strips noise (whitespace/control chars) before parsing and canonicalising', () => {
+    expect(sanitizeRemoteUrl('  git@github.com:acme/api \t .git  '))
+      .toBe('git@github.com:acme/api.git');
+  });
+
+  it('returns the cleaned input for anything that does not parse (never throws, never guesses)', () => {
+    // no host/owner/repo structure → no canonical form exists; the chip shows
+    // the stripped + lowercased input instead.
+    expect(sanitizeRemoteUrl('not a remote')).toBe('notaremote');
+  });
+});
+
 describe('Hub: PR events populate the remote_url filter dimension', { hookTimeout: 30_000 }, () => {
   let app: any;
   let ctx: any;

--- a/packages/hub/src/test/pr-overview-aggregate.test.ts
+++ b/packages/hub/src/test/pr-overview-aggregate.test.ts
@@ -13,6 +13,7 @@ const row = (o: Partial<PrEventRow>): PrEventRow => ({
   bug: 0,
   model: 'claude-opus-4-8',
   harness: 'claude-code',
+  remote_url: null,
   ...o,
 });
 
@@ -255,5 +256,90 @@ describe('aggregatePrOverview', () => {
     const r = aggregatePrOverview([row({ repo: null }), row({ pr_number: null })]);
     expect(r.totals.prs).toBe(0);
     expect(r.totals.medianBucket).toBeNull();
+  });
+});
+
+// CGLAB-131 — the heatmap drill-down: the overview response carries the same
+// resolved PR set as a detail list, so the per-cell modal can never drift from
+// the cell it backs (one aggregation pass, same opener attribution and window).
+describe('prs detail list (drill-down)', () => {
+  const GH = 'git@github.com:acme/api.git';
+
+  it('exposes one entry per PR with the full drill-down shape', () => {
+    const rows = [
+      row({ pr_number: 1, user_key: 'alice@acme.com', occurred_at: '2026-05-03T10:00:00Z', task: 1, remote_url: GH }),
+      row({ pr_number: 2, user_key: 'bob@acme.com', occurred_at: '2026-05-03T11:00:00Z', repo: 'acme/web', leaf_story: 1, remote_url: 'git@github.com:acme/web.git' }),
+    ];
+    const r = aggregatePrOverview(rows);
+    expect(r.prs).toHaveLength(2);
+    const [p1, p2] = r.prs;
+    expect(p1).toMatchObject({
+      repo: 'acme/api', prNumber: 1, user_key: 'alice@acme.com',
+      model: 'claude-opus-4-8', harness: 'claude-code',
+      openedAt: '2026-05-03T10:00:00Z', day: '2026-05-03',
+      points: 2, bucket: 'xs', url: 'https://github.com/acme/api/pull/1',
+    });
+    expect(p2.url).toBe('https://github.com/acme/web/pull/2');
+    expect(p2.bucket).toBe('s'); // leafStory 1 → 4 pts
+    expect(typeof p1.prNumber).toBe('number');
+  });
+
+  it('counts a resized PR once at its latest size, on its open day, at the opener identity', () => {
+    const rows = [
+      row({ pr_number: 9, user_key: 'alice@acme.com', occurred_at: '2026-05-03T09:00:00Z', task: 1, remote_url: GH }), // 2 → xs
+      row({ pr_number: 9, type: 'pr.updated', user_key: 'bob@acme.com', occurred_at: '2026-05-05T09:00:00Z', model: 'glm-5.2', task: 4, remote_url: 'git@ghe.internal:acme/api.git' }), // 8 → m
+    ];
+    const r = aggregatePrOverview(rows);
+    expect(r.prs).toHaveLength(1);
+    const p = r.prs[0];
+    expect(p.user_key).toBe('alice@acme.com'); // opener
+    expect(p.model).toBe('claude-opus-4-8');   // opener's model
+    expect(p.day).toBe('2026-05-03');          // open day
+    expect(p.bucket).toBe('m');                // latest sizing (8 pts)
+    // the link follows the OPENER's remote — bob's GHE remote must not leak in
+    expect(p.url).toBe('https://github.com/acme/api/pull/9');
+  });
+
+  it('returns a null url for non-GitHub remotes (no guessing)', () => {
+    const rows = [row({ pr_number: 5, repo: 'team/service', remote_url: 'git@ghe.internal:team/service.git' })];
+    const r = aggregatePrOverview(rows);
+    expect(r.prs).toHaveLength(1);
+    expect(r.prs[0].url).toBeNull();
+  });
+
+  it('falls back to the payload slug for the link when the remote is missing', () => {
+    const rows = [row({ pr_number: 6, repo: 'acme/api', remote_url: null })];
+    const r = aggregatePrOverview(rows);
+    expect(r.prs[0].url).toBe('https://github.com/acme/api/pull/6');
+  });
+
+  it('applies the window, model and developer filters to the list exactly like the totals', () => {
+    const rows = [
+      row({ pr_number: 1, user_key: 'alice@acme.com', occurred_at: '2026-05-01T09:00:00Z', remote_url: GH }),
+      row({ pr_number: 2, user_key: 'alice@acme.com', occurred_at: '2026-05-03T09:00:00Z', model: 'glm-5.2', remote_url: GH }),
+      row({ pr_number: 3, user_key: 'bob@acme.com', occurred_at: '2026-05-03T09:00:00Z', remote_url: GH }),
+    ];
+    const all = aggregatePrOverview(rows);
+    expect(all.prs).toHaveLength(3);
+    // #1 opened before the window — excluded, same rule as the totals
+    const win = aggregatePrOverview(rows, { from: '2026-05-02T00:00:00Z' });
+    expect(win.prs.map(p => p.prNumber).sort()).toEqual([2, 3]);
+    // model filter matches the OPENER's model
+    const byModel = aggregatePrOverview(rows, { model: 'glm-5.2' });
+    expect(byModel.prs.map(p => p.prNumber)).toEqual([2]);
+    // developer filter is opener-based
+    const byDev = aggregatePrOverview(rows, { developers: ['bob@acme.com'] });
+    expect(byDev.prs.map(p => p.prNumber)).toEqual([3]);
+  });
+
+  it('orders the list by open time, then repo#number (stable for the modal)', () => {
+    const rows = [
+      row({ pr_number: 3, occurred_at: '2026-05-03T09:00:00Z', remote_url: GH }),
+      row({ pr_number: 1, repo: 'acme/zeta', occurred_at: '2026-05-03T08:00:00Z', remote_url: 'git@github.com:acme/zeta.git' }),
+      row({ pr_number: 2, occurred_at: '2026-05-03T08:00:00Z', remote_url: GH }), // ties #1 on time → repo#number breaks it
+    ];
+    const r = aggregatePrOverview(rows);
+    // 'acme/api#2' < 'acme/zeta#1' → the api PR comes first
+    expect(r.prs.map(p => p.prNumber)).toEqual([2, 1, 3]);
   });
 });

--- a/packages/hub/src/test/pr-overview-aggregate.test.ts
+++ b/packages/hub/src/test/pr-overview-aggregate.test.ts
@@ -334,12 +334,175 @@ describe('prs detail list (drill-down)', () => {
 
   it('orders the list by open time, then repo#number (stable for the modal)', () => {
     const rows = [
-      row({ pr_number: 3, occurred_at: '2026-05-03T09:00:00Z', remote_url: GH }),
-      row({ pr_number: 1, repo: 'acme/zeta', occurred_at: '2026-05-03T08:00:00Z', remote_url: 'git@github.com:acme/zeta.git' }),
-      row({ pr_number: 2, occurred_at: '2026-05-03T08:00:00Z', remote_url: GH }), // ties #1 on time → repo#number breaks it
+      row({ pr_number: 9, repo: 'acme/c', occurred_at: '2026-05-03T08:00:00Z', remote_url: 'git@github.com:acme/c.git' }),
+      row({ pr_number: 1, repo: 'acme/a', occurred_at: '2026-05-03T08:00:00Z', remote_url: 'git@github.com:acme/a.git' }),
+      row({ pr_number: 5, repo: 'acme/b', occurred_at: '2026-05-03T08:00:00Z', remote_url: 'git@github.com:acme/b.git' }),
     ];
     const r = aggregatePrOverview(rows);
-    // 'acme/api#2' < 'acme/zeta#1' → the api PR comes first
-    expect(r.prs.map(p => p.prNumber)).toEqual([2, 1, 3]);
+    // Three-way open-time tie: repo#number must order a#1 < b#5 < c#9.
+    // (A 2-way tie is not enough — a coincidental sort reversal can
+    // reproduce the expected 2-element order.)
+    expect(r.prs.map(p => `${p.repo}#${p.prNumber}`))
+      .toEqual(['acme/a#1', 'acme/b#5', 'acme/c#9']);
+  });
+});
+
+// ── Mutation sweep (pure, no DB) ──────────────────────────────────────────
+// Targeted assertions for the survivors Stryker found in the aggregate /
+// normalisation paths (CGLAB-131). Each test maps to a surviving mutant
+// class; the documented equivalents are recorded in the step evidence.
+
+describe('pr-overview-aggregate mutation sweep (pure)', () => {
+  it('keeps well-formed ISO strings verbatim and normalises numeric timestamps', () => {
+    // String inputs pass through untouched; numeric (SQLite INTEGER) inputs
+    // go through Date. Catches the toIso string-branch mutant: for a
+    // non-string input the mutated branch would return the raw value.
+    const r = aggregatePrOverview([
+      row({ occurred_at: '2026-05-03T10:00Z' }),
+      row({ pr_number: 2, occurred_at: Date.UTC(2025, 4, 3, 10) as unknown as string }), // 2025-05-03T10:00:00Z
+    ]);
+    // The 2025 PR sorts first; its numeric input comes back canonicalised,
+    // the 2026 string input verbatim.
+    expect(r.prs.map(p => p.openedAt)).toEqual([
+      '2025-05-03T10:00:00.000Z',
+      '2026-05-03T10:00Z',
+    ]);
+  });
+
+  it('resolves sizing from the latest event even when rows arrive out of order', () => {
+    // pr.updated arrives BEFORE pr.opened in the array: the aggregator must
+    // sort by occurred_at, not trust array order. (Catches the no-op sort
+    // comparator mutant.)
+    const rows = [
+      row({ type: 'pr.updated', pr_number: 7, leaf_story: 2, task: 4, occurred_at: '2026-05-05T10:00:00Z' }),
+      row({ type: 'pr.opened', pr_number: 7, leaf_story: 1, task: 1, occurred_at: '2026-05-03T09:00:00Z' }),
+    ];
+    const r = aggregatePrOverview(rows);
+    // 2×4 + 4×2 = 16pts → l (the later update wins the sizing)
+    expect(r.prs[0]).toMatchObject({ prNumber: 7, points: 16, bucket: 'l', day: '2026-05-03' });
+  });
+
+  it('attributes the PR to the pr.opened event even when an earlier-timestamped update leads the group', () => {
+    // Clock-skew shape: pr.updated @08:00 sorts before pr.opened @09:00.
+    // Attribution (user/model/day) follows the OPENER — so the find-by-type
+    // must not degrade to "first event".
+    const rows = [
+      row({ type: 'pr.updated', pr_number: 7, user_key: 'bob', model: 'glm-5.2', harness: 'codex', leaf_story: 2, task: 4, occurred_at: '2026-05-03T08:00:00Z' }),
+      row({ type: 'pr.opened', pr_number: 7, user_key: 'alice', model: 'opus-4-6', harness: 'claude-code', leaf_story: 1, task: 1, occurred_at: '2026-05-03T09:00:00Z' }),
+    ];
+    const r = aggregatePrOverview(rows);
+    expect(r.prs[0]).toMatchObject({
+      prNumber: 7, user_key: 'alice', model: 'opus-4-6', harness: 'claude-code',
+      day: '2026-05-03', bucket: 's', points: 6,
+    });
+    expect(r.byDeveloper.map(d => d.user_key)).toEqual(['alice']);
+  });
+
+  it('applies the `from` and `to` window bounds inclusively', () => {
+    // PR#3 opens exactly at `from` (kept), PR#1 exactly at `to` (kept),
+    // PR#2 one second after `to` (dropped). Catches the bound-comparison
+    // mutants (>, <) and the window-optional mutations.
+    const rows = [
+      row({ pr_number: 3, occurred_at: '2026-05-03T00:00:00Z' }),
+      row({ pr_number: 1, occurred_at: '2026-05-03T12:00:00Z' }),
+      row({ pr_number: 2, occurred_at: '2026-05-03T12:00:01Z' }),
+    ];
+    const r = aggregatePrOverview(rows, {
+      from: '2026-05-03T00:00:00Z',
+      to: '2026-05-03T12:00:00Z',
+    });
+    expect(r.prs.map(p => p.prNumber)).toEqual([3, 1]);
+  });
+
+  it('counts a developer\'s daily PRs per day (multi-PR days increment, not overwrite)', () => {
+    const r = aggregatePrOverview([
+      row({ pr_number: 1, occurred_at: '2026-05-03T08:00:00Z' }),
+      row({ pr_number: 2, occurred_at: '2026-05-03T11:00:00Z' }),
+    ]);
+    const alice = r.byDeveloper.find(d => d.user_key === 'alice@acme.com')!;
+    expect(alice.daily).toEqual({ '2026-05-03': 2 });
+  });
+
+  it('accumulates per-model sizePoints and bucket distribution', () => {
+    const r = aggregatePrOverview([
+      row({ pr_number: 1, model: 'opus-4-6', leaf_story: 1, task: 1, occurred_at: '2026-05-03T08:00:00Z' }),
+      row({ pr_number: 2, model: 'opus-4-6', leaf_story: 2, task: 4, occurred_at: '2026-05-03T09:00:00Z' }),
+    ]);
+    const opus = r.byModel.find(m => m.model === 'opus-4-6')!;
+    // 1×4+1×2 = 6pts (s) + 2×4+4×2 = 16pts (l)
+    expect(opus.sizePoints).toBe(22);
+    expect(opus.sizes).toMatchObject({ s: 1, l: 1 });
+  });
+
+  it('takes the lower of the two central buckets for an even PR count', () => {
+    // 4 PRs across xs, s, l, xl → ordinal indices [0,1,3,4] → median index
+    // floor(3/2) = 1 → 's'. The rows are deliberately listed in an order that
+    // is NOT the sorted bucket order, so any mutant that drops the median
+    // map/sort/comparator keeps the insertion order and lands on a different
+    // bucket ('l' for the insertion-order mutant, 'xs' for the no-op sort).
+    const r = aggregatePrOverview([
+      row({ pr_number: 3, model: 'm3', leaf_story: 2, task: 4, occurred_at: '2026-05-03T09:00:00Z' }),  // 16pt l
+      row({ pr_number: 1, model: 'm1', leaf_story: 0, task: 1, occurred_at: '2026-05-03T08:00:00Z' }),   // 2pt  xs
+      row({ pr_number: 2, model: 'm2', leaf_story: 1, task: 1, occurred_at: '2026-05-03T08:30:00Z' }),  // 6pt  s
+      row({ pr_number: 4, model: 'm4', leaf_story: 8, task: 8, occurred_at: '2026-05-03T09:30:00Z' }),  // 48pt xl
+    ]);
+    expect(r.totals.medianBucket).toBe('s');
+  });
+
+  it('orders byDeveloper by prs, then sizePoints, then user_key (comparator-robust input)', () => {
+    // 11 PRs across five developers with colliding (prs, sizePoints)
+    // profiles in an insertion order that separates the original comparator
+    // from the surviving logical/conditional mutants (verified by running
+    // the exact Stryker mutants against this input).
+    const rows = [
+      row({ user_key: 'sara@acme.com', pr_number: 1, leaf_story: 0, task: 1, occurred_at: '2026-05-03T10:00:00Z' }),
+      row({ user_key: 'nika@acme.com', pr_number: 2, leaf_story: 2, task: 4, occurred_at: '2026-05-03T11:00:00Z' }),
+      row({ user_key: 'uma@acme.com', pr_number: 3, leaf_story: 8, task: 8, occurred_at: '2026-05-03T12:00:00Z' }),
+      row({ user_key: 'nika@acme.com', pr_number: 4, leaf_story: 2, task: 4, occurred_at: '2026-05-03T13:00:00Z' }),
+      row({ user_key: 'pola@acme.com', pr_number: 5, leaf_story: 8, task: 8, occurred_at: '2026-05-03T14:00:00Z' }),
+      row({ user_key: 'zoe@acme.com', pr_number: 6, leaf_story: 8, task: 8, occurred_at: '2026-05-03T15:00:00Z' }),
+      row({ user_key: 'pola@acme.com', pr_number: 7, leaf_story: 2, task: 4, occurred_at: '2026-05-03T16:00:00Z' }),
+      row({ user_key: 'sara@acme.com', pr_number: 8, leaf_story: 2, task: 4, occurred_at: '2026-05-03T17:00:00Z' }),
+      row({ user_key: 'zoe@acme.com', pr_number: 9, leaf_story: 8, task: 8, occurred_at: '2026-05-03T18:00:00Z' }),
+      row({ user_key: 'pola@acme.com', pr_number: 10, leaf_story: 1, task: 1, occurred_at: '2026-05-03T19:00:00Z' }),
+      row({ user_key: 'nika@acme.com', pr_number: 11, leaf_story: 1, task: 1, occurred_at: '2026-05-03T20:00:00Z' }),
+    ];
+    const r = aggregatePrOverview(rows);
+    // pola (3 prs, 70pt) > nika (3, 38) > zoe (2, 96) > sara (2, 18) > uma (1, 48)
+    expect(r.byDeveloper.map(d => d.user_key)).toEqual([
+      'pola@acme.com', 'nika@acme.com', 'zoe@acme.com', 'sara@acme.com', 'uma@acme.com',
+    ]);
+  });
+
+  it('orders byDay, devBySize, byDeveloper and byModel deterministically (insertion order ≠ sort order)', () => {
+    // Rows arrive in an order deliberately different from every sorted
+    // output, so dropping or breaking any of the .sort() calls is
+    // observable:
+    //  - byDay: the 2026-05-04 PR is listed first in the rows.
+    //  - devBySize (05-03, s): carol & bob before alice in the rows.
+    //  - byDeveloper / byModel: non-alphabetical insertion.
+    const rows = [
+      row({ pr_number: 10, user_key: 'dave', model: 'm4', occurred_at: '2026-05-04T08:00:00Z' }),
+      row({ pr_number: 2, user_key: 'carol', model: 'c-model', occurred_at: '2026-05-03T08:00:00Z' }),
+      row({ pr_number: 3, user_key: 'bob', model: 'b-model', occurred_at: '2026-05-03T08:30:00Z' }),
+      row({ pr_number: 1, user_key: 'alice', model: 'a-model', occurred_at: '2026-05-03T09:00:00Z' }),
+      row({ pr_number: 4, user_key: 'alice', model: 'a-model', occurred_at: '2026-05-03T09:30:00Z' }),
+    ];
+    const r = aggregatePrOverview(rows);
+    expect(r.byDay.map(d => d.day)).toEqual(['2026-05-03', '2026-05-04']);
+    // default row sizing is 2pts → xs bucket
+    expect(r.byDay[0].devBySize.xs.map(e => `${e.user_key}:${e.count}`))
+      .toEqual(['alice:2', 'bob:1', 'carol:1']);
+    expect(r.byDeveloper.map(d => d.user_key)).toEqual(['alice', 'bob', 'carol', 'dave']);
+    expect(r.byModel.map(m => m.model)).toEqual(['a-model', 'b-model', 'c-model', 'm4']);
+  });
+
+  it('sorts a model\'s harness list (insertion order must not leak)', () => {
+    const r = aggregatePrOverview([
+      row({ pr_number: 1, model: 'h-model', harness: 'zeta-harness', occurred_at: '2026-05-03T08:00:00Z' }),
+      row({ pr_number: 2, model: 'h-model', harness: 'alpha-harness', occurred_at: '2026-05-03T09:00:00Z' }),
+    ]);
+    expect(r.byModel.find(m => m.model === 'h-model')!.harnesses)
+      .toEqual(['alpha-harness', 'zeta-harness']);
   });
 });

--- a/packages/hub/src/test/prUrl.test.ts
+++ b/packages/hub/src/test/prUrl.test.ts
@@ -67,4 +67,50 @@ describe('prUrlFor', () => {
     expect(prUrlFor('git@github.com:acme/api.git', null, null)).toBeNull();
     expect(prUrlFor('git@github.com:acme/api.git', null, 0)).toBeNull();
   });
+
+  // Input-hygiene contract: stored remotes are canonical, but pre-fix rows
+  // and slugs can carry stray whitespace/control chars — the link must still
+  // resolve from them (pinning the trims + the noise-strip in both arms).
+  it('tolerates surrounding whitespace in a remote', () => {
+    expect(prUrlFor('  git@github.com:acme/api.git\n', null, 7))
+      .toBe('https://github.com/acme/api/pull/7');
+  });
+
+  it('strips embedded noise (spaces/control chars) from a remote before parsing', () => {
+    expect(prUrlFor('git@github.com:acme/api .git', null, 7))
+      .toBe('https://github.com/acme/api/pull/7');
+    // double noise run: the strip regex must be a quantified match, not a single-char one
+    expect(prUrlFor('git@github.com:acme/api\t.git', null, 7))
+      .toBe('https://github.com/acme/api/pull/7');
+  });
+
+  it('returns null for a non-empty remote that does not parse (no crash, no guess)', () => {
+    expect(prUrlFor('junk-without-any-separator', null, 4)).toBeNull();
+  });
+
+  it('treats a whitespace-only remote as missing and falls back to the slug', () => {
+    // The guard trims: a remote that is only whitespace must not short-circuit
+    // the slug fallback (it carries no host information).
+    expect(prUrlFor('   ', 'acme/api', 4))
+      .toBe('https://github.com/acme/api/pull/4');
+  });
+
+  it('does not accept a github-looking suffix hidden behind garbage (anchor contract)', () => {
+    // The parse regex is fully anchored: a string with a foreign prefix must
+    // fail to parse in its entirety rather than match a trailing fragment.
+    expect(prUrlFor('see https://x.example/ git@github.com:acme/api.git', null, 7)).toBeNull();
+  });
+
+  it('tolerates surrounding whitespace in a slug', () => {
+    expect(prUrlFor(null, '  acme/api ', 4))
+      .toBe('https://github.com/acme/api/pull/4');
+  });
+
+  it('strips embedded noise from a slug before matching', () => {
+    expect(prUrlFor(null, 'acme/ my-api', 4))
+      .toBe('https://github.com/acme/my-api/pull/4');
+    // double noise run in the slug arm
+    expect(prUrlFor(null, 'acme/  my-api', 4))
+      .toBe('https://github.com/acme/my-api/pull/4');
+  });
 });

--- a/packages/hub/src/test/prUrl.test.ts
+++ b/packages/hub/src/test/prUrl.test.ts
@@ -1,0 +1,70 @@
+/**
+ * CGLAB-131 — PR drill-down: the per-cell list links each PR to GitHub.
+ * prUrlFor() derives the link from the OPENER event's authoritative remote_url
+ * (canonical git remote, written at ingest); when that is absent it falls back
+ * to the payload's `owner/repo` slug under the same documented github.com
+ * assumption remoteUrlFromRepo() uses. Non-GitHub hosts (GHE custom domains,
+ * GitLab, …) are deliberately NOT linked — the platform is not derivable from
+ * the host, so the UI shows "repo #N" without a link instead of guessing.
+ */
+import { describe, it, expect } from 'vitest';
+import { prUrlFor } from '../util/remoteUrl';
+
+describe('prUrlFor', () => {
+  it('derives the pull link from a canonical ssh github remote', () => {
+    expect(prUrlFor('git@github.com:acme/api.git', null, 7))
+      .toBe('https://github.com/acme/api/pull/7');
+  });
+
+  it('derives the pull link from an https github remote (no .git)', () => {
+    expect(prUrlFor('https://github.com/acme/api', null, 12))
+      .toBe('https://github.com/acme/api/pull/12');
+  });
+
+  it('tolerates a user prefix and a trailing .git in https remotes', () => {
+    expect(prUrlFor('https://dev@github.com/acme/api.git', null, 3))
+      .toBe('https://github.com/acme/api/pull/3');
+  });
+
+  it('returns null for non-GitHub ssh remotes (GHE custom domains are not guessed)', () => {
+    expect(prUrlFor('git@ghe.internal:team/service.git', null, 5)).toBeNull();
+  });
+
+  it('returns null for non-GitHub https remotes (GitLab is not /pull/)', () => {
+    expect(prUrlFor('https://gitlab.com/g/r.git', null, 9)).toBeNull();
+  });
+
+  it('falls back to the owner/repo slug when the remote is missing (documented github.com assumption)', () => {
+    expect(prUrlFor(null, 'acme/api', 4))
+      .toBe('https://github.com/acme/api/pull/4');
+  });
+
+  it('falls back to the slug with a trailing .git too', () => {
+    expect(prUrlFor(null, 'acme/api.git', 4))
+      .toBe('https://github.com/acme/api/pull/4');
+  });
+
+  it('does not fall back when the slug is host-qualified junk', () => {
+    expect(prUrlFor(null, 'github.com/acme/api', 4)).toBeNull();
+    expect(prUrlFor(null, 'not-a-repo', 4)).toBeNull();
+  });
+
+  it('returns null when neither remote nor slug is usable', () => {
+    expect(prUrlFor(null, null, 4)).toBeNull();
+    expect(prUrlFor('', '', 4)).toBeNull();
+  });
+
+  it('the authoritative remote wins over the slug — a non-github remote means no link, not a github guess', () => {
+    expect(prUrlFor('git@ghe.internal:t/s.git', 'acme/api', 5)).toBeNull();
+  });
+
+  it('accepts a string prNumber (PG jsonb returns text) and normalises it', () => {
+    expect(prUrlFor('git@github.com:acme/api.git', null, '7'))
+      .toBe('https://github.com/acme/api/pull/7');
+  });
+
+  it('returns null for a missing or zero prNumber', () => {
+    expect(prUrlFor('git@github.com:acme/api.git', null, null)).toBeNull();
+    expect(prUrlFor('git@github.com:acme/api.git', null, 0)).toBeNull();
+  });
+});

--- a/packages/hub/src/test/queries.test.ts
+++ b/packages/hub/src/test/queries.test.ts
@@ -539,4 +539,32 @@ describe('GET /v1/prs/overview', () => {
     expect(may3.devBySize.xs).toEqual([{ user_key: 'alice@acme.com', count: 1 }]);
     expect(may3.devBySize.m).toEqual([{ user_key: 'alice@acme.com', count: 1 }]);
   });
+
+  it('exposes the per-PR drill-down list with GitHub links (CGLAB-131)', async () => {
+    const r = await supertest(app).get('/v1/prs/overview').set('Cookie', cookie);
+    expect(r.status).toBe(200);
+    // the same 3 resolved PRs as the totals — nothing more, nothing less
+    expect(r.body.prs).toHaveLength(3);
+    const p1 = r.body.prs.find((p: any) => p.prNumber === 1);
+    expect(p1).toMatchObject({
+      repo: 'acme/api',
+      user_key: 'alice@acme.com',
+      model: 'claude-opus-4-8',
+      day: '2026-05-03',
+      bucket: 'xs',
+      url: 'https://github.com/acme/api/pull/1',
+    });
+    // PR#2 counted at its LATEST (m) size, with its own link
+    const p2 = r.body.prs.find((p: any) => p.prNumber === 2);
+    expect(p2.bucket).toBe('m');
+    expect(p2.url).toBe('https://github.com/acme/api/pull/2');
+  });
+
+  it('applies the developer filter to the drill-down list (opener-based)', async () => {
+    const r = await supertest(app).get('/v1/prs/overview?users=bob@acme.com').set('Cookie', cookie);
+    expect(r.status).toBe(200);
+    expect(r.body.prs).toHaveLength(1);
+    expect(r.body.prs[0].prNumber).toBe(3);
+    expect(r.body.prs[0].url).toBe('https://github.com/acme/api/pull/3');
+  });
 });

--- a/packages/hub/src/util/remoteUrl.ts
+++ b/packages/hub/src/util/remoteUrl.ts
@@ -37,3 +37,48 @@ export function remoteUrlFromRepo(repo: string): string | null {
   if (!m) return null;
   return `git@github.com:${m[1]}/${m[2]}.git`;
 }
+
+/**
+ * CGLAB-131 — a GitHub pull-request link for one PR, for the drill-down list.
+ *
+ * Preference order, mirroring ingest:
+ * 1. the event's authoritative `remote_url` (canonical git form, written at
+ *    ingest — emitter-resolved, or derived from the payload slug). A link is
+ *    emitted ONLY when the host is exactly github.com: the platform is not
+ *    derivable from a custom host (GHE domains, GitLab, …), so guessing would
+ *    mint 404s. A non-GitHub host returns null — it does NOT fall back to the
+ *    slug, which would assume github.com against an authoritative remote.
+ * 2. the payload's `owner/repo` slug, under the same documented github.com
+ *    assumption remoteUrlFromRepo() uses, for rows whose remote is missing.
+ *
+ * prNumber accepts number or string (Postgres jsonb text) and rejects
+ * non-positive / non-integer values. Anything unparseable → null; the UI then
+ * shows "repo #N" without a link rather than a guess.
+ */
+export function prUrlFor(
+  remoteUrl: string | null | undefined,
+  repoSlug: string | null | undefined,
+  prNumber: number | string | null | undefined,
+): string | null {
+  // Coalesce to a plain `number` (Number() is the identity on numbers and
+  // parses the PG text form; null/undefined → NaN, rejected below). Without
+  // the coalesce the null/undefined arms widen the union and defeat the
+  // narrowing on the comparisons that follow.
+  const n = Number(prNumber);
+  if (!Number.isInteger(n) || n <= 0) return null;
+  if (remoteUrl && remoteUrl.trim()) {
+    // Stored remotes are already canonical-lowercase; normalise anyway so a
+    // pre-canonicalisation row still links (GitHub paths are case-insensitive).
+    const m = remoteUrl.trim().replace(REMOTE_URL_NOISE_RE, '').toLowerCase().match(PARSE_REMOTE_RE);
+    if (!m) return null;
+    const [, host, owner, repo] = m;
+    if (host !== 'github.com') return null;
+    return `https://github.com/${owner}/${repo}/pull/${n}`;
+  }
+  if (repoSlug && repoSlug.trim()) {
+    const m = repoSlug.trim().replace(REMOTE_URL_NOISE_RE, '').match(REPO_SLUG_RE);
+    if (!m) return null; // host-qualified or junk: not a bare slug, don't guess
+    return `https://github.com/${m[1]}/${m[2]}/pull/${n}`;
+  }
+  return null;
+}


### PR DESCRIPTION
## What

**Bug fix** — the 'Per developer, per day' heatmap tooltip rendered far from the hovered cell and under sibling cards. Root cause: the position:fixed tooltip was rendered inside a backdrop-blur (backdrop-filter) section, which creates a containing block (re-rooting its fixed coordinates) and a stacking context (swallowing its z-50). Fix: the tooltip now renders at the page root, with placement extracted to a pure placeTooltip() (viewport coords, horizontal clamping, flip-below).

**Feature** — clicking a non-zero heatmap cell opens a drill-down modal listing that developer's PRs for that day, with GitHub links. /v1/prs/overview now returns the resolved per-PR list (opener attribution, latest sizing) — the same set the heatmap counts, so zero drift between cells and modal. Links are derived by prUrlFor(): github.com remotes only (slug fallback under the documented assumption); non-GitHub hosts get no link (the UI shows '#N' without a guess).

Modal a11y: focus trap + initial focus + focus restore, scroll lock, Esc/backdrop/X; non-zero cells are keyboard-operable (role=button, Enter/Space).

## Verification

- Full suite: 2421/2421 green; tsc + vite builds clean
- Stryker 10 mutation testing on the 3 changed logic modules: 364 mutants, 350 killed (96.1%); the 14 non-killed are documented provably-equivalent mutants / dead defensive branches
- Test integrity: 'vitest list' name-diff across the change — growth only (2396 → 2421), no deletions/renames/skips
- Independent adversarial subagent review: APPROVE-WITH-NITS (zero-drift, UTC day alignment, SQL parameterisation and the github.com-only link contract all verified under hostile-input probes); MINOR findings fixed in this branch, remaining NITs logged as follow-ups on the story
- New pg-mem e2e test for /v1/prs/overview (the changed SQL path previously only exercised on SQLite)

## JIRA

CGLAB-131