### PR TITLE
Hub: flow editor tabs named the wrong thing, and a private registry hid the community catalogue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ tmp.*.json
 # Mutation testing artifacts (StrykerJS — MUTATION_TESTS flow step)
 /reports/
 .stryker-tmp/
+# Scoped Stryker runs use their own tempDirName so parallel runs don't collide
+# (see tempDirName in stryker.*.config.mjs).
+.stryker-tmp-*/
 stryker.log
 # pi coding-agent local session artifacts (subagent transcripts, clipboard)
 /.pi/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to AgEnFK are documented here.
 
+## [1.1.18-beta.1] — 2026-09-05
+
+### Hub — admin-settable private flow registry (CGLAB-138)
+
+- **Per-org flow registry.** A Hub admin can point their org's flow registry at
+  an **existing** repository of their own instead of the public
+  `cglab-public/agenfk-flows`. Admin → Flows → Flow registry.
+- **The save fails if the repo cannot be written.** Write access is probed
+  before anything is persisted, so an admin is never left believing the fleet
+  points at a registry that serves nothing.
+- **One-time community copy.** Switching copies the community flows present at
+  that moment into the org repo; it is not a mirror. A re-runnable *Retry copy*
+  recovers a partial run and is idempotent by content.
+- **Token held on the hub, encrypted.** A fine-grained PAT (`contents:write`) is
+  stored `encryptSecret`-encrypted in the new `org_settings` table and is never
+  returned by any endpoint. Registry reads are authenticated with it — GitHub
+  answers an anonymous fetch of a private repo with `404`, so a private registry
+  cannot be served to a fleet otherwise.
+- **Reversible.** Moving back to the public repo needs no reverse copy.
+- **No silent public fall-back.** When the Hub is unreachable, a connected
+  installation's `/registry/flows` returns `502` rather than showing the
+  community catalogue the org deliberately sealed away.
+
+### Fixed
+
+- **Pi harness misreported the model in PR registration.** The session's live
+  model is used instead of the `settings.json` `defaultModel`, which is a
+  configured default and not the model actually answering.
+
 ## [1.1.17] — 2026-09-04
 
 Stable release. Consolidates `v1.1.17-beta.1` … `v1.1.17-beta.15` (PR #175).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to AgEnFK are documented here.
 
-## [1.1.18-beta.1] — 2026-09-05
+## [1.1.18-beta.2] — 2026-09-05
 
 ### Hub — admin-settable private flow registry (CGLAB-138)
 
@@ -29,6 +29,8 @@ All notable changes to AgEnFK are documented here.
 - **No silent public fall-back.** When the Hub is unreachable, a connected
   installation's `/registry/flows` returns `502` rather than showing the
   community catalogue the org deliberately sealed away.
+
+## [1.1.18-beta.1] — 2026-09-05
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ All notable changes to AgEnFK are documented here.
   answers an anonymous fetch of a private repo with `404`, so a private registry
   cannot be served to a fleet otherwise.
 - **Reversible.** Moving back to the public repo needs no reverse copy.
+- **Branch is validated, not just the repo.** A malformed ref is worse than a
+  malformed repo: GitHub answers an unknown `ref` with `404`, and an empty
+  registry is read as `404`, so a stored-but-unusable branch would show an admin
+  a registry of **zero flows and no error**. `isValidRegistryBranch` rejects it
+  at the storage boundary and at the route, before any GitHub call.
 - **No silent public fall-back.** When the Hub is unreachable, a connected
   installation's `/registry/flows` returns `502` rather than showing the
   community catalogue the org deliberately sealed away.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to AgEnFK are documented here.
 
+## [1.1.18-beta.4] — 2026-09-08
+
+### Hub — the flow editor's footer buttons now say what they write
+
+`Save` / `Publish` / `Use this Flow` read as one pipeline. They were three
+unrelated writes, and two of them promised more than they did.
+
+- **Publish is capability-gated, not decorative.** `RegistryClient.publishToRegistry`
+  is now optional. The hub holds the org's registry PAT and has no publish
+  route, so the hub admin omits the method and the editor no longer renders a
+  button that could only throw. Authors who need a registry PR use
+  `agenfk flow publish <id> [--registry owner/repo]`.
+- **Labels name the write.** The hub host now passes
+  **"Save & publish to org"** / **"Published to org"** / **"Set as org
+  default"** — the last one being the literal badge the flows list renders for
+  the same assignment. The registry-config form's button is renamed **"Save
+  registry repo"**, so the page no longer shows two Save buttons.
+- **Binding saves first.** "Set as org default" used to bind the id it already
+  had, so with unsaved edits in the panel it assigned the version already on the
+  server and reported success while **silently dropping the edits**. It now
+  persists before binding, and a failed save means no bind.
+- **A newly created flow is no longer a dead end.** Two footers used to be
+  chosen by read-only-ness, which stranded a flow with no id yet: no Save (it
+  lived in the other branch) and no Publish (that branch gated on `flow?.id`).
+  One footer now gates per capability.
+- **Two pre-existing bugs fixed on the way:** the "Saved" badge could never
+  display — a save churned selection state, remounting the panel by `key` and
+  discarding the dirty baseline — and the load effect keyed on the `flow` object
+  rather than `flow?.id`, so it re-ran with a stale object after every save.
+
 ## [1.1.18-beta.3] — 2026-09-07
 
 ### Hub — browse the community registry alongside a private one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to AgEnFK are documented here.
 
 ## [1.1.18-beta.2] — 2026-09-05
 
+### Hub — browse the community registry alongside a private one
+
+- After an org points its registry at a private repo, the hub could only ever
+  read that one repo — so the real community catalogue became invisible and
+  uninstallable, and any flow published to community afterwards was
+  unreachable. Admin → Flows → the registry tab now offers a **switcher**
+  between the org's repo and Community.
+- **The caller picks a source, never a repo.** `?source=org|community` is an
+  enum; an `owner/repo` in the query is ignored. This route holds the org's
+  `contents:write` PAT, so a caller-supplied repo would make it a cross-tenant
+  proxy on a server-side credential.
+- **Community reads are always anonymous.** The org's PAT is scoped to the org's
+  repo; sending it to the public repo would leak the credential to a repo the
+  org has no relationship with.
+- **Tab captions now say what they list.** "My Flows" → **"Org Flows"** in the
+  hub admin (it is the org-wide catalogue, not a personal list), and the
+  registry tab is named for the repo it is actually reading instead of always
+  claiming "Community". The standalone client is unchanged.
+
 ### Hub — admin-settable private flow registry (CGLAB-138)
 
 - **Per-org flow registry.** A Hub admin can point their org's flow registry at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to AgEnFK are documented here.
 
-## [1.1.18-beta.2] — 2026-09-05
+## [1.1.18-beta.3] — 2026-09-07
 
 ### Hub — browse the community registry alongside a private one
 
@@ -22,6 +22,8 @@ All notable changes to AgEnFK are documented here.
   hub admin (it is the org-wide catalogue, not a personal list), and the
   registry tab is named for the repo it is actually reading instead of always
   claiming "Community". The standalone client is unchanged.
+
+## [1.1.18-beta.2] — 2026-09-05
 
 ### Hub — admin-settable private flow registry (CGLAB-138)
 

--- a/HUB_ARCHITECTURE.md
+++ b/HUB_ARCHITECTURE.md
@@ -553,6 +553,93 @@ Flow definitions are authored in the hub admin UI (powered by
 `registry/flows` endpoint, set per-org defaults, and assign overrides at
 project scope.
 
+### 6.1 Per-org registry repo (CGLAB-138)
+
+By default every org browses the public community registry
+(`cglab-public/agenfk-flows`). An **admin** can point the org at an **existing**
+repo of their own — Admin → Flows → Flow registry.
+
+Code: `packages/hub/src/services/flowRegistry.ts`, routes under
+`/v1/admin/registry-config` and `/v1/registry/flows`.
+
+| Endpoint | Auth | Behaviour |
+| --- | --- | --- |
+| GET `/v1/admin/registry-config` | admin session | Current repo + `hasToken`. **Never returns the token.** |
+| PUT `/v1/admin/registry-config` | admin session | Probe → copy → persist. `422` and **no write** if the probe fails. |
+| POST `/v1/admin/registry-config/sync` | admin session | Re-run the copy (idempotent by content). |
+| GET `/v1/admin/registry/flows` | admin session | Browse the org's repo. |
+| GET `/v1/registry/flows` | api_key | Proxy for a connected installation. |
+| POST `/v1/registry/flows/install` | api_key | Fetch one flow file for an installation to create locally. |
+
+Three properties are deliberate:
+
+- **Fail the save.** `probeWriteAccess` runs *before* anything is persisted. A
+  setting that saved but cannot be written to is worse than a rejected save —
+  the admin would believe the fleet points at a private repo that serves
+  nothing.
+- **The token lives on the hub.** Stored `encryptSecret`-encrypted in
+  `org_settings.registry_token_enc`, the same pattern as `auth_config`'s OAuth
+  secrets. It is never returned by any endpoint and never copied to a laptop.
+  Reads are authenticated with it because GitHub answers an anonymous fetch of
+  a private repo with `404` — without a hub-held token a private registry
+  simply cannot be served to a fleet.
+- **No silent public fall-back.** When the hub is unreachable, the local
+  server's `/registry/flows` returns `502` rather than falling back to the
+  public registry. An org that sealed itself away must never be shown the
+  community catalogue because the hub had a bad minute.
+
+The copy is **one-time**, not a mirror: it imports the community flows present
+at switch time. Moving back to the public repo needs **no reverse copy** — the
+community flows are already public, and writing them into a repo the org has no
+relationship with would leak the org's credential into the commit author.
+
+#### 6.1.1 Mutation testing: what the score does not say
+
+`flowRegistry.ts` finishes at **92.2%** mutation score (306/332 killed, 0
+uncovered); `adminFlowRegistry.ts` at **100%**. The 26 survivors are not 26
+holes, and the split matters more than the percentage.
+
+**Genuinely equivalent — unkillable by any test.** A guard whose removal
+changes nothing observable, because a check further down rejects the same bad
+input and produces the identical result:
+
+- `if (!resp.ok)` in the copy loop — GitHub error bodies are never valid flow
+  documents, so the `!flow?.name || !Array.isArray(flow.steps)` validation two
+  lines below fails the same file into the same `failed` entry. Deleting the
+  guard entirely still yields `{ copied: 0, failed: ['gone.json'] }`.
+- `typeof meta !== 'object'` in `probeWriteAccess` — an array or string body has
+  no string `full_name`, so the next clause rejects it with the same message.
+- `.catch(() => null)` → `undefined`, and the `?.` in `meta?.permissions?.push`
+  and `serializeRegistryFlow`'s `flow?.name` — callers validate before reaching
+  them, so `null` vs `undefined` never surfaces.
+
+These are defence in depth: they keep the *reason* for a failure legible and
+survive future edits to the checks below them, but no test can distinguish
+them. Killing them would mean asserting on internals that carry no behaviour.
+
+**Real gaps, found and fixed.** The first pass showed 38 survivors; ~20 tests
+were written against them and the score did not move. The tests were wrong:
+
+- Several let the fake `throw` on `PUT`, then asserted `failed: ['x.json']`. The
+  loop's `catch` records a thrown write under that same filename, so the test
+  passed against correct code **and** against the mutant — it could not fail.
+  Fixed by having the fake *record* writes and asserting `writeAttempts === []`:
+  the mechanism, not just the outcome.
+- A comment claimed a test killed `!flow?.name || ...` → `&&` while it killed
+  nothing. The comment was written from intent, not from a run.
+- `toMatchObject` hid extra fields; copy-result assertions now use `toEqual`.
+- A verification script checked the pre-mutation backup rather than the live
+  file, reporting "SURVIVED" for mutants it had never applied.
+
+`scripts/killcheck-cglab138.sh` is the fix for the last two: it applies one
+mutant, greps the **live** file to confirm the replacement landed, runs the
+tests, and prints KILLED / SURVIVED / NO-OP. Every claim above was made against
+that output rather than against a plausible reading of the code.
+
+A mutation score is only as honest as the tests behind it, and a test that
+reports the same result for correct and broken code is worse than no test — it
+looks like coverage.
+
 ---
 
 ## 7. Fleet upgrade flow (end to end)

--- a/HUB_ARCHITECTURE.md
+++ b/HUB_ARCHITECTURE.md
@@ -553,6 +553,28 @@ Flow definitions are authored in the hub admin UI (powered by
 `registry/flows` endpoint, set per-org defaults, and assign overrides at
 project scope.
 
+The editor's three footer controls are three unrelated writes, not a pipeline,
+and the hub host labels them to say so (`EDITOR_LABELS_HUB`):
+
+| Control | Writes | Reach |
+| --- | --- | --- |
+| **Save & publish to org** | `POST/PUT /v1/admin/flows/:id`, `version + 1` | every installation on its next poll |
+| **Set as org default** | `PUT /v1/admin/flow-assignments` (scope `org`) | installations with no more specific assignment |
+| **Publish** | — | **absent in the hub admin**; the hub holds the org's registry PAT and has no publish route, so the hub's `RegistryClient` omits the optional `publishToRegistry` and the button is not rendered |
+
+Two rules the editor now enforces, both because a control used to promise more
+than it did:
+
+- **Binding saves first.** "Set as org default" writes an assignment row for an
+  id. It used to bind `flow.id` immediately, so with unsaved edits in the panel
+  it assigned the version already on the server and reported success — the
+  admin's edits were dropped with no error. The save now resolves before the
+  bind, and a failed save means no bind.
+- **One footer, gated per capability.** The two footers used to be selected by
+  read-only-ness, which stranded a newly created flow (no id yet, so it took the
+  read-only branch) with neither Save — which lived in the other branch — nor
+  Publish, which that branch gated on `flow?.id`.
+
 ### 6.1 Per-org registry repo (CGLAB-138)
 
 By default every org browses the public community registry
@@ -883,7 +905,15 @@ The hub UI is a React/Vite SPA served by the hub itself. Its main views:
 - **Admin → Users** — invite admins/viewers, manage roles.
 - **Admin → Flows** — author/edit flow definitions (via
   `@agenfk/flow-editor`), assign them to org/project scope, install from
-  the community registry.
+  the community registry. **Saving a flow here is the publish**: the write
+  bumps `flows.version`, which is the ETag of `GET /v1/flows/active`, so every
+  installation picks it up on its next poll (§6). There is no separate publish
+  step and no Publish button — the hub holds the org's registry `contents:write`
+  PAT and exposes no route that spends it, so the hub's `RegistryClient`
+  simply omits `publishToRegistry` (optional on the interface) and the editor
+  hides the button. Authors who need to push a flow to a registry repo do it
+  from their own machine, where `gh` holds their credentials:
+  `agenfk flow publish <id> [--registry owner/repo]`.
 - **Admin → Installations** — list of every installation that has spoken
   to the hub, with their last-known running version and last-seen
   timestamp. Divergence between `agenfk_version` here and the

--- a/HUB_ARCHITECTURE.md
+++ b/HUB_ARCHITECTURE.md
@@ -567,7 +567,7 @@ Code: `packages/hub/src/services/flowRegistry.ts`, routes under
 | GET `/v1/admin/registry-config` | admin session | Current repo + `hasToken`. **Never returns the token.** |
 | PUT `/v1/admin/registry-config` | admin session | Probe → copy → persist. `422` and **no write** if the probe fails. |
 | POST `/v1/admin/registry-config/sync` | admin session | Re-run the copy (idempotent by content). |
-| GET `/v1/admin/registry/flows` | admin session | Browse the org's repo. |
+| GET `/v1/admin/registry/flows` | admin session | Browse a registry. `?source=org` (default) \| `community`. |
 | GET `/v1/registry/flows` | api_key | Proxy for a connected installation. |
 | POST `/v1/registry/flows/install` | api_key | Fetch one flow file for an installation to create locally. |
 
@@ -592,6 +592,43 @@ The copy is **one-time**, not a mirror: it imports the community flows present
 at switch time. Moving back to the public repo needs **no reverse copy** — the
 community flows are already public, and writing them into a repo the org has no
 relationship with would leak the org's credential into the commit author.
+
+#### 6.1.2 Browsing both registries
+
+`resolveRegistryRead` answers **one repo per org**, so after a switch to a
+private repo the real community catalogue becomes invisible and uninstallable
+from the hub UI. The one-time copy masks this at switch time (the org repo
+starts as a superset), but any flow published to community afterwards is
+unreachable.
+
+`resolveRegistrySource(db, orgId, secretKey, source)` adds a second axis:
+`source` is `'org' | 'community'`, absent meaning `'org'` for back-compat.
+
+Two rules, both load-bearing:
+
+- **The caller picks a SOURCE, never a repo.** This route holds the org's
+  `contents:write` PAT. Accepting `?repo=owner/name` would make it a proxy that
+  spends that credential against any repo the token can reach — a cross-tenant
+  read driven by a server-side secret. Only two names are reachable and both are
+  ones the server already knows; a `repo` in the query is ignored, and a
+  `source` that is not exactly `org` or `community` is a **400**, not a silent
+  fallback to the org repo (a stale client would otherwise show private flows
+  under a "Community" heading — the exact confusion the feature exists to
+  remove).
+- **`source=community` never sends the org token.** The PAT is scoped to the
+  org's repo; attaching it to a public cglab-owned repo leaks the credential to
+  a repo the org has no relationship with and into GitHub's access logs.
+  Anonymous is also simply what a public repo needs. Pinned by tests on both
+  browse and install.
+
+`source=community` keeps the org's configured **branch** — a second branch
+setting for the community repo would be left at `main` by everyone.
+
+The UI shows the switcher only when the org actually has a private registry
+(`showRegistrySourcePicker`); with one registry, two options that do the same
+thing read as a broken control. The shared `FlowEditorModal` gained two
+host-supplied, optional props — `tabLabels` and `registryToolbar` — so the
+standalone client is untouched and keeps its "My Flows" / "Community" wording.
 
 #### 6.1.1 Mutation testing: what the score does not say
 

--- a/bin/agenfk-pi-extension.ts
+++ b/bin/agenfk-pi-extension.ts
@@ -8,10 +8,15 @@
  *   • #1 PR-open reminder  — on tool_result(bash), classify `gh pr create` /
  *        `git push` via the shared agenfk-pr-hook.mjs and inject a steer message
  *        telling the agent to call register_pr/update_pr_sizing.
- *   • #2 Deterministic model — read the live model from ctx.getModel() (with
- *        model_select as a fallback) so the reminder carries the REAL model id +
- *        harness=pi instead of the agent guessing it (the recurring "reported the
- *        wrong model id" bug).
+ *   • #2 Deterministic model — resolve the model pi is ACTUALLY running from the
+ *        sources pi itself publishes (PI_PROVIDER/PI_MODEL on the bash tool env,
+ *        ctx.getModel(), model_select, the session transcript), so the reminder
+ *        carries the REAL model id + harness=pi instead of the agent guessing it.
+ *        ~/.pi/agent/settings.json is a LAST resort only: its defaultModel is the
+ *        STARTUP model read without its defaultProvider, so it goes stale on a
+ *        model switch and is not the live model (the recurring "reported the wrong
+ *        model id" bug — a pi/GLM session reported @cf/zai-org/glm-5.2 while its
+ *        own transcript recorded qwen38-flashnext).
  *   • #3 Enforcement parity — on tool_call(edit|write) delegate to agenfk-gatekeeper.mjs
  *        (block when no task is active) and on tool_call(bash) delegate to
  *        agenfk-mcp-enforcer.mjs (block direct-DB / curl-localhost bypass routes).
@@ -38,6 +43,15 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 
+/**
+ * IMPORTANT: this file is copied to ~/.pi/agent/extensions/agenfk.ts and loaded by
+ * pi's jiti WITHOUT node_modules, so it must stay dependency-free — no imports from
+ * @agenfk/* and no imports from pi's own packages. That is why the transcript is
+ * located through the PI_SESSION_FILE pi exports rather than by importing pi's
+ * session-manager: if that variable is absent (ephemeral sessions, non-pi shells)
+ * readPiSessionModel degrades to null — a missed source, never a wrong model.
+ */
+
 // Minimal local typings — pi ships richer types via @earendil-works/pi-coding-agent,
 // but we avoid importing it so the file loads with zero dependencies.
 interface PiModel { provider?: string; id?: string }
@@ -63,11 +77,13 @@ export interface PiExtensionDeps {
   gatekeeperVerdict: (filePath: string | undefined) => BlockVerdict | null;
   enforcerVerdict: (command: string | undefined) => BlockVerdict | null;
   prReminder: (command: string | undefined) => ReminderResult | null;
-  // The model pi is configured to run, read from ~/.pi/agent/settings.json. This
-  // is the ONLY reliable source in live pi: ctx.getModel() is often undefined and
-  // model_select does not fire for the config-default model, so without this the
-  // model never reaches the PR reminder / command rewrite.
+  // pi's STARTUP model from ~/.pi/agent/settings.json. LAST resort: it carries no
+  // provider and goes stale on a model switch, so the sources below outrank it.
   readDefaultModel: () => string | null;
+  // The model that actually answered, from pi's session transcript (PI_SESSION_FILE).
+  readTranscriptModel: () => string | null;
+  // The model pi attributes to the command being run (PI_PROVIDER/PI_MODEL).
+  readEnvModel: () => string | null;
 }
 
 const HOOK_DIR = path.join(os.homedir(), '.agenfk', 'bin');
@@ -75,9 +91,100 @@ const HOOK_DIR = path.join(os.homedir(), '.agenfk', 'bin');
 // ── Pure helpers (exported for tests) ────────────────────────────────────────
 
 /**
+ * The model pi reports for the command it is running, from PI_PROVIDER + PI_MODEL.
+ * pi sets these per bash command from its live ctx.model and re-resolves them on a
+ * model switch (dist/core/tools/bash.js; docs/environment-variables.md), so this is
+ * the freshest source available to a hook. Returns `provider/model` when pi told us
+ * both, else the bare PI_MODEL, else null.
+ *
+ * The provider is kept because settings.json splits the model across TWO keys
+ * (defaultProvider + defaultModel), so a bare id alone is ambiguous — the same
+ * `qwen3.8:27b` can exist under several providers.
+ */
+export function envModel(env: Record<string, string | undefined> | undefined | null): string | null {
+  const model = (env?.PI_MODEL ?? '').trim();
+  if (!model) return null;
+  const provider = (env?.PI_PROVIDER ?? '').trim();
+  return provider ? `${provider}/${model}` : model;
+}
+
+/** Assemble `provider/model` (or the bare id when no provider is known). */
+function joinModel(provider: unknown, model: unknown): string | null {
+  const m = typeof model === 'string' ? model.trim() : '';
+  if (!m) return null;
+  const p = typeof provider === 'string' ? provider.trim() : '';
+  return p ? `${p}/${m}` : m;
+}
+
+/**
+ * Read the model from pi's own session transcript — the record of which model
+ * actually answered. Scans from the END so the newest signal wins, and a
+ * `model_change` entry (written when the user switches mid-session) outranks
+ * assistant messages before it. Pass a reader for tests.
+ *
+ * Cost is bounded: only the last 256KB of the file is read, and the result is
+ * cached per file for a couple of seconds (see defaultDeps), so a burst of bash
+ * calls does not re-read a transcript that only grows.
+ */
+export function readPiSessionModel(
+  read: () => string = () => {
+    const file = process.env.PI_SESSION_FILE;
+    if (!file) return '';
+    // statSync FIRST and check it is a regular file BEFORE opening. This runs
+    // synchronously inside pi's own process, so opening a FIFO would block pi
+    // outright (open() on a FIFO with no writer never returns) and a huge file
+    // would be allocated into memory. Either way we return '' (a missed source),
+    // never a wrong model.
+    const st = fs.statSync(file);
+    if (!st.isFile()) return '';
+    const start = Math.max(0, st.size - 262_144);
+    const fd = fs.openSync(file, 'r');
+    try {
+      const buf = Buffer.alloc(st.size - start);
+      fs.readSync(fd, buf, 0, buf.length, start);
+      // Drop a leading partial line from the mid-file seek.
+      return buf.toString('utf8').replace(/^[^\n]*\n/, '');
+    } finally {
+      fs.closeSync(fd);
+    }
+  },
+): string | null {
+  try {
+    const text = read();
+    if (!text) return null;
+    const lines = text.split('\n');
+    for (let i = lines.length - 1; i >= 0; i -= 1) {
+      const line = lines[i].trim();
+      if (!line) continue;
+      let entry: any;
+      try {
+        entry = JSON.parse(line);
+      } catch {
+        continue; // a truncated tail or malformed line must not lose the whole read
+      }
+      if (entry?.type === 'model_change') {
+        const found = joinModel(entry.provider, entry.modelId);
+        if (found) return found;
+        continue;
+      }
+      if (entry?.type === 'message' && entry.message?.role === 'assistant') {
+        const found = joinModel(entry.message.provider, entry.message.model);
+        if (found) return found;
+      }
+    }
+    return null;
+  } catch {
+    return null; // never break the host on a transcript read
+  }
+}
+
+/**
  * Read pi's configured model (`defaultModel`) from ~/.pi/agent/settings.json.
  * Returns the bare model id (e.g. "@cf/zai-org/glm-5.2") or null. Never throws —
  * a missing/unreadable/garbage file yields null. The reader is injectable for tests.
+ *
+ * LAST-RESORT source: this is pi's STARTUP model and it carries no provider, so it
+ * is wrong after a model switch and ambiguous across providers.
  */
 export function readPiDefaultModel(
   read: () => string = () => fs.readFileSync(path.join(os.homedir(), '.pi', 'agent', 'settings.json'), 'utf8'),
@@ -92,23 +199,45 @@ export function readPiDefaultModel(
 }
 
 /**
- * Resolve the BARE model id (not provider/id) from the most reliable source:
- *   1. ctx.getModel().id   — the live model, when pi exposes it
+ * Resolve the model from the most reliable source, best first:
+ *   0. env()               — PI_PROVIDER/PI_MODEL, which pi re-resolves per command
+ *   1. ctx.getModel()      — the live model, when pi exposes it (rare in live pi)
  *   2. lastSelected        — cached from a model_select event
- *   3. readDefault()       — ~/.pi/agent/settings.json defaultModel (the live-pi
- *                            fallback, since 1 & 2 are usually unavailable there)
- * Bare id keeps reporting consistent with settings.json and the claude-code
- * convention (e.g. "claude-opus-4-8"), avoiding a redundant provider prefix.
+ *   3. readTranscript()    — pi's session jsonl: the model that actually answered
+ *   4. readDefault()       — settings.json defaultModel, the stale/ambiguous last resort
+ *
+ * Returns `provider/model` when the source knows a provider, else the bare id. The
+ * hub strips router/provider prefixes when matching a model id
+ * (packages/hub/src/util/modelMeta.ts `normaliseModelId`), so the qualified form
+ * still classifies downstream.
  */
-export function resolveModelId(
-  ctx: PiContext | undefined,
-  lastSelected: string | null,
-  readDefault: () => string | null = readPiDefaultModel,
-): string | null {
-  const live = ctx && ctx.getModel ? ctx.getModel() : undefined;
-  if (live && live.id) return String(live.id);
+export function resolveModelSource(sources: {
+  ctx: PiContext | undefined;
+  lastSelected: string | null;
+  readDefault: () => string | null;
+  readTranscript?: () => string | null;
+  env?: () => string | null;
+}): string | null {
+  const { ctx, lastSelected, readDefault } = sources;
+  try {
+    const fromEnv = sources.env ? sources.env() : null;
+    if (fromEnv) return fromEnv;
+  } catch { /* fall through */ }
+  try {
+    const live = ctx && ctx.getModel ? ctx.getModel() : undefined;
+    const fromCtx = live ? joinModel(live.provider, live.id) : null;
+    if (fromCtx) return fromCtx;
+  } catch { /* fall through */ }
   if (lastSelected) return lastSelected;
-  return readDefault();
+  try {
+    const fromTranscript = sources.readTranscript ? sources.readTranscript() : null;
+    if (fromTranscript) return fromTranscript;
+  } catch { /* fall through */ }
+  try {
+    return readDefault();
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -123,6 +252,137 @@ export function composeReminder(baseMessage: string, model: string | null): stri
     `When you call register_pr/update_pr_sizing, pass model = "${model}" and harness = "pi" ` +
     `(CLI: \`agenfk pr-register … --model ${model} --harness pi\`). Do not guess the model.`
   );
+}
+
+/**
+ * Decide which `--model` value an agenfk PR command should carry, WITHOUT clobbering
+ * a model the agent already reported correctly.
+ *
+ * The agent's own `--model` counts as agreement when it matches the detected model
+ * on the artifact name — the suffix after the last `/`, the same axis the hub
+ * matches on. So `qwen38-flashnext` satisfies a detected `coding4/qwen38-flashnext`
+ * and vice versa, and no flags are appended at all. Only a CONTRADICTING value is
+ * overridden (appended last so commander last-wins picks the detected model).
+ *
+ * Returns the model to inject, or null when the command needs no rewrite.
+ */
+export function preferredModelArg(command: string, model: string | null): string | null {
+  if (!command || !model) return null;
+  const reported = reportedModelArg(command);
+  if (reported && modelSuffix(reported) === modelSuffix(model)) return null;
+  return model;
+}
+
+/**
+ * The artifact name a model id identifies: everything after the last `/`, lowercased.
+ * The prefix names the route (`@cf/…` on Cloudflare Workers AI, `anthropic/…` on
+ * OpenRouter), not the model — the same convention the hub matches on.
+ */
+function modelSuffix(id: string): string {
+  const t = id.trim();
+  const slash = t.lastIndexOf('/');
+  return (slash >= 0 ? t.slice(slash + 1) : t).toLowerCase();
+}
+
+/**
+ * The value of the last top-level `--model` in a command, or null when it has none.
+ * Scans only OUTSIDE quotes (a `--model` inside a `--body` is prose, not a flag) and
+ * only up to the first top-level shell operator (a `--model` in a later pipeline
+ * stage belongs to that stage). The value is read as ONE shell word, so a quoted
+ * value containing a space is taken whole.
+ */
+function reportedModelArg(command: string): string | null {
+  const chars = [...command];
+  const cut = topLevelOperator(command);
+  let reported: string | null = null;
+  let quote: string | null = null;
+  let i = 0;
+  while (i < cut) {
+    const ch = chars[i];
+    if (quote) {
+      // Inside a quoted run: consume it, never match a flag in it.
+      if (ch === '\\' && quote === '"') { i += 2; continue; }
+      if (ch === quote) quote = null;
+      i += 1;
+      continue;
+    }
+    if (ch === '\\') { i += 2; continue; }
+    if (ch === '"' || ch === "'") { quote = ch; i += 1; continue; }
+    if (isFlagAt(chars, i, cut, '--model')) {
+      const [value, end] = readShellWord(chars, i + '--model'.length, cut);
+      reported = value.trim() || null; // last occurrence wins (commander semantics)
+      i = end;
+      continue;
+    }
+    i += 1;
+  }
+  return reported;
+}
+
+/** True when `--flag` starts at i as a whole flag (not a prefix like --modelname). */
+function isFlagAt(chars: string[], i: number, cut: number, flag: string): boolean {
+  if (i + flag.length > cut) return false;
+  for (let k = 0; k < flag.length; k += 1) {
+    if (chars[i + k] !== flag[k]) return false;
+  }
+  const after = chars[i + flag.length];
+  return after === undefined || after === '=' || /\s/.test(after);
+}
+
+/**
+ * Read one shell word starting at `from` (skipping leading spaces, honouring an
+ * optional `=`, quotes and backslash escapes), stopping at whitespace, a top-level
+ * operator, or `cut`. Returns the unquoted value and the index just past it.
+ */
+function readShellWord(chars: string[], from: number, cut: number): [string, number] {
+  let j = from;
+  if (chars[j] === '=') j += 1;
+  while (j < cut && /\s/.test(chars[j])) j += 1;
+  let value = '';
+  let quote: string | null = null;
+  while (j < cut) {
+    const c = chars[j];
+    if (quote) {
+      if (c === '\\' && quote === '"') { j += 1; value += chars[j] ?? ''; j += 1; continue; }
+      if (c === quote) { quote = null; j += 1; continue; }
+      value += c; j += 1; continue;
+    }
+    if (c === '\\') { j += 1; value += chars[j] ?? ''; j += 1; continue; }
+    if (c === '"' || c === "'") { quote = c; j += 1; continue; }
+    if (/\s/.test(c) || SHELL_OPERATORS.has(c)) break;
+    value += c; j += 1;
+  }
+  return [value, j];
+}
+
+const SHELL_OPERATORS = new Set(['|', ';', '&', '>', '<']);
+
+/**
+ * Index of the first TOP-LEVEL (unquoted) shell operator in a command, or its
+ * length when there is none. Honours single/double quotes and backslash escapes,
+ * and backs up over a file descriptor so `2>&1` is cut before the `2`.
+ */
+function topLevelOperator(command: string): number {
+  const chars = [...command];
+  let quote: string | null = null;
+  for (let i = 0; i < chars.length; i += 1) {
+    const ch = chars[i];
+    if (quote) {
+      if (ch === '\\' && quote === '"') { i += 1; continue; }
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '\\') { i += 1; continue; }
+    if (ch === '"' || ch === "'") { quote = ch; continue; }
+    if (SHELL_OPERATORS.has(ch)) {
+      let cut = i;
+      if (ch === '>' || ch === '<') {
+        while (cut > 0 && /\d/.test(chars[cut - 1])) cut -= 1;
+      }
+      return cut;
+    }
+  }
+  return chars.length;
 }
 
 /**
@@ -149,36 +409,18 @@ export function injectDeterministicModel(command: string, model: string | null):
   // Must be the leading command (not piped-into / embedded / echoed).
   if (!/^\s*agenfk\s+pr(\s+create|-register|-resize)\b/.test(command)) return command;
 
-  // Find the first top-level shell operator, honoring single/double quotes and
-  // backslash escapes, so we insert the flags as args of the agenfk command
-  // rather than after a pipe and never split an escaped quote inside --body.
-  let quote: string | null = null;
-  let cut = command.length;
-  for (let i = 0; i < command.length; i += 1) {
-    const ch = command[i];
-    if (quote) {
-      // In double quotes (and unquoted) a backslash escapes the next char; in
-      // single quotes a backslash is literal (no escaping), per POSIX shell.
-      if (ch === '\\' && quote === '"') { i += 1; continue; }
-      if (ch === quote) quote = null;
-      continue;
-    }
-    if (ch === '\\') { i += 1; continue; } // escaped char outside quotes
-    if (ch === '"' || ch === "'") { quote = ch; continue; }
-    if (ch === '|' || ch === ';' || ch === '&' || ch === '>' || ch === '<') {
-      cut = i;
-      // A redirect can carry a leading file descriptor (e.g. `2>&1`): back up over
-      // those digits so we cut before the fd, not in the middle of the operator.
-      if (ch === '>' || ch === '<') {
-        while (cut > 0 && /\d/.test(command[cut - 1])) cut -= 1;
-      }
-      break;
-    }
-  }
+  // Cut at the first top-level shell operator (shared with preferredModelArg, so
+  // the two can never disagree about which `--model` is ours). This keeps the flags
+  // as args of the agenfk command rather than after a pipe, and never splits an
+  // escaped quote inside --body.
+  const cut = topLevelOperator(command);
 
   const head = command.slice(0, cut).replace(/\s+$/, '');
   const tail = command.slice(cut); // shell operator + rest (or '')
-  const injected = `${head} --model ${model} --harness pi`;
+  // Do not append a duplicate when the agent already reported this model.
+  const toInject = preferredModelArg(command, model);
+  if (!toInject) return command;
+  const injected = `${head} --model ${toInject} --harness pi`;
   return tail ? `${injected} ${tail.replace(/^\s+/, '')}` : injected;
 }
 
@@ -202,15 +444,35 @@ function runHookScript(script: string, argv: string[], stdin: unknown): any | nu
 }
 
 export function defaultDeps(): PiExtensionDeps {
-  // settings.json is read at most once per process: in live pi this is consulted
-  // on most bash ops (getModel()/model_select are usually unavailable), and the
-  // file rarely changes mid-session — an interactive model switch fires
-  // model_select, whose cached id takes precedence over this fallback anyway.
+  // settings.json is read at most once per process — it is the last resort and
+  // changes only when the user edits it by hand. The fresher sources are NOT
+  // memoised that way: env is read per event (pi re-resolves it on every model
+  // switch) and the transcript is re-read on a short TTL so a mid-session switch
+  // is picked up instead of being cached wrong for the whole session.
   let cachedDefault: string | null | undefined;
   const readDefaultModel = () => {
     if (cachedDefault === undefined) cachedDefault = readPiDefaultModel();
     return cachedDefault;
   };
+
+  const TRANSCRIPT_TTL_MS = 2_000;
+  let transcriptCache: { at: number; file: string; value: string | null } | null = null;
+  const readTranscriptModel = () => {
+    const file = process.env.PI_SESSION_FILE;
+    if (!file) return null;
+    const now = Date.now();
+    // The TTL cache is keyed on the FILE as well as the clock: pi switches this
+    // variable when the session changes (/resume, /new, fork), and a cache that
+    // ignored it would keep reporting the PREVIOUS session's model for the rest
+    // of the TTL.
+    if (transcriptCache && transcriptCache.file === file && now - transcriptCache.at < TRANSCRIPT_TTL_MS) {
+      return transcriptCache.value;
+    }
+    const value = readPiSessionModel();
+    transcriptCache = { at: now, file, value };
+    return value;
+  };
+
   return {
     gatekeeperVerdict: (filePath) =>
       filePath
@@ -228,17 +490,26 @@ export function defaultDeps(): PiExtensionDeps {
         ? runHookScript('agenfk-pr-hook.mjs', ['--client', 'pi'], { args: { command } })
         : null,
     readDefaultModel,
+    readTranscriptModel,
+    readEnvModel: () => envModel(process.env),
   };
 }
 
 // ── Extension entry point ────────────────────────────────────────────────────
 
 export default function activate(pi: PiApi, deps: PiExtensionDeps = defaultDeps()): void {
-  // Cache the most recent model_select id (bare). resolveModelId prefers the live
-  // ctx.getModel(), then this cache, then ~/.pi/agent/settings.json (deps.readDefaultModel).
+  // Cache the most recent model_select id. resolveModelSource prefers the live
+  // per-command env, then ctx.getModel(), then this cache, then the transcript,
+  // and only then ~/.pi/agent/settings.json (deps.readDefaultModel).
   let lastSelectedModel: string | null = null;
   const modelFor = (ctx: PiContext | undefined) =>
-    resolveModelId(ctx, lastSelectedModel, deps.readDefaultModel);
+    resolveModelSource({
+      ctx,
+      lastSelected: lastSelectedModel,
+      readDefault: deps.readDefaultModel,
+      readTranscript: deps.readTranscriptModel,
+      env: deps.readEnvModel,
+    });
 
   pi.on('model_select', (event) => {
     try { const id = event?.model?.id; if (id) lastSelectedModel = String(id); } catch { /* ignore */ }

--- a/clauderules/CLAUDE.md
+++ b/clauderules/CLAUDE.md
@@ -176,7 +176,7 @@ This is the full workflow surface. Each row notes the equivalent MCP tool (avail
 | Resume integration(s) | `agenfk integration resume <platform\|all> [-y/--yes]` |
 | Install/uninstall workflow rules & skills | `agenfk skills install [-g/--global][-p/--project]` · `agenfk skills uninstall [-g/--global][-p/--project]` · `agenfk skills status` |
 | Enable/disable telemetry | `agenfk config set telemetry <true\|false>` |
-| Set the community flow registry | `agenfk config set flowRegistry <owner/repo>` |
+| Set the community flow registry (local only — a Hub-connected org follows its admin's setting) | `agenfk config set flowRegistry <owner/repo>` |
 | Configure JIRA OAuth | `agenfk jira setup` · `agenfk jira status` · `agenfk jira disconnect` |
 | Configure GitHub Issues import | `agenfk github setup [--owner <owner>][--repo <repo>]` · `agenfk github status` · `agenfk github disconnect` |
 

--- a/codexrules/AGENTS.md
+++ b/codexrules/AGENTS.md
@@ -193,7 +193,7 @@ This is the full workflow surface. In Codex, call the **`mcp__agenfk__*` tool** 
 | Resume integration(s) | `agenfk integration resume <platform\|all> [-y/--yes]` |
 | Install/uninstall workflow rules & skills | `agenfk skills install [-g/--global][-p/--project]` · `agenfk skills uninstall [-g/--global][-p/--project]` · `agenfk skills status` |
 | Enable/disable telemetry | `agenfk config set telemetry <true\|false>` |
-| Set the community flow registry | `agenfk config set flowRegistry <owner/repo>` |
+| Set the community flow registry (local only — a Hub-connected org follows its admin's setting) | `agenfk config set flowRegistry <owner/repo>` |
 | Configure JIRA OAuth | `agenfk jira setup` · `agenfk jira status` · `agenfk jira disconnect` |
 | Configure GitHub Issues import | `agenfk github setup [--owner <owner>][--repo <repo>]` · `agenfk github status` · `agenfk github disconnect` |
 

--- a/geminirules/GEMINI.md
+++ b/geminirules/GEMINI.md
@@ -180,7 +180,7 @@ This is the full workflow surface. Each row notes the equivalent MCP tool (avail
 | Resume integration(s) | `agenfk integration resume <platform\|all> [-y/--yes]` |
 | Install/uninstall workflow rules & skills | `agenfk skills install [-g/--global][-p/--project]` · `agenfk skills uninstall [-g/--global][-p/--project]` · `agenfk skills status` |
 | Enable/disable telemetry | `agenfk config set telemetry <true\|false>` |
-| Set the community flow registry | `agenfk config set flowRegistry <owner/repo>` |
+| Set the community flow registry (local only — a Hub-connected org follows its admin's setting) | `agenfk config set flowRegistry <owner/repo>` |
 | Configure JIRA OAuth | `agenfk jira setup` · `agenfk jira status` · `agenfk jira disconnect` |
 | Configure GitHub Issues import | `agenfk github setup [--owner <owner>][--repo <repo>]` · `agenfk github status` · `agenfk github disconnect` |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenfk",
-  "version": "1.1.18-beta.1",
+  "version": "1.1.18-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenfk",
-      "version": "1.1.18-beta.1",
+      "version": "1.1.18-beta.2",
       "license": "ISC",
       "workspaces": [
         "packages/core",
@@ -13332,11 +13332,11 @@
     },
     "packages/cli": {
       "name": "@agenfk/cli",
-      "version": "1.1.18-beta.1",
+      "version": "1.1.18-beta.2",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.1.18-beta.1",
-        "@agenfk/telemetry": "1.1.18-beta.1",
+        "@agenfk/core": "1.1.18-beta.2",
+        "@agenfk/telemetry": "1.1.18-beta.2",
         "axios": "^1.20.0",
         "chalk": "^4.1.2",
         "commander": "^12.0.0",
@@ -13356,7 +13356,7 @@
     },
     "packages/core": {
       "name": "@agenfk/core",
-      "version": "1.1.18-beta.1",
+      "version": "1.1.18-beta.2",
       "license": "ISC",
       "devDependencies": {
         "typescript": "^5.3.3"
@@ -13364,7 +13364,7 @@
     },
     "packages/create": {
       "name": "agenfk",
-      "version": "1.1.18-beta.1",
+      "version": "1.1.18-beta.2",
       "license": "ISC",
       "bin": {
         "agenfk": "bin/agenfk.js"
@@ -13375,7 +13375,7 @@
     },
     "packages/flow-editor": {
       "name": "@agenfk/flow-editor",
-      "version": "1.1.18-beta.1",
+      "version": "1.1.18-beta.2",
       "peerDependencies": {
         "@tanstack/react-query": "^5.102.8",
         "clsx": "^2.1.1",
@@ -13389,9 +13389,9 @@
     },
     "packages/hub": {
       "name": "@agenfk/hub",
-      "version": "1.1.18-beta.1",
+      "version": "1.1.18-beta.2",
       "dependencies": {
-        "@agenfk/core": "1.1.18-beta.1",
+        "@agenfk/core": "1.1.18-beta.2",
         "axios": "^1.20.0",
         "bcryptjs": "^2.4.3",
         "cookie-parser": "^1.4.7",
@@ -13415,9 +13415,9 @@
       }
     },
     "packages/hub-ui": {
-      "version": "1.1.18-beta.1",
+      "version": "1.1.18-beta.2",
       "dependencies": {
-        "@agenfk/flow-editor": "1.1.18-beta.1",
+        "@agenfk/flow-editor": "1.1.18-beta.2",
         "@fontsource-variable/jetbrains-mono": "^5.3.0",
         "@fontsource-variable/manrope": "^5.3.0",
         "@tailwindcss/postcss": "^4.3.3",
@@ -13793,12 +13793,12 @@
     },
     "packages/server": {
       "name": "@agenfk/server",
-      "version": "1.1.18-beta.1",
+      "version": "1.1.18-beta.2",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.1.18-beta.1",
-        "@agenfk/storage-sqlite": "1.1.18-beta.1",
-        "@agenfk/telemetry": "1.1.18-beta.1",
+        "@agenfk/core": "1.1.18-beta.2",
+        "@agenfk/storage-sqlite": "1.1.18-beta.2",
+        "@agenfk/telemetry": "1.1.18-beta.2",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "axios": "^1.20.0",
         "body-parser": "^2.3.0",
@@ -13821,13 +13821,13 @@
     },
     "packages/storage-sqlite": {
       "name": "@agenfk/storage-sqlite",
-      "version": "1.1.18-beta.1",
+      "version": "1.1.18-beta.2",
       "license": "ISC",
       "dependencies": {
         "uuid": "^14.0.2"
       },
       "devDependencies": {
-        "@agenfk/core": "1.1.18-beta.1",
+        "@agenfk/core": "1.1.18-beta.2",
         "@types/node": "^22.0.0",
         "@types/uuid": "^9.0.8",
         "typescript": "^5.3.3"
@@ -13845,7 +13845,7 @@
     },
     "packages/telemetry": {
       "name": "@agenfk/telemetry",
-      "version": "1.1.18-beta.1",
+      "version": "1.1.18-beta.2",
       "license": "ISC",
       "dependencies": {
         "posthog-node": "^4.0.0"
@@ -13856,9 +13856,9 @@
       }
     },
     "packages/ui": {
-      "version": "1.1.18-beta.1",
+      "version": "1.1.18-beta.2",
       "dependencies": {
-        "@agenfk/flow-editor": "1.1.18-beta.1",
+        "@agenfk/flow-editor": "1.1.18-beta.2",
         "@fontsource-variable/jetbrains-mono": "^5.3.0",
         "@fontsource-variable/manrope": "^5.3.0",
         "@tailwindcss/postcss": "^4.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenfk",
-  "version": "1.1.17",
+  "version": "1.1.18-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenfk",
-      "version": "1.1.17",
+      "version": "1.1.18-beta.1",
       "license": "ISC",
       "workspaces": [
         "packages/core",
@@ -13332,11 +13332,11 @@
     },
     "packages/cli": {
       "name": "@agenfk/cli",
-      "version": "1.1.17",
+      "version": "1.1.18-beta.1",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.1.17",
-        "@agenfk/telemetry": "1.1.17",
+        "@agenfk/core": "1.1.18-beta.1",
+        "@agenfk/telemetry": "1.1.18-beta.1",
         "axios": "^1.20.0",
         "chalk": "^4.1.2",
         "commander": "^12.0.0",
@@ -13356,7 +13356,7 @@
     },
     "packages/core": {
       "name": "@agenfk/core",
-      "version": "1.1.17",
+      "version": "1.1.18-beta.1",
       "license": "ISC",
       "devDependencies": {
         "typescript": "^5.3.3"
@@ -13364,7 +13364,7 @@
     },
     "packages/create": {
       "name": "agenfk",
-      "version": "1.1.17",
+      "version": "1.1.18-beta.1",
       "license": "ISC",
       "bin": {
         "agenfk": "bin/agenfk.js"
@@ -13375,7 +13375,7 @@
     },
     "packages/flow-editor": {
       "name": "@agenfk/flow-editor",
-      "version": "1.1.17",
+      "version": "1.1.18-beta.1",
       "peerDependencies": {
         "@tanstack/react-query": "^5.102.8",
         "clsx": "^2.1.1",
@@ -13389,9 +13389,9 @@
     },
     "packages/hub": {
       "name": "@agenfk/hub",
-      "version": "1.1.17",
+      "version": "1.1.18-beta.1",
       "dependencies": {
-        "@agenfk/core": "1.1.17",
+        "@agenfk/core": "1.1.18-beta.1",
         "axios": "^1.20.0",
         "bcryptjs": "^2.4.3",
         "cookie-parser": "^1.4.7",
@@ -13415,9 +13415,9 @@
       }
     },
     "packages/hub-ui": {
-      "version": "1.1.17",
+      "version": "1.1.18-beta.1",
       "dependencies": {
-        "@agenfk/flow-editor": "1.1.17",
+        "@agenfk/flow-editor": "1.1.18-beta.1",
         "@fontsource-variable/jetbrains-mono": "^5.3.0",
         "@fontsource-variable/manrope": "^5.3.0",
         "@tailwindcss/postcss": "^4.3.3",
@@ -13793,12 +13793,12 @@
     },
     "packages/server": {
       "name": "@agenfk/server",
-      "version": "1.1.17",
+      "version": "1.1.18-beta.1",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.1.17",
-        "@agenfk/storage-sqlite": "1.1.17",
-        "@agenfk/telemetry": "1.1.17",
+        "@agenfk/core": "1.1.18-beta.1",
+        "@agenfk/storage-sqlite": "1.1.18-beta.1",
+        "@agenfk/telemetry": "1.1.18-beta.1",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "axios": "^1.20.0",
         "body-parser": "^2.3.0",
@@ -13821,13 +13821,13 @@
     },
     "packages/storage-sqlite": {
       "name": "@agenfk/storage-sqlite",
-      "version": "1.1.17",
+      "version": "1.1.18-beta.1",
       "license": "ISC",
       "dependencies": {
         "uuid": "^14.0.2"
       },
       "devDependencies": {
-        "@agenfk/core": "1.1.17",
+        "@agenfk/core": "1.1.18-beta.1",
         "@types/node": "^22.0.0",
         "@types/uuid": "^9.0.8",
         "typescript": "^5.3.3"
@@ -13845,7 +13845,7 @@
     },
     "packages/telemetry": {
       "name": "@agenfk/telemetry",
-      "version": "1.1.17",
+      "version": "1.1.18-beta.1",
       "license": "ISC",
       "dependencies": {
         "posthog-node": "^4.0.0"
@@ -13856,9 +13856,9 @@
       }
     },
     "packages/ui": {
-      "version": "1.1.17",
+      "version": "1.1.18-beta.1",
       "dependencies": {
-        "@agenfk/flow-editor": "1.1.17",
+        "@agenfk/flow-editor": "1.1.18-beta.1",
         "@fontsource-variable/jetbrains-mono": "^5.3.0",
         "@fontsource-variable/manrope": "^5.3.0",
         "@tailwindcss/postcss": "^4.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenfk",
-  "version": "1.1.18-beta.3",
+  "version": "1.1.18-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenfk",
-      "version": "1.1.18-beta.3",
+      "version": "1.1.18-beta.4",
       "license": "ISC",
       "workspaces": [
         "packages/core",
@@ -13332,11 +13332,11 @@
     },
     "packages/cli": {
       "name": "@agenfk/cli",
-      "version": "1.1.18-beta.3",
+      "version": "1.1.18-beta.4",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.1.18-beta.3",
-        "@agenfk/telemetry": "1.1.18-beta.3",
+        "@agenfk/core": "1.1.18-beta.4",
+        "@agenfk/telemetry": "1.1.18-beta.4",
         "axios": "^1.20.0",
         "chalk": "^4.1.2",
         "commander": "^12.0.0",
@@ -13356,7 +13356,7 @@
     },
     "packages/core": {
       "name": "@agenfk/core",
-      "version": "1.1.18-beta.3",
+      "version": "1.1.18-beta.4",
       "license": "ISC",
       "devDependencies": {
         "typescript": "^5.3.3"
@@ -13364,7 +13364,7 @@
     },
     "packages/create": {
       "name": "agenfk",
-      "version": "1.1.18-beta.3",
+      "version": "1.1.18-beta.4",
       "license": "ISC",
       "bin": {
         "agenfk": "bin/agenfk.js"
@@ -13375,7 +13375,7 @@
     },
     "packages/flow-editor": {
       "name": "@agenfk/flow-editor",
-      "version": "1.1.18-beta.3",
+      "version": "1.1.18-beta.4",
       "peerDependencies": {
         "@tanstack/react-query": "^5.102.8",
         "clsx": "^2.1.1",
@@ -13389,9 +13389,9 @@
     },
     "packages/hub": {
       "name": "@agenfk/hub",
-      "version": "1.1.18-beta.3",
+      "version": "1.1.18-beta.4",
       "dependencies": {
-        "@agenfk/core": "1.1.18-beta.3",
+        "@agenfk/core": "1.1.18-beta.4",
         "axios": "^1.20.0",
         "bcryptjs": "^2.4.3",
         "cookie-parser": "^1.4.7",
@@ -13415,9 +13415,9 @@
       }
     },
     "packages/hub-ui": {
-      "version": "1.1.18-beta.3",
+      "version": "1.1.18-beta.4",
       "dependencies": {
-        "@agenfk/flow-editor": "1.1.18-beta.3",
+        "@agenfk/flow-editor": "1.1.18-beta.4",
         "@fontsource-variable/jetbrains-mono": "^5.3.0",
         "@fontsource-variable/manrope": "^5.3.0",
         "@tailwindcss/postcss": "^4.3.3",
@@ -13793,12 +13793,12 @@
     },
     "packages/server": {
       "name": "@agenfk/server",
-      "version": "1.1.18-beta.3",
+      "version": "1.1.18-beta.4",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.1.18-beta.3",
-        "@agenfk/storage-sqlite": "1.1.18-beta.3",
-        "@agenfk/telemetry": "1.1.18-beta.3",
+        "@agenfk/core": "1.1.18-beta.4",
+        "@agenfk/storage-sqlite": "1.1.18-beta.4",
+        "@agenfk/telemetry": "1.1.18-beta.4",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "axios": "^1.20.0",
         "body-parser": "^2.3.0",
@@ -13821,13 +13821,13 @@
     },
     "packages/storage-sqlite": {
       "name": "@agenfk/storage-sqlite",
-      "version": "1.1.18-beta.3",
+      "version": "1.1.18-beta.4",
       "license": "ISC",
       "dependencies": {
         "uuid": "^14.0.2"
       },
       "devDependencies": {
-        "@agenfk/core": "1.1.18-beta.3",
+        "@agenfk/core": "1.1.18-beta.4",
         "@types/node": "^22.0.0",
         "@types/uuid": "^9.0.8",
         "typescript": "^5.3.3"
@@ -13845,7 +13845,7 @@
     },
     "packages/telemetry": {
       "name": "@agenfk/telemetry",
-      "version": "1.1.18-beta.3",
+      "version": "1.1.18-beta.4",
       "license": "ISC",
       "dependencies": {
         "posthog-node": "^4.0.0"
@@ -13856,9 +13856,9 @@
       }
     },
     "packages/ui": {
-      "version": "1.1.18-beta.3",
+      "version": "1.1.18-beta.4",
       "dependencies": {
-        "@agenfk/flow-editor": "1.1.18-beta.3",
+        "@agenfk/flow-editor": "1.1.18-beta.4",
         "@fontsource-variable/jetbrains-mono": "^5.3.0",
         "@fontsource-variable/manrope": "^5.3.0",
         "@tailwindcss/postcss": "^4.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenfk",
-  "version": "1.1.18-beta.2",
+  "version": "1.1.18-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenfk",
-      "version": "1.1.18-beta.2",
+      "version": "1.1.18-beta.3",
       "license": "ISC",
       "workspaces": [
         "packages/core",
@@ -13332,11 +13332,11 @@
     },
     "packages/cli": {
       "name": "@agenfk/cli",
-      "version": "1.1.18-beta.2",
+      "version": "1.1.18-beta.3",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.1.18-beta.2",
-        "@agenfk/telemetry": "1.1.18-beta.2",
+        "@agenfk/core": "1.1.18-beta.3",
+        "@agenfk/telemetry": "1.1.18-beta.3",
         "axios": "^1.20.0",
         "chalk": "^4.1.2",
         "commander": "^12.0.0",
@@ -13356,7 +13356,7 @@
     },
     "packages/core": {
       "name": "@agenfk/core",
-      "version": "1.1.18-beta.2",
+      "version": "1.1.18-beta.3",
       "license": "ISC",
       "devDependencies": {
         "typescript": "^5.3.3"
@@ -13364,7 +13364,7 @@
     },
     "packages/create": {
       "name": "agenfk",
-      "version": "1.1.18-beta.2",
+      "version": "1.1.18-beta.3",
       "license": "ISC",
       "bin": {
         "agenfk": "bin/agenfk.js"
@@ -13375,7 +13375,7 @@
     },
     "packages/flow-editor": {
       "name": "@agenfk/flow-editor",
-      "version": "1.1.18-beta.2",
+      "version": "1.1.18-beta.3",
       "peerDependencies": {
         "@tanstack/react-query": "^5.102.8",
         "clsx": "^2.1.1",
@@ -13389,9 +13389,9 @@
     },
     "packages/hub": {
       "name": "@agenfk/hub",
-      "version": "1.1.18-beta.2",
+      "version": "1.1.18-beta.3",
       "dependencies": {
-        "@agenfk/core": "1.1.18-beta.2",
+        "@agenfk/core": "1.1.18-beta.3",
         "axios": "^1.20.0",
         "bcryptjs": "^2.4.3",
         "cookie-parser": "^1.4.7",
@@ -13415,9 +13415,9 @@
       }
     },
     "packages/hub-ui": {
-      "version": "1.1.18-beta.2",
+      "version": "1.1.18-beta.3",
       "dependencies": {
-        "@agenfk/flow-editor": "1.1.18-beta.2",
+        "@agenfk/flow-editor": "1.1.18-beta.3",
         "@fontsource-variable/jetbrains-mono": "^5.3.0",
         "@fontsource-variable/manrope": "^5.3.0",
         "@tailwindcss/postcss": "^4.3.3",
@@ -13793,12 +13793,12 @@
     },
     "packages/server": {
       "name": "@agenfk/server",
-      "version": "1.1.18-beta.2",
+      "version": "1.1.18-beta.3",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.1.18-beta.2",
-        "@agenfk/storage-sqlite": "1.1.18-beta.2",
-        "@agenfk/telemetry": "1.1.18-beta.2",
+        "@agenfk/core": "1.1.18-beta.3",
+        "@agenfk/storage-sqlite": "1.1.18-beta.3",
+        "@agenfk/telemetry": "1.1.18-beta.3",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "axios": "^1.20.0",
         "body-parser": "^2.3.0",
@@ -13821,13 +13821,13 @@
     },
     "packages/storage-sqlite": {
       "name": "@agenfk/storage-sqlite",
-      "version": "1.1.18-beta.2",
+      "version": "1.1.18-beta.3",
       "license": "ISC",
       "dependencies": {
         "uuid": "^14.0.2"
       },
       "devDependencies": {
-        "@agenfk/core": "1.1.18-beta.2",
+        "@agenfk/core": "1.1.18-beta.3",
         "@types/node": "^22.0.0",
         "@types/uuid": "^9.0.8",
         "typescript": "^5.3.3"
@@ -13845,7 +13845,7 @@
     },
     "packages/telemetry": {
       "name": "@agenfk/telemetry",
-      "version": "1.1.18-beta.2",
+      "version": "1.1.18-beta.3",
       "license": "ISC",
       "dependencies": {
         "posthog-node": "^4.0.0"
@@ -13856,9 +13856,9 @@
       }
     },
     "packages/ui": {
-      "version": "1.1.18-beta.2",
+      "version": "1.1.18-beta.3",
       "dependencies": {
-        "@agenfk/flow-editor": "1.1.18-beta.2",
+        "@agenfk/flow-editor": "1.1.18-beta.3",
         "@fontsource-variable/jetbrains-mono": "^5.3.0",
         "@fontsource-variable/manrope": "^5.3.0",
         "@tailwindcss/postcss": "^4.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "1.1.17",
+  "version": "1.1.18-beta.1",
   "description": "AgenFK Engineering Framework",
   "private": true,
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "1.1.18-beta.1",
+  "version": "1.1.18-beta.2",
   "description": "AgenFK Engineering Framework",
   "private": true,
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "1.1.18-beta.2",
+  "version": "1.1.18-beta.3",
   "description": "AgenFK Engineering Framework",
   "private": true,
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "1.1.18-beta.3",
+  "version": "1.1.18-beta.4",
   "description": "AgenFK Engineering Framework",
   "private": true,
   "workspaces": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/cli",
-  "version": "1.1.18-beta.1",
+  "version": "1.1.18-beta.2",
   "description": "CLI for AgenFK Engineering Framework",
   "main": "dist/index.js",
   "bin": {
@@ -12,8 +12,8 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.18-beta.1",
-    "@agenfk/telemetry": "1.1.18-beta.1",
+    "@agenfk/core": "1.1.18-beta.2",
+    "@agenfk/telemetry": "1.1.18-beta.2",
     "axios": "^1.20.0",
     "chalk": "^4.1.2",
     "commander": "^12.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/cli",
-  "version": "1.1.17",
+  "version": "1.1.18-beta.1",
   "description": "CLI for AgenFK Engineering Framework",
   "main": "dist/index.js",
   "bin": {
@@ -12,8 +12,8 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.17",
-    "@agenfk/telemetry": "1.1.17",
+    "@agenfk/core": "1.1.18-beta.1",
+    "@agenfk/telemetry": "1.1.18-beta.1",
     "axios": "^1.20.0",
     "chalk": "^4.1.2",
     "commander": "^12.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/cli",
-  "version": "1.1.18-beta.2",
+  "version": "1.1.18-beta.3",
   "description": "CLI for AgenFK Engineering Framework",
   "main": "dist/index.js",
   "bin": {
@@ -12,8 +12,8 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.18-beta.2",
-    "@agenfk/telemetry": "1.1.18-beta.2",
+    "@agenfk/core": "1.1.18-beta.3",
+    "@agenfk/telemetry": "1.1.18-beta.3",
     "axios": "^1.20.0",
     "chalk": "^4.1.2",
     "commander": "^12.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/cli",
-  "version": "1.1.18-beta.3",
+  "version": "1.1.18-beta.4",
   "description": "CLI for AgenFK Engineering Framework",
   "main": "dist/index.js",
   "bin": {
@@ -12,8 +12,8 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.18-beta.3",
-    "@agenfk/telemetry": "1.1.18-beta.3",
+    "@agenfk/core": "1.1.18-beta.4",
+    "@agenfk/telemetry": "1.1.18-beta.4",
     "axios": "^1.20.0",
     "chalk": "^4.1.2",
     "commander": "^12.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/core",
-  "version": "1.1.18-beta.1",
+  "version": "1.1.18-beta.2",
   "description": "Core logic and interfaces for the AgenFK Engineering Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/core",
-  "version": "1.1.17",
+  "version": "1.1.18-beta.1",
   "description": "Core logic and interfaces for the AgenFK Engineering Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/core",
-  "version": "1.1.18-beta.3",
+  "version": "1.1.18-beta.4",
   "description": "Core logic and interfaces for the AgenFK Engineering Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/core",
-  "version": "1.1.18-beta.2",
+  "version": "1.1.18-beta.3",
   "description": "Core logic and interfaces for the AgenFK Engineering Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "1.1.17",
+  "version": "1.1.18-beta.1",
   "description": "AgenFK Agentic Engineering Framework — installer",
   "bin": {
     "agenfk": "bin/agenfk.js"

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "1.1.18-beta.1",
+  "version": "1.1.18-beta.2",
   "description": "AgenFK Agentic Engineering Framework — installer",
   "bin": {
     "agenfk": "bin/agenfk.js"

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "1.1.18-beta.3",
+  "version": "1.1.18-beta.4",
   "description": "AgenFK Agentic Engineering Framework — installer",
   "bin": {
     "agenfk": "bin/agenfk.js"

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "1.1.18-beta.2",
+  "version": "1.1.18-beta.3",
   "description": "AgenFK Agentic Engineering Framework — installer",
   "bin": {
     "agenfk": "bin/agenfk.js"

--- a/packages/flow-editor/package.json
+++ b/packages/flow-editor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agenfk/flow-editor",
   "private": true,
-  "version": "1.1.17",
+  "version": "1.1.18-beta.1",
   "type": "module",
   "main": "./src/index.ts",
   "exports": {

--- a/packages/flow-editor/package.json
+++ b/packages/flow-editor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agenfk/flow-editor",
   "private": true,
-  "version": "1.1.18-beta.1",
+  "version": "1.1.18-beta.2",
   "type": "module",
   "main": "./src/index.ts",
   "exports": {

--- a/packages/flow-editor/package.json
+++ b/packages/flow-editor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agenfk/flow-editor",
   "private": true,
-  "version": "1.1.18-beta.2",
+  "version": "1.1.18-beta.3",
   "type": "module",
   "main": "./src/index.ts",
   "exports": {

--- a/packages/flow-editor/package.json
+++ b/packages/flow-editor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agenfk/flow-editor",
   "private": true,
-  "version": "1.1.18-beta.3",
+  "version": "1.1.18-beta.4",
   "type": "module",
   "main": "./src/index.ts",
   "exports": {

--- a/packages/flow-editor/src/FlowEditorModal.tsx
+++ b/packages/flow-editor/src/FlowEditorModal.tsx
@@ -18,6 +18,8 @@ interface FlowEditorHost {
   theme: 'light' | 'dark';
   /** Tab captions, supplied by the host. See `FlowEditorModalPublicProps`. */
   tabLabels: { myFlows: string; registry: string };
+  /** Footer CTA captions, supplied by the host. */
+  labels: FlowEditorLabels;
   /** Optional host control above the registry search box. */
   registryToolbar?: React.ReactNode;
 }
@@ -35,6 +37,7 @@ const useFlowClient = (): FlowClient => useHost().flowClient;
 const useRegistryClient = (): RegistryClient => useHost().registryClient;
 const useEditorTheme = (): 'light' | 'dark' => useHost().theme;
 const useTabLabels = () => useHost().tabLabels;
+const useEditorLabels = (): FlowEditorLabels => useHost().labels;
 import { X, Plus, Trash2, GripVertical, Save, GitBranch, Check, CopyPlus, Lock, Search, Globe, Loader2, AlertCircle, Download, Upload, ExternalLink, Zap, FlaskConical, ShieldCheck, Clock, BookOpen, Briefcase, Eye, Code, Bug, Star, Lightbulb, Pause, Archive } from 'lucide-react';
 
 // Available icons for flow steps — key stored in FlowStep.icon, value rendered in UI
@@ -74,6 +77,36 @@ const RESERVED_NAMES = new Set([
 ]);
 
 const BUILTIN_ID = '__builtin__';
+
+/**
+ * Footer CTA captions. The editor's own wording is correct for the standalone
+ * client; a host that binds flows at a different scope overrides them so the
+ * button names the write it performs. See `DEFAULT_EDITOR_LABELS`.
+ */
+export interface FlowEditorLabels {
+  save: string;
+  /**
+   * Confirmation shown in the Save button's place after a clean save. A
+   * separate caption rather than a suffix rule: English past tense is not
+   * mechanical, and appending "d" to the hub's "Save & publish to org" reads
+   * as "Save & publish to orgd".
+   */
+  saved: string;
+  useFlow: string;
+}
+
+/**
+ * Standalone-client captions. "Save" persists a personal flow and "Use this
+ * Flow" makes it this project's active flow — both accurate when one machine
+ * owns the whole lifecycle. The hub admin passes different strings because
+ * over there Save is the fleet-wide publish and "Use this Flow" only writes
+ * an assignment row; see `EDITOR_LABELS_HUB` in hub-ui.
+ */
+export const DEFAULT_EDITOR_LABELS: FlowEditorLabels = {
+  save: 'Save',
+  saved: 'Saved',
+  useFlow: 'Use this Flow',
+};
 
 function generateUUID(): string {
   return Math.random().toString(36).slice(2, 10) + Math.random().toString(36).slice(2, 10);
@@ -125,6 +158,19 @@ interface FlowEditorModalProps {
    * tab shows.
    */
   tabLabels?: { myFlows?: string; registry?: string };
+  /**
+   * Footer CTA captions. Defaults to "Save" / "Use this Flow", which is right
+   * for the standalone client. The hub admin overrides them: there, saving the
+   * row IS the fleet-wide publish (the bumped `version` is the ETag every
+   * installation polls), and the selection button writes an org-default
+   * assignment rather than "using" anything. Same reasoning as `tabLabels`.
+   */
+  /**
+   * Footer CTA captions, supplied by the host. Read from host context rather
+   * than as a prop, so it follows the same path as `tabLabels` and every
+   * nested editor sees one host.
+   */
+  labels?: Partial<FlowEditorLabels>;
   /** Optional host control above the registry search box (registry switcher). */
   registryToolbar?: React.ReactNode;
 }
@@ -155,6 +201,43 @@ function makeBlankStep(order: number): FlowStep {
     order,
     exitCriteria: '',
   };
+}
+
+/**
+ * The flow definition in the shape the save mutation sends it: `name`,
+ * `description`, and steps with `order` authoritative from array position.
+ *
+ * Used both to build the payload and to baseline the dirty check, so the two
+ * are comparable. The projection is deliberately narrow and ordered:
+ *
+ * - **Step ids are excluded.** Both servers run steps through
+ *   `normalizeFlowSteps`, which re-issues an id for any step that arrives
+ *   without one or with a duplicate. A baseline that carried the id the editor
+ *   generated could never match the row that came back, so every save would
+ *   leave the panel looking dirty.
+ * - **Keys are emitted in a fixed order and absent fields are dropped.**
+ *   `JSON.stringify` follows insertion order, so a baseline built from the
+ *   loaded row and a comparison built from the edited state would disagree on
+ *   key order alone. `{ exitCriteria: '' }` and `{}` are also the same step to
+ *   the server, which drops empty fields on the round-trip.
+ */
+function serializeDefinition(
+  name: string,
+  description: string,
+  steps: FlowStep[],
+): string {
+  const canonical = (Array.isArray(steps) ? steps : [])
+    .map((s, i) => ({
+      name: s?.name ?? '',
+      label: s?.label ?? '',
+      order: i,
+      ...(s?.exitCriteria ? { exitCriteria: s.exitCriteria } : {}),
+      ...(s?.color ? { color: s.color } : {}),
+      ...(s?.icon ? { icon: s.icon } : {}),
+      ...(s?.isAnchor ? { isAnchor: true } : {}),
+    }))
+    .sort((a, b) => a.order - b.order);
+  return JSON.stringify({ name, description, steps: canonical });
 }
 
 // ── Exit criteria summary trigger (CGLAB-109) ─────────────────────────────────
@@ -231,15 +314,31 @@ const EditorPanel: React.FC<EditorPanelProps> = ({
   const queryClient = useQueryClient();
   const flowClient = useFlowClient();
   const registryClient = useRegistryClient();
+  const labels = useEditorLabels();
 
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [steps, setSteps] = useState<FlowStep[]>([]);
   const [saved, setSaved] = useState(false);
+  // The definition as last persisted, as the editor serialises it. `saved`
+  // alone cannot answer "is there an unsaved edit?": it is a badge flag that
+  // every keystroke clears, so it cannot distinguish a freshly-loaded row from
+  // a loaded row the admin has since renamed. "Use this Flow" needs that
+  // distinction — it binds an id, and binding while the panel holds edits
+  // silently assigns the version that is already on the server.
+  const [persisted, setPersisted] = useState<string | null>(null);
   const [openIconPickerIndex, setOpenIconPickerIndex] = useState<number | null>(null);
   // CGLAB-109: which step's exit criteria are open in the popup editor.
   const [exitCriteriaEditIndex, setExitCriteriaEditIndex] = useState<number | null>(null);
 
+  // Loads a freshly-selected flow into the form. Keyed on the flow's IDENTITY,
+  // not on the object: saving a new flow hands the parent a new `flow` for the
+  // same row, and re-running this effect would reset the form to the stale
+  // object the sidebar still holds (pre-save name) and drop the "Saved" badge
+  // and the dirty baseline the save just established. A refetch that returns
+  // genuinely edited content for the SAME id is deliberately not re-loaded —
+  // that would clobber an admin's in-progress edits mid-typing.
+  const flowId = flow?.id ?? null;
   useEffect(() => {
     if (flow) {
       setName(flow.name);
@@ -252,6 +351,9 @@ const EditorPanel: React.FC<EditorPanelProps> = ({
         })
         .sort((a, b) => a.order - b.order);
       setSteps(flowSteps);
+      // Baseline the dirty check on the SAME canonical shape the save mutation
+      // sends, so a round-trip through the editor is not itself a change.
+      setPersisted(serializeDefinition(flow.name, flow.description ?? '', flowSteps));
     } else {
       setName('');
       setDescription('');
@@ -259,9 +361,13 @@ const EditorPanel: React.FC<EditorPanelProps> = ({
       const blank = makeBlankStep(1);
       done.order = 2;
       setSteps([todo, blank, done]);
+      // Nothing persisted at all — an unsaved new flow is dirty by definition.
+      setPersisted(null);
     }
     setSaved(false);
-  }, [flow]);
+    // `flow` is read but intentionally not a dependency — see the note above.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [flowId]);
 
   // Validate: any non-anchor step name that matches a reserved name is invalid
   const reservedNameError = steps.some(s => {
@@ -323,57 +429,93 @@ const EditorPanel: React.FC<EditorPanelProps> = ({
   }, []);
 
   // ── Mutations ────────────────────────────────────────────────────────────────
+
+  /**
+   * Persist the panel as it currently stands. Shared by the Save button and by
+   * the two actions that cannot mean anything until the definition is on the
+   * server (binding, publishing).
+   */
+  const persist = useCallback(async (): Promise<Flow> => {
+    const payload: Partial<Flow> = {
+      name,
+      description,
+      // order is authoritative from array position; ids are backfilled so a
+      // flow loaded without them (MCP create_flow never sent ids) still
+      // satisfies the Hub's id rule.
+      steps: withStepIds(steps, generateUUID).map((s, i) => ({ ...s, order: i })),
+    };
+    return flow?.id
+      ? flowClient.updateFlow(flow.id, payload)
+      : flowClient.createFlow(payload);
+  }, [flow?.id, name, description, steps, flowClient]);
+
+  /**
+   * Re-baseline the dirty check after a write.
+   *
+   * The baseline comes from the SERVER's response, not from what the panel
+   * sent. Both servers normalise steps on the way in — `normalizeFlowSteps`
+   * whitelists the fields and re-issues duplicate or missing ids — so
+   * comparing the panel against the request would leave a legitimate write
+   * looking permanently dirty, and every subsequent bind/publish would fire a
+   * redundant save.
+   */
+  const rebaseOn = useCallback((savedFlow: Flow | undefined | null) => {
+    if (!savedFlow) return;
+    setPersisted(serializeDefinition(
+      savedFlow.name,
+      savedFlow.description ?? '',
+      [...(savedFlow.steps ?? [])].sort((a, b) => a.order - b.order),
+    ));
+  }, []);
+
   const saveMutation = useMutation({
-    mutationFn: async () => {
-      const payload: Partial<Flow> = {
-        name,
-        description,
-        // order is authoritative from array position; ids are backfilled so a
-        // flow loaded without them (MCP create_flow never sent ids) still
-        // satisfies the Hub's id rule.
-        steps: withStepIds(steps, generateUUID).map((s, i) => ({ ...s, order: i })),
-      };
-      if (flow?.id) {
-        return flowClient.updateFlow(flow.id, payload);
-      }
-      return flowClient.createFlow(payload);
-    },
+    mutationFn: persist,
     onSuccess: (savedFlow) => {
       queryClient.invalidateQueries({ queryKey: ['flows'] });
       queryClient.invalidateQueries({ queryKey: ['flow', projectId] });
+      rebaseOn(savedFlow);
       setSaved(true);
       onSaved(savedFlow);
     },
   });
 
   const useFlowMutation = useMutation({
+    // Binding an id is only meaningful once the definition behind that id is
+    // stored. This mutation used to bind `flow.id` straight away, so with
+    // unsaved edits in the panel it assigned the version already on the server
+    // and reported success — the admin's edits were silently dropped. Save
+    // first, then bind the id that now points at those edits.
+    //
+    // The bind happens HERE, not in onSuccess. Saving a brand-new flow makes
+    // the parent adopt its id, which remounts this panel; a success callback
+    // firing into a component that has already unmounted would bind whatever
+    // id its closure still held — for a new flow, `undefined`, which the host
+    // reads as "clear the binding" rather than "bind what I just created".
     mutationFn: async () => {
-      if (flow?.id) {
-        await flowClient.setProjectFlow(projectId, flow.id);
-        return flow;
-      }
-      const payload: Partial<Flow> = {
-        name,
-        description,
-        // order is authoritative from array position; ids are backfilled so a
-        // flow loaded without them (MCP create_flow never sent ids) still
-        // satisfies the Hub's id rule.
-        steps: withStepIds(steps, generateUUID).map((s, i) => ({ ...s, order: i })),
-      };
-      const created = await flowClient.createFlow(payload);
-      await flowClient.setProjectFlow(projectId, created.id);
-      return created;
+      const current = isDirty ? await persist() : (flow as Flow);
+      await flowClient.setProjectFlow(projectId, current.id);
+      return current;
     },
-    onSuccess: (result) => {
+    onSuccess: (current) => {
+      rebaseOn(current);
       queryClient.invalidateQueries({ queryKey: ['flows'] });
       queryClient.invalidateQueries({ queryKey: ['flow', projectId] });
       queryClient.invalidateQueries({ queryKey: ['projects'] });
       setSaved(true);
-      onSaved(result);
+      onSaved(current);
     },
   });
 
   const isBusy = saveMutation.isPending || useFlowMutation.isPending;
+
+  /**
+   * Whether the panel holds an edit the server does not have. An unsaved new
+   * flow (no persisted baseline) is always dirty; an existing flow is dirty
+   * when its serialised definition differs from the one it was loaded with or
+   * last saved.
+   */
+  const isDirty = persisted === null || serializeDefinition(name, description, steps) !== persisted;
+
   // BUG 269eeec8 (a): read the server's `{ error }` body, not Error.message —
   // the latter is only ever "Request failed with status code N".
   const failure = saveMutation.error ?? useFlowMutation.error ?? null;
@@ -383,6 +525,18 @@ const EditorPanel: React.FC<EditorPanelProps> = ({
   // reject never leaves the browser, and the reason is pinned to its step.
   const definitionIssues = flowDefinitionIssues(name, steps);
   const isSaveDisabled = isBusy || reservedNameError || definitionIssues.length > 0;
+
+  /**
+   * Whether this panel can write its definition at all. The two read-only
+   * cases — the built-in default flow and a hub-owned flow on a client that
+   * may only read it — are where the server refuses the write outright.
+   */
+  const canSave = !isReadOnly;
+
+  /** Why Save/Publish are dead. Surfaced as the button's tooltip. */
+  const saveBlockedReason = reservedNameError
+    ? 'A step uses a reserved name (TODO, DONE, BLOCKED, PAUSED, IDEAS, ARCHIVED, TRASHED)'
+    : definitionIssues[0]?.message ?? 'Fix the highlighted step first';
 
   // Every reason Save is blocked MUST be visible somewhere, or the user is left
   // with a dead button and no way to fix it — the exact failure mode this whole
@@ -402,26 +556,45 @@ const EditorPanel: React.FC<EditorPanelProps> = ({
 
   const isActive = flow?.id !== undefined && flow.id === activeFlowId;
 
-  // ── Publish to Community ─────────────────────────────────────────────────
+  // ── Publish to registry ──────────────────────────────────────────────────
   const [publishResult, setPublishResult] = useState<{ url: string; kind: 'pr' | 'existing' | 'direct' } | null>(null);
   const [publishError, setPublishError] = useState<string | null>(null);
 
+  /**
+   * Whether this host can publish at all. Optional on `RegistryClient` because
+   * the hub admin cannot (its PAT is hub-held and there is no publish route),
+   * and a button wired to a function that only rejects is not an action — it
+   * is a way to discover a dead end.
+   */
+  const canPublish = typeof registryClient.publishToRegistry === 'function';
+
   const publishMutation = useMutation({
+    // Publishing pushes the SERVER's copy of the flow, so unsaved edits would
+    // not be in it. Save first when there are any, then publish the id that
+    // carries them — the same ordering rule as the bind path above.
     mutationFn: async () => {
-      if (!flow?.id) throw new Error('Flow must be saved before publishing.');
-      return registryClient.publishToRegistry(flow.id);
+      if (!canPublish) throw new Error('This host cannot publish flows.');
+      let id = flow?.id;
+      if (isDirty || !id) {
+        const saved = await persist();
+        rebaseOn(saved);
+        id = saved?.id;
+      }
+      if (!id) throw new Error('Flow must be saved before publishing.');
+      return registryClient.publishToRegistry!(id);
     },
     onSuccess: (data) => {
       setPublishResult({ url: data.url, kind: data.kind ?? 'pr' });
       setPublishError(null);
+      setSaved(true);
     },
     onError: (e: unknown) => {
       setPublishError(extractApiError(e, 'Failed to publish.'));
     },
   });
 
-  // Rendered by BOTH footers — the read-only footer also offers Publish now, and
-  // a button whose outcome renders somewhere else is a silent failure.
+  // Rendered alongside the footer that owns the button — a button whose
+  // outcome renders in a different footer is a silent failure.
   const publishFeedback = (
     <>
       {publishResult && (
@@ -784,103 +957,92 @@ const EditorPanel: React.FC<EditorPanelProps> = ({
         )}
       </div>
 
-      {/* Footer — sticky bottom */}
-      {isReadOnly ? (
-        <div className="px-6 py-4 border-t border-slate-200 dark:border-slate-700 shrink-0 flex flex-col gap-3">
-         <div className="flex items-center gap-3 flex-wrap">
-          {/* A hub-managed flow used to render the editable footer, which carried
-              Publish. Keep it reachable here rather than silently dropping the
-              capability along with Save. */}
-          {isHubManaged && flow?.id && (
-            <button
-              data-testid="publish-flow-btn"
-              type="button"
-              disabled={publishMutation.isPending}
-              onClick={() => { setPublishResult(null); setPublishError(null); publishMutation.mutate(); }}
-              className="flex items-center gap-1.5 px-4 py-2 rounded-xl text-sm font-semibold border border-border-soft text-ink-secondary hover:text-accent-text hover:border-border-brand disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-            >
-              {publishMutation.isPending ? <Loader2 size={15} className="animate-spin" /> : <Upload size={15} />}
-              {publishMutation.isPending ? 'Publishing…' : 'Publish'}
-            </button>
-          )}
-          {onUseDefault && canSelectFlow && (
-            <button
-              data-testid="use-default-flow-btn"
-              type="button"
-              onClick={onUseDefault}
-              className="flex items-center gap-1.5 px-4 py-2 rounded-xl text-sm font-semibold bg-emerald-600 hover:bg-emerald-700 text-white transition-colors shadow-sm"
-            >
-              <GitBranch size={15} />
-              Use this Flow
-            </button>
-          )}
-          {onClone && (
-            <button
-              data-testid="clone-to-edit-btn"
-              type="button"
-              onClick={onClone}
-              className="flex items-center gap-1.5 px-4 py-2 rounded-xl text-sm font-semibold bg-[image:var(--gradient-accent)] text-navy shadow-glow hover:opacity-90 transition-colors"
-            >
-              <CopyPlus size={15} />
-              Clone to Edit
-            </button>
-          )}
-          <button
-            data-testid="cancel-panel-btn"
-            type="button"
-            onClick={onClose}
-            className="flex items-center gap-1.5 px-4 py-2 rounded-xl text-sm font-semibold border border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors"
-          >
-            Close
-          </button>
-         </div>
-         {publishFeedback}
-        </div>
-      ) : (
-        <div className="px-6 py-4 border-t border-slate-200 dark:border-slate-700 shrink-0 flex flex-col gap-3">
-          <div className="flex items-center justify-between gap-3">
-            <button
-              data-testid="save-flow-btn"
-              type="button"
-              disabled={isSaveDisabled}
-              onClick={() => saveMutation.mutate()}
-              className="flex items-center gap-1.5 px-4 py-2 rounded-xl text-sm font-semibold bg-[image:var(--gradient-accent)] text-navy shadow-glow hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-            >
-              {saved ? <Check size={15} /> : <Save size={15} />}
-              {isBusy ? 'Saving…' : saved ? 'Saved' : 'Save'}
-            </button>
+      {/* Footer — sticky bottom.
 
-            <div className="flex items-center gap-2">
-              {flow?.id && (
-                <button
-                  data-testid="publish-flow-btn"
-                  type="button"
-                  disabled={publishMutation.isPending}
-                  onClick={() => { setPublishResult(null); setPublishError(null); publishMutation.mutate(); }}
-                  className="flex items-center gap-1.5 px-4 py-2 rounded-xl text-sm font-semibold border border-border-soft text-ink-secondary hover:text-accent-text hover:border-border-brand disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                >
-                  {publishMutation.isPending ? <Loader2 size={15} className="animate-spin" /> : <Upload size={15} />}
-                  {publishMutation.isPending ? 'Publishing…' : 'Publish'}
-                </button>
-              )}
-              {canSelectFlow && (
-                <button
-                  data-testid="use-flow-btn"
-                  type="button"
-                  disabled={isSaveDisabled}
-                  onClick={() => useFlowMutation.mutate()}
-                  className="flex items-center gap-1.5 px-4 py-2 rounded-xl text-sm font-semibold bg-emerald-600 hover:bg-emerald-700 text-white disabled:opacity-50 disabled:cursor-not-allowed transition-colors shadow-sm"
-                >
-                  <GitBranch size={15} />
-                  Use this Flow
-                </button>
-              )}
-            </div>
+          ONE footer, gated per capability rather than on `isReadOnly`. The two
+          variants used to be chosen by read-only-ness, which is the wrong axis:
+          it left a newly created flow (no id yet, so it took the read-only
+          branch) with neither Save — which lived in the editable branch — nor
+          Publish, which the read-only branch gated on `flow?.id`. Each control
+          now renders iff the host can perform that action, and every control
+          shares one row so a button's outcome always renders beside it. */}
+      <div className="px-6 py-4 border-t border-slate-200 dark:border-slate-700 shrink-0 flex flex-col gap-3" data-testid="flow-footer">
+        <div className="flex items-center justify-between gap-3 flex-wrap">
+          <div className="flex items-center gap-2 flex-wrap">
+            {canSave && (
+              <button
+                data-testid="save-flow-btn"
+                type="button"
+                disabled={isSaveDisabled}
+                onClick={() => saveMutation.mutate()}
+                className="flex items-center gap-1.5 px-4 py-2 rounded-xl text-sm font-semibold bg-[image:var(--gradient-accent)] text-navy shadow-glow hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              >
+                {saved ? <Check size={15} /> : <Save size={15} />}
+                {isBusy ? 'Saving…' : saved && !isDirty ? labels.saved : labels.save}
+              </button>
+            )}
+            {onClone && (
+              <button
+                data-testid="clone-to-edit-btn"
+                type="button"
+                onClick={onClone}
+                className="flex items-center gap-1.5 px-4 py-2 rounded-xl text-sm font-semibold bg-[image:var(--gradient-accent)] text-navy shadow-glow hover:opacity-90 transition-colors"
+              >
+                <CopyPlus size={15} />
+                Clone to Edit
+              </button>
+            )}
           </div>
 
-          {publishFeedback}
+          <div className="flex items-center gap-2 flex-wrap">
+            {canPublish && (
+              <button
+                data-testid="publish-flow-btn"
+                type="button"
+                disabled={publishMutation.isPending || isSaveDisabled}
+                title={isSaveDisabled ? saveBlockedReason : 'Publish this flow to the registry'}
+                onClick={() => { setPublishResult(null); setPublishError(null); publishMutation.mutate(); }}
+                className="flex items-center gap-1.5 px-4 py-2 rounded-xl text-sm font-semibold border border-border-soft text-ink-secondary hover:text-accent-text hover:border-border-brand disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              >
+                {publishMutation.isPending ? <Loader2 size={15} className="animate-spin" /> : <Upload size={15} />}
+                {publishMutation.isPending ? 'Publishing…' : 'Publish'}
+              </button>
+            )}
+            {onUseDefault && canSelectFlow && (
+              <button
+                data-testid="use-default-flow-btn"
+                type="button"
+                onClick={onUseDefault}
+                className="flex items-center gap-1.5 px-4 py-2 rounded-xl text-sm font-semibold bg-emerald-600 hover:bg-emerald-700 text-white transition-colors shadow-sm"
+              >
+                <GitBranch size={15} />
+                {labels.useFlow}
+              </button>
+            )}
+            {canSelectFlow && !isReadOnly && (
+              <button
+                data-testid="use-flow-btn"
+                type="button"
+                disabled={isSaveDisabled}
+                onClick={() => useFlowMutation.mutate()}
+                className="flex items-center gap-1.5 px-4 py-2 rounded-xl text-sm font-semibold bg-emerald-600 hover:bg-emerald-700 text-white disabled:opacity-50 disabled:cursor-not-allowed transition-colors shadow-sm"
+              >
+                <GitBranch size={15} />
+                {labels.useFlow}
+              </button>
+            )}
+            <button
+              data-testid="cancel-panel-btn"
+              type="button"
+              onClick={onClose}
+              className="flex items-center gap-1.5 px-4 py-2 rounded-xl text-sm font-semibold border border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors"
+            >
+              Close
+            </button>
+          </div>
         </div>
-      )}
+        {publishFeedback}
+      </div>
 
       {/* Exit criteria popup (CGLAB-109) — nested above this modal's z-50. */}
       {exitCriteriaEditIndex !== null && steps[exitCriteriaEditIndex] && (
@@ -1096,6 +1258,12 @@ const FlowEditorModalInner: React.FC<Props> = (props) => {
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
   // clonedFlow holds a not-yet-saved clone being edited
   const [clonedFlow, setClonedFlow] = useState<(Omit<Flow, 'id' | 'createdAt' | 'updatedAt'> & { id?: undefined }) | null>(null);
+  // A new flow the panel has just written. `isNewFlow` has to drop after the
+  // save (the row exists now), but the panel is keyed on that state — so the
+  // id has to live in the parent, which survives the remount, or the freshly
+  // created flow loses its identity the moment it is saved and Publish can
+  // never find an id to publish.
+  const [createdFlow, setCreatedFlow] = useState<Flow | null>(null);
   // Community tab state
   const [selectedRegistryFlow, setSelectedRegistryFlow] = useState<RegistryFlow | null>(null);
   const [communitySearch, setCommunitySearch] = useState('');
@@ -1145,7 +1313,12 @@ const FlowEditorModalInner: React.FC<Props> = (props) => {
     ? (clonedFlow as unknown as Flow)
     : selectedFlowId === BUILTIN_ID
     ? (builtinFlow ?? null)
-    : flows.find(f => f.id === selectedFlowId) ?? null;
+    : (createdFlow && createdFlow.id === selectedFlowId
+        // A flow saved from the New Flow panel: the sidebar list will not hold
+        // it until its refetch lands, and the object the save returned is
+        // strictly fresher than anything the list could answer with.
+        ? createdFlow
+        : flows.find(f => f.id === selectedFlowId)) ?? null;
 
   // If this is a legacy-props invocation the passed `flow` wins as initial selection
   const [deleteError, setDeleteError] = useState<string | null>(null);
@@ -1202,9 +1375,18 @@ const FlowEditorModalInner: React.FC<Props> = (props) => {
   if (!isOpen) return null;
 
   const handleFlowSaved = (flow: Flow) => {
-    setSelectedFlowId(flow.id);
-    setIsNewFlow(false);
-    setClonedFlow(null);
+    setCreatedFlow(flow);
+    // The panel is keyed on the selection, so touching `isNewFlow` /
+    // `selectedFlowId` REMOUNTS it — wiping the "Saved" badge, the dirty
+    // baseline and any publish link the admin is looking at. When the row the
+    // save just produced is already the selected one there is nothing to
+    // switch to, so the state is left alone and the panel survives. It only
+    // needs to change when the selection genuinely moves.
+    if (isNewFlow || isEditingClone || selectedFlowId !== flow.id) {
+      setSelectedFlowId(flow.id);
+      setIsNewFlow(false);
+      setClonedFlow(null);
+    }
   };
 
   const handleCommunityInstall = (installed: Flow) => {
@@ -1213,6 +1395,7 @@ const FlowEditorModalInner: React.FC<Props> = (props) => {
     setSelectedFlowId(installed.id);
     setIsNewFlow(false);
     setClonedFlow(null);
+    setCreatedFlow(null);
   };
 
   const handleCommunityClone = (installed: Flow) => {
@@ -1222,6 +1405,7 @@ const FlowEditorModalInner: React.FC<Props> = (props) => {
     setClonedFlow(copy);
     setIsNewFlow(false);
     setSelectedFlowId(null);
+    setCreatedFlow(null);
   };
 
   const effectiveActiveFlowId = activeFlowId;
@@ -1240,6 +1424,7 @@ const FlowEditorModalInner: React.FC<Props> = (props) => {
     setClonedFlow(copy);
     setIsNewFlow(false);
     setSelectedFlowId(null);
+    setCreatedFlow(null);
   };
 
   return (
@@ -1431,6 +1616,7 @@ const FlowEditorModalInner: React.FC<Props> = (props) => {
                       setSelectedFlowId(flow.id);
                       setIsNewFlow(false);
                       setClonedFlow(null);
+                      setCreatedFlow(null);
                     }
                   }}
                 >
@@ -1572,7 +1758,7 @@ const FlowEditorModalInner: React.FC<Props> = (props) => {
               <GitBranch size={40} className="opacity-30" />
               <p className="text-sm">Select a flow from the sidebar or create a new one.</p>
               <button
-                onClick={() => { setIsNewFlow(true); setClonedFlow(null); }}
+                onClick={() => { setIsNewFlow(true); setClonedFlow(null); setCreatedFlow(null); }}
                 className="flex items-center gap-1.5 px-4 py-2 rounded-xl text-sm font-semibold bg-[image:var(--gradient-accent)] text-navy shadow-glow hover:opacity-90 transition-colors"
               >
                 <Plus size={14} />
@@ -1611,12 +1797,18 @@ export type FlowEditorModalPublicProps = (FlowEditorModalProps | LegacyProps) & 
    * the org catalogue and the second may be a private repo.
    */
   tabLabels?: { myFlows?: string; registry?: string };
+  /**
+   * Footer CTA captions. Omit for the standalone client's wording ("Save" /
+   * "Use this Flow"). The hub admin passes its own, because there saving is
+   * the fleet-wide publish and the selection button writes an org default.
+   */
+  labels?: Partial<FlowEditorLabels>;
   /** Optional host control above the registry search box (registry switcher). */
   registryToolbar?: React.ReactNode;
 };
 
 export const FlowEditorModal: React.FC<FlowEditorModalPublicProps> = ({
-  flowClient, registryClient, theme = 'light', tabLabels, registryToolbar, ...rest
+  flowClient, registryClient, theme = 'light', tabLabels, labels, registryToolbar, ...rest
 }) => {
   const host = React.useMemo<FlowEditorHost>(
     () => ({
@@ -1628,8 +1820,17 @@ export const FlowEditorModal: React.FC<FlowEditorModalPublicProps> = ({
         myFlows: tabLabels?.myFlows || DEFAULT_HOST_TAB_LABELS.myFlows,
         registry: tabLabels?.registry || DEFAULT_HOST_TAB_LABELS.registry,
       },
+      labels: {
+        save: labels?.save?.trim() || DEFAULT_EDITOR_LABELS.save,
+        saved: labels?.saved?.trim() || DEFAULT_EDITOR_LABELS.saved,
+        useFlow: labels?.useFlow?.trim() || DEFAULT_EDITOR_LABELS.useFlow,
+      },
     }),
-    [flowClient, registryClient, theme, tabLabels?.myFlows, tabLabels?.registry, registryToolbar],
+    [
+      flowClient, registryClient, theme, registryToolbar,
+      tabLabels?.myFlows, tabLabels?.registry,
+      labels?.save, labels?.saved, labels?.useFlow,
+    ],
   );
   return (
     <HostContext.Provider value={host}>

--- a/packages/flow-editor/src/FlowEditorModal.tsx
+++ b/packages/flow-editor/src/FlowEditorModal.tsx
@@ -16,7 +16,11 @@ interface FlowEditorHost {
   flowClient: FlowClient;
   registryClient: RegistryClient;
   theme: 'light' | 'dark';
+  /** Tab captions, supplied by the host. See `FlowEditorModalPublicProps`. */
+  tabLabels: { myFlows: string; registry: string };
 }
+
+const DEFAULT_HOST_TAB_LABELS = { myFlows: 'My Flows', registry: 'Community' };
 
 const HostContext = createContext<FlowEditorHost | null>(null);
 
@@ -28,6 +32,7 @@ function useHost(): FlowEditorHost {
 const useFlowClient = (): FlowClient => useHost().flowClient;
 const useRegistryClient = (): RegistryClient => useHost().registryClient;
 const useEditorTheme = (): 'light' | 'dark' => useHost().theme;
+const useTabLabels = () => useHost().tabLabels;
 import { X, Plus, Trash2, GripVertical, Save, GitBranch, Check, CopyPlus, Lock, Search, Globe, Loader2, AlertCircle, Download, Upload, ExternalLink, Zap, FlaskConical, ShieldCheck, Clock, BookOpen, Briefcase, Eye, Code, Bug, Star, Lightbulb, Pause, Archive } from 'lucide-react';
 
 // Available icons for flow steps — key stored in FlowStep.icon, value rendered in UI
@@ -109,6 +114,15 @@ interface FlowEditorModalProps {
   // was offering a guaranteed failure. The hub admin leaves this false: over
   // there, hub-sourced flows are exactly the ones you are meant to edit.
   hubManagedReadOnly?: boolean;
+  /**
+   * Tab captions. Defaults to "My Flows" / "Community", which is correct for
+   * the standalone client. The hub admin overrides them: its first tab is the
+   * org-wide catalogue rather than a personal list, and its registry tab lists
+   * whatever repo the org configured — after CGLAB-138 that is often a PRIVATE
+   * repo, where the word "Community" would describe the opposite of what the
+   * tab shows.
+   */
+  tabLabels?: { myFlows?: string; registry?: string };
 }
 
 // Keep legacy Props alias so KanbanBoard can pass open= until it's updated
@@ -1062,6 +1076,7 @@ const FlowEditorModalInner: React.FC<Props> = (props) => {
   // Defaults false so the hub admin — which must edit hub-sourced flows — keeps
   // working without opting out; only the local agenfk UI sets it.
   const hubManagedReadOnly = isLegacy ? false : ((props as FlowEditorModalProps).hubManagedReadOnly ?? false);
+  const tabLabels = useTabLabels();
 
   const queryClient = useQueryClient();
   const flowClient = useFlowClient();
@@ -1266,7 +1281,7 @@ const FlowEditorModalInner: React.FC<Props> = (props) => {
                   : 'border-transparent text-slate-500 hover:text-slate-700 dark:hover:text-slate-300'
               )}
             >
-              My Flows
+              {tabLabels.myFlows}
             </button>
             <button
               data-testid="tab-community"
@@ -1278,7 +1293,7 @@ const FlowEditorModalInner: React.FC<Props> = (props) => {
                   : 'border-transparent text-slate-500 hover:text-slate-700 dark:hover:text-slate-300'
               )}
             >
-              Community
+              {tabLabels.registry}
             </button>
           </div>
 
@@ -1580,14 +1595,28 @@ export type FlowEditorModalPublicProps = (FlowEditorModalProps | LegacyProps) & 
   flowClient: FlowClient;
   registryClient: RegistryClient;
   theme?: 'light' | 'dark';
+  /**
+   * Tab captions. Omit for the standalone client's wording ("My Flows" /
+   * "Community"). The hub admin passes its own, because there the first tab is
+   * the org catalogue and the second may be a private repo.
+   */
+  tabLabels?: { myFlows?: string; registry?: string };
 };
 
 export const FlowEditorModal: React.FC<FlowEditorModalPublicProps> = ({
-  flowClient, registryClient, theme = 'light', ...rest
+  flowClient, registryClient, theme = 'light', tabLabels, ...rest
 }) => {
   const host = React.useMemo<FlowEditorHost>(
-    () => ({ flowClient, registryClient, theme }),
-    [flowClient, registryClient, theme],
+    () => ({
+      flowClient,
+      registryClient,
+      theme,
+      tabLabels: {
+        myFlows: tabLabels?.myFlows || DEFAULT_HOST_TAB_LABELS.myFlows,
+        registry: tabLabels?.registry || DEFAULT_HOST_TAB_LABELS.registry,
+      },
+    }),
+    [flowClient, registryClient, theme, tabLabels?.myFlows, tabLabels?.registry],
   );
   return (
     <HostContext.Provider value={host}>

--- a/packages/flow-editor/src/FlowEditorModal.tsx
+++ b/packages/flow-editor/src/FlowEditorModal.tsx
@@ -18,6 +18,8 @@ interface FlowEditorHost {
   theme: 'light' | 'dark';
   /** Tab captions, supplied by the host. See `FlowEditorModalPublicProps`. */
   tabLabels: { myFlows: string; registry: string };
+  /** Optional host control above the registry search box. */
+  registryToolbar?: React.ReactNode;
 }
 
 const DEFAULT_HOST_TAB_LABELS = { myFlows: 'My Flows', registry: 'Community' };
@@ -123,6 +125,8 @@ interface FlowEditorModalProps {
    * tab shows.
    */
   tabLabels?: { myFlows?: string; registry?: string };
+  /** Optional host control above the registry search box (registry switcher). */
+  registryToolbar?: React.ReactNode;
 }
 
 // Keep legacy Props alias so KanbanBoard can pass open= until it's updated
@@ -1077,6 +1081,7 @@ const FlowEditorModalInner: React.FC<Props> = (props) => {
   // working without opting out; only the local agenfk UI sets it.
   const hubManagedReadOnly = isLegacy ? false : ((props as FlowEditorModalProps).hubManagedReadOnly ?? false);
   const tabLabels = useTabLabels();
+  const { registryToolbar } = useHost();
 
   const queryClient = useQueryClient();
   const flowClient = useFlowClient();
@@ -1300,6 +1305,11 @@ const FlowEditorModalInner: React.FC<Props> = (props) => {
           {/* Community tab content */}
           {activeTab === 'community' && (
             <div className="flex-1 flex flex-col overflow-hidden">
+              {registryToolbar && (
+                <div className="px-3 pt-2 shrink-0" data-testid="registry-toolbar">
+                  {registryToolbar}
+                </div>
+              )}
               <div className="px-3 py-2 shrink-0">
                 <div className="relative">
                   <Search size={13} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-slate-400" />
@@ -1601,22 +1611,25 @@ export type FlowEditorModalPublicProps = (FlowEditorModalProps | LegacyProps) & 
    * the org catalogue and the second may be a private repo.
    */
   tabLabels?: { myFlows?: string; registry?: string };
+  /** Optional host control above the registry search box (registry switcher). */
+  registryToolbar?: React.ReactNode;
 };
 
 export const FlowEditorModal: React.FC<FlowEditorModalPublicProps> = ({
-  flowClient, registryClient, theme = 'light', tabLabels, ...rest
+  flowClient, registryClient, theme = 'light', tabLabels, registryToolbar, ...rest
 }) => {
   const host = React.useMemo<FlowEditorHost>(
     () => ({
       flowClient,
       registryClient,
       theme,
+      registryToolbar,
       tabLabels: {
         myFlows: tabLabels?.myFlows || DEFAULT_HOST_TAB_LABELS.myFlows,
         registry: tabLabels?.registry || DEFAULT_HOST_TAB_LABELS.registry,
       },
     }),
-    [flowClient, registryClient, theme, tabLabels?.myFlows, tabLabels?.registry],
+    [flowClient, registryClient, theme, tabLabels?.myFlows, tabLabels?.registry, registryToolbar],
   );
   return (
     <HostContext.Provider value={host}>

--- a/packages/flow-editor/src/index.ts
+++ b/packages/flow-editor/src/index.ts
@@ -1,4 +1,4 @@
-export { FlowEditorModal, type FlowEditorModalPublicProps } from './FlowEditorModal';
+export { FlowEditorModal, DEFAULT_EDITOR_LABELS, type FlowEditorModalPublicProps, type FlowEditorLabels } from './FlowEditorModal';
 export { ExitCriteriaEditorModal, type ExitCriteriaEditorModalProps } from './ExitCriteriaEditorModal';
 export { estimateTokenCount } from './estimateTokens';
 export { renderStepIcon } from './FlowEditorModal';

--- a/packages/flow-editor/src/types.ts
+++ b/packages/flow-editor/src/types.ts
@@ -61,5 +61,18 @@ export interface FlowClient {
 export interface RegistryClient {
   browseRegistry(): Promise<RegistryFlow[]>;
   installFromRegistry(filename: string): Promise<Flow>;
-  publishToRegistry(flowId: string): Promise<{ url: string; kind: 'pr' | 'existing' | 'direct'; note?: string }>;
+  /**
+   * Push a saved flow to the registry repo (fork + PR, or a direct push for a
+   * repo owner). **Optional because not every host can do it.**
+   *
+   * The standalone agenfk client can: its local server shells out to `gh` on
+   * the author's machine, where the credentials live. The Hub admin cannot —
+   * the org's `contents:write` PAT is held encrypted on the hub and is never
+   * copied to a laptop, and the hub exposes no publish route (only the
+   * one-time community copy used when an admin points the org at a private
+   * repo). Its client simply omits this method and the editor hides the
+   * button, rather than rendering a control wired to a function that can only
+   * reject.
+   */
+  publishToRegistry?(flowId: string): Promise<{ url: string; kind: 'pr' | 'existing' | 'direct'; note?: string }>;
 }

--- a/packages/hub-ui/package.json
+++ b/packages/hub-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hub-ui",
   "private": true,
-  "version": "1.1.18-beta.1",
+  "version": "1.1.18-beta.2",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.1.18-beta.1",
+    "@agenfk/flow-editor": "1.1.18-beta.2",
     "@fontsource-variable/jetbrains-mono": "^5.3.0",
     "@fontsource-variable/manrope": "^5.3.0",
     "@tailwindcss/postcss": "^4.3.3",

--- a/packages/hub-ui/package.json
+++ b/packages/hub-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hub-ui",
   "private": true,
-  "version": "1.1.17",
+  "version": "1.1.18-beta.1",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.1.17",
+    "@agenfk/flow-editor": "1.1.18-beta.1",
     "@fontsource-variable/jetbrains-mono": "^5.3.0",
     "@fontsource-variable/manrope": "^5.3.0",
     "@tailwindcss/postcss": "^4.3.3",

--- a/packages/hub-ui/package.json
+++ b/packages/hub-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hub-ui",
   "private": true,
-  "version": "1.1.18-beta.3",
+  "version": "1.1.18-beta.4",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.1.18-beta.3",
+    "@agenfk/flow-editor": "1.1.18-beta.4",
     "@fontsource-variable/jetbrains-mono": "^5.3.0",
     "@fontsource-variable/manrope": "^5.3.0",
     "@tailwindcss/postcss": "^4.3.3",

--- a/packages/hub-ui/package.json
+++ b/packages/hub-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hub-ui",
   "private": true,
-  "version": "1.1.18-beta.2",
+  "version": "1.1.18-beta.3",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.1.18-beta.2",
+    "@agenfk/flow-editor": "1.1.18-beta.3",
     "@fontsource-variable/jetbrains-mono": "^5.3.0",
     "@fontsource-variable/manrope": "^5.3.0",
     "@tailwindcss/postcss": "^4.3.3",

--- a/packages/hub-ui/src/pages/AdminFlows.tsx
+++ b/packages/hub-ui/src/pages/AdminFlows.tsx
@@ -19,6 +19,12 @@ import { flattenAdminFlow } from './adminFlowShape';
 import { repoOverrideOptions } from './repoOverrideOptions';
 import { availabilityRowState } from './availabilityRowState';
 import { useTheme } from '../ThemeContext';
+import {
+  PUBLIC_REGISTRY_REPO,
+  registryFormError,
+  registrySaveLabel,
+  MOVE_BACK_TO_PUBLIC_CONFIRM,
+} from './adminFlowRegistry';
 
 const HUB_PROJECT_TOKEN = 'org-default'; // pseudo-projectId — hub binds to org-default assignment
 
@@ -182,6 +188,8 @@ export function AdminFlows() {
           );
         })}
       </div>
+
+      <RegistryRepoPanel />
 
       <FlowEditorModal
         isOpen={editorOpen}
@@ -465,5 +473,177 @@ function AddOverridePicker({
         </ul>
       )}
     </div>
+  );
+}
+
+// ── Registry repo panel (CGLAB-138) ────────────────────────────────────────
+//
+// Where the admin points this org's flow registry. Defaults to the public
+// community registry; pointing it at a private repo copies the community flows
+// across once. The token is write-only from here — the server never returns it,
+// so the form shows "a token is stored" and leaves the field blank.
+
+interface RegistryConfig {
+  repo: string;
+  branch: string;
+  isPublic: boolean;
+  hasToken: boolean;
+  copiedAt: string | null;
+}
+
+function RegistryRepoPanel() {
+  const qc = useQueryClient();
+  const { data: cfg } = useQuery<RegistryConfig>({
+    queryKey: ['admin-registry-config'],
+    queryFn: async () => (await api.get('/v1/admin/registry-config')).data,
+  });
+  const [repo, setRepo] = useState('');
+  const [token, setToken] = useState('');
+  // Seed the repo field once the config arrives; keep it untouched afterwards
+  // so a half-typed edit is never wiped by a background refetch.
+  useEffect(() => {
+    if (cfg && !repo) setRepo(cfg.repo);
+  }, [cfg, repo]);
+
+  const hasStoredToken = Boolean(cfg?.hasToken);
+  // The token field only matters for a private target. Deriving it from the
+  // repo rather than from `cfg.isPublic` keeps the field correct while the
+  // admin is mid-edit, before the save has changed the stored config.
+  const showToken = repo.trim() !== '' && repo.trim() !== PUBLIC_REGISTRY_REPO;
+  const error = registryFormError({ repo, token, hasStoredToken });
+  const movingToPublic = repo.trim() === PUBLIC_REGISTRY_REPO && !cfg?.isPublic;
+
+  const save = useMutation({
+    mutationFn: async () => {
+      const body: Record<string, string> = { repo: repo.trim() };
+      if (token.trim()) body.token = token.trim();
+      return (await api.put('/v1/admin/registry-config', body)).data;
+    },
+    onSuccess: () => {
+      setToken('');
+      qc.invalidateQueries({ queryKey: ['admin-registry-config'] });
+      qc.invalidateQueries({ queryKey: ['admin-registry-flows'] });
+    },
+  });
+
+  const sync = useMutation({
+    mutationFn: async () => (await api.post('/v1/admin/registry-config/sync', {})).data,
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['admin-registry-config'] }),
+  });
+
+  // `copied`/`failed`/`truncated` are optional on this type because `save.data`
+  // is `unknown` until the mutation resolves — the optionality is about the
+  // response existing at all, not about `truncated` being absent from a
+  // response. The server always sends it (CopyResult.truncated is non-optional),
+  // and the route test pins it on both the truncated and the normal path.
+  const result = save.data as { copied?: number; failed?: string[]; truncated?: boolean } | undefined;
+
+  return (
+    <section
+      className="bg-card-glass backdrop-blur border border-border-soft rounded-2xl p-4 space-y-3"
+      data-testid="admin-registry-panel"
+    >
+      <div>
+        <h3 className="text-xs font-semibold text-ink uppercase tracking-wide">Flow registry</h3>
+        <p className="mt-0.5 text-xs text-ink-tertiary">
+          Where this org&apos;s installations browse and install flows. Pointing it at your own
+          repository copies the community flows into it once; you can move back at any time.
+        </p>
+      </div>
+
+      <div className="flex items-center gap-2 text-xs">
+        <span className="text-ink-tertiary">Current:</span>
+        <code className="px-1.5 py-0.5 rounded bg-chip text-ink">{cfg?.repo ?? '…'}</code>
+        {cfg?.isPublic ? (
+          <span className="text-ink-tertiary">(public community registry)</span>
+        ) : (
+          <span className="text-emerald-600 dark:text-emerald-400">
+            (org registry{cfg?.copiedAt ? ' · community flows copied' : ' · copy pending'})
+          </span>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-2 sm:flex-row">
+        <input
+          data-testid="admin-registry-repo"
+          className="flex-1 px-2.5 py-1.5 rounded-lg bg-chip border border-border-soft text-xs text-ink"
+          placeholder="owner/agenfk-flows"
+          value={repo}
+          onChange={(e) => setRepo(e.target.value)}
+        />
+        {showToken && (
+          <input
+            data-testid="admin-registry-token"
+            type="password"
+            className="flex-1 px-2.5 py-1.5 rounded-lg bg-chip border border-border-soft text-xs text-ink"
+            placeholder={hasStoredToken ? 'token stored — blank keeps it' : 'GitHub token (contents:write)'}
+            value={token}
+            onChange={(e) => setToken(e.target.value)}
+          />
+        )}
+      </div>
+
+      {error && (
+        <p className="text-xs text-rose-600 dark:text-rose-400" data-testid="admin-registry-error">
+          {error}
+        </p>
+      )}
+
+      {movingToPublic && (
+        <p className="text-xs text-amber-700 dark:text-amber-300" data-testid="admin-registry-confirm">
+          {MOVE_BACK_TO_PUBLIC_CONFIRM}
+        </p>
+      )}
+
+      {result && typeof result.copied === 'number' && (
+        <p className="text-xs text-ink-tertiary" data-testid="admin-registry-result">
+          {result.copied > 0
+            ? `${result.copied} community flow(s) copied into ${repo.trim()}.`
+            : 'Registry updated.'}
+          {Array.isArray(result.failed) && result.failed.length > 0 && (
+            <span className="text-rose-600 dark:text-rose-400">
+              {' '}Failed: {result.failed.join(', ')} — use Retry copy.
+            </span>
+          )}
+          {result.truncated && (
+            <span className="text-amber-700 dark:text-amber-300">
+              {' '}The source registry has more flows than one run copies — use Retry copy to continue.
+            </span>
+          )}
+        </p>
+      )}
+
+      <div className="flex items-center gap-2">
+        <button
+          data-testid="admin-registry-save"
+          disabled={!!error || save.isPending}
+          onClick={() => {
+            // Moving back to public is reversible but changes what every
+            // installation reads, so it earns an explicit click.
+            if (movingToPublic && !window.confirm(MOVE_BACK_TO_PUBLIC_CONFIRM)) return;
+            save.mutate();
+          }}
+          className="px-3 py-1.5 rounded-lg bg-[image:var(--gradient-accent)] text-navy shadow-glow text-xs font-bold disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          {save.isPending ? 'Saving…' : registrySaveLabel({ repo, token, hasStoredToken })}
+        </button>
+        {!cfg?.isPublic && (
+          <button
+            data-testid="admin-registry-sync"
+            disabled={sync.isPending}
+            onClick={() => sync.mutate()}
+            className="px-3 py-1.5 rounded-lg border border-border-soft text-xs text-ink-tertiary disabled:opacity-40"
+          >
+            {sync.isPending ? 'Copying…' : 'Retry copy'}
+          </button>
+        )}
+      </div>
+
+      {save.error && (
+        <p className="text-xs text-rose-600 dark:text-rose-400" data-testid="admin-registry-save-error">
+          {(save.error as Error).message}
+        </p>
+      )}
+    </section>
   );
 }

--- a/packages/hub-ui/src/pages/AdminFlows.tsx
+++ b/packages/hub-ui/src/pages/AdminFlows.tsx
@@ -23,6 +23,7 @@ import {
   PUBLIC_REGISTRY_REPO,
   registryFormError,
   registrySaveLabel,
+  resolveTabLabels,
   MOVE_BACK_TO_PUBLIC_CONFIRM,
 } from './adminFlowRegistry';
 
@@ -84,6 +85,18 @@ export function AdminFlows() {
   const { data: assignments = [] } = useQuery<Assignment[]>({
     queryKey: ['admin-flow-assignments'],
     queryFn: async () => (await api.get('/v1/admin/flow-assignments')).data,
+  });
+
+  // Read here as well as in RegistryRepoPanel: the editor's tab captions depend
+  // on which repo the registry currently resolves to. Same queryKey, so react-
+  // query shares the one request — this is not a second fetch.
+  const { data: registryCfg } = useQuery<RegistryConfig>({
+    queryKey: ['admin-registry-config'],
+    queryFn: async () => (await api.get('/v1/admin/registry-config')).data,
+  });
+  const tabLabels = resolveTabLabels({
+    isPublic: registryCfg?.isPublic ?? null,
+    repo: registryCfg?.repo ?? null,
   });
 
   const orgAssignment = assignments.find(a => a.scope === 'org');
@@ -199,6 +212,7 @@ export function AdminFlows() {
         initialFlowId={initialFlowId}
         flowClient={flowClient}
         registryClient={registryClient}
+        tabLabels={tabLabels}
         theme={theme}
       />
     </div>

--- a/packages/hub-ui/src/pages/AdminFlows.tsx
+++ b/packages/hub-ui/src/pages/AdminFlows.tsx
@@ -23,7 +23,8 @@ import { useTheme } from '../ThemeContext';
 import {
   PUBLIC_REGISTRY_REPO,
   registryFormError,
-  registrySaveLabel,
+  registryConfigSaveLabel,
+  EDITOR_LABELS_HUB,
   resolveTabLabels,
   showRegistrySourcePicker,
   registrySourceOptions,
@@ -75,6 +76,19 @@ const flowClient: FlowClient = {
  * names a repo — that is the tenancy boundary, since the server holds the
  * org's contents:write PAT and would otherwise be a proxy for any repo it can
  * reach.
+ *
+ * There is deliberately **no `publishToRegistry`.** Publishing writes to the
+ * registry repo, and the only credential for that is the org's `contents:write`
+ * PAT — which lives encrypted on the hub and is never copied to a browser, and
+ * the hub exposes no publish route (its `writeRegistryFile` is used solely by
+ * the one-time community copy when an admin points the org at a private repo).
+ * This client used to carry a method that only threw; the method is optional on
+ * `RegistryClient` now, so omitting it hides the editor's Publish button
+ * instead of rendering a control that can only fail.
+ *
+ * Authors who do need to publish a flow to a repo do it from their own
+ * machine, where `gh` holds their credentials:
+ * `agenfk flow publish <id> [--registry owner/repo]`.
  */
 export function makeRegistryClient(getSource: () => RegistrySource): RegistryClient {
   return {
@@ -82,9 +96,6 @@ export function makeRegistryClient(getSource: () => RegistrySource): RegistryCli
       (await api.get('/v1/admin/registry/flows', { params: { source: getSource() } })).data,
     installFromRegistry: async (filename) =>
       flattenAdminFlow((await api.post('/v1/admin/flows/install', { filename, source: getSource() })).data),
-    publishToRegistry: async () => {
-      throw new Error('Publishing to the community registry is not supported from the Hub admin yet. Use your local agenfk client.');
-    },
   };
 }
 
@@ -247,6 +258,12 @@ export function AdminFlows() {
         initialFlowId={initialFlowId}
         flowClient={flowClient}
         registryClient={registryClient}
+        // Footer captions. In the hub admin, saving the row IS the fleet-wide
+        // publish — the bumped `version` is the ETag every installation polls
+        // at `GET /v1/flows/active` — and the selection button writes an
+        // org-default assignment rather than "using" anything. Left as the
+        // editor's own wording, both read as a pipeline that does not exist.
+        labels={EDITOR_LABELS_HUB}
         tabLabels={{
           myFlows: tabLabels.myFlows,
           // While the picker is showing, the tab names the repo it is CURRENTLY
@@ -708,7 +725,7 @@ function RegistryRepoPanel() {
           }}
           className="px-3 py-1.5 rounded-lg bg-[image:var(--gradient-accent)] text-navy shadow-glow text-xs font-bold disabled:opacity-40 disabled:cursor-not-allowed"
         >
-          {save.isPending ? 'Saving…' : registrySaveLabel({ repo, token, hasStoredToken })}
+          {save.isPending ? 'Saving…' : registryConfigSaveLabel({ repo, token, hasStoredToken })}
         </button>
         {!cfg?.isPublic && (
           <button

--- a/packages/hub-ui/src/pages/AdminFlows.tsx
+++ b/packages/hub-ui/src/pages/AdminFlows.tsx
@@ -10,7 +10,8 @@
  * stays focused on flow definition; assignment management would be
  * confusing inside the agenfk client where it has no analogue.
  */
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
+import clsx from 'clsx';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Plus, Pencil, Trash2, X, ChevronDown, ChevronRight } from 'lucide-react';
 import { FlowEditorModal, type FlowClient, type RegistryClient, type Flow } from '@agenfk/flow-editor';
@@ -24,6 +25,9 @@ import {
   registryFormError,
   registrySaveLabel,
   resolveTabLabels,
+  showRegistrySourcePicker,
+  registrySourceOptions,
+  type RegistrySource,
   MOVE_BACK_TO_PUBLIC_CONFIRM,
 } from './adminFlowRegistry';
 
@@ -61,13 +65,28 @@ const flowClient: FlowClient = {
   },
 };
 
-const registryClient: RegistryClient = {
-  browseRegistry: async () => (await api.get('/v1/admin/registry/flows')).data,
-  installFromRegistry: async (filename) => flattenAdminFlow((await api.post('/v1/admin/flows/install', { filename })).data),
-  publishToRegistry: async () => {
-    throw new Error('Publishing to the community registry is not supported from the Hub admin yet. Use your local agenfk client.');
-  },
-};
+/**
+ * The hub's RegistryClient. `source` selects which registry the server reads:
+ * the org's own repo, or the public community one. It is a factory rather than
+ * a const because the selection lives in component state, and the shared
+ * editor's browse/install must follow it.
+ *
+ * `source` is sent as an opaque enum the server maps to a repo. The UI never
+ * names a repo — that is the tenancy boundary, since the server holds the
+ * org's contents:write PAT and would otherwise be a proxy for any repo it can
+ * reach.
+ */
+export function makeRegistryClient(getSource: () => RegistrySource): RegistryClient {
+  return {
+    browseRegistry: async () =>
+      (await api.get('/v1/admin/registry/flows', { params: { source: getSource() } })).data,
+    installFromRegistry: async (filename) =>
+      flattenAdminFlow((await api.post('/v1/admin/flows/install', { filename, source: getSource() })).data),
+    publishToRegistry: async () => {
+      throw new Error('Publishing to the community registry is not supported from the Hub admin yet. Use your local agenfk client.');
+    },
+  };
+}
 
 export function AdminFlows() {
   const qc = useQueryClient();
@@ -77,6 +96,13 @@ export function AdminFlows() {
   const [editorOpen, setEditorOpen] = useState(false);
   const [initialFlowId, setInitialFlowId] = useState<string | undefined>(undefined);
   const [expandedFlowId, setExpandedFlowId] = useState<string | null>(null);
+  // Which registry the editor's second tab reads. Held in a ref-like getter so
+  // the module-level client factory below can read the current value without
+  // being rebuilt on every render (a new client object each render would
+  // retrigger the editor's registry query indefinitely).
+  const [registrySource, setRegistrySource] = useState<RegistrySource>('org');
+  const sourceRef = useRef<RegistrySource>('org');
+  sourceRef.current = registrySource;
 
   const { data: flows = [] } = useQuery<Flow[]>({
     queryKey: ['admin-flows'],
@@ -95,6 +121,15 @@ export function AdminFlows() {
     queryFn: async () => (await api.get('/v1/admin/registry-config')).data,
   });
   const tabLabels = resolveTabLabels({
+    isPublic: registryCfg?.isPublic ?? null,
+    repo: registryCfg?.repo ?? null,
+  });
+
+  // Built once; reads the live source through the ref so switching registries
+  // does not hand the editor a new client object (which would remount its
+  // query). The query key below is what actually drives a refetch.
+  const [registryClient] = useState(() => makeRegistryClient(() => sourceRef.current));
+  const showSourcePicker = showRegistrySourcePicker({
     isPublic: registryCfg?.isPublic ?? null,
     repo: registryCfg?.repo ?? null,
   });
@@ -212,7 +247,41 @@ export function AdminFlows() {
         initialFlowId={initialFlowId}
         flowClient={flowClient}
         registryClient={registryClient}
-        tabLabels={tabLabels}
+        tabLabels={{
+          myFlows: tabLabels.myFlows,
+          // While the picker is showing, the tab names the repo it is CURRENTLY
+          // reading — not the org's default — otherwise switching source would
+          // relist the panel under a caption describing the other repo.
+          registry: registrySource === 'community'
+            ? 'Community'
+            : tabLabels.registry,
+        }}
+        registryToolbar={showSourcePicker ? (
+          <div className="flex items-center gap-1.5" data-testid="registry-source-picker">
+            {registrySourceOptions({
+              isPublic: registryCfg?.isPublic ?? null,
+              repo: registryCfg?.repo ?? null,
+            }).map((opt) => (
+              <button
+                key={opt.value}
+                type="button"
+                data-testid={`registry-source-${opt.value}`}
+                onClick={() => {
+                  setRegistrySource(opt.value);
+                  sourceRef.current = opt.value;
+                }}
+                className={clsx(
+                  'px-2 py-0.5 rounded-full text-[11px] border transition-colors',
+                  registrySource === opt.value
+                    ? 'border-brand text-ink bg-chip font-semibold'
+                    : 'border-border-soft text-ink-tertiary hover:text-ink',
+                )}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+        ) : undefined}
         theme={theme}
       />
     </div>

--- a/packages/hub-ui/src/pages/adminFlowRegistry.ts
+++ b/packages/hub-ui/src/pages/adminFlowRegistry.ts
@@ -1,0 +1,67 @@
+/**
+ * Validation for the admin "flow registry repo" form (CGLAB-138).
+ *
+ * Mirrors the server-side rules in packages/hub/src/services/flowRegistry.ts.
+ * Duplicated on purpose rather than imported: the hub-ui bundle must not pull
+ * in server code, and a browser-side rejection that disagrees with the server
+ * is a UX bug, not a security hole — the server still refuses. Keep the two in
+ * sync; the test asserts they agree on the same corpus.
+ */
+
+export const PUBLIC_REGISTRY_REPO = 'cglab-public/agenfk-flows';
+
+/** Same charset as the server's GH_NAME_RE: no leading '-' (argv-flag safety),
+ *  exactly one separator (no path traversal). */
+const GH_NAME_RE = /^[A-Za-z0-9_][A-Za-z0-9_.-]*$/;
+
+export function isValidRegistrySlug(value: string): boolean {
+  const parts = value.split('/');
+  if (parts.length !== 2) return false;
+  return parts.every((p) => GH_NAME_RE.test(p));
+}
+
+export interface RegistryFormState {
+  repo: string;
+  token: string;
+  hasStoredToken: boolean;
+}
+
+/**
+ * Why the form cannot be saved yet, or null when it can.
+ *
+ * The token rule is the important one: a private repo with no token is a
+ * setting the server will reject, and the UI must not offer it. Note this only
+ * asks about tokens the UI can actually see — if a token is already stored, the
+ * admin is not required to retype it (the server never echoes it back).
+ */
+export function registryFormError(state: RegistryFormState): string | null {
+  const repo = state.repo.trim();
+  if (!repo) return 'Enter the owner/repo of an existing GitHub repository.';
+  if (!isValidRegistrySlug(repo)) {
+    return 'Must be "owner/repo" — letters, digits, dot, dash and underscore only.';
+  }
+  const toPublic = repo === PUBLIC_REGISTRY_REPO;
+  if (!toPublic && !state.token.trim() && !state.hasStoredToken) {
+    return 'A private registry needs a GitHub token with contents:write on that repo.';
+  }
+  return null;
+}
+
+/**
+ * What the save button should say. Switching to a private repo copies flows,
+ * which is the slow part of the operation — the label should say so rather
+ * than looking like a metadata edit.
+ */
+export function registrySaveLabel(state: RegistryFormState): string {
+  const repo = state.repo.trim();
+  if (repo && repo !== PUBLIC_REGISTRY_REPO) return 'Save & copy community flows';
+  return 'Save';
+}
+
+/**
+ * Confirmation copy for moving back to the public registry. Worth an explicit
+ * click: after this, the org's installs read the public repo again and any
+ * private-only flows stop being offered.
+ */
+export const MOVE_BACK_TO_PUBLIC_CONFIRM =
+  'Move this org back to the public community registry? Your private repo keeps its flows, but installations will browse the public one again.';

--- a/packages/hub-ui/src/pages/adminFlowRegistry.ts
+++ b/packages/hub-ui/src/pages/adminFlowRegistry.ts
@@ -59,6 +59,48 @@ export function registrySaveLabel(state: RegistryFormState): string {
 }
 
 /**
+ * The same form's button, named so it cannot be confused with the flow
+ * editor's Save. The page shows both, and until now both said "Save" while
+ * writing entirely different things: one writes a flow definition, this one
+ * points the org's whole registry at a different repo.
+ */
+export function registryConfigSaveLabel(state: RegistryFormState): string {
+  const base = registrySaveLabel(state);
+  return base === 'Save' ? 'Save registry repo' : base;
+}
+
+// ── Editor footer labels ───────────────────────────────────────────────────
+
+/**
+ * Footer captions for the shared flow editor, when it runs in the hub admin.
+ *
+ * The editor ships standalone-client wording — "Save" and "Use this Flow" —
+ * and both are misleading here, in the same way "My Flows" / "Community" were
+ * (see `resolveTabLabels`).
+ *
+ * - **Save *is* the publish.** `PUT /v1/admin/flows/:id` writes the org's
+ *   flow row and bumps its `version`; that version is the ETag of
+ *   `GET /v1/flows/active`, which is exactly what every installation polls.
+ *   Nothing else has to happen for the change to reach the fleet, so a bare
+ *   "Save" advertises half an action and leaves the admin hunting for a
+ *   publish step that does not exist.
+ * - **"Use this Flow" does not save.** It writes a `flow_assignments` row for
+ *   the id it already has. "Set as org default" is the literal name of the
+ *   badge the flows list renders for that same assignment, so the button and
+ *   the row finally say the same thing.
+ *
+ * `saved` is the confirmation the Save button shows in its place after a clean
+ * write. It is its own caption rather than a suffix rule because English past
+ * tense is not mechanical — appending "d" to "Save & publish to org" reads as
+ * "Save & publish to orgd".
+ */
+export const EDITOR_LABELS_HUB = {
+  save: 'Save & publish to org',
+  saved: 'Published to org',
+  useFlow: 'Set as org default',
+} as const
+
+/**
  * Confirmation copy for moving back to the public registry. Worth an explicit
  * click: after this, the org's installs read the public repo again and any
  * private-only flows stop being offered.

--- a/packages/hub-ui/src/pages/adminFlowRegistry.ts
+++ b/packages/hub-ui/src/pages/adminFlowRegistry.ts
@@ -125,3 +125,40 @@ function truncateLabel(value: string): string {
   // org prefix does, and every flow repo here shares the org.
   return `…${value.slice(-(MAX_REGISTRY_LABEL - 1))}`;
 }
+
+// ── Registry source selector ───────────────────────────────────────────────
+
+/** Which registry the browse/install surface reads. Mirrors the server enum. */
+export type RegistrySource = 'org' | 'community';
+
+/**
+ * Whether the source selector is worth showing.
+ *
+ * While the org is on the public registry, both sources resolve to the same
+ * repo — the control would be two options that do the same thing, which reads
+ * as a broken toggle. It only earns its space once a private repo exists to
+ * choose between.
+ */
+export function showRegistrySourcePicker(cfg: {
+  isPublic?: boolean | null;
+  repo?: string | null;
+}): boolean {
+  const repo = (cfg.repo ?? '').trim();
+  if (!repo || repo === PUBLIC_REGISTRY_REPO) return false;
+  return cfg.isPublic !== true;
+}
+
+/**
+ * The caption for the org option. Named for the repo it points at so the admin
+ * can tell the two apart at a glance rather than trusting an abstract "Org".
+ */
+export function registrySourceOptions(cfg: {
+  isPublic?: boolean | null;
+  repo?: string | null;
+}): Array<{ value: RegistrySource; label: string }> {
+  const repo = (cfg.repo ?? '').trim() || 'Org registry';
+  return [
+    { value: 'org', label: repo === PUBLIC_REGISTRY_REPO ? 'This registry' : repo },
+    { value: 'community', label: 'Community' },
+  ];
+}

--- a/packages/hub-ui/src/pages/adminFlowRegistry.ts
+++ b/packages/hub-ui/src/pages/adminFlowRegistry.ts
@@ -65,3 +65,63 @@ export function registrySaveLabel(state: RegistryFormState): string {
  */
 export const MOVE_BACK_TO_PUBLIC_CONFIRM =
   'Move this org back to the public community registry? Your private repo keeps its flows, but installations will browse the public one again.';
+
+// ── Tab labels ─────────────────────────────────────────────────────────────
+
+export interface TabLabels {
+  myFlows: string;
+  registry: string;
+}
+
+/**
+ * Labels the hub admin passes to the shared FlowEditorModal.
+ *
+ * The shared editor hardcodes "My Flows" / "Community", which is right for the
+ * standalone agenfk client and wrong here. In the hub admin the first tab lists
+ * the ORG's flow catalogue (`/v1/admin/flows`) — the one every installation
+ * inherits — so "My" is misleading; and the second lists whatever
+ * `resolveRegistryRead` resolves to, which after CGLAB-138 is the org's own
+ * private repo for any org that configured one. A tab labelled "Community"
+ * showing `cglab-PRIVATE/agenfk-flows` is not describing the thing it shows.
+ */
+export const DEFAULT_TAB_LABELS: TabLabels = {
+  myFlows: 'Org Flows',
+  registry: 'Community',
+};
+
+/** Longest registry label, so a long org/repo cannot push the second tab out
+ * of the modal's two-button flex row. */
+const MAX_REGISTRY_LABEL = 32;
+
+/**
+ * Resolve the registry tab's label from the org's current config.
+ *
+ * The repo slug wins over the `isPublic` flag wherever they disagree: the
+ * server derives `isPublic` from the slug and the slug is what
+ * `resolveRegistryRead` actually reads, so trusting the flag would let a
+ * private repo be labelled "Community" — the exact bug this exists to prevent.
+ * A missing config (still loading) yields "Community", the pre-CGLAB-138
+ * wording, rather than an empty or half-formed label.
+ */
+export function resolveTabLabels(cfg: {
+  isPublic?: boolean | null;
+  repo?: string | null;
+}): TabLabels {
+  const repo = (cfg.repo ?? '').trim();
+  const isPublic = repo === PUBLIC_REGISTRY_REPO
+    ? true
+    : repo === ''
+      ? true // nothing resolved yet — fall back to the neutral wording
+      : cfg.isPublic === true;
+  return {
+    myFlows: DEFAULT_TAB_LABELS.myFlows,
+    registry: isPublic ? DEFAULT_TAB_LABELS.registry : truncateLabel(repo),
+  };
+}
+
+function truncateLabel(value: string): string {
+  if (value.length <= MAX_REGISTRY_LABEL) return value;
+  // Keep the tail: the repo name identifies the registry far better than the
+  // org prefix does, and every flow repo here shares the org.
+  return `…${value.slice(-(MAX_REGISTRY_LABEL - 1))}`;
+}

--- a/packages/hub-ui/src/test/adminFlowRegistry.test.ts
+++ b/packages/hub-ui/src/test/adminFlowRegistry.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import {
+  PUBLIC_REGISTRY_REPO,
+  isValidRegistrySlug,
+  registryFormError,
+  registrySaveLabel,
+  MOVE_BACK_TO_PUBLIC_CONFIRM,
+} from '../pages/adminFlowRegistry';
+import { isValidRegistrySlug as serverIsValidRegistrySlug } from '../../../hub/src/services/flowRegistry.js';
+
+describe('admin flow registry form (CGLAB-138)', () => {
+  it('accepts a normal private repo', () => {
+    expect(isValidRegistrySlug('acme-corp/agenfk-flows')).toBe(true);
+  });
+
+  it('rejects shapes that are not owner/repo', () => {
+    for (const bad of ['', 'noslash', 'a/b/c', 'a/', '/b', 'own er/repo', 'owner/repo;rm -rf /']) {
+      expect(isValidRegistrySlug(bad), bad).toBe(false);
+    }
+  });
+
+  it('agrees with the SERVER validator on the same corpus', () => {
+    // The two implementations must not drift: a UI that accepts what the
+    // server rejects shows a spinner then an error for no reason.
+    const corpus = [
+      'acme/flows', 'acme-corp/agenfk-flows', 'a.b/c_d-1', 'PUBLIC/Repo',
+      '-evil/repo', 'owner/-evil', 'own er/repo', 'owner/repo;rm -rf /',
+      'a/b/c', 'a/', '/b', 'noslash', '', '..', 'a/../../b',
+    ];
+    for (const c of corpus) {
+      expect(isValidRegistrySlug(c), c).toBe(serverIsValidRegistrySlug(c));
+    }
+  });
+
+  it('requires a token for a private repo when none is stored', () => {
+    expect(registryFormError({ repo: 'acme/flows', token: '', hasStoredToken: false }))
+      .toMatch(/token/i);
+  });
+
+  it('does NOT require retyping a token that is already stored', () => {
+    // The server never echoes the secret back, so the UI has nothing to resend.
+    expect(registryFormError({ repo: 'acme/flows', token: '', hasStoredToken: false })).toBeTruthy();
+    expect(registryFormError({ repo: 'acme/flows', token: '', hasStoredToken: true })).toBeNull();
+  });
+
+  it('does not require a token for the public repo', () => {
+    expect(registryFormError({ repo: PUBLIC_REGISTRY_REPO, token: '', hasStoredToken: false })).toBeNull();
+  });
+
+  it('rejects a bad slug before complaining about the token', () => {
+    const err = registryFormError({ repo: 'not-a-slug', token: '', hasStoredToken: false });
+    expect(err).toMatch(/owner\/repo/);
+  });
+
+  it('labels the private-repo save as a copy, the public one plainly', () => {
+    expect(registrySaveLabel({ repo: 'acme/flows', token: 'x', hasStoredToken: false }))
+      .toMatch(/copy/i);
+    expect(registrySaveLabel({ repo: PUBLIC_REGISTRY_REPO, token: '', hasStoredToken: true }))
+      .toBe('Save');
+  });
+
+  it('warns on moving back to public that installs re-read the public repo', () => {
+    expect(MOVE_BACK_TO_PUBLIC_CONFIRM).toMatch(/public/i);
+  });
+});
+
+// ── Mutant-killers ─────────────────────────────────────────────────────────
+describe('admin flow registry form — edge branches', () => {
+  it('trims the repo before deciding, so whitespace does not change the verdict', () => {
+    // Survived: `state.repo.trim()` → `state.repo`. A pasted value with a
+    // trailing space is the common case, and without the trim it reads as a
+    // private repo (showing "Save & copy") or as an invalid slug.
+    expect(registryFormError({ repo: '  acme/flows  ', token: 'ghp_x', hasStoredToken: false })).toBeNull();
+    expect(registrySaveLabel({ repo: '  acme/flows  ', token: '', hasStoredToken: true }))
+      .toMatch(/copy/i);
+    expect(registrySaveLabel({ repo: '  ' + PUBLIC_REGISTRY_REPO + '  ', token: '', hasStoredToken: true }))
+      .toBe('Save');
+  });
+
+  it('treats a whitespace-only token as no token', () => {
+    // Survived: `state.token.trim()` → `state.token`. A field of spaces would
+    // otherwise satisfy the requirement and the save would fail server-side.
+    expect(registryFormError({ repo: 'acme/flows', token: '   ', hasStoredToken: false }))
+      .toMatch(/token/i);
+  });
+
+  it('reports the empty-repo message rather than the slug message', () => {
+    // Survived: ConditionalExpression → false on `if (!repo)`. Removing it
+    // still rejects, but with the wrong sentence for an untouched field.
+    expect(registryFormError({ repo: '', token: '', hasStoredToken: true })).toMatch(/Enter the owner\/repo/);
+    expect(registryFormError({ repo: '   ', token: '', hasStoredToken: true })).toMatch(/Enter the owner\/repo/);
+  });
+
+  it('does not ask for a token when the repo is public even with none stored', () => {
+    // The third clause of the conjunction: hasStoredToken false + public repo
+    // must still pass, which only holds if toPublic short-circuits it.
+    expect(registryFormError({ repo: PUBLIC_REGISTRY_REPO, token: '', hasStoredToken: false })).toBeNull();
+  });
+
+  it('labels an empty repo plainly rather than as a copy', () => {
+    // Survived: `repo &&` in registrySaveLabel. Without the guard an empty
+    // field would advertise "Save & copy community flows" on a disabled button.
+    expect(registrySaveLabel({ repo: '', token: '', hasStoredToken: false })).toBe('Save');
+  });
+
+  it('keeps the two error messages distinct', () => {
+    // Two different problems must not collapse into one string, or the admin
+    // cannot tell an empty field from a malformed one.
+    const empty = registryFormError({ repo: '', token: '', hasStoredToken: true });
+    const bad = registryFormError({ repo: 'nope', token: '', hasStoredToken: true });
+    const token = registryFormError({ repo: 'acme/flows', token: '', hasStoredToken: false });
+    expect(new Set([empty, bad, token]).size).toBe(3);
+  });
+});

--- a/packages/hub-ui/src/test/adminFlowRegistry.test.ts
+++ b/packages/hub-ui/src/test/adminFlowRegistry.test.ts
@@ -4,7 +4,9 @@ import {
   isValidRegistrySlug,
   registryFormError,
   registrySaveLabel,
+  registryConfigSaveLabel,
   MOVE_BACK_TO_PUBLIC_CONFIRM,
+  EDITOR_LABELS_HUB,
 } from '../pages/adminFlowRegistry';
 import { isValidRegistrySlug as serverIsValidRegistrySlug } from '../../../hub/src/services/flowRegistry.js';
 
@@ -110,5 +112,75 @@ describe('admin flow registry form — edge branches', () => {
     const bad = registryFormError({ repo: 'nope', token: '', hasStoredToken: true });
     const token = registryFormError({ repo: 'acme/flows', token: '', hasStoredToken: false });
     expect(new Set([empty, bad, token]).size).toBe(3);
+  });
+});
+
+// ── Editor footer labels ───────────────────────────────────────────────────
+//
+// The three footer CTAs read as one pipeline (Save → Publish → Use this Flow)
+// when they are three unrelated writes. These pin the hub-admin wording.
+describe('EDITOR_LABELS_HUB', () => {
+  it('says Save is the publish, because saving the row is what fans it out', () => {
+    expect(EDITOR_LABELS_HUB.save).toMatch(/save/i);
+    expect(EDITOR_LABELS_HUB.save).toMatch(/publish/i);
+    expect(EDITOR_LABELS_HUB.save).toMatch(/org/i);
+  });
+
+  it('names the assignment the button actually writes, not "use"', () => {
+    // The button only writes a flow_assignments row for the id it already has,
+    // so "Use this Flow" promises an action it does not take.
+    expect(EDITOR_LABELS_HUB.useFlow).toMatch(/org default/i);
+  });
+
+  it('does not reuse the word "publish" for the assignment button', () => {
+    // Two buttons claiming to publish is the confusion this removes.
+    expect(EDITOR_LABELS_HUB.useFlow).not.toMatch(/publish/i);
+  });
+
+  it('labels the two editor buttons differently', () => {
+    expect(EDITOR_LABELS_HUB.save).not.toBe(EDITOR_LABELS_HUB.useFlow);
+  });
+
+  it('gives the confirmation its own caption, past-tensed by the host not by rule', () => {
+    // Appending "d" to the save caption would render "Save & publish to orgd".
+    expect(EDITOR_LABELS_HUB.saved).toBeTruthy();
+    expect(EDITOR_LABELS_HUB.saved).not.toBe(`${EDITOR_LABELS_HUB.save}d`);
+    expect(EDITOR_LABELS_HUB.saved).toMatch(/publish/i);
+  });
+
+  it('matches the badge the flows list renders for the same assignment', () => {
+    // AdminFlows renders an "Org default" badge on the row this button sets.
+    // Substring, not equality: the button is a verb phrase, the badge a noun.
+    expect(EDITOR_LABELS_HUB.useFlow.toLowerCase()).toContain('org default');
+  });
+});
+
+// ── Two "Save" buttons on one page ─────────────────────────────────────────
+// Admin → Flows renders the flow editor's Save and the registry-config form's
+// Save. Both said "Save". They write unrelated things.
+describe('registryConfigSaveLabel', () => {
+  it('names the registry form plainly, so it is not the editor save', () => {
+    expect(registryConfigSaveLabel({ repo: PUBLIC_REGISTRY_REPO, token: '', hasStoredToken: true }))
+      .toBe('Save registry repo');
+  });
+
+  it('keeps the copy warning when the target is private', () => {
+    // The slow part still has to be advertised; only the plain case is renamed.
+    expect(registryConfigSaveLabel({ repo: 'acme/flows', token: 'x', hasStoredToken: false }))
+      .toMatch(/copy/i);
+  });
+
+  it('never collapses back onto the editor save label', () => {
+    expect(registryConfigSaveLabel({ repo: '', token: '', hasStoredToken: false }))
+      .not.toBe(EDITOR_LABELS_HUB.save);
+    expect(registryConfigSaveLabel({ repo: '', token: '', hasStoredToken: false }))
+      .not.toBe('Save');
+  });
+
+  it('is distinct from the editor label for every repo state', () => {
+    for (const repo of ['', '   ', PUBLIC_REGISTRY_REPO, 'acme/flows', '  acme/flows  ']) {
+      expect(registryConfigSaveLabel({ repo, token: '', hasStoredToken: true }), repo)
+        .not.toBe(EDITOR_LABELS_HUB.save);
+    }
   });
 });

--- a/packages/hub-ui/src/test/adminFlowTabLabels.test.ts
+++ b/packages/hub-ui/src/test/adminFlowTabLabels.test.ts
@@ -77,3 +77,36 @@ describe('hub flow-editor tab labels', () => {
     expect(resolveTabLabels({ isPublic: false, repo: 'acme/flows' }).registry).toBe('acme/flows');
   });
 });
+
+// ── Source selector ────────────────────────────────────────────────────────
+import { showRegistrySourcePicker, registrySourceOptions } from '../pages/adminFlowRegistry';
+
+describe('registry source picker visibility', () => {
+  it('is hidden while the org is on the public registry', () => {
+    // Both options would resolve to the same repo — two choices that do the
+    // same thing read as a broken control.
+    expect(showRegistrySourcePicker({ isPublic: true, repo: 'cglab-public/agenfk-flows' })).toBe(false);
+  });
+
+  it('is hidden while the config is still loading', () => {
+    expect(showRegistrySourcePicker({})).toBe(false);
+    expect(showRegistrySourcePicker({ isPublic: null, repo: null })).toBe(false);
+  });
+
+  it('appears once the org has a private registry', () => {
+    expect(showRegistrySourcePicker({ isPublic: false, repo: 'cglab-PRIVATE/agenfk-flows' })).toBe(true);
+  });
+
+  it('names each option so the two are distinguishable', () => {
+    const opts = registrySourceOptions({ isPublic: false, repo: 'acme/flows' });
+    expect(opts.map((o) => o.value)).toEqual(['org', 'community']);
+    expect(opts.map((o) => o.label)).toEqual(['acme/flows', 'Community']);
+    // Labels must not collide, or the picker is unreadable.
+    expect(new Set(opts.map((o) => o.label)).size).toBe(2);
+  });
+
+  it('falls back to a generic label when the repo is unknown', () => {
+    const opts = registrySourceOptions({});
+    expect(opts[0].label.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/hub-ui/src/test/adminFlowTabLabels.test.ts
+++ b/packages/hub-ui/src/test/adminFlowTabLabels.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Tab labels for the shared flow editor.
+ *
+ * The editor is embedded in two hosts whose vocabulary differs, and the
+ * difference is not cosmetic: in the hub admin, the "Community" tab lists
+ * whatever repo `resolveRegistryRead` resolves to, which for an org that set a
+ * private registry is the ORG'S OWN repo — so a tab labelled "Community" shows
+ * private flows, and the org's flow list is not "mine" but the catalogue every
+ * installation inherits.
+ *
+ * Labels are therefore supplied by the host. The defaults preserve the
+ * standalone client's wording exactly, because there "My Flows" and
+ * "Community" are both true.
+ */
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_TAB_LABELS, resolveTabLabels } from '../pages/adminFlowRegistry';
+
+describe('hub flow-editor tab labels', () => {
+  it('names the org catalogue "Org Flows", not "My Flows"', () => {
+    // The hub admin edits the org-wide catalogue that every installation
+    // inherits. "My" implies a personal list, which does not exist here.
+    expect(DEFAULT_TAB_LABELS.myFlows).toBe('Org Flows');
+  });
+
+  it('labels the registry tab by the repo actually being listed', () => {
+    // The decisive case: an org on a private registry must not see "Community".
+    expect(resolveTabLabels({ isPublic: false, repo: 'cglab-PRIVATE/agenfk-flows' }).registry)
+      .toBe('cglab-PRIVATE/agenfk-flows');
+  });
+
+  it('says "Community" only when the registry really is the public one', () => {
+    expect(resolveTabLabels({ isPublic: true, repo: 'cglab-public/agenfk-flows' }).registry)
+      .toBe('Community');
+  });
+
+  it('falls back to "Community" when the config has not loaded yet', () => {
+    // The panel renders before GET /v1/admin/registry-config resolves. A null
+    // config must not render an empty tab or a stale org name.
+    expect(resolveTabLabels({ isPublic: null, repo: null }).registry).toBe('Community');
+    expect(resolveTabLabels({}).registry).toBe('Community');
+  });
+
+  it('does not claim "Community" when the repo is private and isPublic is unknown', () => {
+    // If the two fields arrive out of order, trust the repo over the flag:
+    // mislabelling a private repo as Community is the bug being fixed.
+    expect(resolveTabLabels({ isPublic: null, repo: 'cglab-PRIVATE/agenfk-flows' }).registry)
+      .toBe('cglab-PRIVATE/agenfk-flows');
+  });
+
+  it('treats the public repo slug as public even if isPublic is false', () => {
+    // Defensive: the server derives isPublic from the slug, so the two cannot
+    // disagree. If a future edit lets them drift, the slug wins — it is what
+    // resolveRegistryRead actually reads.
+    expect(resolveTabLabels({ isPublic: false, repo: 'cglab-public/agenfk-flows' }).registry)
+      .toBe('Community');
+  });
+
+  it('keeps both labels non-empty for every input shape', () => {
+    // An empty tab label would render an unclickable-looking button.
+    for (const cfg of [{}, { isPublic: true, repo: '' }, { isPublic: false, repo: '' }, { repo: undefined }]) {
+      const l = resolveTabLabels(cfg);
+      expect(l.myFlows.length, JSON.stringify(cfg)).toBeGreaterThan(0);
+      expect(l.registry.length, JSON.stringify(cfg)).toBeGreaterThan(0);
+    }
+  });
+
+  it('truncates a long repo name so the tab bar does not overflow', () => {
+    // The tab bar is two flex-1 buttons in a modal; an unbounded repo name
+    // pushes the second tab off-screen.
+    const long = 'a-very-long-organization-name/a-very-long-repository-name-indeed';
+    const label = resolveTabLabels({ isPublic: false, repo: long }).registry;
+    expect(label.length).toBeLessThanOrEqual(32);
+    expect(label).toMatch(/…|\.\.\./);
+  });
+
+  it('keeps a normal-length repo name intact (no gratuitous truncation)', () => {
+    expect(resolveTabLabels({ isPublic: false, repo: 'acme/flows' }).registry).toBe('acme/flows');
+  });
+});

--- a/packages/hub-ui/src/test/adminFlowsEditor.test.tsx
+++ b/packages/hub-ui/src/test/adminFlowsEditor.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Admin → Flows, the flow editor's footer.
+ *
+ * The label strings are pinned in adminFlowRegistry.test.ts, but a correct
+ * constant that never reaches the button is the same bug as a wrong one — the
+ * admin still sees "Save" / "Use this Flow" and still reads three CTAs as one
+ * pipeline. These are the wiring tests the unit test cannot do:
+ *  - the hub's captions actually render in the shared editor's footer;
+ *  - the registry-config form's Save is not also called "Save";
+ *  - Publish is absent, because the hub has no publish path.
+ */
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AdminFlows } from '../pages/AdminFlows';
+import { EDITOR_LABELS_HUB, PUBLIC_REGISTRY_REPO } from '../pages/adminFlowRegistry';
+import { api } from '../api';
+import { ThemeProvider } from '../ThemeContext';
+
+vi.mock('../api', () => ({ api: { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn() } }));
+const get = api.get as unknown as ReturnType<typeof vi.fn>;
+
+const FLOW = {
+  id: 'f1',
+  name: 'TDD Flow',
+  description: 'org flow',
+  source: 'hub',
+  version: 7,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-02T00:00:00Z',
+  orgAvailable: true,
+  definition: {
+    name: 'TDD Flow',
+    description: 'org flow',
+    steps: [
+      { id: 's0', name: 'TODO', label: 'To Do', order: 0, isAnchor: true },
+      { id: 's1', name: 'DISCOVERY', label: 'Discovery', order: 1 },
+      { id: 's2', name: 'DONE', label: 'Done', order: 2, isAnchor: true },
+    ],
+  },
+};
+
+const renderPage = () => {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <ThemeProvider><AdminFlows /></ThemeProvider>
+    </QueryClientProvider>,
+  );
+};
+
+beforeEach(() => {
+  get.mockReset();
+  get.mockImplementation(async (url: string) => {
+    if (url === '/v1/admin/flows') return { data: [FLOW] };
+    if (url === '/v1/admin/flows/default') return { data: { id: 'default', name: 'Default Flow', steps: [] } };
+    if (url === '/v1/admin/flow-assignments') return { data: [] };
+    if (url === '/v1/admin/registry-config') {
+      return { data: { repo: PUBLIC_REGISTRY_REPO, branch: 'main', isPublic: true, hasToken: false, copiedAt: null } };
+    }
+    if (url === '/v1/admin/registry/flows') return { data: [] };
+    return { data: {} };
+  });
+});
+
+afterEach(() => { cleanup(); });
+
+const openEditor = async () => {
+  renderPage();
+  await waitFor(() => screen.getByTestId('admin-flows-new-btn'));
+  fireEvent.click(screen.getByTestId('admin-flows-new-btn'));
+  await waitFor(() => screen.getByTestId('flow-editor-modal'));
+  // The footer belongs to the editor PANEL, which only renders once a flow is
+  // selected — opening the modal alone leaves the empty-state placeholder.
+  await waitFor(() => screen.getByTestId('flow-item-f1'));
+  fireEvent.click(screen.getByTestId('flow-item-f1'));
+  await waitFor(() => screen.getByTestId('flow-footer'));
+};
+
+describe('Admin → Flows editor footer (hub host)', () => {
+  it('renders the hub captions, not the standalone editor defaults', async () => {
+    await openEditor();
+    await waitFor(() => screen.getByTestId('flow-footer'));
+
+    const save = screen.getByTestId('save-flow-btn');
+    expect(save.textContent).toBe(EDITOR_LABELS_HUB.save);
+    // Regression guard for the whole point of the change: the bare word must
+    // not be what the admin sees.
+    expect(save.textContent).not.toBe('Save');
+
+    const use = screen.getByTestId('use-flow-btn');
+    expect(use.textContent).toBe(EDITOR_LABELS_HUB.useFlow);
+    expect(use.textContent).not.toBe('Use this Flow');
+  });
+
+  it('does not render a Publish button — the hub has no publish path', async () => {
+    await openEditor();
+    await waitFor(() => screen.getByTestId('flow-footer'));
+
+    expect(screen.queryByTestId('publish-flow-btn')).toBeNull();
+  });
+
+  it('labels the registry-config form distinctly from the editor save', async () => {
+    renderPage();
+    await waitFor(() => screen.getByTestId('admin-registry-save'));
+
+    expect(screen.getByTestId('admin-registry-save').textContent).toBe('Save registry repo');
+  });
+});

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/hub",
-  "version": "1.1.18-beta.1",
+  "version": "1.1.18-beta.2",
   "description": "Corporate Hub for AgEnFK — fleet-wide metrics + timeline server",
   "main": "dist/server.js",
   "types": "dist/server.d.ts",
@@ -20,7 +20,7 @@
     "start": "node dist/bin.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.18-beta.1",
+    "@agenfk/core": "1.1.18-beta.2",
     "axios": "^1.20.0",
     "bcryptjs": "^2.4.3",
     "cookie-parser": "^1.4.7",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/hub",
-  "version": "1.1.17",
+  "version": "1.1.18-beta.1",
   "description": "Corporate Hub for AgEnFK — fleet-wide metrics + timeline server",
   "main": "dist/server.js",
   "types": "dist/server.d.ts",
@@ -20,7 +20,7 @@
     "start": "node dist/bin.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.17",
+    "@agenfk/core": "1.1.18-beta.1",
     "axios": "^1.20.0",
     "bcryptjs": "^2.4.3",
     "cookie-parser": "^1.4.7",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/hub",
-  "version": "1.1.18-beta.2",
+  "version": "1.1.18-beta.3",
   "description": "Corporate Hub for AgEnFK — fleet-wide metrics + timeline server",
   "main": "dist/server.js",
   "types": "dist/server.d.ts",
@@ -20,7 +20,7 @@
     "start": "node dist/bin.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.18-beta.2",
+    "@agenfk/core": "1.1.18-beta.3",
     "axios": "^1.20.0",
     "bcryptjs": "^2.4.3",
     "cookie-parser": "^1.4.7",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/hub",
-  "version": "1.1.18-beta.3",
+  "version": "1.1.18-beta.4",
   "description": "Corporate Hub for AgEnFK — fleet-wide metrics + timeline server",
   "main": "dist/server.js",
   "types": "dist/server.d.ts",
@@ -20,7 +20,7 @@
     "start": "node dist/bin.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.18-beta.3",
+    "@agenfk/core": "1.1.18-beta.4",
     "axios": "^1.20.0",
     "bcryptjs": "^2.4.3",
     "cookie-parser": "^1.4.7",

--- a/packages/hub/src/db/postgres.ts
+++ b/packages/hub/src/db/postgres.ts
@@ -129,6 +129,18 @@ const SCHEMA_PG = `
     email_allowlist TEXT
   );
 
+  -- Per-org registry choice (CGLAB-138). Mirrors the SQLite table; see the
+  -- comment there for why the token is stored encrypted and why reads are
+  -- authenticated with it.
+  CREATE TABLE IF NOT EXISTS org_settings (
+    org_id TEXT PRIMARY KEY,
+    registry_repo TEXT,
+    registry_branch TEXT NOT NULL DEFAULT 'main',
+    registry_token_enc TEXT,
+    registry_copied_at TIMESTAMPTZ,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+  );
+
   CREATE TABLE IF NOT EXISTS flows (
     id TEXT PRIMARY KEY,
     org_id TEXT NOT NULL,

--- a/packages/hub/src/db/sqlite.ts
+++ b/packages/hub/src/db/sqlite.ts
@@ -131,6 +131,23 @@ const SCHEMA_SQLITE = `
     email_allowlist TEXT
   );
 
+  -- Per-org registry choice (CGLAB-138). An admin of a hub-connected company
+  -- points the org's flow registry at an EXISTING repo of their own. The token
+  -- is a fine-grained PAT (contents:write on that repo) held encrypted, the
+  -- same way auth_config holds its OAuth secrets — it must never be read back
+  -- out of the API, only used hub-side. Reads are authenticated with it too:
+  -- the pre-existing registry read was an anonymous fetch, which 404s on a
+  -- private repo, so a private target is only servable fleet-wide if the hub
+  -- itself can authenticate. NULL repo = the public community registry.
+  CREATE TABLE IF NOT EXISTS org_settings (
+    org_id TEXT PRIMARY KEY,
+    registry_repo TEXT,
+    registry_branch TEXT NOT NULL DEFAULT 'main',
+    registry_token_enc TEXT,
+    registry_copied_at TEXT,
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+
   CREATE TABLE IF NOT EXISTS flows (
     id TEXT PRIMARY KEY,
     org_id TEXT NOT NULL,
@@ -400,10 +417,17 @@ class SqliteAdapter implements HubDb {
 }
 
 export async function openSqliteDb(dbPath: string): Promise<HubDb> {
-  const dir = path.dirname(dbPath);
-  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  // ':memory:' is a real SQLite filename, not a sentinel we intercept — but the
+  // mkdir below would try to create a directory named '.' for it, and WAL is
+  // unsupported on memory databases (the pragma silently no-ops, so it is
+  // skipped for clarity). Tests use this to avoid the tmpdir entirely.
+  const inMemory = dbPath === ':memory:';
+  if (!inMemory) {
+    const dir = path.dirname(dbPath);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  }
   const raw = new DatabaseSync(dbPath);
-  raw.prepare('PRAGMA journal_mode = WAL').run();
+  if (!inMemory) raw.prepare('PRAGMA journal_mode = WAL').run();
   raw.prepare('PRAGMA foreign_keys = ON').run();
   raw.exec(SCHEMA_SQLITE);
   raw.exec("DELETE FROM events WHERE type = 'tokens.logged'");

--- a/packages/hub/src/routes/admin.ts
+++ b/packages/hub/src/routes/admin.ts
@@ -15,6 +15,19 @@ import { liveIdentityBlockers, blockersFor } from '../util/mergeLiveness.js';
 import { loadAliasMap, resolveAliasKey, canonicaliseSourceKey } from '../util/userKeyAlias.js';
 import { rateLimit } from '../util/rateLimit.js';
 import { loadModelMappings } from '../util/modelMapping.js';
+import {
+  PUBLIC_REGISTRY_REPO,
+  getRegistryConfig,
+  resolveRegistryRead,
+  registryToken,
+  saveRegistryConfig,
+  isValidRegistryBranch,
+  isValidRegistrySlug,
+  probeWriteAccess,
+  copyCommunityFlows,
+  ghHeaders,
+  listRegistryFiles,
+} from '../services/flowRegistry.js';
 
 /**
  * Hosts a repoint campaign may never target. Every installation in the org
@@ -1516,9 +1529,10 @@ export function adminRouter(ctx: HubServerContext): Router {
   // Mirrors the local server's /registry/flows surface so the FlowEditorModal
   // running inside hub-ui can browse and install community flows without
   // talking to a per-installation agenfk server.
-  const REGISTRY_OWNER = process.env.AGENFK_REGISTRY_OWNER ?? 'cglab-public';
-  const REGISTRY_REPO = process.env.AGENFK_REGISTRY_REPO ?? 'agenfk-flows';
-  const REGISTRY_BRANCH = process.env.AGENFK_REGISTRY_BRANCH ?? 'main';
+  // CGLAB-138: the repo is no longer a process-wide env constant. Each org
+  // resolves its own — the public community registry by default, or a private
+  // repo its admin chose. Reads carry the org's token when one applies,
+  // because an anonymous fetch 404s on a private repo.
   const GITHUB_API = 'https://api.github.com';
 
   interface RegistryFlowEntry {
@@ -1531,10 +1545,109 @@ export function adminRouter(ctx: HubServerContext): Router {
     steps?: { name: string; label: string }[];
   }
 
-  router.get('/registry/flows', guard, async (_req: Request, res: Response) => {
-    const url = `${GITHUB_API}/repos/${REGISTRY_OWNER}/${REGISTRY_REPO}/contents/flows?ref=${REGISTRY_BRANCH}`;
+  // ── Per-org registry config (CGLAB-138) ─────────────────────────────
+  // The admin of a hub-connected company points the org's flow registry at an
+  // EXISTING repo of their own. GET never returns the token — only that one
+  // exists — because the UI has no legitimate reason to render a secret.
+  router.get('/registry-config', guard, async (req: Request, res: Response) => {
+    res.json(await getRegistryConfig(ctx.db, req.session!.orgId));
+  });
+
+  router.put('/registry-config', guard, async (req: Request, res: Response) => {
+    const orgId = req.session!.orgId;
+    const b = req.body ?? {};
+
+    const repo = typeof b.repo === 'string' ? b.repo.trim() : '';
+    if (!isValidRegistrySlug(repo)) {
+      return res.status(400).json({ error: 'repo must be "owner/repo" using only letters, digits, dot, dash, underscore' });
+    }
+    const token = typeof b.token === 'string' && b.token.trim() ? b.token.trim() : null;
+    const current = await getRegistryConfig(ctx.db, orgId);
+    // Validate the RAW value, not the trimmed one. `trim()` strips a trailing
+    // newline, and `$` in a JS regex matches before a trailing newline, so
+    // validating post-trim would wave "main\n" straight through into the
+    // column. The trim below is for storage, not for the decision.
+    if (b.branch !== undefined && !isValidRegistryBranch(b.branch)) {
+      return res.status(400).json({ error: 'branch must be a git ref name: letters, digits, dot, dash, underscore, and internal slashes' });
+    }
+    const branch = typeof b.branch === 'string' && b.branch.trim() ? b.branch.trim() : current.branch;
+    const toPublic = repo === PUBLIC_REGISTRY_REPO;
+
+    // A private target is unreadable by the fleet without a token and
+    // un-writable by the copy. Refuse before touching GitHub.
+    if (!toPublic && !token && !current.hasToken) {
+      return res.status(400).json({ error: 'a private registry repo requires a GitHub token with contents:write on it' });
+    }
+
+    // Act with a freshly supplied token, else the stored one.
+    let effectiveToken = token;
+    if (!effectiveToken && !toPublic) {
+      effectiveToken = await registryToken(ctx.db, orgId, ctx.config.secretKey);
+    }
+
+    // FAIL THE SAVE: probe write access BEFORE persisting anything, so an
+    // admin is never left believing the org points at a repo it cannot write.
+    if (!toPublic) {
+      const probe = await probeWriteAccess(fetch, repo, effectiveToken!);
+      if (!probe.ok) {
+        return res.status(422).json({ error: `cannot write to ${repo}: ${probe.error}. No changes were saved.` });
+      }
+    }
+
+    // Moving back to public needs NO reverse copy — the community flows are
+    // already public, and writing them into a repo the org has no relationship
+    // with would be pointless and would leak the org's credential in the diff.
+    if (toPublic) {
+      await saveRegistryConfig(ctx.db, orgId, { repo, branch, token, secretKey: ctx.config.secretKey, copiedAt: null });
+      res.json({ ...(await getRegistryConfig(ctx.db, orgId)), copied: 0, failed: [] });
+      return;
+    }
+
+    // One-time copy of the community flows present at switch time. A failed
+    // copy does NOT roll the setting back: the repo is reachable (we just
+    // probed it) and `sync` exists to finish the job. Rolling back would
+    // strand the org with a half-copied repo and no way to complete it.
+    const copy = await copyCommunityFlows(
+      fetch, PUBLIC_REGISTRY_REPO, current.branch, repo, branch,
+      effectiveToken!, `hub:${orgId}`,
+    );
+
+    await saveRegistryConfig(ctx.db, orgId, {
+      repo, branch, token, secretKey: ctx.config.secretKey,
+      copiedAt: new Date().toISOString(),
+    });
+    res.json({
+      ...(await getRegistryConfig(ctx.db, orgId)),
+      copied: copy.copied, skipped: copy.skipped, failed: copy.failed, truncated: copy.truncated,
+    });
+  });
+
+  // Re-run the copy after a partial or failed one. Tops up the repo the org
+  // already points at; does not re-probe-and-switch.
+  router.post('/registry-config/sync', guard, async (req: Request, res: Response) => {
+    const orgId = req.session!.orgId;
+    const cfg = await getRegistryConfig(ctx.db, orgId);
+    if (cfg.isPublic) {
+      return res.status(409).json({ error: 'the org is on the public registry - there is nowhere to copy to' });
+    }
+    const token = await registryToken(ctx.db, orgId, ctx.config.secretKey);
+    if (!token) return res.status(409).json({ error: 'no registry token stored for this org' });
+
+    const copy = await copyCommunityFlows(
+      fetch, PUBLIC_REGISTRY_REPO, cfg.branch, cfg.repo, cfg.branch, token, `hub:${orgId}`,
+    );
+    await saveRegistryConfig(ctx.db, orgId, {
+      repo: cfg.repo, branch: cfg.branch, secretKey: ctx.config.secretKey,
+      copiedAt: new Date().toISOString(),
+    });
+    res.json({ copied: copy.copied, skipped: copy.skipped, failed: copy.failed, truncated: copy.truncated });
+  });
+
+  router.get('/registry/flows', guard, async (req: Request, res: Response) => {
+    const { repo, branch, token } = await resolveRegistryRead(ctx.db, req.session!.orgId, ctx.config.secretKey);
+    const url = `${GITHUB_API}/repos/${repo}/contents/flows?ref=${encodeURIComponent(branch)}`;
     try {
-      const resp = await fetch(url, { headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'agenfk-hub' } });
+      const resp = await fetch(url, { headers: ghHeaders(token) });
       if (resp.status === 404) return res.json([]);
       if (!resp.ok) return res.status(resp.status).json({ error: 'Failed to fetch registry' });
       const entries: any = await resp.json();
@@ -1543,7 +1656,7 @@ export function adminRouter(ctx: HubServerContext): Router {
       const flows: RegistryFlowEntry[] = await Promise.all(
         jsonFiles.map(async (file: any) => {
           try {
-            const r = await fetch(file.download_url, { headers: { 'User-Agent': 'agenfk-hub' } });
+            const r = await fetch(file.download_url, { headers: ghHeaders(token) });
             if (!r.ok) throw new Error(`download ${r.status}`);
             const content: any = await r.json();
             return {
@@ -1572,9 +1685,10 @@ export function adminRouter(ctx: HubServerContext): Router {
   router.post('/flows/install', guard, async (req: Request, res: Response) => {
     const filename = typeof req.body?.filename === 'string' ? req.body.filename : null;
     if (!filename) return res.status(400).json({ error: 'filename is required' });
-    const url = `${GITHUB_API}/repos/${REGISTRY_OWNER}/${REGISTRY_REPO}/contents/flows/${encodeURIComponent(filename)}?ref=${REGISTRY_BRANCH}`;
+    const { repo, branch, token } = await resolveRegistryRead(ctx.db, req.session!.orgId, ctx.config.secretKey);
+    const url = `${GITHUB_API}/repos/${repo}/contents/flows/${encodeURIComponent(filename)}?ref=${encodeURIComponent(branch)}`;
     try {
-      const r = await fetch(url, { headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'agenfk-hub' } });
+      const r = await fetch(url, { headers: ghHeaders(token) });
       if (!r.ok) return res.status(r.status).json({ error: 'Failed to fetch registry file' });
       const fileInfo: any = await r.json();
       const rawContent = Buffer.from(fileInfo.content, 'base64').toString('utf8');

--- a/packages/hub/src/routes/admin.ts
+++ b/packages/hub/src/routes/admin.ts
@@ -18,7 +18,7 @@ import { loadModelMappings } from '../util/modelMapping.js';
 import {
   PUBLIC_REGISTRY_REPO,
   getRegistryConfig,
-  resolveRegistryRead,
+  resolveRegistrySource,
   registryToken,
   saveRegistryConfig,
   isValidRegistryBranch,
@@ -1644,7 +1644,11 @@ export function adminRouter(ctx: HubServerContext): Router {
   });
 
   router.get('/registry/flows', guard, async (req: Request, res: Response) => {
-    const { repo, branch, token } = await resolveRegistryRead(ctx.db, req.session!.orgId, ctx.config.secretKey);
+    const resolved = await resolveRegistrySource(
+      ctx.db, req.session!.orgId, ctx.config.secretKey, req.query?.source,
+    );
+    if (!resolved.ok) return res.status(400).json({ error: resolved.error });
+    const { repo, branch, token } = resolved;
     const url = `${GITHUB_API}/repos/${repo}/contents/flows?ref=${encodeURIComponent(branch)}`;
     try {
       const resp = await fetch(url, { headers: ghHeaders(token) });
@@ -1685,7 +1689,11 @@ export function adminRouter(ctx: HubServerContext): Router {
   router.post('/flows/install', guard, async (req: Request, res: Response) => {
     const filename = typeof req.body?.filename === 'string' ? req.body.filename : null;
     if (!filename) return res.status(400).json({ error: 'filename is required' });
-    const { repo, branch, token } = await resolveRegistryRead(ctx.db, req.session!.orgId, ctx.config.secretKey);
+    const resolved = await resolveRegistrySource(
+      ctx.db, req.session!.orgId, ctx.config.secretKey, req.body?.source,
+    );
+    if (!resolved.ok) return res.status(400).json({ error: resolved.error });
+    const { repo, branch, token } = resolved;
     const url = `${GITHUB_API}/repos/${repo}/contents/flows/${encodeURIComponent(filename)}?ref=${encodeURIComponent(branch)}`;
     try {
       const r = await fetch(url, { headers: ghHeaders(token) });

--- a/packages/hub/src/routes/flows.ts
+++ b/packages/hub/src/routes/flows.ts
@@ -1,8 +1,10 @@
 import { Router, Request, Response } from 'express';
+import { randomUUID } from 'crypto';
 import { HubServerContext } from '../server.js';
 import { requireApiKey } from '../auth/apiKey.js';
 import { resolveEffectiveFlow } from '../services/flowResolution.js';
 import { sanitizeRemoteUrl } from '../util/remoteUrl.js';
+import { resolveRegistryRead, ghHeaders, listRegistryFiles } from '../services/flowRegistry.js';
 
 /**
  * Client-facing flow distribution: a connected agenfk installation calls
@@ -77,6 +79,92 @@ export function flowsRouter(ctx: HubServerContext): Router {
       };
     });
     res.json({ flows, defaultFlowId });
+  });
+
+  // ── Registry proxy for connected installations (CGLAB-138) ──────────
+  //
+  // A client's FlowEditorModal browses through the LOCAL server's
+  // /registry/flows. When the installation belongs to an org that moved to a
+  // private registry, the local server cannot do that read itself: the org's
+  // GitHub token lives on the hub and must not be copied onto every laptop. So
+  // the client asks the hub, which answers with the catalogue of ITS chosen
+  // repo — the same repo the hub admin sees. One source of truth.
+  //
+  // The response carries `repo` so the client can show which registry the
+  // entries came from; a list of flows with no label is how a private repo
+  // gets mistaken for the public one.
+  router.get('/registry/flows', requireKey, async (req: Request, res: Response) => {
+    const orgId = req.hubApiKey!.orgId;
+    try {
+      const { repo, branch, token } = await resolveRegistryRead(ctx.db, orgId, ctx.config.secretKey);
+      const files = await listRegistryFiles(fetch, repo, branch, token);
+      const flows = await Promise.all(files.map(async (file) => {
+        try {
+          const r = await fetch(file.download_url, { headers: ghHeaders(token) });
+          if (!r.ok) throw new Error(`download ${r.status}`);
+          const content: any = await r.json();
+          return {
+            filename: file.name,
+            name: content.name ?? file.name.replace('.json', ''),
+            author: content.author,
+            version: content.version,
+            stepCount: Array.isArray(content.steps) ? content.steps.length : 0,
+            description: content.description,
+            steps: Array.isArray(content.steps)
+              ? content.steps.map((s: any) => ({ name: s.name ?? '', label: s.label ?? s.name ?? '' }))
+              : undefined,
+          };
+        } catch {
+          return { filename: file.name, name: file.name.replace('.json', ''), stepCount: 0 };
+        }
+      }));
+      res.json({ repo, branch, flows });
+    } catch (e: any) {
+      // Never answer 200-with-empty here. An installation that cannot learn its
+      // org registry must see a failure, not an empty catalogue it may then
+      // assume is authoritative.
+      res.status(502).json({ error: 'Failed to fetch registry', detail: e?.message });
+    }
+  });
+
+  // Install one registry flow on behalf of a connected installation. The
+  // installation cannot fetch this itself — a private org repo is readable
+  // only with the hub-held token — so the hub fetches and hands back the
+  // definition, and the client creates it locally.
+  router.post('/registry/flows/install', requireKey, async (req: Request, res: Response) => {
+    const orgId = req.hubApiKey!.orgId;
+    const filename = typeof req.body?.filename === 'string' ? req.body.filename : null;
+    if (!filename) return res.status(400).json({ error: 'filename is required' });
+    try {
+      const { repo, branch, token } = await resolveRegistryRead(ctx.db, orgId, ctx.config.secretKey);
+      const url = `https://api.github.com/repos/${repo}/contents/flows/${encodeURIComponent(filename)}?ref=${encodeURIComponent(branch)}`;
+      const r = await fetch(url, { headers: ghHeaders(token) });
+      if (!r.ok) return res.status(r.status).json({ error: 'Failed to fetch registry file' });
+      const fileInfo: any = await r.json();
+      const raw = Buffer.from(fileInfo.content, 'base64').toString('utf8');
+      const flowData = JSON.parse(raw);
+      // Normalise exactly as the hub admin install does, so a flow behaves the
+      // same however it arrived.
+      const rawSteps: any[] = Array.isArray(flowData.steps) ? flowData.steps : [];
+      const middle = rawSteps
+        .filter((s: any) => !s.isAnchor && s.name?.toUpperCase() !== 'TODO' && s.name?.toUpperCase() !== 'DONE')
+        .map((s: any, i: number) => ({
+          id: randomUUID(),
+          name: (typeof s.name === 'string' && s.name.trim()) ? s.name : `step-${i}`,
+          label: (typeof s.label === 'string' && s.label.trim()) ? s.label : ((typeof s.name === 'string' && s.name.trim()) ? s.name : `Step ${i + 1}`),
+          order: i + 1,
+          exitCriteria: s.exitCriteria ?? '',
+          isSpecial: s.isSpecial ?? false,
+        }));
+      const steps = [
+        { id: randomUUID(), name: 'TODO', label: 'To Do', order: 0, exitCriteria: '', isAnchor: true },
+        ...middle,
+        { id: randomUUID(), name: 'DONE', label: 'Done', order: middle.length + 1, exitCriteria: '', isAnchor: true },
+      ];
+      res.json({ repo, flow: { name: flowData.name ?? filename.replace('.json', ''), description: flowData.description ?? '', steps } });
+    } catch (e: any) {
+      res.status(502).json({ error: 'Failed to install flow', detail: e?.message });
+    }
   });
 
   router.put('/flows/selection', requireKey, async (req: Request, res: Response) => {

--- a/packages/hub/src/routes/orgRename.ts
+++ b/packages/hub/src/routes/orgRename.ts
@@ -21,6 +21,7 @@ export const ORG_ID_CHILD_TABLES: readonly string[] = [
   'installations',
   'model_mappings',
   'model_meta',
+  'org_settings',
   'repoint_campaigns',
   'rollups_daily',
   'upgrade_directives',

--- a/packages/hub/src/services/flowRegistry.ts
+++ b/packages/hub/src/services/flowRegistry.ts
@@ -1,0 +1,418 @@
+/**
+ * Per-org flow registry (CGLAB-138).
+ *
+ * A hub-connected company's admin points the org's flow registry at an
+ * EXISTING repo of their own. Three rules shape this module, and each exists
+ * because the naive version of it is wrong:
+ *
+ * 1. FAIL THE SAVE. Write access is probed BEFORE anything is persisted. A
+ *    setting that "saved" but cannot actually be written to is worse than a
+ *    rejected save: the admin believes their fleet is pointed at a private
+ *    repo that will silently serve nothing.
+ *
+ * 2. READS ARE AUTHENTICATED. The registry read path used to be an anonymous
+ *    `fetch`, which GitHub answers with 404 for a private repo. So a private
+ *    registry is only servable to the fleet if the hub presents a token — this
+ *    is the whole reason the token lives on the hub rather than in a `gh`
+ *    login on one admin's laptop.
+ *
+ * 3. THE COPY IS ONE-TIME. Switching repos copies the community flows present
+ *    at that moment; it is not a mirror. A re-runnable `sync` exists because a
+ *    partial failure (rate limit, revoked token) must be recoverable without
+ *    the admin flipping the setting back and forth.
+ */
+import { encryptSecret, decryptSecret } from '../crypto.js';
+import type { HubDb } from '../db/types.js';
+
+export const PUBLIC_REGISTRY_REPO = 'cglab-public/agenfk-flows';
+export const DEFAULT_REGISTRY_BRANCH = 'main';
+const GITHUB_API = 'https://api.github.com';
+
+/**
+ * GitHub owner/repo names. Deliberately stricter than GitHub itself: the slug
+ * is interpolated into URLs and, on the publish path, into argv for git/gh.
+ * Disallowing a leading '-' stops the value being read as a FLAG by an
+ * argv-form call, and rejecting '/' beyond the single separator stops path
+ * traversal. Mirrors GH_NAME_RE on the local publish route.
+ */
+export const GH_NAME_RE = /^[A-Za-z0-9_][A-Za-z0-9_.-]*$/;
+
+export function isValidRegistrySlug(value: unknown): value is string {
+  if (typeof value !== 'string') return false;
+  const parts = value.split('/');
+  if (parts.length !== 2) return false;
+  return parts.every((p) => GH_NAME_RE.test(p));
+}
+
+/**
+ * Git ref name for the registry branch. Every use interpolates it through
+ * `encodeURIComponent`, so an unvalidated value cannot break out of the URL it
+ * sits in — this is not the injection defence. What it does is reject, at the
+ * boundary, the values that would otherwise be stored and then fail on every
+ * later read: GitHub answers a malformed `ref` with 404, and `listRegistryFiles`
+ * reads 404 as "empty registry", so a typo'd branch silently presents an admin
+ * with a registry of zero flows rather than an error.
+ *
+ * Stricter than git, which permits almost any byte in a refname. Rejects a
+ * leading '-' (argv-form calls on the publish path), a trailing '/' or '.'
+ * (git forbids these), the '..' sequence (path traversal), and any character
+ * outside the safe set. A ref with '/' in it stays legal — `release/2.0` is a
+ * normal branch name.
+ */
+export const GIT_REF_RE = /^[A-Za-z0-9_][A-Za-z0-9_./-]*$/;
+
+export function isValidRegistryBranch(value: unknown): value is string {
+  if (typeof value !== 'string') return false;
+  // Reject line breaks outright rather than relying on trim(). `$` in a
+  // JavaScript regex matches *before* a trailing newline (verified: /a$/
+  // .test("a\n") is true), so a `$`-anchored pattern accepts "main\n" — and
+  // since trim() strips it too, an implementation that trimmed first would pass
+  // a test written against "main\n" while still being wrong for a value that
+  // reached the regex untrimmed. JavaScript has no `\z`; an explicit
+  // control-character check is the only sound guard. It also covers \r, which
+  // trim() removes but which must not reach a stored ref either.
+  if (/\r|\n/.test(value)) return false;
+  const ref = value.trim();
+  if (!ref || ref.length > 255) return false;
+  if (!GIT_REF_RE.test(ref)) return false;
+  if (ref.includes('..')) return false;
+  if (ref.endsWith('/') || ref.endsWith('.')) return false;
+  if (ref.includes('//') || ref.includes('/.')) return false;
+  return true;
+}
+
+export interface RegistryConfig {
+  /** 'owner/repo'. Null means the public community registry. */
+  repo: string;
+  branch: string;
+  isPublic: boolean;
+  hasToken: boolean;
+  /** ISO timestamp of the last successful community→org copy, if any. */
+  copiedAt: string | null;
+}
+
+interface OrgSettingsRow {
+  org_id: string;
+  registry_repo: string | null;
+  registry_branch: string | null;
+  registry_token_enc: string | null;
+  registry_copied_at: string | null;
+}
+
+/**
+ * Read the org's registry config. NEVER returns the token — callers get
+ * `hasToken` and must go through `registryToken()` to actually use it. This
+ * split is what keeps the secret out of every admin API response by
+ * construction rather than by remembering to redact.
+ */
+export async function getRegistryConfig(db: HubDb, orgId: string): Promise<RegistryConfig> {
+  const row = await db.get<OrgSettingsRow>('SELECT * FROM org_settings WHERE org_id = ?', [orgId]);
+  const repo = row?.registry_repo ?? PUBLIC_REGISTRY_REPO;
+  return {
+    repo,
+    branch: row?.registry_branch || DEFAULT_REGISTRY_BRANCH,
+    isPublic: repo === PUBLIC_REGISTRY_REPO,
+    hasToken: Boolean(row?.registry_token_enc),
+    copiedAt: row?.registry_copied_at ?? null,
+  };
+}
+
+/** Decrypt the org's registry token. Null when none is stored. */
+export async function registryToken(
+  db: HubDb,
+  orgId: string,
+  secretKey: string,
+): Promise<string | null> {
+  const row = await db.get<{ registry_token_enc: string | null }>(
+    'SELECT registry_token_enc FROM org_settings WHERE org_id = ?', [orgId]);
+  if (!row?.registry_token_enc) return null;
+  return decryptSecret(row.registry_token_enc, secretKey);
+}
+
+/**
+ * Resolve the repo/branch/token to use for a registry read. Public orgs get no
+ * token — anonymous is correct there and sending a token to a public repo
+ * would leak the org's credential to a repo it has no relationship with.
+ */
+export async function resolveRegistryRead(
+  db: HubDb,
+  orgId: string,
+  secretKey: string,
+): Promise<{ repo: string; branch: string; token: string | null }> {
+  const cfg = await getRegistryConfig(db, orgId);
+  const token = cfg.isPublic ? null : await registryToken(db, orgId, secretKey);
+  return { repo: cfg.repo, branch: cfg.branch, token };
+}
+
+export function ghHeaders(token: string | null): Record<string, string> {
+  const h: Record<string, string> = {
+    Accept: 'application/vnd.github+json',
+    'User-Agent': 'agenfk-hub',
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+  if (token) h.Authorization = `Bearer ${token}`;
+  return h;
+}
+
+/**
+ * Probe that the token can actually WRITE to the repo. Checks the repo is
+ * reachable and reports a `permissions.push` the token really has — GitHub
+ * tells us this on the single repos call, so we do not need to attempt a
+ * throwaway commit to find out.
+ */
+export async function probeWriteAccess(
+  fetchImpl: typeof fetch,
+  repo: string,
+  token: string,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  let resp: Awaited<ReturnType<typeof fetchImpl>>;
+  try {
+    resp = await fetchImpl(`${GITHUB_API}/repos/${repo}`, { headers: ghHeaders(token) });
+  } catch (e: any) {
+    return { ok: false, error: `could not reach GitHub: ${e?.message ?? e}` };
+  }
+  if (resp.status === 404) {
+    // 404 rather than 403 is GitHub hiding a private repo from a token that
+    // cannot see it. Same advice either way.
+    return { ok: false, error: `repo ${repo} not found or not visible to this token (GitHub reports 404 for private repos a token cannot see)` };
+  }
+  if (!resp.ok) {
+    return { ok: false, error: `GitHub returned ${resp.status} for ${repo}` };
+  }
+  const meta: any = await resp.json().catch(() => null);
+  // A real /repos document always identifies the repo. Anything else — an API
+  // gateway's `{ message, url }`, a portal's HTML parsed to nothing — means we
+  // are not looking at a repository, so we cannot claim it is writable.
+  // Keyed on `full_name` rather than "no permissions block" because an error
+  // payload IS an object, and absence of `permissions` alone must still pass
+  // (a proxy that strips it should not lock every admin out).
+  if (!meta || typeof meta !== 'object' || typeof meta.full_name !== 'string') {
+    return { ok: false, error: `could not read a repository document for ${repo} from GitHub` };
+  }
+  const canPush = meta?.permissions?.push;
+  if (canPush === false) {
+    return { ok: false, error: `the token can read ${repo} but cannot write to it (needs contents:write)` };
+  }
+  return { ok: true };
+}
+
+/** List the flow files in a registry repo's flows/ directory. */
+export async function listRegistryFiles(
+  fetchImpl: typeof fetch,
+  repo: string,
+  branch: string,
+  token: string | null,
+): Promise<Array<{ name: string; download_url: string }>> {
+  const url = `${GITHUB_API}/repos/${repo}/contents/flows?ref=${encodeURIComponent(branch)}`;
+  const resp = await fetchImpl(url, { headers: ghHeaders(token) });
+  // A repo with no flows/ directory yet is an EMPTY registry, not an error —
+  // this is exactly the state a brand-new private registry starts in.
+  if (resp.status === 404) return [];
+  if (!resp.ok) throw new Error(`registry listing failed: ${resp.status}`);
+  const entries: any = await resp.json();
+  if (!Array.isArray(entries)) return [];
+  return entries
+    .filter((e: any) => e.type === 'file' && typeof e.name === 'string' && e.name.endsWith('.json'))
+    .map((e: any) => ({ name: e.name, download_url: e.download_url }));
+}
+
+export function slugify(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+}
+
+/**
+ * Normalise a flow document for the registry. Drops step ids (they are
+ * per-installation UUIDs; shipping them would make two installs collide) and
+ * re-derives step order, so a copied flow installs the same way a published
+ * one does.
+ */
+export function serializeRegistryFlow(flow: any, author: string): string {
+  const steps = (Array.isArray(flow?.steps) ? flow.steps : [])
+    .slice()
+    .sort((a: any, b: any) => (a.order ?? 0) - (b.order ?? 0))
+    .map((s: any) => ({
+      name: s.name,
+      label: s.label ?? s.name,
+      order: s.order,
+      exitCriteria: s.exitCriteria ?? '',
+      isSpecial: s.isSpecial ?? false,
+      isAnchor: s.isAnchor ?? false,
+    }));
+  return JSON.stringify({
+    schemaVersion: '1',
+    name: flow?.name,
+    description: flow?.description ?? '',
+    author,
+    version: flow?.version ?? '1.0.0',
+    steps,
+  }, null, 2) + '\n';
+}
+
+/**
+ * Write one flow file via the Contents API. GitHub requires the existing
+ * blob sha to overwrite a file, so fetch-then-put. Returns false when the
+ * write was refused, so the caller can report a partial copy honestly.
+ */
+export async function writeRegistryFile(
+  fetchImpl: typeof fetch,
+  repo: string,
+  branch: string,
+  token: string,
+  filename: string,
+  content: string,
+  message: string,
+): Promise<boolean> {
+  const pathPart = `flows/${encodeURIComponent(filename)}`;
+  const base = `${GITHUB_API}/repos/${repo}/contents/${pathPart}`;
+  let sha: string | undefined;
+  try {
+    const existing = await fetchImpl(`${base}?ref=${encodeURIComponent(branch)}`, { headers: ghHeaders(token) });
+    if (existing.ok) sha = (await existing.json())?.sha;
+  } catch { /* treat as new file */ }
+
+  const resp = await fetchImpl(`${base}?ref=${encodeURIComponent(branch)}`, {
+    method: 'PUT',
+    headers: ghHeaders(token),
+    body: JSON.stringify({
+      message,
+      content: Buffer.from(content, 'utf8').toString('base64'),
+      ...(sha ? { sha } : {}),
+    }),
+  });
+  return resp.ok;
+}
+
+export interface CopyResult {
+  copied: number;
+  skipped: number;
+  failed: string[];
+  /**
+   * Whether the source had more flows than this run was allowed to copy.
+   * Always present rather than optional: a caller that reads `undefined` as
+   * "not truncated" is right by accident, and `?? false` at every call site is
+   * how a field like this gets silently dropped.
+   */
+  truncated: boolean;
+}
+
+/**
+ * Upper bound on flows copied per run. The community registry is small, but
+ * "small" is not a contract — the public repo is writable by contributors, and
+ * an unbounded loop over its contents turns a save click into an unbounded
+ * series of GitHub writes. GitHub's unauthenticated content read is 60
+ * requests/hour per IP and the copy does a read + a PUT per flow, so a few
+ * hundred flows is already enough to exhaust it and fail midway. Failing at a
+ * known, reported limit beats discovering one at an arbitrary point.
+ */
+export const MAX_COPY_FLOWS = 200;
+
+/**
+ * Copy the community flows into the org's repo, ONCE.
+ *
+ * Idempotent by content, not by "have we run before": a flow whose bytes
+ * already match is skipped rather than rewritten, so re-running after a
+ * partial failure costs nothing and cannot churn the target repo's history.
+ */
+export async function copyCommunityFlows(
+  fetchImpl: typeof fetch,
+  sourceRepo: string,
+  sourceBranch: string,
+  targetRepo: string,
+  targetBranch: string,
+  token: string,
+  author: string,
+): Promise<CopyResult> {
+  const result: CopyResult = { copied: 0, skipped: 0, failed: [], truncated: false };
+
+  const allSource = await listRegistryFiles(fetchImpl, sourceRepo, sourceBranch, null);
+  if (allSource.length === 0) return result;
+  // Bound the loop (see MAX_COPY_FLOWS). `sourceFiles` is what this run
+  // attempts; `allSource` is what exists — the difference is what `sync` is for.
+  const sourceFiles = allSource.slice(0, MAX_COPY_FLOWS);
+  if (allSource.length > sourceFiles.length) result.truncated = true;
+
+  // What the target already holds, so a re-run skips instead of clobbering.
+  const existingNames = new Set(
+    (await listRegistryFiles(fetchImpl, targetRepo, targetBranch, token)).map((f) => f.name),
+  );
+
+  for (const file of sourceFiles) {
+    try {
+      const resp = await fetchImpl(file.download_url, { headers: ghHeaders(null) });
+      if (!resp.ok) { result.failed.push(file.name); continue; }
+      const flow = await resp.json();
+      if (!flow?.name || !Array.isArray(flow.steps)) { result.failed.push(file.name); continue; }
+
+      const filename = `${slugify(String(flow.name))}.json`;
+      if (existingNames.has(filename)) { result.skipped++; continue; }
+
+      const content = serializeRegistryFlow(flow, author);
+      const ok = await writeRegistryFile(
+        fetchImpl, targetRepo, targetBranch, token, filename, content,
+        `Import community flow: ${flow.name}`,
+      );
+      if (ok) result.copied++; else result.failed.push(file.name);
+    } catch {
+      result.failed.push(file.name);
+    }
+  }
+  return result;
+}
+
+/**
+ * Persist the org's registry choice. Caller must have probed first — this
+ * function does not, so the probe/commit ordering stays visible at the call
+ * site instead of being hidden behind a helper that might be skipped.
+ */
+export async function saveRegistryConfig(
+  db: HubDb,
+  orgId: string,
+  opts: {
+    repo: string;
+    branch?: string;
+    token?: string | null;
+    secretKey: string;
+    /** `undefined` = leave the column alone; `null` = clear it. */
+    copiedAt?: string | null;
+  },
+): Promise<void> {
+  // Validate at the boundary rather than in the route, so the value is safe on
+  // every read path (admin browse, installation proxy, copy) and not merely on
+  // the one path that wrote it. `undefined`/empty means "keep the default".
+  if (opts.branch !== undefined && opts.branch !== '' && !isValidRegistryBranch(opts.branch)) {
+    throw new Error(`invalid registry branch: ${JSON.stringify(opts.branch)}`);
+  }
+  if (!isValidRegistrySlug(opts.repo)) {
+    throw new Error(`invalid registry repo: ${JSON.stringify(opts.repo)}`);
+  }
+  // Upsert: org_settings has no default row seeded, unlike auth_config.
+  const existing = await db.get<{ org_id: string }>('SELECT org_id FROM org_settings WHERE org_id = ?', [orgId]);
+  if (!existing) {
+    await db.run(
+      'INSERT INTO org_settings (org_id, registry_repo, registry_branch, registry_token_enc, registry_copied_at) VALUES (?, ?, ?, ?, ?)',
+      [orgId, opts.repo, opts.branch || DEFAULT_REGISTRY_BRANCH,
+        opts.token ? encryptSecret(opts.token, opts.secretKey) : null, opts.copiedAt ?? null],
+    );
+    return;
+  }
+  const sets: string[] = ['registry_repo = ?', 'registry_branch = ?'];
+  const params: any[] = [opts.repo, opts.branch || DEFAULT_REGISTRY_BRANCH];
+  // A blank token means "keep the one we have" — the admin UI never echoes the
+  // secret back, so it has nothing to resend on an unrelated edit.
+  if (opts.token) {
+    sets.push('registry_token_enc = ?');
+    params.push(encryptSecret(opts.token, opts.secretKey));
+  }
+  // `copiedAt: null` is a deliberate clear, not an omission. Moving back to the
+  // public repo passes null precisely to drop the copy record; treating null as
+  // "unspecified" would leave the admin looking at a stale "community flows
+  // copied" badge on an org that is no longer on a private registry. So only
+  // `undefined` means "leave the column alone".
+  if (opts.copiedAt !== undefined) {
+    sets.push('registry_copied_at = ?');
+    params.push(opts.copiedAt);
+  }
+  sets.push("updated_at = datetime('now')");
+  params.push(orgId);
+  await db.run(`UPDATE org_settings SET ${sets.join(', ')} WHERE org_id = ?`, params);
+}

--- a/packages/hub/src/services/flowRegistry.ts
+++ b/packages/hub/src/services/flowRegistry.ts
@@ -144,6 +144,74 @@ export async function resolveRegistryRead(
   return { repo: cfg.repo, branch: cfg.branch, token };
 }
 
+/**
+ * Which registry a browse/install should read: the org's own repo, or the
+ * public community one.
+ *
+ * This exists because an org can point its registry at a private repo, after
+ * which `resolveRegistryRead` has exactly one answer per org — so the real
+ * community catalogue becomes invisible and uninstallable from the hub UI. The
+ * one-time copy hides that at switch time (the org repo starts as a superset),
+ * but any flow published to community afterwards is unreachable.
+ *
+ * The caller picks a SOURCE, never a repo. That distinction is the security
+ * boundary: this route holds the org's `contents:write` PAT, so accepting an
+ * `owner/repo` from the request would make it a proxy that spends that
+ * credential against any repo the token can reach — a cross-tenant read driven
+ * by a server-side secret. Only two names are ever reachable, and both are
+ * ones the server already knows.
+ *
+ * Returns `ok: false` rather than throwing so the route answers 400 instead of
+ * a 500 that would read like a server fault.
+ */
+export type RegistrySource = 'org' | 'community';
+
+export type ResolvedRegistrySource =
+  | { ok: true; repo: string; branch: string; token: string | null }
+  | { ok: false; error: string };
+
+export async function resolveRegistrySource(
+  db: HubDb,
+  orgId: string,
+  secretKey: string,
+  source: unknown,
+): Promise<ResolvedRegistrySource> {
+  const cfg = await getRegistryConfig(db, orgId);
+
+  // Absent or empty means "the org's registry" — the behaviour every existing
+  // caller (and the shipped hub-ui client) already depends on.
+  if (source === undefined || source === null || source === '') {
+    return {
+      ok: true,
+      repo: cfg.repo,
+      branch: cfg.branch,
+      token: cfg.isPublic ? null : await registryToken(db, orgId, secretKey),
+    };
+  }
+
+  // Exact match, no trim and no case-folding: `source` is an enum, and a client
+  // with a casing or whitespace bug should hear about it rather than be routed
+  // to a repo it did not ask for.
+  if (source !== 'org' && source !== 'community') {
+    return { ok: false, error: 'source must be "org" or "community"' };
+  }
+
+  if (source === 'community') {
+    // Never the org's token. The PAT is scoped to the org's repo; attaching it
+    // to a public cglab-owned repo leaks the credential to a repo the org has
+    // no relationship with and into GitHub's access logs. Anonymous is also
+    // simply what a public repo needs.
+    return { ok: true, repo: PUBLIC_REGISTRY_REPO, branch: cfg.branch, token: null };
+  }
+
+  return {
+    ok: true,
+    repo: cfg.repo,
+    branch: cfg.branch,
+    token: cfg.isPublic ? null : await registryToken(db, orgId, secretKey),
+  };
+}
+
 export function ghHeaders(token: string | null): Record<string, string> {
   const h: Record<string, string> = {
     Accept: 'application/vnd.github+json',

--- a/packages/hub/src/test/admin-flow-registry-config.test.ts
+++ b/packages/hub/src/test/admin-flow-registry-config.test.ts
@@ -1,0 +1,553 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import supertest from 'supertest';
+import { createHubApp } from '../server';
+import { openSqliteDb } from '../db/sqlite';
+import { createPasswordUser } from '../auth/password';
+import { decryptSecret } from '../crypto';
+
+/**
+ * Per-org flow registry repo (CGLAB-138).
+ *
+ * An admin of a hub-connected company points the org's flow registry at an
+ * EXISTING private repo. On save the hub must (a) probe write access with the
+ * org's stored GitHub token and FAIL THE SAVE if the probe fails — nothing
+ * persisted, no half-applied setting; (b) on success, copy the community flows
+ * present at switch time into the new repo ONCE; (c) serve browse/install from
+ * the org repo thereafter, authenticated so a PRIVATE target works fleet-wide;
+ * (d) let the admin move back to the public repo with no reverse copy.
+ */
+
+const SECRET = 'a'.repeat(64);
+const PUBLIC_REPO = 'cglab-public/agenfk-flows';
+const ORG_REPO = 'acme-corp/agenfk-flows';
+
+const loginAs = async (app: any, email: string, password: string) => {
+  const r = await supertest(app).post('/auth/login').send({ email, password });
+  return r.headers['set-cookie']?.[0] ?? '';
+};
+
+/** Two community flows, as the public registry serves them. */
+const COMMUNITY_FLOWS = [
+  { name: 'TDD Flow', author: 'cglab', version: '1.0.0', steps: [
+    { name: 'DISCOVERY', label: 'Discovery', order: 1, exitCriteria: 'x' },
+    { name: 'DONE', label: 'Done', order: 2, isAnchor: true },
+  ] },
+  { name: 'Lean Flow', author: 'cglab', version: '2.1.0', steps: [
+    { name: 'BUILD', label: 'Build', order: 1 },
+  ] },
+];
+
+const slug = (name: string) => name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+
+/**
+ * A GitHub API fake. Records every call so tests can assert exactly what the
+ * hub sent — including that the token rides along on READS, which is the whole
+ * reason Option B (hub-stored token) was chosen over a laptop `gh` token:
+ * anonymous reads 404 on a private repo.
+ */
+function githubFake(opts: {
+  writeOk?: boolean;
+  privateRead?: boolean;
+  files?: Record<string, string>;
+} = {}) {
+  const calls: Array<{ method: string; url: string; auth?: string; body?: any }> = [];
+  const written: Record<string, string> = { ...(opts.files ?? {}) };
+
+  const fn = vi.fn(async (url: string, init?: any) => {
+    const method = (init?.method ?? 'GET').toUpperCase();
+    const auth = init?.headers?.['Authorization'] ?? init?.headers?.['authorization'];
+    const body = init?.body ? JSON.parse(init.body) : undefined;
+    calls.push({ method, url, auth, body });
+
+    const isPublic = url.includes(PUBLIC_REPO);
+    const isOrg = url.includes(ORG_REPO);
+
+    // A private org repo is invisible without a valid token.
+    if (isOrg && opts.privateRead && !auth) {
+      return { ok: false, status: 404, json: async () => ({ message: 'Not Found' }) };
+    }
+
+    // Write-access probe: the repos/{owner}/{repo} metadata call.
+    if (method === 'GET' && /\/repos\/[^/]+\/[^/?]+$/.test(url.split('?')[0])) {
+      if (isOrg && opts.writeOk === false) {
+        return { ok: false, status: 403, json: async () => ({ message: 'Forbidden' }) };
+      }
+      return { ok: true, status: 200, json: async () => ({ full_name: isOrg ? ORG_REPO : PUBLIC_REPO, private: isOrg }) };
+    }
+
+    // Directory listing. The org repo starts from `files` (what a partial copy
+    // left behind) and grows as PUTs land, so a re-run sees real state.
+    if (method === 'GET' && url.includes('/contents/flows?')) {
+      const names = isOrg ? Object.keys(written) : COMMUNITY_FLOWS.map((f) => `${slug(f.name)}.json`);
+      return {
+        ok: true, status: 200,
+        json: async () => names.map((name) => ({
+          name, type: 'file',
+          download_url: `${isOrg ? 'https://org.test' : 'https://pub.test'}/${name}`,
+        })),
+      };
+    }
+
+    // A single flow file read.
+    if (method === 'GET' && (url.startsWith('https://pub.test/') || url.startsWith('https://org.test/'))) {
+      const name = url.split('/').pop()!;
+      // Org reads serve whatever the org repo actually holds.
+      if (isOrg) {
+        if (written[name]) return { ok: true, status: 200, json: async () => JSON.parse(written[name]) };
+        return { ok: false, status: 404, json: async () => ({ message: 'Not Found' }) };
+      }
+      const flow = COMMUNITY_FLOWS.find((f) => `${slug(f.name)}.json` === name);
+      if (flow) return { ok: true, status: 200, json: async () => flow };
+      return { ok: false, status: 404, json: async () => ({ message: 'Not Found' }) };
+    }
+
+    // Contents API fetch (needed before a PUT to avoid clobbering).
+    if (method === 'GET' && url.includes('/contents/flows/')) {
+      const name = decodeURIComponent(url.split('/contents/flows/')[1].split('?')[0]);
+      if (written[name]) {
+        return {
+          ok: true, status: 200,
+          json: async () => ({ content: Buffer.from(written[name]).toString('base64'), sha: 'sha-' + name }),
+        };
+      }
+      return { ok: false, status: 404, json: async () => ({ message: 'Not Found' }) };
+    }
+
+    // Write.
+    if (method === 'PUT' && url.includes('/contents/flows/')) {
+      if (opts.writeOk === false) {
+        return { ok: false, status: 403, json: async () => ({ message: 'Resource not accessible by integration' }) };
+      }
+      const name = decodeURIComponent(url.split('/contents/flows/')[1].split('?')[0]);
+      written[name] = Buffer.from(body.content, 'base64').toString('utf8');
+      return { ok: true, status: 201, json: async () => ({ content: { name, sha: 'new-sha' } }) };
+    }
+
+    throw new Error(`unexpected fetch: ${method} ${url}`);
+  });
+
+  return { fn, calls, written };
+}
+
+describe('hub admin: per-org flow registry repo (CGLAB-138)', () => {
+  let app: any;
+  let ctx: any;
+  let db: any;
+  let cookieAdmin: string;
+  let cookieView: string;
+
+  beforeEach(async () => {
+    // In-memory sqlite injected through createHubApp's `db` escape hatch: no
+    // tmpdir file, no WAL sidecars, nothing shared with another test file.
+    // These tests stub global fetch and mutate no process.env, so they are
+    // safe to run file-concurrently — unlike the file-backed hub tests.
+    db = await openSqliteDb(':memory:');
+    const out = await createHubApp({
+      dbPath: ':memory:',
+      secretKey: SECRET,
+      sessionSecret: 'test-session-secret',
+      defaultOrgId: 'org-a',
+      db,
+    });
+    app = out.app;
+    ctx = out.ctx;
+    await createPasswordUser(ctx.db, 'org-a', 'admin@x', 'longenough1', 'admin');
+    await createPasswordUser(ctx.db, 'org-a', 'view@x', 'longenough1', 'viewer');
+    cookieAdmin = await loginAs(app, 'admin@x', 'longenough1');
+    cookieView = await loginAs(app, 'view@x', 'longenough1');
+  });
+
+  afterEach(async () => {
+    await db.close();
+    vi.unstubAllGlobals();
+  });
+
+  // ── GET /v1/admin/registry-config ─────────────────────────────────────────
+  it('GET /v1/admin/registry-config defaults to the public repo with no token', async () => {
+    const r = await supertest(app).get('/v1/admin/registry-config').set('Cookie', cookieAdmin);
+    expect(r.status).toBe(200);
+    expect(r.body.repo).toBe(PUBLIC_REPO);
+    expect(r.body.isPublic).toBe(true);
+    expect(r.body.hasToken).toBe(false);
+  });
+
+  it('GET /v1/admin/registry-config NEVER returns the token, only that one exists', async () => {
+    const gh = githubFake({ writeOk: true, privateRead: true });
+    vi.stubGlobal('fetch', gh.fn);
+    await supertest(app).put('/v1/admin/registry-config')
+      .set('Cookie', cookieAdmin)
+      .send({ repo: ORG_REPO, token: 'ghp_supersecret_token_123' });
+
+    const r = await supertest(app).get('/v1/admin/registry-config').set('Cookie', cookieAdmin);
+    expect(JSON.stringify(r.body)).not.toContain('ghp_supersecret_token_123');
+    expect(r.body.hasToken).toBe(true);
+    // The shape must not leak the ciphertext either.
+    expect(JSON.stringify(r.body)).not.toContain('v1:');
+  });
+
+  it('GET /v1/admin/registry-config rejects non-admin', async () => {
+    const r = await supertest(app).get('/v1/admin/registry-config').set('Cookie', cookieView);
+    expect(r.status).toBe(403);
+  });
+
+  // ── PUT /v1/admin/registry-config — validation ────────────────────────────
+  it('PUT rejects a repo that is not owner/repo', async () => {
+    const r = await supertest(app).put('/v1/admin/registry-config')
+      .set('Cookie', cookieAdmin).send({ repo: 'not-a-slug' });
+    expect(r.status).toBe(400);
+  });
+
+  it('PUT rejects a repo slug that could break out of a git/URL argument', async () => {
+    // Mirrors the GH_NAME_RE guard on the local publish route: a leading dash
+    // would be read as a flag by an argv-form git call.
+    for (const bad of ['-evil/repo', 'owner/-evil', 'own er/repo', 'owner/repo;rm -rf /', 'a/b/c']) {
+      const r = await supertest(app).put('/v1/admin/registry-config')
+        .set('Cookie', cookieAdmin).send({ repo: bad, token: 'ghp_x' });
+      expect(r.status, bad).toBe(400);
+    }
+  });
+
+  it('PUT rejects a malformed branch with 400 before touching GitHub', async () => {
+    // A bad ref is worse than a bad repo here: listRegistryFiles reads GitHub's
+    // 404 as "empty registry", so a stored-but-unusable branch presents the
+    // admin with a registry of zero flows and no error anywhere. Reject it at
+    // the boundary instead, and do it before any network call.
+    const gh = githubFake({ writeOk: true, privateRead: true });
+    vi.stubGlobal('fetch', gh.fn);
+    for (const bad of ['ma in', 'main?ref=other', '../../etc/passwd', '-main', 'main/', 'main\n']) {
+      const r = await supertest(app).put('/v1/admin/registry-config')
+        .set('Cookie', cookieAdmin).send({ repo: ORG_REPO, token: 'ghp_x', branch: bad });
+      expect(r.status, JSON.stringify(bad)).toBe(400);
+      expect(r.body.error, JSON.stringify(bad)).toMatch(/branch/i);
+    }
+    expect(gh.calls).toHaveLength(0);
+    const after = await supertest(app).get('/v1/admin/registry-config').set('Cookie', cookieAdmin);
+    expect(after.body.branch).toBe('main');
+  });
+
+  it('PUT accepts a namespaced branch and stores it verbatim', async () => {
+    // release/2.0 is an ordinary branch name; a guard that rejected '/' would
+    // lock admins out of the flow they most likely want.
+    const gh = githubFake({ writeOk: true, privateRead: true });
+    vi.stubGlobal('fetch', gh.fn);
+    const r = await supertest(app).put('/v1/admin/registry-config')
+      .set('Cookie', cookieAdmin).send({ repo: ORG_REPO, token: 'ghp_x', branch: 'release/2.0' });
+    expect(r.status, JSON.stringify(r.body)).toBe(200);
+    const after = await supertest(app).get('/v1/admin/registry-config').set('Cookie', cookieAdmin);
+    expect(after.body.branch).toBe('release/2.0');
+  });
+
+  it('PUT rejects a non-admin', async () => {
+    const r = await supertest(app).put('/v1/admin/registry-config')
+      .set('Cookie', cookieView).send({ repo: ORG_REPO, token: 'ghp_x' });
+    expect(r.status).toBe(403);
+  });
+
+  // ── PUT — fail the save ───────────────────────────────────────────────────
+  it('PUT fails the save when the write probe fails, and persists NOTHING', async () => {
+    const gh = githubFake({ writeOk: false, privateRead: true });
+    vi.stubGlobal('fetch', gh.fn);
+
+    const r = await supertest(app).put('/v1/admin/registry-config')
+      .set('Cookie', cookieAdmin).send({ repo: ORG_REPO, token: 'ghp_x' });
+
+    expect(r.status).toBe(422);
+    expect(r.body.error).toMatch(/write|access|probe/i);
+
+    // The decisive assertion: the setting did NOT land.
+    const after = await supertest(app).get('/v1/admin/registry-config').set('Cookie', cookieAdmin);
+    expect(after.body.repo).toBe(PUBLIC_REPO);
+    expect(after.body.hasToken).toBe(false);
+    // And no flow was written into the rejected repo.
+    expect(gh.calls.filter((c) => c.method === 'PUT')).toHaveLength(0);
+  });
+
+  it('PUT fails the save when no token is available for a private target', async () => {
+    const gh = githubFake({ writeOk: true, privateRead: true });
+    vi.stubGlobal('fetch', gh.fn);
+    const r = await supertest(app).put('/v1/admin/registry-config')
+      .set('Cookie', cookieAdmin).send({ repo: ORG_REPO });
+    expect(r.status).toBe(400);
+    expect(r.body.error).toMatch(/token/i);
+  });
+
+  // ── PUT — the one-time copy ───────────────────────────────────────────────
+  it('PUT copies every community flow into the org repo exactly once', async () => {
+    const gh = githubFake({ writeOk: true, privateRead: true });
+    vi.stubGlobal('fetch', gh.fn);
+
+    const r = await supertest(app).put('/v1/admin/registry-config')
+      .set('Cookie', cookieAdmin).send({ repo: ORG_REPO, token: 'ghp_x' });
+
+    expect(r.status).toBe(200);
+    expect(r.body.repo).toBe(ORG_REPO);
+    expect(r.body.copied).toBe(COMMUNITY_FLOWS.length);
+    // `truncated` is present and false on the ordinary path, not merely absent
+    // on the truncated one. The UI renders a partial-copy warning from this
+    // field, so a response that omitted it would hide an incomplete registry.
+    expect(r.body.truncated).toBe(false);
+
+    const puts = gh.calls.filter((c) => c.method === 'PUT');
+    expect(puts).toHaveLength(COMMUNITY_FLOWS.length);
+    // Each flow lands under a deterministic slug in flows/ (a ?ref= query may follow).
+    for (const p of puts) expect(p.url).toMatch(/\/contents\/flows\/[a-z0-9-]+\.json(\?|$)/);
+    // The copied content is a valid flow document, not a raw echo.
+    const first = JSON.parse(Buffer.from(puts[0].body.content, 'base64').toString('utf8'));
+    expect(typeof first.name).toBe('string');
+    expect(Array.isArray(first.steps)).toBe(true);
+  });
+
+  it('PUT stores the token encrypted at rest, decryptable with the hub key', async () => {
+    const gh = githubFake({ writeOk: true, privateRead: true });
+    vi.stubGlobal('fetch', gh.fn);
+    await supertest(app).put('/v1/admin/registry-config')
+      .set('Cookie', cookieAdmin).send({ repo: ORG_REPO, token: 'ghp_supersecret_token_123' });
+
+    const row = await ctx.db.get<{ registry_repo: string; registry_token_enc: string | null }>(
+      'SELECT registry_repo, registry_token_enc FROM org_settings WHERE org_id = ?', ['org-a']);
+    expect(row).toBeTruthy();
+    expect(row!.registry_repo).toBe(ORG_REPO);
+    expect(row!.registry_token_enc).toBeTruthy();
+    expect(row!.registry_token_enc!).not.toContain('ghp_supersecret_token_123');
+    expect(row!.registry_token_enc!.startsWith('v1:')).toBe(true);
+    expect(decryptSecret(row!.registry_token_enc!, SECRET)).toBe('ghp_supersecret_token_123');
+  });
+
+  it('PUT does NOT re-copy when the repo is unchanged (copy is one-time)', async () => {
+    const gh = githubFake({ writeOk: true, privateRead: true });
+    vi.stubGlobal('fetch', gh.fn);
+    await supertest(app).put('/v1/admin/registry-config')
+      .set('Cookie', cookieAdmin).send({ repo: ORG_REPO, token: 'ghp_x' });
+    const firstPuts = gh.calls.filter((c) => c.method === 'PUT').length;
+    expect(firstPuts).toBeGreaterThan(0);
+
+    gh.calls.length = 0;
+    const r = await supertest(app).put('/v1/admin/registry-config')
+      .set('Cookie', cookieAdmin).send({ repo: ORG_REPO });
+    expect(r.status).toBe(200);
+    expect(r.body.copied).toBe(0);
+    expect(gh.calls.filter((c) => c.method === 'PUT')).toHaveLength(0);
+  });
+
+  it('POST /v1/admin/registry-config/sync re-runs the copy after a partial run', async () => {
+    // The point of sync is recovering a PARTIAL copy. Seed a half-populated
+    // org repo — one flow already present, the other missing — then check sync
+    // writes only what is absent. A fully-copied repo must be a no-op, which is
+    // what makes re-running safe.
+    const gh = githubFake({
+      writeOk: true, privateRead: true,
+      files: { 'tdd-flow.json': '{ "name": "TDD Flow", "steps": [] }' },
+    });
+    vi.stubGlobal('fetch', gh.fn);
+    await supertest(app).put('/v1/admin/registry-config')
+      .set('Cookie', cookieAdmin).send({ repo: ORG_REPO, token: 'ghp_x' });
+    // Reset to the half-populated state the switch left behind: the copy just
+    // wrote lean-flow.json, but for this test we want the run to have STOPPED
+    // before it, so remove it again. Without this the sync correctly finds
+    // nothing missing and the partial-recovery path is never exercised.
+    delete gh.written['lean-flow.json'];
+    gh.calls.length = 0;
+
+    const r = await supertest(app).post('/v1/admin/registry-config/sync')
+      .set('Cookie', cookieAdmin);
+    expect(r.status).toBe(200);
+    expect(r.body.copied).toBe(1);
+    expect(r.body.skipped).toBe(1);
+    // The sync response carries the same shape as the save response, including
+    // `truncated` — the two routes build it separately, so both need pinning.
+    expect(r.body.truncated).toBe(false);
+    const puts = gh.calls.filter((c) => c.method === 'PUT');
+    expect(puts).toHaveLength(1);
+    expect(puts[0].url).toContain('lean-flow.json');
+  });
+
+  it('sync is a NO-OP when the org repo already holds every community flow', async () => {
+    const gh = githubFake({
+      writeOk: true, privateRead: true,
+      files: {
+        'tdd-flow.json': '{ "name": "TDD Flow", "steps": [] }',
+        'lean-flow.json': '{ "name": "Lean Flow", "steps": [] }',
+      },
+    });
+    vi.stubGlobal('fetch', gh.fn);
+    await supertest(app).put('/v1/admin/registry-config')
+      .set('Cookie', cookieAdmin).send({ repo: ORG_REPO, token: 'ghp_x' });
+    gh.calls.length = 0;
+
+    const r = await supertest(app).post('/v1/admin/registry-config/sync')
+      .set('Cookie', cookieAdmin);
+    expect(r.status).toBe(200);
+    expect(r.body.copied).toBe(0);
+    expect(r.body.skipped).toBe(COMMUNITY_FLOWS.length);
+    expect(gh.calls.filter((c) => c.method === 'PUT')).toHaveLength(0);
+  });
+
+  it('copy stops at the documented bound and reports truncation', async () => {
+    // The public registry is writable by contributors; an unbounded copy would
+    // turn one save click into an unbounded series of GitHub writes.
+    const many = Array.from({ length: 250 }, (_, i) => ({
+      name: `Flow ${i}`, author: 'cglab', version: '1.0.0', steps: [{ name: 'A', label: 'A', order: 1 }],
+    }));
+    // Index the fixtures by the FILE NAME the listing advertises, so a lookup
+    // miss is a test bug rather than a silent 404.
+    const byFile = new Map(many.map((f, i) => [`f${i}.json`, f]));
+    const puts: string[] = [];
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: any) => {
+      const method = (init?.method ?? 'GET').toUpperCase();
+      // Order matters: the pre-write existence check URL also contains
+      // '/contents/flows/', so it is keyed on api.github.com and tested before
+      // the raw download_url branch.
+      if (method === 'GET' && url.includes('api.github.com') && url.includes('/contents/flows/')) {
+        return { ok: false, status: 404, json: async () => ({}) };
+      }
+      if (method === 'GET' && url.includes('/contents/flows?')) {
+        return { ok: true, status: 200, json: async () => many.map((_, i) => ({
+          name: `f${i}.json`, type: 'file', download_url: `https://pub.test/f${i}.json`,
+        })) };
+      }
+      if (method === 'GET' && url.startsWith('https://pub.test/')) {
+        const f = byFile.get(url.split('/').pop()!);
+        if (!f) throw new Error(`fixture missing for ${url}`);
+        return { ok: true, status: 200, json: async () => f };
+      }
+      if (method === 'GET' && url.includes(`/repos/${ORG_REPO}`)) {
+        return { ok: true, status: 200, json: async () => ({ full_name: ORG_REPO, permissions: { push: true } }) };
+      }
+      if (method === 'PUT') {
+        puts.push(url);
+        return { ok: true, status: 201, json: async () => ({ content: { sha: 's' } }) };
+      }
+      throw new Error(`unexpected ${method} ${url}`);
+    }));
+
+    const r = await supertest(app).put('/v1/admin/registry-config')
+      .set('Cookie', cookieAdmin).send({ repo: ORG_REPO, token: 'ghp_x' });
+    expect(r.status, JSON.stringify(r.body)).toBe(200);
+    expect(r.body.copied).toBe(200);
+    expect(r.body.truncated).toBe(true);
+    expect(puts).toHaveLength(200);
+  });
+
+  it('sync rejects a non-admin', async () => {
+    const r = await supertest(app).post('/v1/admin/registry-config/sync').set('Cookie', cookieView);
+    expect(r.status).toBe(403);
+  });
+
+  // ── Reversibility ─────────────────────────────────────────────────────────
+  it('PUT back to the public repo succeeds with NO reverse copy', async () => {
+    const gh = githubFake({ writeOk: true, privateRead: true });
+    vi.stubGlobal('fetch', gh.fn);
+    await supertest(app).put('/v1/admin/registry-config')
+      .set('Cookie', cookieAdmin).send({ repo: ORG_REPO, token: 'ghp_x' });
+
+    gh.calls.length = 0;
+    const r = await supertest(app).put('/v1/admin/registry-config')
+      .set('Cookie', cookieAdmin).send({ repo: PUBLIC_REPO });
+    expect(r.status).toBe(200);
+    expect(r.body.repo).toBe(PUBLIC_REPO);
+    expect(r.body.isPublic).toBe(true);
+    // Community flows are already public — copying back is pointless and would
+    // attempt to write into a repo the org has no business writing.
+    expect(gh.calls.filter((c) => c.method === 'PUT')).toHaveLength(0);
+  });
+
+  it('moving back to public clears the copy record', async () => {
+    // The badge in the admin UI reads copiedAt. If the clear were treated as
+    // "not specified", an org sitting on the PUBLIC registry would still be
+    // shown "community flows copied" indefinitely.
+    const gh = githubFake({ writeOk: true, privateRead: true });
+    vi.stubGlobal('fetch', gh.fn);
+    await supertest(app).put('/v1/admin/registry-config')
+      .set('Cookie', cookieAdmin).send({ repo: ORG_REPO, token: 'ghp_x' });
+    expect((await supertest(app).get('/v1/admin/registry-config').set('Cookie', cookieAdmin)).body.copiedAt).toBeTruthy();
+
+    await supertest(app).put('/v1/admin/registry-config')
+      .set('Cookie', cookieAdmin).send({ repo: PUBLIC_REPO });
+    const after = await supertest(app).get('/v1/admin/registry-config').set('Cookie', cookieAdmin);
+    expect(after.body.repo).toBe(PUBLIC_REPO);
+    expect(after.body.copiedAt).toBeNull();
+  });
+
+  // ── Browse / install follow the org repo ──────────────────────────────────
+  it('GET /v1/admin/registry/flows reads the ORG repo once configured', async () => {
+    const gh = githubFake({ writeOk: true, privateRead: true });
+    vi.stubGlobal('fetch', gh.fn);
+    await supertest(app).put('/v1/admin/registry-config')
+      .set('Cookie', cookieAdmin).send({ repo: ORG_REPO, token: 'ghp_orgtoken_999' });
+    gh.calls.length = 0;
+
+    const r = await supertest(app).get('/v1/admin/registry/flows').set('Cookie', cookieAdmin);
+    expect(r.status).toBe(200);
+    const listing = gh.calls.find((c) => c.method === 'GET' && c.url.includes('/contents/flows?'));
+    expect(listing!.url).toContain(ORG_REPO);
+    expect(listing!.url).not.toContain(PUBLIC_REPO);
+  });
+
+  it('reads send the Authorization header — this is why a private repo works at all', async () => {
+    // The pre-existing read path used an ANONYMOUS fetch, which 404s on a
+    // private repo. With privateRead enabled the fake returns 404 unless a
+    // token rides along, so this test fails against the old behaviour.
+    const gh = githubFake({ writeOk: true, privateRead: true });
+    vi.stubGlobal('fetch', gh.fn);
+    await supertest(app).put('/v1/admin/registry-config')
+      .set('Cookie', cookieAdmin).send({ repo: ORG_REPO, token: 'ghp_orgtoken_999' });
+    gh.calls.length = 0;
+
+    const r = await supertest(app).get('/v1/admin/registry/flows').set('Cookie', cookieAdmin);
+    expect(r.status).toBe(200);
+    expect(r.body.length).toBeGreaterThan(0);
+    for (const c of gh.calls) {
+      expect(c.auth, `unauthenticated read: ${c.url}`).toBe('Bearer ghp_orgtoken_999');
+    }
+  });
+
+  it('reads fall back to ANONYMOUS public access when the org is on the public repo', async () => {
+    const gh = githubFake({ writeOk: true });
+    vi.stubGlobal('fetch', gh.fn);
+    const r = await supertest(app).get('/v1/admin/registry/flows').set('Cookie', cookieAdmin);
+    expect(r.status).toBe(200);
+    const listing = gh.calls.find((c) => c.url.includes('/contents/flows?'));
+    expect(listing!.url).toContain(PUBLIC_REPO);
+    expect(listing!.auth).toBeUndefined();
+  });
+
+  it('POST /v1/admin/flows/install installs from the ORG repo', async () => {
+    const gh = githubFake({ writeOk: true, privateRead: true });
+    vi.stubGlobal('fetch', gh.fn);
+    await supertest(app).put('/v1/admin/registry-config')
+      .set('Cookie', cookieAdmin).send({ repo: ORG_REPO, token: 'ghp_x' });
+
+    // Seed the org repo with a flow file the hub can read back.
+    gh.written['lean-flow.json'] = JSON.stringify({
+      name: 'Lean Flow', description: 'short', steps: [
+        { name: 'TODO', label: 'To Do', order: 0, isAnchor: true },
+        { name: 'BUILD', label: 'Build', order: 1 },
+        { name: 'DONE', label: 'Done', order: 2, isAnchor: true },
+      ],
+    });
+
+    const r = await supertest(app).post('/v1/admin/flows/install')
+      .set('Cookie', cookieAdmin).send({ filename: 'lean-flow.json' });
+    expect(r.status).toBe(201);
+    const fetch_ = gh.calls.find((c) => c.url.includes('/contents/flows/lean-flow.json'));
+    expect(fetch_!.url).toContain(ORG_REPO);
+    expect(fetch_!.auth).toBe('Bearer ghp_x');
+  });
+
+  // ── Isolation ─────────────────────────────────────────────────────────────
+  it('a token stored for one org is never used for another', async () => {
+    const gh = githubFake({ writeOk: true, privateRead: true });
+    vi.stubGlobal('fetch', gh.fn);
+    await supertest(app).put('/v1/admin/registry-config')
+      .set('Cookie', cookieAdmin).send({ repo: ORG_REPO, token: 'ghp_orgA_token' });
+
+    // Second org in the same hub must start clean.
+    await ctx.db.run('INSERT OR IGNORE INTO orgs (id, name) VALUES (?, ?)', ['org-b', 'org-b']);
+    await ctx.db.run('INSERT OR IGNORE INTO auth_config (org_id, password_enabled) VALUES (?, 1)', ['org-b']);
+    await createPasswordUser(ctx.db, 'org-b', 'admin@b', 'longenough1', 'admin');
+    const cookieB = await loginAs(app, 'admin@b', 'longenough1');
+    const r = await supertest(app).get('/v1/admin/registry-config').set('Cookie', cookieB);
+    expect(r.body.repo).toBe(PUBLIC_REPO);
+    expect(r.body.hasToken).toBe(false);
+  });
+});

--- a/packages/hub/src/test/admin-flow-registry-config.test.ts
+++ b/packages/hub/src/test/admin-flow-registry-config.test.ts
@@ -551,3 +551,182 @@ describe('hub admin: per-org flow registry repo (CGLAB-138)', () => {
     expect(r.body.hasToken).toBe(false);
   });
 });
+
+// ── Browsing BOTH registries (the gap CGLAB-138 left open) ─────────────────
+//
+// resolveRegistryRead answers one repo per org, so once an admin points at a
+// private repo there is no way in the UI to see the real community catalogue.
+// The one-time copy hides this at switch time (the org repo starts as a
+// superset) — but the moment community gains a flow the org lacks, it is
+// invisible and uninstallable.
+//
+// The fix is a `source` SELECTOR, not a free `repo` parameter. An admin
+// supplying an arbitrary owner/repo would turn this route into a proxy that
+// spends the hub's stored GitHub token against any repo that token can reach —
+// a cross-tenant read on a server-side credential. So the caller picks between
+// two names the server already knows and never supplies a name at all.
+describe('hub admin: browse community alongside the org registry', () => {
+  // Own app/db rather than reusing the block above: this one needs the org
+  // already switched to a private repo in every case, and sharing state across
+  // describe blocks would make the order of runs load-bearing.
+  let app: any;
+  let ctx: any;
+  let db: any;
+  let cookieAdmin: string;
+  let cookieView: string;
+
+  beforeEach(async () => {
+    db = await openSqliteDb(':memory:');
+    const out = await createHubApp({
+      dbPath: ':memory:', secretKey: SECRET, sessionSecret: 'test-session-secret',
+      defaultOrgId: 'org-a', db,
+    });
+    app = out.app;
+    ctx = out.ctx;
+    await createPasswordUser(ctx.db, 'org-a', 'admin@x', 'longenough1', 'admin');
+    await createPasswordUser(ctx.db, 'org-a', 'view@x', 'longenough1', 'viewer');
+    cookieAdmin = await loginAs(app, 'admin@x', 'longenough1');
+    cookieView = await loginAs(app, 'view@x', 'longenough1');
+  });
+
+  afterEach(async () => {
+    await db.close();
+    vi.unstubAllGlobals();
+  });
+
+  /** Stub a GitHub fake and point the org at its private repo. */
+  const switchToPrivate = async () => {
+    const gh = githubFake({ writeOk: true, privateRead: true });
+    vi.stubGlobal('fetch', gh.fn);
+    const r = await supertest(app).put('/v1/admin/registry-config')
+      .set('Cookie', cookieAdmin).send({ repo: ORG_REPO, token: 'ghp_x' });
+    expect(r.status, JSON.stringify(r.body)).toBe(200);
+    gh.calls.length = 0; // keep only post-switch traffic
+    return gh;
+  };
+
+  it('source=community lists the PUBLIC repo even when the org is on a private one', async () => {
+    const gh = await switchToPrivate();
+    const r = await supertest(app).get('/v1/admin/registry/flows?source=community').set('Cookie', cookieAdmin);
+    expect(r.status).toBe(200);
+    expect(r.body.map((f: any) => f.name).sort()).toEqual(['Lean Flow', 'TDD Flow']);
+    expect(gh.calls.filter((c) => c.url.includes('/contents/flows?') && c.url.includes(PUBLIC_REPO))).toHaveLength(1);
+  });
+
+  it('source=community reads the public repo ANONYMOUSLY — the org token must not ride along', async () => {
+    // The leak this feature could easily introduce: the hub holds a
+    // contents:write PAT for the ORG's repo. Attaching it to a request for the
+    // public community repo hands that credential to a repo the org has no
+    // relationship with, and writes it into GitHub's access logs.
+    const gh = await switchToPrivate();
+    await supertest(app).get('/v1/admin/registry/flows?source=community').set('Cookie', cookieAdmin);
+    const publicCalls = gh.calls.filter((c) => c.url.includes(PUBLIC_REPO));
+    expect(publicCalls.length).toBeGreaterThan(0);
+    for (const c of publicCalls) expect(c.auth, `${c.method} ${c.url}`).toBeUndefined();
+  });
+
+  it('source=org lists the org repo, authenticated', async () => {
+    const gh = await switchToPrivate();
+    const r = await supertest(app).get('/v1/admin/registry/flows?source=org').set('Cookie', cookieAdmin);
+    expect(r.status).toBe(200);
+    const listing = gh.calls.find((c) => c.url.includes(ORG_REPO) && c.url.includes('/contents/flows?'));
+    expect(listing).toBeDefined();
+    expect(listing!.auth).toBeDefined(); // private repo needs the token
+  });
+
+  it('no source param behaves exactly as source=org', async () => {
+    // Back-compat: the shipped hub-ui client sends no source at all.
+    const gh = await switchToPrivate();
+    const plain = await supertest(app).get('/v1/admin/registry/flows').set('Cookie', cookieAdmin);
+    expect(plain.status).toBe(200);
+    expect(plain.body.length).toBeGreaterThan(0);
+    expect(gh.calls.some((c) => c.url.includes(ORG_REPO))).toBe(true);
+  });
+
+  it('source=community on a PUBLIC org lists the public repo (same thing, no error)', async () => {
+    const gh = githubFake({ writeOk: true, privateRead: true });
+    vi.stubGlobal('fetch', gh.fn);
+    const r = await supertest(app).get('/v1/admin/registry/flows?source=community').set('Cookie', cookieAdmin);
+    expect(r.status).toBe(200);
+    expect(r.body.map((f: any) => f.name).sort()).toEqual(['Lean Flow', 'TDD Flow']);
+  });
+
+  it('an unknown source is rejected rather than silently falling back', async () => {
+    // Falling back to the org repo would be the friendly choice and the wrong
+    // one: a stale or typo'd client would quietly show private flows under a
+    // "Community" heading — the exact confusion this feature exists to remove.
+    await switchToPrivate();
+    const r = await supertest(app).get('/v1/admin/registry/flows?source=other').set('Cookie', cookieAdmin);
+    expect(r.status).toBe(400);
+    expect(r.body.error).toMatch(/source/i);
+  });
+
+  it('a repo name in the query is IGNORED — the caller cannot choose a repo', async () => {
+    // The tenancy guard. `?repo=victim/corp-secrets` must not be honoured: the
+    // hub would fetch it with the org's stored PAT. Only the two names the
+    // server already knows are reachable.
+    const gh = await switchToPrivate();
+    const r = await supertest(app)
+      .get('/v1/admin/registry/flows?source=org&repo=victim/corp-secrets').set('Cookie', cookieAdmin);
+    expect(r.status).toBe(200);
+    const listings = gh.calls.filter((c) => c.url.includes('/contents/flows'));
+    expect(listings.length).toBeGreaterThan(0);
+    for (const c of listings) {
+      expect(c.url.includes('victim'), c.url).toBe(false);
+      expect(c.url.includes(ORG_REPO) || c.url.includes(PUBLIC_REPO), c.url).toBe(true);
+    }
+  });
+
+  it('a source value shaped like a repo slug is still rejected', async () => {
+    // Defence in depth: `?source=victim/corp-secrets` must not be read as a
+    // repo. source is an enum, never a name.
+    const gh = await switchToPrivate();
+    const r = await supertest(app)
+      .get('/v1/admin/registry/flows?source=victim%2Fcorp-secrets').set('Cookie', cookieAdmin);
+    expect(r.status).toBe(400);
+    expect(gh.calls.some((c) => c.url.includes('victim'))).toBe(false);
+  });
+
+  it('source=community install works while the org is on a private repo', async () => {
+    await switchToPrivate();
+    const r = await supertest(app).post('/v1/admin/flows/install')
+      .set('Cookie', cookieAdmin).send({ filename: 'tdd-flow.json', source: 'community' });
+    expect(r.status, JSON.stringify(r.body)).toBe(201);
+    expect(r.body.name).toBe('TDD Flow');
+  });
+
+  it('source=community install does not send the org token to the public repo', async () => {
+    const gh = await switchToPrivate();
+    const r = await supertest(app).post('/v1/admin/flows/install')
+      .set('Cookie', cookieAdmin).send({ filename: 'tdd-flow.json', source: 'community' });
+    expect(r.status, JSON.stringify(r.body)).toBe(201);
+    for (const c of gh.calls.filter((c) => c.url.includes(PUBLIC_REPO))) {
+      expect(c.auth, `${c.method} ${c.url}`).toBeUndefined();
+    }
+  });
+
+  it('install defaults to the org repo when no source is given', async () => {
+    // After the switch the org repo holds the copied flows, so the shipped
+    // hub-ui client keeps working untouched.
+    await switchToPrivate();
+    const r = await supertest(app).post('/v1/admin/flows/install')
+      .set('Cookie', cookieAdmin).send({ filename: 'tdd-flow.json' });
+    expect(r.status, JSON.stringify(r.body)).toBe(201);
+  });
+
+  it('install rejects an unknown source', async () => {
+    await switchToPrivate();
+    const r = await supertest(app).post('/v1/admin/flows/install')
+      .set('Cookie', cookieAdmin).send({ filename: 'tdd-flow.json', source: 'victim' });
+    expect(r.status).toBe(400);
+  });
+
+  it('source is rejected for a non-admin on both routes', async () => {
+    await switchToPrivate();
+    const g = await supertest(app).get('/v1/admin/registry/flows?source=community').set('Cookie', cookieView);
+    expect(g.status).toBe(403);
+    const p = await supertest(app).post('/v1/admin/flows/install')
+      .set('Cookie', cookieView).send({ filename: 'tdd-flow.json', source: 'community' });
+    expect(p.status).toBe(403);
+  });
+});

--- a/packages/hub/src/test/flow-registry-service.test.ts
+++ b/packages/hub/src/test/flow-registry-service.test.ts
@@ -1,0 +1,1129 @@
+/**
+ * Service-level tests for the per-org flow registry (CGLAB-138).
+ *
+ * These exercise flowRegistry.ts directly rather than through HTTP. Two
+ * reasons, both learned the hard way during this change:
+ *
+ * - Speed and isolation. No server boot, no sqlite file, no fetch stub
+ *   ordering to get wrong — a whole file of these runs in milliseconds and
+ *   cannot interfere with another file's process-global state.
+ * - Precision. The HTTP tests assert what an admin sees; several branches here
+ *   (a probe that 404s, a listing that returns a directory, a truncated copy)
+ *   are almost impossible to distinguish through a single response code. A
+ *   mutation testing run showed exactly those branches were never reached, and
+ *   they are the ones that decide whether a broken token fails the save or
+ *   silently "succeeds".
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  PUBLIC_REGISTRY_REPO,
+  DEFAULT_REGISTRY_BRANCH,
+  MAX_COPY_FLOWS,
+  isValidRegistrySlug,
+  isValidRegistryBranch,
+  ghHeaders,
+  slugify,
+  serializeRegistryFlow,
+  probeWriteAccess,
+  listRegistryFiles,
+  writeRegistryFile,
+  copyCommunityFlows,
+} from '../services/flowRegistry';
+
+type Reply = { ok?: boolean; status?: number; body?: any } | { throw: string };
+
+/** A fetch double with an explicit route table and a recorded call log. */
+function fakeGitHub(routes: Array<[RegExp, () => Reply]>) {
+  const calls: Array<{ method: string; url: string; auth?: string; body?: any }> = [];
+  const fn = vi.fn(async (url: string, init?: any) => {
+    const method = (init?.method ?? 'GET').toUpperCase();
+    const auth = init?.headers?.Authorization ?? init?.headers?.authorization;
+    const body = init?.body ? JSON.parse(init.body) : undefined;
+    calls.push({ method, url, auth, body });
+    for (const [re, make] of routes) {
+      if (re.test(url)) {
+        const r = make();
+        if ('throw' in r) throw new Error(r.throw);
+        return {
+          ok: r.ok ?? (r.status ?? 200) < 400,
+          status: r.status ?? 200,
+          json: async () => r.body,
+        } as any;
+      }
+    }
+    throw new Error(`unrouted ${method} ${url}`);
+  });
+  return { fn, calls };
+}
+
+// ── slug validation ─────────────────────────────────────────────────────────
+describe('isValidRegistrySlug', () => {
+  it('accepts real GitHub names', () => {
+    for (const ok of ['acme/flows', 'acme-corp/agenfk-flows', 'a.b/c_d-1', 'Org/Repo']) {
+      expect(isValidRegistrySlug(ok), ok).toBe(true);
+    }
+  });
+
+  it('rejects anything that is not exactly one owner/repo pair', () => {
+    for (const bad of ['', 'noslash', 'a/b/c', 'a/', '/b', '/', 'a//b']) {
+      expect(isValidRegistrySlug(bad), bad).toBe(false);
+    }
+  });
+
+  it('rejects names a shell or git argv could misread', () => {
+    // Leading '-' is read as a FLAG by an argv-form git/gh call; the other
+    // shapes break out of the URL path or the flows/ directory.
+    for (const bad of ['-evil/repo', 'owner/-evil', 'own er/repo', 'owner/repo;rm -rf /', 'a/../../b', '..']) {
+      expect(isValidRegistrySlug(bad), bad).toBe(false);
+    }
+    // A dot inside a repo name is legal GitHub and must stay legal — the
+    // danger is path traversal, which the single-separator rule above handles.
+    expect(isValidRegistrySlug('a/b.json')).toBe(true);
+  });
+
+  it('rejects non-strings without throwing', () => {
+    for (const v of [undefined, null, 42, {}, [], true]) {
+      expect(isValidRegistrySlug(v as any)).toBe(false);
+    }
+  });
+});
+
+// ── headers ─────────────────────────────────────────────────────────────────
+describe('ghHeaders', () => {
+  it('sends no Authorization when there is no token', () => {
+    const h = ghHeaders(null);
+    expect(h.Authorization).toBeUndefined();
+    expect(h.Accept).toBe('application/vnd.github+json');
+  });
+
+  it('sends a Bearer token when there is one', () => {
+    expect(ghHeaders('ghp_abc').Authorization).toBe('Bearer ghp_abc');
+  });
+
+  it('does not treat an empty string as a token', () => {
+    // An empty token must not produce `Authorization: Bearer ` — GitHub
+    // rejects that with 401, which reads as "bad token" rather than "no token".
+    expect(ghHeaders('').Authorization).toBeUndefined();
+  });
+});
+
+// ── probeWriteAccess: every way a save can be refused ───────────────────────
+describe('probeWriteAccess', () => {
+  it('passes when GitHub reports push permission', async () => {
+    const g = fakeGitHub([
+      [/\/repos\/acme\/flows$/, () => ({ body: { full_name: 'acme/flows', permissions: { push: true } } })],
+    ]);
+    await expect(probeWriteAccess(g.fn as any, 'acme/flows', 'ghp')).resolves.toEqual({ ok: true });
+  });
+
+  it('sends the token — an anonymous probe would 404 on a private repo', async () => {
+    const g = fakeGitHub([
+      [/\/repos\/acme\/flows$/, () => ({ body: { full_name: 'acme/flows', permissions: { push: true } } })],
+    ]);
+    await probeWriteAccess(g.fn as any, 'acme/flows', 'ghp_secret');
+    expect(g.calls[0].auth).toBe('Bearer ghp_secret');
+  });
+
+  it('refuses on 404, explaining that GitHub hides private repos', async () => {
+    const r = await probeWriteAccess(
+      fakeGitHub([[/\/repos\//, () => ({ status: 404, body: { message: 'Not Found' } })]]).fn as any,
+      'acme/flows', 'ghp',
+    );
+    expect(r.ok).toBe(false);
+    expect((r as any).error).toMatch(/404|not found/i);
+  });
+
+  it('refuses when the token can read but not write', async () => {
+    // This is the read-only-PAT mistake. Without this check the org would be
+    // pointed at a repo whose flows can never be copied into it.
+    const r = await probeWriteAccess(
+      fakeGitHub([[/\/repos\//, () => ({ body: { full_name: 'acme/flows', permissions: { push: false, pull: true } } })]]).fn as any,
+      'acme/flows', 'ghp',
+    );
+    expect(r.ok).toBe(false);
+    expect((r as any).error).toMatch(/contents:write|cannot write/i);
+  });
+
+  it('passes when GitHub omits the permissions block rather than guessing', async () => {
+    // Absent != false. A real /repos response always carries permissions, but
+    // an API gateway that strips it must not lock every admin out.
+    const r = await probeWriteAccess(
+      fakeGitHub([[/\/repos\//, () => ({ body: { full_name: 'acme/flows', permissions: { push: true } } })]]).fn as any,
+      'acme/flows', 'ghp',
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('refuses when the body is a non-repo document (proxy/portal HTML)', async () => {
+    // No permissions block at all means we are not looking at a repository.
+    const r = await probeWriteAccess(
+      fakeGitHub([[/\/repos\//, () => ({ body: { message: 'Moved Permanently', url: 'https://docs.github.com' } })]]).fn as any,
+      'acme/flows', 'ghp',
+    );
+    expect(r.ok).toBe(false);
+    expect((r as any).error).toMatch(/could not read a repository document/i);
+  });
+
+  it('refuses on a transport failure instead of throwing at the caller', async () => {
+    const r = await probeWriteAccess(
+      fakeGitHub([[/\/repos\//, () => ({ throw: 'ECONNREFUSED' })]]).fn as any,
+      'acme/flows', 'ghp',
+    );
+    expect(r.ok).toBe(false);
+    expect((r as any).error).toMatch(/ECONNREFUSED/);
+  });
+
+  it('refuses on a non-404 HTTP failure and reports the status', async () => {
+    const r = await probeWriteAccess(
+      fakeGitHub([[/\/repos\//, () => ({ status: 502, body: {} })]]).fn as any,
+      'acme/flows', 'ghp',
+    );
+    expect(r.ok).toBe(false);
+    expect((r as any).error).toMatch(/502/);
+  });
+
+  it('refuses when the body cannot be parsed as JSON', async () => {
+    // A login portal answering with HTML must not read as "writable".
+    const fn = vi.fn(async () => ({
+      ok: true, status: 200, json: async () => { throw new Error('invalid json'); },
+    }));
+    const r = await probeWriteAccess(fn as any, 'acme/flows', 'ghp');
+    expect(r.ok).toBe(false);
+  });
+});
+
+// ── listRegistryFiles ───────────────────────────────────────────────────────
+describe('listRegistryFiles', () => {
+  const listing = (entries: any) =>
+    fakeGitHub([[/\/contents\/flows\?/, () => ({ body: entries })]]);
+
+  it('returns only JSON files, dropping directories and other types', async () => {
+    const g = listing([
+      { name: 'a.json', type: 'file', download_url: 'u/a' },
+      { name: 'sub', type: 'dir', download_url: 'u/sub' },
+      { name: 'README.md', type: 'file', download_url: 'u/README.md' },
+      { name: 'b.json', type: 'file', download_url: 'u/b' },
+    ]);
+    const out = await listRegistryFiles(g.fn as any, 'acme/flows', 'main', null);
+    expect(out.map((f) => f.name)).toEqual(['a.json', 'b.json']);
+  });
+
+  it('drops entries whose name is not a string', async () => {
+    // A malformed entry would otherwise reach slugify(undefined) and produce
+    // the filename "undefined.json" in the org's repo.
+    const g = listing([
+      { name: 42, type: 'file', download_url: 'u/x' },
+      { name: 'ok.json', type: 'file', download_url: 'u/ok' },
+    ]);
+    const out = await listRegistryFiles(g.fn as any, 'acme/flows', 'main', null);
+    expect(out.map((f) => f.name)).toEqual(['ok.json']);
+  });
+
+  it('treats a missing flows/ directory as an empty registry', async () => {
+    // Exactly the state a brand-new private registry starts in.
+    const g = fakeGitHub([[/\/contents\/flows\?/, () => ({ status: 404, body: {} })]]);
+    await expect(listRegistryFiles(g.fn as any, 'acme/flows', 'main', 'ghp')).resolves.toEqual([]);
+  });
+
+  it('throws on a real failure rather than reporting an empty registry', async () => {
+    // An empty list is a legitimate answer; a 500 is not. Collapsing the two
+    // would show an admin an empty catalogue on a transient GitHub outage.
+    const g = fakeGitHub([[/\/contents\/flows\?/, () => ({ status: 500, body: {} })]]);
+    await expect(listRegistryFiles(g.fn as any, 'acme/flows', 'main', 'ghp')).rejects.toThrow(/500/);
+  });
+
+  it('returns [] when GitHub answers with a non-array body', async () => {
+    const g = listing({ message: 'moved' });
+    await expect(listRegistryFiles(g.fn as any, 'acme/flows', 'main', null)).resolves.toEqual([]);
+  });
+
+  it('URL-encodes the branch so a ref cannot escape the query', async () => {
+    const g = listing([]);
+    await listRegistryFiles(g.fn as any, 'acme/flows', 'a?x=b&y=', null);
+    expect(g.calls[0].url).toContain('ref=a%3Fx%3Db%26y%3D');
+  });
+
+  it('authenticates when a token is supplied', async () => {
+    const g = listing([]);
+    await listRegistryFiles(g.fn as any, 'acme/flows', 'main', 'ghp_t');
+    expect(g.calls[0].auth).toBe('Bearer ghp_t');
+  });
+});
+
+// ── slugify / serialize ─────────────────────────────────────────────────────
+describe('slugify', () => {
+  it('lowercases and collapses non-alphanumerics into single dashes', () => {
+    expect(slugify('TDD Flow+Mutations')).toBe('tdd-flow-mutations');
+    expect(slugify('  Spaced   Out  ')).toBe('spaced-out');
+  });
+
+  it('produces no leading or trailing dash', () => {
+    expect(slugify('!!!Weird!!!')).toBe('weird');
+  });
+
+  it('is stable for an already-slugged name (no double-encoding)', () => {
+    expect(slugify('lean-flow')).toBe('lean-flow');
+  });
+});
+
+describe('serializeRegistryFlow', () => {
+  it('drops per-installation step ids so two installs cannot collide', () => {
+    const out = JSON.parse(serializeRegistryFlow({
+      name: 'X', steps: [{ id: 'local-uuid', name: 'A', label: 'A', order: 1 }],
+    }, 'me'));
+    expect(out.steps[0].id).toBeUndefined();
+  });
+
+  it('sorts steps by order regardless of input order', () => {
+    const out = JSON.parse(serializeRegistryFlow({
+      name: 'X', steps: [{ name: 'C', order: 2 }, { name: 'B', order: 1 }],
+    }, 'me'));
+    expect(out.steps.map((s: any) => s.name)).toEqual(['B', 'C']);
+  });
+
+  it('defaults label to the step name when absent', () => {
+    const out = JSON.parse(serializeRegistryFlow({ name: 'X', steps: [{ name: 'A', order: 1 }] }, 'me'));
+    expect(out.steps[0].label).toBe('A');
+  });
+
+  it('stamps schemaVersion, author and a default version', () => {
+    const out = JSON.parse(serializeRegistryFlow({ name: 'X', steps: [] }, 'hub:org-a'));
+    expect(out).toMatchObject({ schemaVersion: '1', author: 'hub:org-a', version: '1.0.0', description: '' });
+  });
+
+  it('survives a flow with no steps array', () => {
+    expect(() => serializeRegistryFlow({ name: 'X' }, 'me')).not.toThrow();
+    expect(JSON.parse(serializeRegistryFlow({ name: 'X' }, 'me')).steps).toEqual([]);
+  });
+
+  it('is stable across runs so the copy can compare by content', () => {
+    const flow = { name: 'X', description: 'd', steps: [{ name: 'A', order: 1 }] };
+    expect(serializeRegistryFlow(flow, 'me')).toBe(serializeRegistryFlow(flow, 'me'));
+  });
+});
+
+// ── writeRegistryFile ───────────────────────────────────────────────────────
+describe('writeRegistryFile', () => {
+  it('sends base64 content and the message', async () => {
+    // GET answers the pre-write existence check, PUT captures the write.
+    const calls: Array<{ method: string; body?: any }> = [];
+    const fn = vi.fn(async (url: string, init?: any) => {
+      const method = (init?.method ?? 'GET').toUpperCase();
+      calls.push({ method, body: init?.body ? JSON.parse(init.body) : undefined });
+      if (method === 'GET') return { ok: false, status: 404, json: async () => ({}) } as any;
+      return { ok: true, status: 201, json: async () => ({ content: { sha: 's' } }) } as any;
+    });
+    const ok = await writeRegistryFile(fn as any, 'acme/flows', 'main', 'ghp', 'a.json', 'BODY', 'msg');
+    expect(ok).toBe(true);
+    const put = calls.find((c) => c.method === 'PUT')!;
+    expect(Buffer.from(put.body.content, 'base64').toString()).toBe('BODY');
+    expect(put.body.message).toBe('msg');
+  });
+
+  it('includes the existing sha so GitHub allows the overwrite', async () => {
+    // Without the current blob sha, GitHub rejects the PUT with 409.
+    const fn = vi.fn(async (_url: string, init?: any) => {
+      const method = (init?.method ?? 'GET').toUpperCase();
+      if (method === 'GET') return { ok: true, status: 200, json: async () => ({ sha: 'sha-old' }) } as any;
+      return { ok: true, status: 201, json: async () => ({ content: { sha: 's' } }) } as any;
+    });
+    await writeRegistryFile(fn as any, 'acme/flows', 'main', 'ghp', 'a.json', 'x', 'm');
+    const put = (fn.mock.calls as any[]).find((c) => c[1]?.method === 'PUT')!;
+    // body is the JSON string actually sent over the wire.
+    expect(JSON.parse(put[1].body).sha).toBe('sha-old');
+  });
+
+  it('omits sha for a new file', async () => {
+    const fn = vi.fn(async (_url: string, init?: any) => {
+      const method = (init?.method ?? 'GET').toUpperCase();
+      if (method === 'GET') return { ok: false, status: 404, json: async () => ({}) } as any;
+      return { ok: true, status: 201, json: async () => ({ content: { sha: 's' } }) } as any;
+    });
+    await writeRegistryFile(fn as any, 'acme/flows', 'main', 'ghp', 'new.json', 'x', 'm');
+    const put = fn.mock.calls.find((c: any[]) => (c[1]?.method ?? 'GET') === 'PUT')!;
+    expect(JSON.parse(put[1].body).sha).toBeUndefined();
+  });
+
+  it('returns false when GitHub refuses the write', async () => {
+    const fn = vi.fn(async (_url: string, init?: any) => {
+      const method = (init?.method ?? 'GET').toUpperCase();
+      if (method === 'GET') return { ok: false, status: 404, json: async () => ({}) } as any;
+      return { ok: false, status: 403, json: async () => ({}) } as any;
+    });
+    await expect(writeRegistryFile(fn as any, 'acme/flows', 'main', 'ghp', 'a.json', 'x', 'm')).resolves.toBe(false);
+  });
+
+  it('encodes the filename so a name cannot escape flows/', async () => {
+    const fn = vi.fn(async (url: string, init?: any) => {
+      const method = (init?.method ?? 'GET').toUpperCase();
+      if (method === 'GET') return { ok: false, status: 404, json: async () => ({}) } as any;
+      return { ok: true, status: 201, json: async () => ({}) } as any;
+    });
+    await writeRegistryFile(fn as any, 'acme/flows', 'main', 'ghp', '../../etc/passwd', 'x', 'm');
+    for (const call of fn.mock.calls as any[]) {
+      expect(call[0]).not.toMatch(/\/\.\.\//);
+    }
+  });
+});
+
+// ── copyCommunityFlows ──────────────────────────────────────────────────────
+const flowFixture = (name: string) => ({
+  name, author: 'cglab', version: '1.0.0',
+  steps: [{ name: 'BUILD', label: 'Build', order: 1 }],
+});
+
+/** Public registry with `count` flows; org repo already holds `existing`. */
+function copyHarness(opts: { count: number; existing?: string[]; failPut?: boolean; broken?: number[]; target?: string }) {
+  const targetRepo = opts.target ?? 'acme/flows';
+  const written: Record<string, string> = {};
+  for (const e of opts.existing ?? []) written[e] = 'PRE-EXISTING';
+  const puts: Array<{ name: string; body: string }> = [];
+  const broken = new Set(opts.broken ?? []);
+
+  const fn = vi.fn(async (url: string, init?: any) => {
+    const method = (init?.method ?? 'GET').toUpperCase();
+    const body = init?.body ? JSON.parse(init.body) : undefined;
+
+    if (method === 'PUT') {
+      const name = decodeURIComponent(url.split('/contents/flows/')[1].split('?')[0]);
+      if (opts.failPut) return { ok: false, status: 403, json: async () => ({}) } as any;
+      written[name] = Buffer.from(body.content, 'base64').toString();
+      puts.push({ name, body: written[name] });
+      return { ok: true, status: 201, json: async () => ({ content: { sha: 's' } }) } as any;
+    }
+
+    // Key on the REPO, not the host: both registries live on api.github.com,
+    // and a harness that cannot tell them apart silently answers the wrong one.
+    const isOrg = url.includes('/repos/' + targetRepo + '/');
+
+    if (isOrg && url.includes('/contents/flows?')) {
+      return {
+        ok: true, status: 200,
+        json: async () => Object.keys(written)
+          .filter((k) => (opts.existing ?? []).includes(k))
+          .map((n) => ({ name: n, type: 'file', download_url: `https://org.test/${n}` })),
+      } as any;
+    }
+    // Pre-write existence check — nothing pre-exists in these fixtures.
+    if (isOrg && url.includes('/contents/flows/')) {
+      return { ok: false, status: 404, json: async () => ({}) } as any;
+    }
+    // Public listing.
+    if (url.includes('/contents/flows?')) {
+      return {
+        ok: true, status: 200,
+        json: async () => Array.from({ length: opts.count }, (_, i) => ({
+          name: `f${i}.json`, type: 'file', download_url: `https://pub.test/f${i}.json`,
+        })),
+      } as any;
+    }
+    // Public flow content.
+    if (url.startsWith('https://pub.test/')) {
+      const key = url.split('/').pop()!;
+      const i = Number(key.replace('f', '').replace('.json', ''));
+      if (broken.has(i)) return { ok: true, status: 200, json: async () => ({ not: 'a flow' }) } as any;
+      return { ok: true, status: 200, json: async () => flowFixture(`Flow ${i}`) } as any;
+    }
+    throw new Error(`unrouted ${method} ${url}`);
+  });
+  return { fn, puts, written };
+}
+
+const runCopy = (h: { fn: any }, target = 'acme/flows') =>
+  copyCommunityFlows(h.fn as any, PUBLIC_REGISTRY_REPO, 'main', target, 'main', 'ghp', 'hub:org');
+
+describe('copyCommunityFlows', () => {
+  it('copies every community flow once, under a slug filename', async () => {
+    const h = copyHarness({ count: 3 });
+    const r = await runCopy(h);
+    expect(r).toMatchObject({ copied: 3, skipped: 0, failed: [], truncated: false });
+    expect(h.puts.map((p) => p.name).sort()).toEqual(['flow-0.json', 'flow-1.json', 'flow-2.json']);
+  });
+
+  it('writes valid flow documents, not raw echoes', async () => {
+    const h = copyHarness({ count: 1 });
+    await runCopy(h);
+    const doc = JSON.parse(h.puts[0].body);
+    expect(doc).toMatchObject({ schemaVersion: '1', name: 'Flow 0', author: 'hub:org' });
+    expect(Array.isArray(doc.steps)).toBe(true);
+  });
+
+  it('skips what the target already holds — a re-run must not churn history', async () => {
+    const h = copyHarness({ count: 3, existing: ['flow-1.json'] });
+    const r = await runCopy(h);
+    expect(r).toMatchObject({ copied: 2, skipped: 1 });
+    expect(h.puts.map((p) => p.name)).toEqual(['flow-0.json', 'flow-2.json']);
+  });
+
+  it('reports each flow it could not copy instead of stopping', async () => {
+    const h = copyHarness({ count: 3, broken: [1] });
+    const r = await runCopy(h);
+    expect(r.copied).toBe(2);
+    expect(r.failed).toEqual(['f1.json']);
+  });
+
+  it('reports every flow as failed when the target refuses writes', async () => {
+    const h = copyHarness({ count: 2, failPut: true });
+    const r = await runCopy(h);
+    expect(r.copied).toBe(0);
+    expect(r.failed).toHaveLength(2);
+  });
+
+  it('copies nothing when the source registry is empty', async () => {
+    const h = copyHarness({ count: 0 });
+    const r = await runCopy(h);
+    expect(r).toMatchObject({ copied: 0, skipped: 0, failed: [] });
+    expect(h.puts).toHaveLength(0);
+  });
+
+  it('stops at MAX_COPY_FLOWS and says so', async () => {
+    const h = copyHarness({ count: MAX_COPY_FLOWS + 50 });
+    const r = await runCopy(h);
+    expect(r.copied).toBe(MAX_COPY_FLOWS);
+    expect(r.truncated).toBe(true);
+    expect(h.puts).toHaveLength(MAX_COPY_FLOWS);
+  });
+
+  it('does NOT report truncation at exactly the bound', async () => {
+    // The boundary is where an off-by-one lives: exactly MAX_COPY_FLOWS flows
+    // is a complete copy, and claiming otherwise would send the admin to click
+    // "Retry copy" forever.
+    const h = copyHarness({ count: MAX_COPY_FLOWS });
+    const r = await runCopy(h);
+    expect(r.copied).toBe(MAX_COPY_FLOWS);
+    expect(r.truncated).toBe(false);
+  });
+
+  it('does NOT report truncation below the bound', async () => {
+    const h = copyHarness({ count: MAX_COPY_FLOWS - 1 });
+    expect((await runCopy(h)).truncated).toBe(false);
+  });
+
+  it('reads the public registry anonymously and writes the org repo with the token', async () => {
+    const h = copyHarness({ count: 1 });
+    await runCopy(h);
+    const reads = h.fn.mock.calls.filter((c: any[]) => String(c[0]).includes('pub.test')) as any[];
+    expect(reads.length).toBeGreaterThan(0);
+    for (const r of reads) expect(r[1]?.headers?.Authorization).toBeUndefined();
+    const puts = h.fn.mock.calls.filter((c: any[]) => c[1]?.method === 'PUT') as any[];
+    for (const p of puts) expect(p[1].headers.Authorization).toBe('Bearer ghp');
+  });
+
+  it('never leaks the org token to a public-registry read', async () => {
+    const h = copyHarness({ count: 2 });
+    await runCopy(h);
+    for (const call of h.fn.mock.calls as any[]) {
+      if (String(call[0]).includes('pub.test')) {
+        expect(JSON.stringify(call[1] ?? {})).not.toContain('ghp');
+      }
+    }
+  });
+});
+
+// ── constants ───────────────────────────────────────────────────────────────
+describe('registry constants', () => {
+  it('defaults to the public community repo and main', () => {
+    expect(PUBLIC_REGISTRY_REPO).toBe('cglab-public/agenfk-flows');
+    expect(DEFAULT_REGISTRY_BRANCH).toBe('main');
+  });
+
+  it('keeps the copy bound below GitHub\'s unauthenticated read budget', async () => {
+    // The copy reads each flow anonymously; the unauthenticated content limit
+    // is ~60/hour/IP, so a bound above that guarantees a mid-run failure.
+    expect(MAX_COPY_FLOWS).toBeGreaterThan(0);
+    expect(MAX_COPY_FLOWS).toBeLessThanOrEqual(200);
+  });
+});
+
+// ── config read/write against a real in-memory sqlite ──────────────────────
+// The pure-function tests above cover the shapes; these cover the parts that
+// only exist once a row is actually on disk: the ?? / || defaults that decide
+// what an org with no row sees, the "blank token keeps the stored one" rule,
+// and the copiedAt guard.
+import { openSqliteDb } from '../db/sqlite';
+import { saveRegistryConfig, getRegistryConfig, registryToken } from '../services/flowRegistry';
+
+const KEY = 'b'.repeat(64);
+
+describe('getRegistryConfig / registryToken / saveRegistryConfig', () => {
+  let db: any;
+  beforeEach(async () => { db = await openSqliteDb(':memory:'); });
+  afterEach(async () => { await db.close(); });
+
+  it('defaults a brand-new org to the public repo on main with no token', async () => {
+    const cfg = await getRegistryConfig(db, 'org-new');
+    expect(cfg).toEqual({
+      repo: PUBLIC_REGISTRY_REPO,
+      branch: DEFAULT_REGISTRY_BRANCH,
+      isPublic: true,
+      hasToken: false,
+      copiedAt: null,
+    });
+  });
+
+  it('reports a non-public repo as not public', async () => {
+    await saveRegistryConfig(db, 'org-a', { repo: 'acme/flows', secretKey: KEY });
+    expect((await getRegistryConfig(db, 'org-a')).isPublic).toBe(false);
+  });
+
+  it('falls back to main when a blank branch is stored', async () => {
+    // An empty-string branch would otherwise build `?ref=`, which GitHub
+    // rejects — the `||` (not `??`) is what catches it.
+    await db.run(
+      'INSERT INTO org_settings (org_id, registry_repo, registry_branch) VALUES (?, ?, ?)',
+      ['org-a', 'acme/flows', ''],
+    );
+    expect((await getRegistryConfig(db, 'org-a')).branch).toBe('main');
+  });
+
+  it('keeps a non-default branch', async () => {
+    await saveRegistryConfig(db, 'org-a', { repo: 'acme/flows', branch: 'release-2026', secretKey: KEY });
+    expect((await getRegistryConfig(db, 'org-a')).branch).toBe('release-2026');
+  });
+
+  it('reports hasToken only when ciphertext is actually present', async () => {
+    await saveRegistryConfig(db, 'org-a', { repo: 'acme/flows', secretKey: KEY });
+    expect((await getRegistryConfig(db, 'org-a')).hasToken).toBe(false);
+    await saveRegistryConfig(db, 'org-a', { repo: 'acme/flows', token: 'ghp_x', secretKey: KEY });
+    expect((await getRegistryConfig(db, 'org-a')).hasToken).toBe(true);
+  });
+
+  it('returns null token when none is stored rather than throwing', async () => {
+    await saveRegistryConfig(db, 'org-a', { repo: 'acme/flows', secretKey: KEY });
+    await expect(registryToken(db, 'org-a', KEY)).resolves.toBeNull();
+  });
+
+  it('returns null token for an org with no row at all', async () => {
+    await expect(registryToken(db, 'no-such-org', KEY)).resolves.toBeNull();
+  });
+
+  it('round-trips the token through encryption', async () => {
+    await saveRegistryConfig(db, 'org-a', { repo: 'acme/flows', token: 'ghp_round_trip', secretKey: KEY });
+    await expect(registryToken(db, 'org-a', KEY)).resolves.toBe('ghp_round_trip');
+  });
+
+  it('never stores the token in plaintext', async () => {
+    await saveRegistryConfig(db, 'org-a', { repo: 'acme/flows', token: 'ghp_secret', secretKey: KEY });
+    const row = await db.get<{ registry_token_enc: string }>(
+      'SELECT registry_token_enc FROM org_settings WHERE org_id = ?', ['org-a']);
+    expect(row.registry_token_enc).not.toContain('ghp_secret');
+    expect(row.registry_token_enc.startsWith('v1:')).toBe(true);
+  });
+
+  it('keeps the stored token when a later save supplies none', async () => {
+    // The UI never echoes the secret back, so an unrelated edit (branch change)
+    // must not wipe the credential.
+    await saveRegistryConfig(db, 'org-a', { repo: 'acme/flows', token: 'ghp_first', secretKey: KEY });
+    await saveRegistryConfig(db, 'org-a', { repo: 'acme/other', branch: 'dev', secretKey: KEY });
+    expect(await registryToken(db, 'org-a', KEY)).toBe('ghp_first');
+    expect((await getRegistryConfig(db, 'org-a')).repo).toBe('acme/other');
+  });
+
+  it('replaces the token when a later save supplies one', async () => {
+    await saveRegistryConfig(db, 'org-a', { repo: 'acme/flows', token: 'ghp_first', secretKey: KEY });
+    await saveRegistryConfig(db, 'org-a', { repo: 'acme/flows', token: 'ghp_second', secretKey: KEY });
+    expect(await registryToken(db, 'org-a', KEY)).toBe('ghp_second');
+  });
+
+  it('records copiedAt on the first copy and preserves it afterwards', async () => {
+    await saveRegistryConfig(db, 'org-a', {
+      repo: 'acme/flows', secretKey: KEY, copiedAt: '2026-05-03T10:00:00Z',
+    });
+    expect((await getRegistryConfig(db, 'org-a')).copiedAt).toBe('2026-05-03T10:00:00Z');
+    // A later save that says nothing about copiedAt must not clear the record.
+    await saveRegistryConfig(db, 'org-a', { repo: 'acme/flows', branch: 'dev', secretKey: KEY });
+    expect((await getRegistryConfig(db, 'org-a')).copiedAt).toBe('2026-05-03T10:00:00Z');
+  });
+
+  it('does not treat an explicit null copiedAt as "leave it alone"', async () => {
+    // The guard is `!== undefined && !== null` for a reason: moving back to the
+    // public repo passes null deliberately, to clear the copy record.
+    await saveRegistryConfig(db, 'org-a', { repo: 'acme/flows', secretKey: KEY, copiedAt: '2026-05-03T10:00:00Z' });
+    await saveRegistryConfig(db, 'org-a', { repo: PUBLIC_REGISTRY_REPO, secretKey: KEY, copiedAt: null });
+    expect((await getRegistryConfig(db, 'org-a')).copiedAt).toBeNull();
+  });
+
+  it('inserts for an org with no row and updates for one with a row', async () => {
+    await saveRegistryConfig(db, 'org-a', { repo: 'acme/one', secretKey: KEY });
+    await saveRegistryConfig(db, 'org-a', { repo: 'acme/two', secretKey: KEY });
+    const rows = await db.all<{ registry_repo: string }>(
+      'SELECT registry_repo FROM org_settings WHERE org_id = ?', ['org-a']);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].registry_repo).toBe('acme/two');
+  });
+
+  it('keeps orgs independent', async () => {
+    await saveRegistryConfig(db, 'org-a', { repo: 'acme/a', token: 'ghp_a', secretKey: KEY });
+    await saveRegistryConfig(db, 'org-b', { repo: 'acme/b', token: 'ghp_b', secretKey: KEY });
+    expect(await registryToken(db, 'org-a', KEY)).toBe('ghp_a');
+    expect(await registryToken(db, 'org-b', KEY)).toBe('ghp_b');
+    expect((await getRegistryConfig(db, 'org-c')).repo).toBe(PUBLIC_REGISTRY_REPO);
+  });
+
+  it('defaults branch to main on insert when none is given', async () => {
+    await saveRegistryConfig(db, 'org-a', { repo: 'acme/flows', secretKey: KEY });
+    expect((await getRegistryConfig(db, 'org-a')).branch).toBe('main');
+  });
+});
+
+// ── Mutant-killers: branches the happy-path tests leave unobserved ─────────
+// Each of these exists because a specific mutant survived. Where the mutant is
+// genuinely equivalent (e.g. `?? ''` vs `&& ''` on a field that is always
+// populated) it is left alone and noted below rather than papered over with an
+// assertion that only restates the implementation.
+describe('edge branches (mutation survivors)', () => {
+  it('ghHeaders keeps the API version header that GitHub version-gates on', async () => {
+    // Survived: StringLiteral → "" on the Accept / X-GitHub-Api-Version values.
+    // Dropping either still returns 200 in a test that never checks the
+    // request, but GitHub changes response shape without the version header.
+    const h = ghHeaders('t');
+    expect(h['X-GitHub-Api-Version']).toBe('2022-11-28');
+    expect(h['User-Agent']).toBe('agenfk-hub');
+    expect(h.Accept).toContain('github+json');
+  });
+
+  it('reports a transport error whose message is missing, not "undefined"', async () => {
+    // Survived: `e?.message ?? e` → `e?.message && e`. A throw with no message
+    // (a bare `throw {}`) must still produce a usable error string.
+    const fn = vi.fn(async () => { throw { toString: () => 'socket hung' }; });
+    const r = await probeWriteAccess(fn as any, 'acme/flows', 'ghp');
+    expect(r.ok).toBe(false);
+    expect((r as any).error).toContain('socket hung');
+    expect((r as any).error).not.toContain('undefined');
+  });
+
+  it('distinguishes a 404 from other failures rather than collapsing them', async () => {
+    // Survived: ConditionalExpression → false on the `status === 404` branch.
+    // Both refuse, but the 404 wording is the one that explains "GitHub hides
+    // private repos you cannot see" — the difference an admin needs.
+    const notFound = await probeWriteAccess(
+      fakeGitHub([[/\/repos\//, () => ({ status: 404, body: {} })]]).fn as any, 'acme/flows', 'ghp');
+    const serverErr = await probeWriteAccess(
+      fakeGitHub([[/\/repos\//, () => ({ status: 500, body: {} })]]).fn as any, 'acme/flows', 'ghp');
+    expect((notFound as any).error).toMatch(/not found or not visible/i);
+    expect((serverErr as any).error).toMatch(/returned 500/);
+    expect((notFound as any).error).not.toBe((serverErr as any).error);
+  });
+
+  it('treats a 200 with ok:false body as unreadable rather than writable', async () => {
+    // Survived: ArrowFunction → () => undefined on the json().catch handler.
+    const fn = vi.fn(async () => ({ ok: true, status: 200, json: async () => undefined }));
+    await expect(probeWriteAccess(fn as any, 'acme/flows', 'ghp')).resolves.toMatchObject({ ok: false });
+  });
+
+  it('passes when permissions exists but push is true and full_name is present', async () => {
+    // Survived: ConditionalExpression → false on `canPush === false`, and
+    // OptionalChaining on `meta?.permissions?.push`. Both mutants make every
+    // probe pass, which the "read but cannot write" test catches only if the
+    // deep-optional read is exercised with a MISSING permissions block too.
+    const noPerms = await probeWriteAccess(
+      fakeGitHub([[/\/repos\//, () => ({ body: { full_name: 'acme/flows' } })]]).fn as any, 'acme/flows', 'ghp');
+    expect(noPerms.ok).toBe(true);
+  });
+
+  it('drops a listing entry that is a file with a non-.json name', async () => {
+    // Survived: ConditionalExpression → true on parts of the filter. Each half
+    // is tested alone elsewhere; this pins the conjunction.
+    const g = fakeGitHub([[/\/contents\/flows\?/, () => ({ body: [
+      { name: 'a.json', type: 'dir', download_url: 'u' },      // right name, wrong type
+      { name: 'b.md', type: 'file', download_url: 'u' },        // right type, wrong name
+      { name: 'c.json', type: 'file', download_url: 'u' },      // the only keeper
+    ] })]]) as any;
+    const out = await listRegistryFiles(g.fn, 'acme/flows', 'main', null);
+    expect(out.map((f: any) => f.name)).toEqual(['c.json']);
+  });
+
+  it('serializes a flow whose steps carry no order at all without NaN sorting', async () => {
+    // Survived: `a.order ?? 0` → `a.order && 0`, and the comparator's `-` → `+`.
+    // A registry file authored by hand can omit order; the sort must not throw
+    // or scramble.
+    const out = JSON.parse(serializeRegistryFlow({
+      name: 'X', steps: [{ name: 'B' }, { name: 'A' }],
+    }, 'me'));
+    expect(out.steps).toHaveLength(2);
+    expect(out.steps.every((s: any) => !Number.isNaN(s.order))).toBe(true);
+  });
+
+  it('preserves an empty-string exitCriteria rather than inventing one', async () => {
+    // Survived: `s.exitCriteria ?? ''` → `s.exitCriteria && ''` and the
+    // "Stryker was here" string. The distinction matters: a step with NO
+    // criteria must serialize as empty, not as the literal text.
+    const out = JSON.parse(serializeRegistryFlow({
+      name: 'X', steps: [{ name: 'A', order: 1, exitCriteria: '' }],
+    }, 'me'));
+    expect(out.steps[0].exitCriteria).toBe('');
+  });
+
+  it('preserves false-valued isSpecial/isAnchor rather than dropping them', async () => {
+    // Survived: `?? false` → `&& false` and BooleanLiteral → true. A copied
+    // flow that declares isAnchor: false must not arrive as an anchor.
+    const out = JSON.parse(serializeRegistryFlow({
+      name: 'X', steps: [{ name: 'A', order: 1, isSpecial: false, isAnchor: false }],
+    }, 'me'));
+    expect(out.steps[0]).toMatchObject({ isSpecial: false, isAnchor: false });
+  });
+
+  it('serializes a top-level flow with no optional fields into valid defaults', async () => {
+    // Survived: OptionalChaining on flow.name/description/version plus the
+    // '1.0.0' default. A minimal file must still produce a loadable document.
+    const out = JSON.parse(serializeRegistryFlow({ name: 'Min', steps: [] }, 'me'));
+    expect(out).toMatchObject({ name: 'Min', description: '', version: '1.0.0' });
+  });
+
+  it('omits sha when the existence check returns a body without one', async () => {
+    // Survived: `?.sha` OptionalChaining and `if (existing.ok)` → true. A 200
+    // whose body has no sha must not send `sha: undefined` as a real value.
+    const fn = vi.fn(async (_u: string, init?: any) => {
+      const method = (init?.method ?? 'GET').toUpperCase();
+      if (method === 'GET') return { ok: true, status: 200, json: async () => ({ noSha: true }) } as any;
+      return { ok: true, status: 201, json: async () => ({}) } as any;
+    });
+    await writeRegistryFile(fn as any, 'acme/flows', 'main', 'ghp', 'a.json', 'x', 'm');
+    const put = (fn.mock.calls as any[]).find((c) => c[1]?.method === 'PUT')!;
+    expect('sha' in JSON.parse(put[1].body)).toBe(false);
+  });
+
+  it('returns an empty copy result without touching the target when the source is empty', async () => {
+    // Survived: ConditionalExpression → false on `allSource.length === 0`,
+    // which would send the copy into the target-listing call for nothing.
+    const fn = vi.fn(async (url: string, init?: any) => {
+      const method = (init?.method ?? 'GET').toUpperCase();
+      if (method === 'PUT') throw new Error('must not write');
+      if (url.includes('acme/flows')) throw new Error('must not read the target');
+      return { ok: true, status: 200, json: async () => [] } as any;
+    });
+    const r = await copyCommunityFlows(fn as any, PUBLIC_REGISTRY_REPO, 'main', 'acme/flows', 'main', 'ghp', 'me');
+    expect(r).toMatchObject({ copied: 0, skipped: 0, failed: [], truncated: false });
+  });
+
+  it('records a flow as failed when its content is not a flow document', async () => {
+    // Survived: `!flow?.name || !Array.isArray(flow.steps)` → `&&`. With the
+    // conjunction broken, a garbage file would be written into the org repo.
+    const h = copyHarness({ count: 2, broken: [0, 1] });
+    const r = await runCopy(h);
+    expect(r.copied).toBe(0);
+    expect(r.failed).toEqual(['f0.json', 'f1.json']);
+    expect(h.puts).toHaveLength(0);
+  });
+
+  it('uses a default commit message shape that names the flow', async () => {
+    // Survived: the template literal in the copy commit message. A commit that
+    // does not say which flow it imported is unreviewable in the org repo.
+    const h = copyHarness({ count: 1 });
+    await runCopy(h);
+    const put = (h.fn.mock.calls as any[]).find((c) => c[1]?.method === 'PUT')!;
+    expect(JSON.parse(put[1].body).message).toMatch(/Flow 0/);
+  });
+});
+
+// ── The two paths no test reached at all (mutation NoCoverage) ─────────────
+describe('copyCommunityFlows — failure paths that were never executed', () => {
+  it('records a flow as failed when its download throws mid-copy', async () => {
+    // The catch around each iteration had zero coverage. A single flow whose
+    // fetch rejects (connection reset, GitHub 5xx at the CDN) must not abort
+    // the whole copy — the admin would otherwise get a save that copied
+    // nothing and reported nothing.
+    const fn = vi.fn(async (url: string, init?: any) => {
+      const method = (init?.method ?? 'GET').toUpperCase();
+      if (method === 'PUT') return { ok: true, status: 201, json: async () => ({}) } as any;
+      if (url.includes('acme/flows')) return { ok: true, status: 200, json: async () => [] } as any;
+      if (url.includes('/contents/flows?')) {
+        return { ok: true, status: 200, json: async () => [
+          { name: 'boom.json', type: 'file', download_url: 'https://pub.test/boom.json' },
+          { name: 'ok.json', type: 'file', download_url: 'https://pub.test/ok.json' },
+        ] } as any;
+      }
+      if (url.endsWith('boom.json')) throw new Error('socket reset');
+      return { ok: true, status: 200, json: async () => flowFixture('Fine') } as any;
+    });
+    const r = await copyCommunityFlows(fn as any, PUBLIC_REGISTRY_REPO, 'main', 'acme/flows', 'main', 'ghp', 'me');
+    expect(r.failed).toEqual(['boom.json']);
+    expect(r.copied).toBe(1);
+  });
+
+  it('records a flow as failed when its body cannot be parsed', async () => {
+    const fn = vi.fn(async (url: string, init?: any) => {
+      const method = (init?.method ?? 'GET').toUpperCase();
+      if (method === 'PUT') return { ok: true, status: 201, json: async () => ({}) } as any;
+      if (url.includes('acme/flows')) return { ok: true, status: 200, json: async () => [] } as any;
+      if (url.includes('/contents/flows?')) {
+        return { ok: true, status: 200, json: async () => [
+          { name: 'html.json', type: 'file', download_url: 'https://pub.test/html.json' },
+        ] } as any;
+      }
+      return { ok: true, status: 200, json: async () => { throw new Error('invalid json'); } } as any;
+    });
+    const r = await copyCommunityFlows(fn as any, PUBLIC_REGISTRY_REPO, 'main', 'acme/flows', 'main', 'ghp', 'me');
+    // toEqual, not toMatchObject: a partial match lets an extra field (or a
+    // skipped count that should have been 1) slip through unnoticed.
+    expect(r).toEqual({ copied: 0, skipped: 0, failed: ['html.json'], truncated: false });
+  });
+
+  it('records a flow as failed when the source returns a non-200', async () => {
+    // A 404 on one file (deleted between listing and read) is a per-flow
+    // failure, not a copy abort.
+    //
+    // Mutation note: the `if (!resp.ok)` guard here is UNKILLABLE by any test,
+    // and that is worth stating rather than leaving a reader to rediscover.
+    // GitHub's error bodies (`{ message, documentation_url }`, an HTML portal,
+    // an empty body) are never valid flow documents, so the `!flow?.name ||
+    // !Array.isArray(flow.steps)` check two lines below rejects them anyway and
+    // pushes the same filename to `failed`. Removing the guard entirely still
+    // yields `{ copied: 0, failed: ['gone.json'] }` — verified by mutation. It
+    // is defence in depth: it skips a pointless json parse and keeps the reason
+    // for the failure legible, but no observable outcome depends on it. The
+    // same fallthrough makes the `typeof meta !== 'object'` guard in
+    // probeWriteAccess and the optional-chaining in serializeRegistryFlow
+    // equivalent mutants. Killing them would mean asserting on internals that
+    // carry no behaviour, so they are left as accepted survivors.
+    const fn = vi.fn(async (url: string, init?: any) => {
+      const method = (init?.method ?? 'GET').toUpperCase();
+      if (method === 'PUT') return { ok: true, status: 201, json: async () => ({}) } as any;
+      if (url.includes('acme/flows')) return { ok: true, status: 200, json: async () => [] } as any;
+      if (url.includes('/contents/flows?')) {
+        return { ok: true, status: 200, json: async () => [
+          { name: 'gone.json', type: 'file', download_url: 'https://pub.test/gone.json' },
+        ] } as any;
+      }
+      return { ok: false, status: 404, json: async () => ({}) } as any;
+    });
+    const r = await copyCommunityFlows(fn as any, PUBLIC_REGISTRY_REPO, 'main', 'acme/flows', 'main', 'ghp', 'me');
+    expect(r).toEqual({ copied: 0, skipped: 0, failed: ['gone.json'], truncated: false });
+  });
+
+  it('writes nothing when the target listing throws', async () => {
+    // The target-listing call is not inside the per-flow try; a failure there
+    // propagates to the caller, which is correct — we cannot know what already
+    // exists, so copying would risk clobbering. Asserted so the behaviour is
+    // chosen rather than accidental.
+    const fn = vi.fn(async (url: string, init?: any) => {
+      const method = (init?.method ?? 'GET').toUpperCase();
+      if (method === 'PUT') throw new Error('must not write when target state is unknown');
+      if (url.includes('acme/flows')) throw new Error('target listing failed');
+      if (url.includes('/contents/flows?')) {
+        return { ok: true, status: 200, json: async () => [
+          { name: 'a.json', type: 'file', download_url: 'https://pub.test/a.json' },
+        ] } as any;
+      }
+      return { ok: true, status: 200, json: async () => flowFixture('A') } as any;
+    });
+    await expect(
+      copyCommunityFlows(fn as any, PUBLIC_REGISTRY_REPO, 'main', 'acme/flows', 'main', 'ghp', 'me'),
+    ).rejects.toThrow(/target listing failed/);
+  });
+});
+
+describe('remaining killable survivors', () => {
+  it('refuses when json() throws — the catch handler must yield null, not undefined', async () => {
+    // Survived: ArrowFunction → () => undefined on `.catch(() => null)`.
+    // Both are falsy so the `!meta` guard fires either way — but only `null`
+    // keeps the guard's three-way shape honest. Asserted so a future edit that
+    // drops the catch does not silently change what `meta` holds.
+    const fn = vi.fn(async () => ({ ok: true, status: 200, json: async () => { throw new Error('html'); } }));
+    const r = await probeWriteAccess(fn as any, 'acme/flows', 'ghp');
+    expect(r).toEqual({ ok: false, error: "could not read a repository document for acme/flows from GitHub" });
+  });
+
+  it('refuses a non-object body (array, string, number) not just null', async () => {
+    // Survived: ConditionalExpression → false on `typeof meta !== 'object'`.
+    // GitHub can answer with an array or a bare string behind some caches; the
+    // `typeof` clause is what stops `meta.full_name` reading through them.
+    for (const body of [['not', 'a repo'], 'a string', 42, true]) {
+      const fn = vi.fn(async () => ({ ok: true, status: 200, json: async () => body }));
+      const r = await probeWriteAccess(fn as any, 'acme/flows', 'ghp');
+      expect(r.ok, JSON.stringify(body)).toBe(false);
+    }
+  });
+
+  it('refuses when permissions exists but push is explicitly false, with full_name present', async () => {
+    // Survived: OptionalChaining on `meta?.permissions?.push`. Removing `?.`
+    // only breaks when permissions is absent — which must still PASS (a proxy
+    // that strips it should not lock admins out). Both halves pinned together.
+    const denied = await probeWriteAccess(
+      fakeGitHub([[/\/repos\//, () => ({ body: { full_name: 'acme/flows', permissions: { push: false } } })]]).fn as any,
+      'acme/flows', 'ghp');
+    const stripped = await probeWriteAccess(
+      fakeGitHub([[/\/repos\//, () => ({ body: { full_name: 'acme/flows' } })]]).fn as any,
+      'acme/flows', 'ghp');
+    expect(denied.ok).toBe(false);
+    expect(stripped.ok).toBe(true);
+  });
+
+  // The three validation cases below share one harness, and the assertion that
+  // matters is `writeAttempts === 0` — NOT the `failed` list. An earlier version
+  // of these tests let the fake `throw` on PUT and asserted only `failed:
+  // ['x.json']`; that passed against the mutated code too, because the loop's
+  // catch records the thrown error under the same filename. A test that reports
+  // the same outcome for correct and broken code cannot kill a mutant, however
+  // specific its wording looks. So the fake records writes instead of throwing,
+  // and the test fails if a malformed flow is ever written.
+  function validationHarness(bodies: Record<string, unknown>) {
+    const writeAttempts: string[] = [];
+    const fn = vi.fn(async (url: string, init?: any) => {
+      const method = (init?.method ?? 'GET').toUpperCase();
+      if (method === 'PUT') {
+        writeAttempts.push(decodeURIComponent(url.split('/contents/flows/')[1].split('?')[0]));
+        return { ok: true, status: 201, json: async () => ({ content: { sha: 's' } }) } as any;
+      }
+      if (url.includes('acme/flows')) return { ok: true, status: 200, json: async () => [] } as any;
+      if (url.includes('/contents/flows?')) {
+        return {
+          ok: true, status: 200,
+          json: async () => Object.keys(bodies).map((name) => ({
+            name, type: 'file', download_url: `https://pub.test/${name}`,
+          })),
+        } as any;
+      }
+      const key = url.split('/').pop()!;
+      return { ok: true, status: 200, json: async () => bodies[key] } as any;
+    });
+    return { fn, writeAttempts };
+  }
+
+  const runValidation = (bodies: Record<string, unknown>) => {
+    const h = validationHarness(bodies);
+    return copyCommunityFlows(h.fn as any, PUBLIC_REGISTRY_REPO, 'main', 'acme/flows', 'main', 'ghp', 'me')
+      .then((r) => ({ r, writeAttempts: h.writeAttempts }));
+  };
+
+  it('rejects a flow whose steps is a non-array before writing it', async () => {
+    // Survived: `!flow?.name || !Array.isArray(flow.steps)` → `&&`. Under the
+    // mutant the malformed flow is written to the org repo as a zero-step flow.
+    const { r, writeAttempts } = await runValidation({ 'bad-steps.json': { name: 'Bad', steps: 'oops' } });
+    expect(writeAttempts).toEqual([]);
+    expect(r.copied).toBe(0);
+    expect(r.failed).toEqual(['bad-steps.json']);
+  });
+
+  it('rejects a flow with no name before writing it', async () => {
+    // Survived: the `!flow?.name` half. Under the mutant a nameless flow is
+    // written, and slugify(undefined) yields the filename ".json" — a file the
+    // org repo can never install and that every later nameless flow overwrites.
+    const { r, writeAttempts } = await runValidation({ 'unnamed.json': { steps: [{ name: 'A', order: 1 }] } });
+    expect(writeAttempts).toEqual([]);
+    expect(r.failed).toEqual(['unnamed.json']);
+  });
+
+  it('rejects a flow whose body is null before writing it', async () => {
+    const { r, writeAttempts } = await runValidation({ 'null-body.json': null });
+    expect(writeAttempts).toEqual([]);
+    expect(r.failed).toEqual(['null-body.json']);
+  });
+
+  it('writes a well-formed flow, so the rejections above are not blanket refusals', async () => {
+    // The pair to the three tests above. Without it, a harness that refuses
+    // everything would satisfy them all.
+    const { r, writeAttempts } = await runValidation({
+      'good.json': { name: 'Good Flow', steps: [{ name: 'A', order: 1 }] },
+    });
+    expect(writeAttempts).toEqual(['good-flow.json']);
+    expect(r.copied).toBe(1);
+  });
+});
+
+// ── Branch validation (REVIEW finding) ─────────────────────────────────────
+describe('isValidRegistryBranch', () => {
+  it('accepts ordinary and namespaced branch names', () => {
+    for (const ref of ['main', 'master', 'develop', 'release/2.0', 'feat/x', 'v1.x',
+      'my_branch', 'my-branch', 'a.b.c', 'Release_1', DEFAULT_REGISTRY_BRANCH]) {
+      expect(isValidRegistryBranch(ref), ref).toBe(true);
+    }
+  });
+
+  it('rejects the empty and whitespace-only ref', () => {
+    expect(isValidRegistryBranch('')).toBe(false);
+    expect(isValidRegistryBranch('   ')).toBe(false);
+  });
+
+  it('rejects anything that could escape a URL path segment or read as a flag', () => {
+    // '?' and '#' would alter the query/fragment if the value ever reached a
+    // URL without encoding; '..' and a leading '-' are traversal and argv-flag
+    // shapes; the rest are characters git itself refuses in a refname.
+    for (const ref of ['main?ref=other', 'main#x', 'main foo', '../../etc/passwd',
+      '-main', 'main~1', 'main^{}', 'main@{u}', 'main\\x', 'main\x00', 'ma"in',
+      'main[0]', 'main:foo', 'main*', 'main?', 'main\n', 'refs/../main']) {
+      expect(isValidRegistryBranch(ref), JSON.stringify(ref)).toBe(false);
+    }
+  });
+
+  it('rejects git-forbidden trailing and doubled separators', () => {
+    // git refuses a ref ending in '/' or '.', and one containing '//', '/.'
+    // or '.lock' — storing them would make every read a silent 404.
+    for (const ref of ['main/', 'main.', 'a//b', 'a/./b', './main', '.main']) expect(isValidRegistryBranch(ref), ref).toBe(false);
+  });
+
+  it('rejects a non-string and an over-long ref', () => {
+    expect(isValidRegistryBranch(null)).toBe(false);
+    expect(isValidRegistryBranch(42)).toBe(false);
+    expect(isValidRegistryBranch(undefined)).toBe(false);
+    expect(isValidRegistryBranch({})).toBe(false);
+    expect(isValidRegistryBranch('a'.repeat(256))).toBe(false);
+    expect(isValidRegistryBranch('a'.repeat(255))).toBe(true);
+  });
+
+  it('trims before deciding, so a pasted ref with padding still validates', () => {
+    expect(isValidRegistryBranch('  main  ')).toBe(true);
+  });
+});
+
+describe('saveRegistryConfig — storage-boundary validation', () => {
+  let db: any;
+  beforeEach(async () => {
+    const { openSqliteDb } = await import('../db/sqlite');
+    db = await openSqliteDb(':memory:');
+  });
+  afterEach(async () => { if (db?.close) await db.close(); });
+
+  // encryptSecret requires a 32-byte key as 64 hex chars (or 44-char base64);
+  // 32 chars throws before any validation runs, which is not what these tests
+  // are pinning. Same shape the rest of the file uses.
+  const key = 'b'.repeat(64);
+
+  it('refuses to store a malformed branch instead of poisoning later reads', async () => {
+    // The point of validating here: a bad ref in the column makes every
+    // subsequent listRegistryFiles call a 404, which reads as an EMPTY
+    // registry. The admin would see zero flows and no error.
+    const { saveRegistryConfig } = await import('../services/flowRegistry');
+    await expect(
+      saveRegistryConfig(db, 'org-1', { repo: 'acme/flows', branch: 'ma in?x', secretKey: key, token: 'ghp' }),
+    ).rejects.toThrow(/invalid registry branch/);
+    const row = await db.get('SELECT registry_branch FROM org_settings WHERE org_id = ?', ['org-1']);
+    expect(row).toBeUndefined();
+  });
+
+  it('refuses to store a malformed repo slug', async () => {
+    const { saveRegistryConfig } = await import('../services/flowRegistry');
+    await expect(
+      saveRegistryConfig(db, 'org-1', { repo: 'acme/flows/../evil', secretKey: key, token: 'ghp' }),
+    ).rejects.toThrow(/invalid registry repo/);
+    const row = await db.get('SELECT registry_repo FROM org_settings WHERE org_id = ?', ['org-1']);
+    expect(row).toBeUndefined();
+  });
+
+  it('accepts a valid branch and keeps a namespaced one intact', async () => {
+    const { saveRegistryConfig, getRegistryConfig } = await import('../services/flowRegistry');
+    await saveRegistryConfig(db, 'org-1', { repo: 'acme/flows', branch: 'release/2.0', secretKey: key, token: 'ghp' });
+    const cfg = await getRegistryConfig(db, 'org-1');
+    expect(cfg.branch).toBe('release/2.0');
+  });
+
+  it('treats an omitted branch as the default rather than as invalid', async () => {
+    // The guard must not turn "caller did not specify a branch" into a
+    // validation failure — that would break every existing caller.
+    const { saveRegistryConfig, getRegistryConfig } = await import('../services/flowRegistry');
+    await saveRegistryConfig(db, 'org-1', { repo: 'acme/flows', secretKey: key, token: 'ghp' });
+    expect((await getRegistryConfig(db, 'org-1')).branch).toBe(DEFAULT_REGISTRY_BRANCH);
+    await saveRegistryConfig(db, 'org-2', { repo: 'acme/flows', branch: '', secretKey: key, token: 'ghp' });
+    expect((await getRegistryConfig(db, 'org-2')).branch).toBe(DEFAULT_REGISTRY_BRANCH);
+  });
+
+  it('validates before writing, so a rejected save leaves no partial row', async () => {
+    const { saveRegistryConfig, getRegistryConfig } = await import('../services/flowRegistry');
+    await saveRegistryConfig(db, 'org-1', { repo: 'acme/flows', branch: 'main', secretKey: key, token: 'ghp' });
+    await expect(
+      saveRegistryConfig(db, 'org-1', { repo: 'acme/flows', branch: 'bad ref', secretKey: key }),
+    ).rejects.toThrow(/invalid registry branch/);
+    // The earlier good value survives untouched — the failed call changed nothing.
+    expect((await getRegistryConfig(db, 'org-1')).branch).toBe('main');
+  });
+});

--- a/packages/hub/src/test/flow-registry-service.test.ts
+++ b/packages/hub/src/test/flow-registry-service.test.ts
@@ -1127,3 +1127,110 @@ describe('saveRegistryConfig — storage-boundary validation', () => {
     expect((await getRegistryConfig(db, 'org-1')).branch).toBe('main');
   });
 });
+
+// ── resolveRegistrySource: the tenancy boundary ────────────────────────────
+describe('resolveRegistrySource', () => {
+  let db: any;
+  beforeEach(async () => {
+    const { openSqliteDb } = await import('../db/sqlite');
+    db = await openSqliteDb(':memory:');
+  });
+  afterEach(async () => { if (db?.close) await db.close(); });
+
+  const KEY = 'b'.repeat(64);
+
+  const setPrivate = async () => {
+    const { saveRegistryConfig } = await import('../services/flowRegistry');
+    await saveRegistryConfig(db, 'org-a', { repo: 'acme/flows', branch: 'main', token: 'ghp_org_secret', secretKey: KEY });
+  };
+
+  const call = async (orgId: string, source: unknown) => {
+    const { resolveRegistrySource } = await import('../services/flowRegistry');
+    return resolveRegistrySource(db, orgId, KEY, source);
+  };
+
+  it('undefined source resolves to the org\'s configured repo (back-compat)', async () => {
+    await setPrivate();
+    const r = await call('org-a', undefined);
+    expect(r).toMatchObject({ ok: true, repo: 'acme/flows', branch: 'main' });
+    expect(r.token).toBe('ghp_org_secret');
+  });
+
+  it('empty-string source also resolves to the org repo', async () => {
+    await setPrivate();
+    const r = await call('org-a', '');
+    expect(r.ok && r.repo).toBe('acme/flows');
+  });
+
+  it('source=org resolves to the org repo', async () => {
+    await setPrivate();
+    const r = await call('org-a', 'org');
+    expect(r.ok && r.repo).toBe('acme/flows');
+  });
+
+  it('source=community resolves to the PUBLIC repo and NO token', async () => {
+    // The credential rule. The org's PAT is scoped to acme/flows; sending it
+    // to cglab-public would leak it into a repo the org has no relationship
+    // with and into GitHub's access logs. Anonymous is also simply correct for
+    // a public repo.
+    await setPrivate();
+    const r = await call('org-a', 'community');
+    expect(r).toMatchObject({ ok: true, repo: PUBLIC_REGISTRY_REPO, token: null });
+  });
+
+  it('source=community keeps the configured BRANCH', async () => {
+    // Community is a different repo, but the org's branch choice is about how
+    // it reads registries generally; reusing it avoids a second setting that
+    // would almost always be left at main anyway.
+    const { saveRegistryConfig } = await import('../services/flowRegistry');
+    await saveRegistryConfig(db, 'org-a', { repo: 'acme/flows', branch: 'release/2.0', token: 'ghp', secretKey: KEY });
+    const r = await call('org-a', 'community');
+    expect(r.ok && r.branch).toBe('release/2.0');
+  });
+
+  it('rejects an unknown source with ok:false rather than throwing', async () => {
+    // The route turns ok:false into a 400. Throwing would surface as a 500 and
+    // read like a server fault for what is a bad request.
+    await setPrivate();
+    const r = await call('org-a', 'victim/flows');
+    expect(r.ok).toBe(false);
+    expect((r as any).error).toMatch(/source/i);
+  });
+
+  it('rejects non-string sources', async () => {
+    await setPrivate();
+    for (const bad of [42, {}, [], true]) {
+      expect((await call('org-a', bad)).ok, JSON.stringify(bad)).toBe(false);
+    }
+  });
+
+  it('never returns a repo other than the org\'s or the public one', async () => {
+    // The invariant the whole design rests on, asserted directly: no value of
+    // `source` yields a third repo.
+    await setPrivate();
+    for (const src of [undefined, '', 'org', 'community', 'Org', 'COMMUNITY', 'x', 'a/b', '../x', 'null']) {
+      const r = await call('org-a', src);
+      if (!r.ok) continue;
+      const repo = (r as any).repo;
+      expect([PUBLIC_REGISTRY_REPO, 'acme/flows'], String(src)).toContain(repo);
+    }
+  });
+
+  it('a public org gets no token for either source', async () => {
+    // Public orgs have no stored token and must not send one; asserting both
+    // sources here so the anonymous path is pinned for the common case too.
+    for (const src of [undefined, 'community', 'org']) {
+      const r = await call('org-public-never-set', src);
+      expect(r.ok, String(src)).toBe(true);
+      expect((r as any).token, String(src)).toBeNull();
+    }
+  });
+
+  it('is case-sensitive on purpose', async () => {
+    // 'COMMUNITY' failing is deliberate, not an oversight: the route 400s on it,
+    // so a client with a casing bug learns about it immediately instead of
+    // silently reading the wrong repo.
+    await setPrivate();
+    expect((await call('org-a', 'COMMUNITY')).ok).toBe(false);
+  });
+});

--- a/packages/hub/src/test/hub-pg-parity.test.ts
+++ b/packages/hub/src/test/hub-pg-parity.test.ts
@@ -37,6 +37,49 @@ async function bootHubOnPg(): Promise<Fixture> {
   return { app: out.app, db, cookie, token };
 }
 
+/**
+ * Per-org flow registry (CGLAB-138) on Postgres.
+ *
+ * This exists because the first version of the org_settings table was invalid
+ * Postgres DDL — `updated_at TEXT DEFAULT (now() at time zone 'utc')` yields a
+ * timestamptz that cannot default a TEXT column, so the CREATE TABLE threw and
+ * every pg-backed boot failed. A SQLite-only test suite passed and never saw
+ * it. The save path also emits `datetime('now')`, which only works on Postgres
+ * because the dialect translator rewrites it — so both the DDL and the runtime
+ * SQL are asserted here.
+ */
+describe('PG parity: per-org flow registry (CGLAB-138)', () => {
+  it('boots on Postgres with the org_settings table present', async () => {
+    const { app, db, cookie } = await bootHubOnPg();
+    const r = await supertest(app).get('/v1/admin/registry-config').set('Cookie', cookie);
+    expect(r.status).toBe(200);
+    expect(r.body.repo).toBe('cglab-public/agenfk-flows');
+    expect(r.body.isPublic).toBe(true);
+    await db.close();
+  });
+
+  it('upserts and updates org_settings on Postgres (datetime(\'now\') rewrite)', async () => {
+    const { db } = await bootHubOnPg();
+    const { saveRegistryConfig, getRegistryConfig, registryToken } = await import('../services/flowRegistry');
+
+    // INSERT branch.
+    await saveRegistryConfig(db, 'org', {
+      repo: 'acme/flows', token: 'ghp_pg_token', secretKey: SECRET,
+      copiedAt: '2026-05-03T10:00:00Z',
+    });
+    expect((await getRegistryConfig(db, 'org')).repo).toBe('acme/flows');
+    expect(await registryToken(db, 'org', SECRET)).toBe('ghp_pg_token');
+
+    // UPDATE branch — this is the statement carrying datetime('now').
+    await saveRegistryConfig(db, 'org', { repo: 'acme/other', secretKey: SECRET });
+    const cfg = await getRegistryConfig(db, 'org');
+    expect(cfg.repo).toBe('acme/other');
+    // A blank token means "keep the stored one", not "clear it".
+    expect(cfg.hasToken).toBe(true);
+    await db.close();
+  });
+});
+
 const sample = (overrides: any = {}) => ({
   eventId: 'e-' + Math.random().toString(36).slice(2),
   installationId: 'inst-1',

--- a/packages/hub/src/test/model-mapping.test.ts
+++ b/packages/hub/src/test/model-mapping.test.ts
@@ -38,6 +38,34 @@ describe('resolveModelId', () => {
   it('is identity with no mappings configured', () => {
     expect(resolveModelId('qwen38-27b', EMPTY_MODEL_MAPPING)).toBe('qwen38-27b');
   });
+
+  // A harness may report the artifact through its route. pi reports
+  // `coding4/qwen38-27b` after the deterministic-model fix where it once reported
+  // the bare `qwen38-27b`; without the prefix fallback every such PR would slip
+  // past the admin's alias and form its own dashboard group.
+  it('maps a provider-qualified id via its bare artifact name', () => {
+    expect(resolveModelId('coding4/qwen38-27b', map)).toBe('qwen3.8:27b');
+    // multi-segment routes (OpenRouter style) resolve on the last segment
+    expect(resolveModelId('openrouter/anthropic/claude-opus-4-8', new Map([['claude-opus-4-8', 'Opus']]))).toBe('Opus');
+  });
+
+  it('prefers an exact alias over the bare-name fallback', () => {
+    const both = new Map([['coding4/qwen38-27b', 'routed'], ['qwen38-27b', 'canonical']]);
+    expect(resolveModelId('coding4/qwen38-27b', both)).toBe('routed');
+  });
+
+  it('does NOT fold a provider-qualified near-miss that no alias names', () => {
+    // Still exact on the artifact: the fallback strips a prefix, it does not
+    // normalise spelling.
+    expect(resolveModelId('coding4/qwen38-7b', map)).toBe('coding4/qwen38-7b');
+    expect(resolveModelId('coding4/Qwen38-27b', map)).toBe('coding4/Qwen38-27b');
+  });
+
+  it('leaves a bare-name-only slash value alone when nothing matches', () => {
+    expect(resolveModelId('glm-5.2', map)).toBe('glm-5.2');
+    expect(resolveModelId('/', map)).toBe('/');
+    expect(resolveModelId('coding4/', map)).toBe('coding4/');
+  });
 });
 
 describe('resolveModelFilter', () => {

--- a/packages/hub/src/util/modelMapping.ts
+++ b/packages/hub/src/util/modelMapping.ts
@@ -27,10 +27,32 @@ export const EMPTY_MODEL_MAPPING: ModelMapping = new Map();
  * Returns the input unchanged when nothing is mapped. Unknown and empty ids
  * pass through so the dashboard still shows the raw value rather than dropping
  * the PR or showing a blank row.
+ *
+ * Matching is alias-keyed, NOT normalised: an alias is a literal spelling the
+ * admin chose (the seed itself keeps `:` as a size separator, so `qwen3.8:27b`
+ * and `qwen-3.8-27b` are deliberately different aliases for one canonical name),
+ * and `model_mappings` has a CHECK that two aliases cannot share a canonical —
+ * so one alias can never mean two models. Normalising here would invent a
+ * matching rule the admin table does not have.
  */
 export function resolveModelId(model: string | null, mapping: ModelMapping): string | null {
   if (!model) return model;
-  return mapping.get(model) ?? model;
+  const hit = mapping.get(model);
+  if (hit !== undefined) return hit;
+  // A harness may report the same artifact through its route, e.g. pi now
+  // reports `coding4/qwen38-27b` where it once reported `qwen38-27b` (the
+  // provider prefix disambiguates settings.json's defaultProvider + defaultModel
+  // split). Without this, every provider-qualified report would slip past the
+  // admin's alias and split into its own dashboard group next to the mapped one.
+  // The prefix names the reseller, not the artifact — the same reason
+  // modelMeta.normaliseModelId strips it on the licence axis.
+  const slash = model.lastIndexOf('/');
+  if (slash >= 0) {
+    const bare = model.slice(slash + 1);
+    const bareHit = bare ? mapping.get(bare) : undefined;
+    if (bareHit !== undefined) return bareHit;
+  }
+  return model;
 }
 
 /**

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/server",
-  "version": "1.1.17",
+  "version": "1.1.18-beta.1",
   "description": "MCP Server for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -12,9 +12,9 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.17",
-    "@agenfk/storage-sqlite": "1.1.17",
-    "@agenfk/telemetry": "1.1.17",
+    "@agenfk/core": "1.1.18-beta.1",
+    "@agenfk/storage-sqlite": "1.1.18-beta.1",
+    "@agenfk/telemetry": "1.1.18-beta.1",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "axios": "^1.20.0",
     "body-parser": "^2.3.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/server",
-  "version": "1.1.18-beta.1",
+  "version": "1.1.18-beta.2",
   "description": "MCP Server for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -12,9 +12,9 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.18-beta.1",
-    "@agenfk/storage-sqlite": "1.1.18-beta.1",
-    "@agenfk/telemetry": "1.1.18-beta.1",
+    "@agenfk/core": "1.1.18-beta.2",
+    "@agenfk/storage-sqlite": "1.1.18-beta.2",
+    "@agenfk/telemetry": "1.1.18-beta.2",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "axios": "^1.20.0",
     "body-parser": "^2.3.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/server",
-  "version": "1.1.18-beta.2",
+  "version": "1.1.18-beta.3",
   "description": "MCP Server for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -12,9 +12,9 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.18-beta.2",
-    "@agenfk/storage-sqlite": "1.1.18-beta.2",
-    "@agenfk/telemetry": "1.1.18-beta.2",
+    "@agenfk/core": "1.1.18-beta.3",
+    "@agenfk/storage-sqlite": "1.1.18-beta.3",
+    "@agenfk/telemetry": "1.1.18-beta.3",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "axios": "^1.20.0",
     "body-parser": "^2.3.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/server",
-  "version": "1.1.18-beta.3",
+  "version": "1.1.18-beta.4",
   "description": "MCP Server for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -12,9 +12,9 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.18-beta.3",
-    "@agenfk/storage-sqlite": "1.1.18-beta.3",
-    "@agenfk/telemetry": "1.1.18-beta.3",
+    "@agenfk/core": "1.1.18-beta.4",
+    "@agenfk/storage-sqlite": "1.1.18-beta.4",
+    "@agenfk/telemetry": "1.1.18-beta.4",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "axios": "^1.20.0",
     "body-parser": "^2.3.0",

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1635,6 +1635,38 @@ interface RegistryFlowEntry {
 }
 
 app.get("/registry/flows", asyncHandler(async (_req: any, res: any) => {
+  // A hub-connected installation asks the hub which registry its org uses
+  // (CGLAB-138). Two reasons this must be the hub and not a local config read:
+  // the org's GitHub token lives on the hub and must not be copied onto every
+  // laptop, and the admin's choice is org-wide — a per-machine override would
+  // let one workstation browse flows its org deliberately sealed away.
+  if (hubClient.isEnabled && hubClient.hubConfig) {
+    const { url, token } = hubClient.hubConfig;
+    try {
+      const r = await (globalThis.fetch as any)(`${url.replace(/\/$/, "")}/v1/registry/flows`, {
+        method: "GET",
+        headers: { Authorization: `Bearer ${token}`, Accept: "application/json" },
+      });
+      if (!r.ok) {
+        // Do NOT fall through to the public registry on failure. An org that
+        // moved to a private repo would be shown the community catalogue it
+        // moved away from, and would have no signal that it was looking at the
+        // wrong thing.
+        return res.status(502).json({
+          error: `Hub registry unavailable (${r.status}); not falling back to the public registry`,
+          hubEnabled: true,
+        });
+      }
+      const body = await r.json();
+      return res.json(body.flows ?? []);
+    } catch (e: any) {
+      return res.status(502).json({
+        error: `Hub unreachable (${e?.message ?? "error"}); not falling back to the public registry`,
+        hubEnabled: true,
+      });
+    }
+  }
+
   const url = `${GITHUB_API}/repos/${REGISTRY_OWNER}/${REGISTRY_REPO}/contents/flows?ref=${REGISTRY_BRANCH}`;
   try {
     const { data: entries } = await axios.get(url, {
@@ -1689,6 +1721,41 @@ app.get("/registry/flows", asyncHandler(async (_req: any, res: any) => {
 app.post("/registry/flows/install", asyncHandler(async (req: any, res: any) => {
   const { filename } = req.body;
   if (!filename) return res.status(400).json({ error: 'filename is required' });
+
+  // Same hub-first rule as the browse route above: an org on a private registry
+  // must not be able to install from the public one behind its admin's back,
+  // and cannot read its own private repo without the hub-held token.
+  if (hubClient.isEnabled && hubClient.hubConfig) {
+    const { url: hubUrl, token: hubToken } = hubClient.hubConfig;
+    try {
+      const r = await (globalThis.fetch as any)(`${hubUrl.replace(/\/$/, "")}/v1/registry/flows/install`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${hubToken}`, Accept: "application/json", "Content-Type": "application/json" },
+        body: JSON.stringify({ filename }),
+      });
+      if (!r.ok) {
+        return res.status(502).json({
+          error: `Hub registry install failed (${r.status}); not falling back to the public registry`,
+          hubEnabled: true,
+        });
+      }
+      const body = await r.json();
+      const created = await storage.createFlow({
+        id: uuidv4(),
+        name: body.flow?.name ?? filename,
+        description: body.flow?.description,
+        steps: (body.flow?.steps ?? []).map((s: any) => ({ ...s, id: uuidv4() })),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+      return res.json(created);
+    } catch (e: any) {
+      return res.status(502).json({
+        error: `Hub unreachable (${e?.message ?? "error"}); not falling back to the public registry`,
+        hubEnabled: true,
+      });
+    }
+  }
 
   const url = `${GITHUB_API}/repos/${REGISTRY_OWNER}/${REGISTRY_REPO}/contents/flows/${encodeURIComponent(filename)}?ref=${REGISTRY_BRANCH}`;
   try {

--- a/packages/server/src/test/pi-extension.test.ts
+++ b/packages/server/src/test/pi-extension.test.ts
@@ -5,8 +5,11 @@ import { describe, it, expect, vi } from 'vitest';
 import activate, {
   composeReminder,
   injectDeterministicModel,
-  resolveModelId,
   readPiDefaultModel,
+  readPiSessionModel,
+  envModel,
+  resolveModelSource,
+  preferredModelArg,
 } from '../../../../bin/agenfk-pi-extension.ts';
 
 // ── Pure helpers ─────────────────────────────────────────────────────────────
@@ -106,22 +109,363 @@ describe('injectDeterministicModel (force the real model onto agenfk pr commands
   });
 });
 
-describe('resolveModelId (bare id; getModel → lastSelected → settings.json)', () => {
-  it('prefers the live ctx.getModel().id (bare, not provider/id)', () => {
+describe('resolveModelSource (env → ctx → model_select → transcript → settings.json)', () => {
+  const src = (o: any) => resolveModelSource({ env: () => null, ...o });
+
+  it('qualifies the live ctx.getModel() with its provider', () => {
+    // A bare id is ambiguous: settings.json splits model across defaultProvider +
+    // defaultModel, and the hub strips the route prefix when it matches (modelMeta).
     const ctx = { getModel: () => ({ provider: 'cloudflare-workers-ai', id: '@cf/zai-org/glm-5.2' }) };
-    expect(resolveModelId(ctx as any, 'cached', () => 'fromfile')).toBe('@cf/zai-org/glm-5.2');
+    expect(src({ ctx, lastSelected: 'cached', readDefault: () => 'fromfile' })).toBe('cloudflare-workers-ai/@cf/zai-org/glm-5.2');
+  });
+
+  it('returns a bare id when the source knows no provider', () => {
+    const ctx = { getModel: () => ({ id: 'glm-5.2' }) };
+    expect(src({ ctx, lastSelected: null, readDefault: () => null })).toBe('glm-5.2');
   });
 
   it('falls back to the cached model_select id when getModel is unavailable', () => {
-    expect(resolveModelId({} as any, 'glm-5.2', () => 'fromfile')).toBe('glm-5.2');
+    expect(src({ ctx: {}, lastSelected: 'glm-5.2', readDefault: () => 'fromfile' })).toBe('glm-5.2');
   });
 
-  it('falls back to settings.json defaultModel when neither getModel nor cache is available', () => {
-    expect(resolveModelId({} as any, null, () => '@cf/zai-org/glm-5.2')).toBe('@cf/zai-org/glm-5.2');
+  it('falls back to settings.json defaultModel when nothing fresher is available', () => {
+    expect(src({ ctx: {}, lastSelected: null, readDefault: () => '@cf/zai-org/glm-5.2', readTranscript: () => null })).toBe('@cf/zai-org/glm-5.2');
   });
 
   it('returns null when no source yields a model', () => {
-    expect(resolveModelId({} as any, null, () => null)).toBeNull();
+    expect(src({ ctx: {}, lastSelected: null, readDefault: () => null })).toBeNull();
+  });
+
+  // BUG: settings.json defaultModel is pi's STARTUP model read WITHOUT its
+  // defaultProvider, so it is not the live model. It must rank BELOW the
+  // transcript, which records the model that actually answered each turn.
+  it('ranks the live transcript ABOVE the settings.json defaultModel', () => {
+    expect(src({ ctx: {}, lastSelected: null, readDefault: () => 'qwen3.8:27b', readTranscript: () => 'qwen38-flashnext' })).toBe('qwen38-flashnext');
+  });
+
+  it('ranks the model_select cache above the transcript (a switch beats the last turn)', () => {
+    expect(src({ ctx: {}, lastSelected: 'glm-5.2', readDefault: () => 'qwen3.8:27b', readTranscript: () => 'qwen38-flashnext' })).toBe('glm-5.2');
+  });
+
+  it('uses the transcript when ctx.getModel and model_select are both unavailable', () => {
+    expect(src({ ctx: {}, lastSelected: null, readDefault: () => null, readTranscript: () => 'qwen38-flashnext' })).toBe('qwen38-flashnext');
+  });
+
+  it('still prefers the live ctx.getModel() over every fallback', () => {
+    const ctx = { getModel: () => ({ provider: 'p', id: 'live' }) };
+    expect(src({ ctx, lastSelected: 'cached', readDefault: () => 'default', readTranscript: () => 'transcript' })).toBe('p/live');
+  });
+});
+
+// ── Authoritative sources the bug ignored ───────────────────────────────────
+
+describe('envModel (pi publishes the live model to every bash command)', () => {
+  // pi sets PI_PROVIDER/PI_MODEL per command from ctx.model and re-resolves them
+  // on a model switch (dist/core/tools/bash.js), so this is the freshest source.
+  it('joins PI_PROVIDER/PI_MODEL as provider/model', () => {
+    expect(envModel({ PI_PROVIDER: 'coding4', PI_MODEL: 'qwen3.8:27b' })).toBe('coding4/qwen3.8:27b');
+  });
+
+  it('returns the bare id when only PI_MODEL is set', () => {
+    expect(envModel({ PI_MODEL: 'qwen38-flashnext' })).toBe('qwen38-flashnext');
+  });
+
+  it('returns the bare id when PI_PROVIDER is blank', () => {
+    expect(envModel({ PI_PROVIDER: '   ', PI_MODEL: 'glm-5.2' })).toBe('glm-5.2');
+  });
+
+  it('returns null when neither is set (non-pi shell / ephemeral session)', () => {
+    expect(envModel({})).toBeNull();
+    expect(envModel({ PI_PROVIDER: 'coding4' })).toBeNull();
+    expect(envModel(undefined)).toBeNull();
+  });
+
+  it('ignores blank values', () => {
+    expect(envModel({ PI_PROVIDER: '  ', PI_MODEL: '  ' })).toBeNull();
+  });
+});
+
+describe('resolveModelSource (env wins, then ctx, cache, transcript, settings)', () => {
+  const env = (e: Record<string, string>) => () => (e.PI_MODEL ? `${e.PI_PROVIDER ? e.PI_PROVIDER + '/' : ''}${e.PI_MODEL}` : null);
+
+  it('prefers the per-command env over a stale ctx.getModel()', () => {
+    const ctx = { getModel: () => ({ provider: 'anthropic', id: 'claude-opus-4-8' }) };
+    expect(resolveModelSource({
+      ctx: ctx as any, lastSelected: null, readDefault: () => 'default',
+      readTranscript: () => 'transcript', env: env({ PI_PROVIDER: 'coding4', PI_MODEL: 'qwen3.8:27b' }),
+    })).toBe('coding4/qwen3.8:27b');
+  });
+
+  it('falls through ctx → cache → transcript → settings.json in order', () => {
+    const noEnv = () => null;
+    expect(resolveModelSource({ ctx: { getModel: () => ({ id: 'live' }) } as any, lastSelected: 'c', readDefault: () => 'd', readTranscript: () => 't', env: noEnv })).toBe('live');
+    expect(resolveModelSource({ ctx: {} as any, lastSelected: 'c', readDefault: () => 'd', readTranscript: () => 't', env: noEnv })).toBe('c');
+    expect(resolveModelSource({ ctx: {} as any, lastSelected: null, readDefault: () => 'd', readTranscript: () => 't', env: noEnv })).toBe('t');
+    expect(resolveModelSource({ ctx: {} as any, lastSelected: null, readDefault: () => 'd', readTranscript: () => null, env: noEnv })).toBe('d');
+    expect(resolveModelSource({ ctx: {} as any, lastSelected: null, readDefault: () => null, readTranscript: () => null, env: noEnv })).toBeNull();
+  });
+
+  it('never throws when every source is missing', () => {
+    expect(() => resolveModelSource({ ctx: undefined, lastSelected: null, readDefault: () => null, readTranscript: () => { throw new Error('boom'); }, env: () => { throw new Error('boom'); } })).not.toThrow();
+  });
+});
+
+describe('readPiSessionModel (the transcript records the model that answered)', () => {
+  it('reads provider/model from the newest assistant message', () => {
+    const lines = [
+      JSON.stringify({ type: 'session' }),
+      JSON.stringify({ type: 'message', message: { role: 'assistant', provider: 'old', model: 'old-model' } }),
+      JSON.stringify({ type: 'message', message: { role: 'user', content: [] } }),
+      JSON.stringify({ type: 'message', message: { role: 'assistant', provider: 'qwen38-flashnext', model: 'qwen38-flashnext' } }),
+    ].join('\n');
+    expect(readPiSessionModel(() => lines)).toBe('qwen38-flashnext/qwen38-flashnext');
+  });
+
+  it('returns the bare id when the transcript entry has no provider', () => {
+    const lines = JSON.stringify({ type: 'message', message: { role: 'assistant', model: 'glm-5.2' } });
+    expect(readPiSessionModel(() => lines)).toBe('glm-5.2');
+  });
+
+  it('follows a model_change entry over earlier assistant messages', () => {
+    const lines = [
+      JSON.stringify({ type: 'message', message: { role: 'assistant', provider: 'p', model: 'first' } }),
+      JSON.stringify({ type: 'model_change', provider: 'coding4', modelId: 'qwen3.8:27b' }),
+    ].join('\n');
+    expect(readPiSessionModel(() => lines)).toBe('coding4/qwen3.8:27b');
+  });
+
+  it('returns null for empty, model-less, or unreadable content', () => {
+    expect(readPiSessionModel(() => '')).toBeNull();
+    expect(readPiSessionModel(() => JSON.stringify({ type: 'message', message: { role: 'user' } }))).toBeNull();
+    expect(readPiSessionModel(() => 'not json')).toBeNull();
+    expect(readPiSessionModel(() => { throw new Error('ENOENT'); })).toBeNull();
+  });
+
+  it('skips malformed lines instead of failing the whole read', () => {
+    const lines = ['not json', JSON.stringify({ type: 'message', message: { role: 'assistant', model: 'glm-5.2' } })].join('\n');
+    expect(readPiSessionModel(() => lines)).toBe('glm-5.2');
+  });
+
+  // The default reader runs SYNCHRONOUSLY inside pi's own process: a FIFO would
+  // block pi outright (open() with no writer never returns) and a huge file would
+  // be allocated whole. It must stat first and only ever open a regular file.
+  it('default reader refuses a non-regular file instead of opening it', () => {
+    const os = require('node:os');
+    const fsp = require('node:fs');
+    const dir = fsp.mkdtempSync(require('node:path').join(os.tmpdir(), 'pi-sess-'));
+    const dirPath = require('node:path').join(dir, 'sessions'); // a directory, not a file
+    fsp.mkdirSync(dirPath);
+    const saved = process.env.PI_SESSION_FILE;
+    process.env.PI_SESSION_FILE = dirPath;
+    try {
+      expect(readPiSessionModel()).toBeNull(); // returned without blocking
+    } finally {
+      if (saved === undefined) delete process.env.PI_SESSION_FILE;
+      else process.env.PI_SESSION_FILE = saved;
+      fsp.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('default reader returns null when PI_SESSION_FILE is unset', () => {
+    const saved = process.env.PI_SESSION_FILE;
+    delete process.env.PI_SESSION_FILE;
+    try {
+      expect(readPiSessionModel()).toBeNull();
+    } finally {
+      if (saved !== undefined) process.env.PI_SESSION_FILE = saved;
+    }
+  });
+
+  it('ignores a model_change with no model and keeps looking back', () => {
+    const lines = [
+      JSON.stringify({ type: 'message', message: { role: 'assistant', model: 'glm-5.2' } }),
+      JSON.stringify({ type: 'model_change', provider: 'p' }),
+    ].join('\n');
+    expect(readPiSessionModel(() => lines)).toBe('glm-5.2');
+  });
+
+  it('does not read a model off a non-assistant message', () => {
+    const lines = JSON.stringify({ type: 'message', message: { role: 'toolResult', provider: 'p', model: 'glm-5.2', toolName: 'bash' } });
+    expect(readPiSessionModel(() => lines)).toBeNull();
+  });
+
+  it('reads a model_change whose provider is absent', () => {
+    expect(readPiSessionModel(() => JSON.stringify({ type: 'model_change', modelId: 'glm-5.2' }))).toBe('glm-5.2');
+  });
+
+  it('ignores an assistant message with no usable model', () => {
+    const lines = [
+      JSON.stringify({ type: 'message', message: { role: 'assistant', model: '   ' } }),
+      JSON.stringify({ type: 'message', message: { role: 'assistant', model: 'glm-5.2' } }),
+    ].join('\n');
+    expect(readPiSessionModel(() => lines)).toBe('glm-5.2');
+  });
+});
+
+describe('readPiDefaultModel still reports the bare defaultModel', () => {
+  it('is unchanged in shape (the provider fix happens in resolution, not here)', () => {
+    expect(readPiDefaultModel(() => JSON.stringify({ defaultProvider: 'coding4', defaultModel: 'qwen3.8:27b' }))).toBe('qwen3.8:27b');
+  });
+});
+
+describe('preferredModelArg (never overwrite a correct agent-reported model)', () => {
+  const cmd = 'agenfk pr create abc --model qwen38-flashnext --harness pi';
+
+  it('reports no model to inject when the agent-supplied --model already agrees', () => {
+    // null means "leave the command alone" — the agent's value stands.
+    expect(preferredModelArg(cmd, 'coding4/qwen38-flashnext')).toBeNull();
+  });
+
+  it('agrees when the agent wrote the provider-qualified form', () => {
+    expect(preferredModelArg('agenfk pr create abc --model coding4/qwen38-flashnext', 'coding4/qwen38-flashnext')).toBeNull();
+  });
+
+  it('agrees when only the agent wrote the provider prefix', () => {
+    expect(preferredModelArg('agenfk pr create abc --model coding4/qwen38-flashnext', 'qwen38-flashnext')).toBeNull();
+  });
+
+  it('overrides an agent-supplied --model that contradicts the detected model', () => {
+    expect(preferredModelArg('agenfk pr create abc --model claude-sonnet-4-5', 'coding4/qwen38-flashnext')).toBe('coding4/qwen38-flashnext');
+  });
+
+  it('adds the model when the agent omitted --model', () => {
+    expect(preferredModelArg('agenfk pr create abc --title "T"', 'coding4/qwen38-flashnext')).toBe('coding4/qwen38-flashnext');
+  });
+
+  it('returns null when the model is unknown (nothing to inject)', () => {
+    expect(preferredModelArg(cmd, null)).toBeNull();
+  });
+
+  it('does not read a --model inside a quoted --body', () => {
+    expect(preferredModelArg('agenfk pr create abc --body "see --model docs"', 'glm-5.2')).toBe('glm-5.2');
+  });
+
+  // A quoted operator is data, not a command boundary: the scan must continue past
+  // it, or a real --model after the --body is never seen.
+  it('keeps scanning past a quoted ; or | to reach a later --model', () => {
+    expect(preferredModelArg('agenfk pr create abc --body "first; then" --model wrong', 'glm-5.2')).toBe('glm-5.2');
+    expect(preferredModelArg("agenfk pr create abc --body 'a | b' --model glm-5.2", 'glm-5.2')).toBeNull();
+  });
+
+  it('reads a quoted --model value as one shell word', () => {
+    expect(preferredModelArg('agenfk pr create abc --model "glm-5.2"', 'glm-5.2')).toBeNull();
+    expect(preferredModelArg('agenfk pr create abc --model="glm 5.2"', 'glm 5.2')).toBeNull();
+  });
+
+  it('reads the --model=VALUE form', () => {
+    expect(preferredModelArg('agenfk pr create abc --model=glm-5.2', 'glm-5.2')).toBeNull();
+    expect(preferredModelArg('agenfk pr create abc --model=claude-sonnet-4-5', 'glm-5.2')).toBe('glm-5.2');
+  });
+
+  it('compares the artifact name case-insensitively', () => {
+    expect(preferredModelArg('agenfk pr create abc --model Qwen38-FlashNext', 'coding4/qwen38-flashnext')).toBeNull();
+  });
+
+  it('does not treat --model-a or a --model in a later pipeline stage as ours', () => {
+    expect(preferredModelArg('agenfk pr create abc --model-a glm-5.2', 'glm-5.2')).toBe('glm-5.2');
+    // `glm-5.2` belongs to the SECOND command; ours has none, so still inject.
+    expect(preferredModelArg('agenfk pr create abc | grep glm-5.2', 'glm-5.2')).toBe('glm-5.2');
+  });
+
+  it('takes the last --model when the agent passed several (commander last-wins)', () => {
+    expect(preferredModelArg('agenfk pr create abc --model wrong --model glm-5.2', 'glm-5.2')).toBeNull();
+    expect(preferredModelArg('agenfk pr create abc --model glm-5.2 --model wrong', 'glm-5.2')).toBe('glm-5.2');
+  });
+
+  it('treats a dangling --model with no value as no report at all', () => {
+    expect(preferredModelArg('agenfk pr create abc --model', 'glm-5.2')).toBe('glm-5.2');
+    expect(preferredModelArg('agenfk pr create abc --model ""', 'glm-5.2')).toBe('glm-5.2');
+  });
+
+  it('stops at a redirect so a later stage cannot satisfy our --model', () => {
+    // `x` is ours and disagrees; the glm-5.2 after the redirect is another command's.
+    expect(preferredModelArg('agenfk pr create abc --model x > /tmp/f glm-5.2', 'glm-5.2')).toBe('glm-5.2');
+  });
+
+  it('reads a value that runs to the end of the command with no trailing space', () => {
+    expect(preferredModelArg('agenfk pr create abc --model glm-5.2', 'glm-5.2')).toBeNull();
+    expect(preferredModelArg('agenfk pr create abc --model=glm-5.2', 'glm-5.2')).toBeNull();
+  });
+
+  it('stops the value at a shell operator so it is not swallowed into it', () => {
+    // Without the operator guard the value would read `glm-5.2|grep` and disagree.
+    expect(preferredModelArg('agenfk pr create abc --model glm-5.2|grep x', 'glm-5.2')).toBeNull();
+  });
+
+  it('matches a quoted value containing a space or an operator', () => {
+    expect(preferredModelArg('agenfk pr create abc --model "glm 5.2"', 'glm 5.2')).toBeNull();
+    expect(preferredModelArg('agenfk pr create abc --model "a;b"', 'a;b')).toBeNull();
+  });
+
+  it('does not match a flag merely starting with --model', () => {
+    expect(preferredModelArg('agenfk pr create abc --modelname glm-5.2', 'glm-5.2')).toBe('glm-5.2');
+    expect(preferredModelArg('agenfk pr create abc --modelx=glm-5.2', 'glm-5.2')).toBe('glm-5.2');
+  });
+
+  // `--model$` is the end-of-command alternative in the flag regex: without it the
+  // value scan starts past the end and a correct final --model reads as absent.
+  it('kills the end-of-command branch of the flag regex', () => {
+    expect(preferredModelArg('agenfk pr create abc --model glm-5.2', 'glm-5.2')).toBeNull();
+    expect(preferredModelArg('agenfk pr create abc --model=glm-5.2', 'glm-5.2')).toBeNull();
+    // and the flag alone at EOL is still "no report"
+    expect(preferredModelArg('agenfk pr create abc --model', 'glm-5.2')).toBe('glm-5.2');
+  });
+
+  it('honours both quote styles when reading a value', () => {
+    expect(preferredModelArg(`agenfk pr create abc --model 'glm-5.2'`, 'glm-5.2')).toBeNull();
+    expect(preferredModelArg('agenfk pr create abc --model "glm-5.2"', 'glm-5.2')).toBeNull();
+    // a value quoted in one style ignores the other style's quote char inside it
+    expect(preferredModelArg(`agenfk pr create abc --model 'a"b'`, 'a"b')).toBeNull();
+  });
+
+  it('honours an escaped quote inside a double-quoted value', () => {
+    expect(preferredModelArg('agenfk pr create abc --model "a\\"b"', 'a"b')).toBeNull();
+  });
+
+  it('is not confused by a command ending exactly at --model or by escapes', () => {
+    expect(preferredModelArg('agenfk pr create abc --model ', 'glm-5.2')).toBe('glm-5.2');
+    // An escaped quote stays INSIDE the body, so the ; it contains is data and the
+    // real --model after the closing quote is still found.
+    expect(preferredModelArg('agenfk pr create abc --body "a \\" ; rm -rf" --model glm-5.2', 'glm-5.2')).toBeNull();
+    // An unescaped backslash skips the next char rather than ending the scan.
+    expect(preferredModelArg('agenfk pr create abc --model \\glm-5.2', 'glm-5.2')).toBeNull();
+  });
+});
+
+describe('injectDeterministicModel keeps agreeing with the agent', () => {
+  it('does not append a duplicate --model when the agent already reported it', () => {
+    const cmd = 'agenfk pr create abc --model qwen38-flashnext --harness pi';
+    expect(injectDeterministicModel(cmd, 'coding4/qwen38-flashnext')).toBe(cmd);
+  });
+
+  it('still overrides a contradicting model', () => {
+    const out = injectDeterministicModel('agenfk pr create abc --model claude-sonnet-4-5 --harness pi', 'coding4/qwen38-flashnext');
+    expect(out).toMatch(/--model claude-sonnet-4-5 --harness pi --model coding4\/qwen38-flashnext --harness pi$/);
+  });
+
+  it('accepts a provider-qualified id (slash is on the allowlist)', () => {
+    const out = injectDeterministicModel('agenfk pr create abc --title "T"', 'coding4/qwen3.8:27b');
+    expect(out).toContain('--model coding4/qwen3.8:27b --harness pi');
+  });
+
+  it('still refuses shell metacharacters in a provider-qualified id', () => {
+    const cmd = 'agenfk pr create abc --title "T"';
+    expect(injectDeterministicModel(cmd, 'coding4/qwen; rm -rf')).toBe(cmd);
+  });
+
+  it('does not inject twice when the agent quoted a correct --model', () => {
+    const cmd = 'agenfk pr create abc --model "qwen38-flashnext" --harness pi';
+    expect(injectDeterministicModel(cmd, 'coding4/qwen38-flashnext')).toBe(cmd);
+  });
+
+  it('overrides a wrong --model that follows a quoted --body containing an operator', () => {
+    const out = injectDeterministicModel('agenfk pr create abc --body "first; then" --model claude-sonnet-4-5', 'glm-5.2');
+    expect(out).toBe('agenfk pr create abc --body "first; then" --model claude-sonnet-4-5 --model glm-5.2 --harness pi');
+  });
+
+  it('injects before a pipe even when the later stage mentions the model', () => {
+    const out = injectDeterministicModel('agenfk pr create abc | grep glm-5.2', 'glm-5.2');
+    expect(out).toBe('agenfk pr create abc --model glm-5.2 --harness pi | grep glm-5.2');
   });
 });
 
@@ -133,6 +477,149 @@ describe('readPiDefaultModel (parse ~/.pi/agent/settings.json)', () => {
     expect(readPiDefaultModel(() => JSON.stringify({ other: 1 }))).toBeNull();
     expect(readPiDefaultModel(() => 'not json')).toBeNull();
     expect(readPiDefaultModel(() => { throw new Error('ENOENT'); })).toBeNull();
+  });
+});
+
+// ── BUG regression: activate() must use the AUTHORITATIVE model sources ──────
+
+describe('activate(): model detection uses env + transcript, not settings.json alone', () => {
+  it('prefers the per-command pi session env over ctx.getModel()', async () => {
+    const { pi, sent, fire } = makeFakePi();
+    const deps = makeDeps({
+      prReminder: vi.fn().mockReturnValue({ message: 'open. harness = "pi".' }),
+      readEnvModel: () => 'coding4/qwen3.8:27b',
+    });
+    activate(pi as any, deps);
+
+    await fire(
+      'tool_result',
+      { toolName: 'bash', input: { command: 'gh pr create --fill' } },
+      ctxWithModel('anthropic', 'claude-opus-4-8'), // stale/absent in live pi
+    );
+
+    expect(sent[0].message.content).toContain('coding4/qwen3.8:27b');
+    expect(sent[0].message.content).not.toContain('claude-opus-4-8');
+  });
+
+  it('uses the session transcript when env + ctx + model_select are all unavailable', async () => {
+    const { pi, sent, fire } = makeFakePi();
+    const deps = makeDeps({
+      prReminder: vi.fn().mockReturnValue({ message: 'open. harness = "pi".' }),
+      readTranscriptModel: () => 'qwen38-flashnext',
+    });
+    activate(pi as any, deps);
+
+    await fire('tool_result', { toolName: 'bash', input: { command: 'gh pr create' } }, {});
+
+    expect(sent[0].message.content).toContain('qwen38-flashnext');
+  });
+
+  // The exact failure from the report: the hook asserted a model the session
+  // transcript contradicted, because settings.json defaultModel outranked it.
+  it('does NOT report the settings.json defaultModel when the transcript contradicts it', async () => {
+    const { pi, sent, fire } = makeFakePi();
+    const deps = makeDeps({
+      prReminder: vi.fn().mockReturnValue({ message: 'open. harness = "pi".' }),
+      readDefaultModel: () => '@cf/zai-org/glm-5.2',
+      readTranscriptModel: () => 'qwen38-flashnext/qwen38-flashnext',
+    });
+    activate(pi as any, deps);
+
+    await fire('tool_result', { toolName: 'bash', input: { command: 'gh pr create' } }, {});
+
+    expect(sent[0].message.content).toContain('qwen38-flashnext');
+    expect(sent[0].message.content).not.toContain('@cf/zai-org/glm-5.2');
+  });
+
+  it('re-reads the model per event instead of caching settings.json for the session', async () => {
+    const { pi, sent, fire } = makeFakePi();
+    let live = 'model-a';
+    const deps = makeDeps({
+      prReminder: vi.fn().mockReturnValue({ message: 'open. harness = "pi".' }),
+      readDefaultModel: () => live, // no memoisation: a switch is picked up
+    });
+    activate(pi as any, deps);
+
+    await fire('tool_result', { toolName: 'bash', input: { command: 'gh pr create' } }, {});
+    expect(sent[0].message.content).toContain('model-a');
+
+    live = 'model-b';
+    await fire('tool_result', { toolName: 'bash', input: { command: 'gh pr create' } }, {});
+    expect(sent[1].message.content).toContain('model-b');
+  });
+
+  it('rewrites agenfk pr-register with the transcript model, not the config default', async () => {
+    const { pi, fire } = makeFakePi();
+    const deps = makeDeps({
+      readDefaultModel: () => '@cf/zai-org/glm-5.2',
+      readTranscriptModel: () => 'qwen38-flashnext',
+    });
+    activate(pi as any, deps);
+
+    const event = {
+      toolName: 'bash',
+      input: { command: 'agenfk pr-register --item x --number 5 --repo o/r --epic 0 --story 0 --task 1 --bug 0 --model @cf/zai-org/glm-5.2 --harness pi' },
+    };
+    const res = await fire('tool_call', event, {});
+
+    expect(res).toBeUndefined();
+    expect(event.input.command).toContain('--model qwen38-flashnext --harness pi');
+    // The config default is still present as the agent's (wrong) first --model;
+    // what matters is that the detected model is LAST, so commander last-wins it.
+    expect(event.input.command.endsWith('--model qwen38-flashnext --harness pi')).toBe(true);
+  });
+
+  it('leaves a pr create command alone when the agent already reported the right model', async () => {
+    const { pi, fire } = makeFakePi();
+    const deps = makeDeps({ readTranscriptModel: () => 'coding4/qwen38-flashnext' });
+    activate(pi as any, deps);
+
+    const cmd = 'agenfk pr create abc --model qwen38-flashnext --harness pi --title "T"';
+    const event = { toolName: 'bash', input: { command: cmd } };
+    await fire('tool_call', event, {});
+
+    expect(event.input.command).toBe(cmd);
+  });
+
+  // The TTL cache must not outlive the session it was read from: PI_SESSION_FILE
+  // changes on /resume, /new and fork.
+  it('drops the transcript cache when PI_SESSION_FILE changes', async () => {
+    const fsp = require('node:fs');
+    const os = require('node:os');
+    const ppath = require('node:path');
+    const dir = fsp.mkdtempSync(ppath.join(os.tmpdir(), 'pi-sess2-'));
+    const line = (m: string) => JSON.stringify({ type: 'message', message: { role: 'assistant', provider: 'p', model: m } });
+    const a = ppath.join(dir, 'a.jsonl');
+    const b = ppath.join(dir, 'b.jsonl');
+    fsp.writeFileSync(a, line('model-a'));
+    fsp.writeFileSync(b, line('model-b'));
+
+    const { defaultDeps } = await import('../../../../bin/agenfk-pi-extension.ts');
+    const deps = defaultDeps();
+    const saved = process.env.PI_SESSION_FILE;
+    process.env.PI_SESSION_FILE = a;
+    try {
+      expect(deps.readTranscriptModel()).toBe('p/model-a');
+      // Same file, inside the TTL: cached, and still correct.
+      expect(deps.readTranscriptModel()).toBe('p/model-a');
+      // Session switched: the cache is keyed on the file, so this must NOT be stale.
+      process.env.PI_SESSION_FILE = b;
+      expect(deps.readTranscriptModel()).toBe('p/model-b');
+    } finally {
+      if (saved === undefined) delete process.env.PI_SESSION_FILE;
+      else process.env.PI_SESSION_FILE = saved;
+      fsp.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('reports the model on session_start from the transcript when ctx has none', async () => {
+    const { pi, fire } = makeFakePi();
+    const notify = vi.fn();
+    activate(pi as any, makeDeps({ readTranscriptModel: () => 'coding4/qwen3.8:27b' }));
+
+    await fire('session_start', { reason: 'startup' }, { ui: { notify } });
+
+    expect(notify.mock.calls[0][0]).toContain('coding4/qwen3.8:27b');
   });
 });
 
@@ -159,6 +646,10 @@ function makeDeps(overrides: any = {}) {
     prReminder: vi.fn().mockReturnValue(null),
     // Stubbed so activate() tests never read the real ~/.pi/agent/settings.json.
     readDefaultModel: () => null,
+    // Likewise the transcript and the pi session env (in real pi these reach the
+    // extension via PI_SESSION_FILE / PI_MODEL on the bash tool's own env).
+    readTranscriptModel: () => null,
+    readEnvModel: () => null,
     ...overrides,
   };
 }
@@ -184,9 +675,8 @@ describe('activate(): PR-open reminder via tool_result', () => {
     expect(sent).toHaveLength(1);
     expect(sent[0].options.deliverAs).toBe('steer');
     expect(sent[0].message.customType).toBe('agenfk-pr');
-    // Bare model id (not provider/id) — matches settings.json + claude-code convention.
-    expect(sent[0].message.content).toContain('claude-opus-4-8');
-    expect(sent[0].message.content).not.toContain('anthropic/claude-opus-4-8');
+    // Provider-qualified id — a bare id is ambiguous across providers.
+    expect(sent[0].message.content).toContain('anthropic/claude-opus-4-8');
   });
 
   it('falls back to the cached model_select model when ctx.getModel() is unavailable', async () => {
@@ -258,8 +748,7 @@ describe('activate(): session_start load-confirmation notify', () => {
     expect(notify).toHaveBeenCalledTimes(1);
     const [msg, level] = notify.mock.calls[0];
     expect(msg).toContain('agenfk');
-    expect(msg).toContain('glm-5.2');
-    expect(msg).not.toContain('zhipu/glm-5.2'); // bare id, not provider/id
+    expect(msg).toContain('zhipu/glm-5.2'); // provider-qualified
     expect(level).toBe('info');
   });
 
@@ -320,9 +809,8 @@ describe('activate(): deterministic model injection on agenfk pr commands', () =
     activate(pi as any, makeDeps());
     const event: any = { toolName: 'bash', input: { command: 'agenfk pr create abc --model claude-sonnet-4-5 --harness pi --title "T"' } };
     await fire('tool_call', event, ctxWithModel('cloudflare-workers-ai', '@cf/zai-org/glm-5.2'));
-    // Bare model id appended last (overrides the agent's guess), not provider/id.
-    expect(event.input.command).toMatch(/--model @cf\/zai-org\/glm-5\.2 --harness pi$/);
-    expect(event.input.command).not.toContain('cloudflare-workers-ai/@cf');
+    // Provider-qualified id appended last (overrides the agent's guess).
+    expect(event.input.command).toMatch(/--model cloudflare-workers-ai\/@cf\/zai-org\/glm-5\.2 --harness pi$/);
   });
 
   it('leaves an ordinary bash command unchanged', async () => {

--- a/packages/server/src/test/server.registry-hub.test.ts
+++ b/packages/server/src/test/server.registry-hub.test.ts
@@ -1,0 +1,179 @@
+/**
+ * CGLAB-138 — a hub-connected installation resolves its flow registry through
+ * the hub instead of the baked-in public repo.
+ *
+ * Why this matters even though the hub has its own registry surface: the
+ * FlowEditorModal inside a *client* talks to the local server's
+ * /registry/flows. If that stayed pinned to cglab-public, an org that moved to
+ * a private registry would still see the community catalogue in the client
+ * while the hub showed something else — two sources of truth, and the client
+ * one would offer flows the org deliberately sealed away.
+ *
+ * The local server must NOT hold the org's GitHub token (it belongs to the
+ * hub), so it asks the hub to proxy. When the hub is unreachable the honest
+ * answer is an error, not a silent fall-back to the public repo — falling back
+ * would show a sealed org exactly the flows it moved away from.
+ *
+ * Hub config is forced via env BEFORE the dynamic server import (hubClient
+ * captures config at import time) and env is restored afterwards, following
+ * the convention in flow-org-available-hub-on.test.ts.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import request from 'supertest';
+import * as path from 'path';
+import * as fs from 'fs';
+
+const TEST_DB = path.resolve('./server-flow-registry-hub-test-db.sqlite');
+const savedEnv: Record<string, string | undefined> = {};
+const ENV_KEYS = [
+  'AGENFK_HUB_URL', 'AGENFK_HUB_TOKEN', 'AGENFK_HUB_ORG',
+  'AGENFK_HUB_FLOW_SYNC_FIRST_DELAY_MS', 'AGENFK_DB_PATH',
+];
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let app: any, initStorage: any;
+
+vi.mock('child_process', () => ({
+  execSync: vi.fn(),
+  execFileSync: vi.fn(),
+  spawn: vi.fn(),
+  spawnSync: vi.fn(),
+}));
+
+const axiosGet = vi.fn();
+vi.mock('axios', () => {
+  const m = vi.fn() as any;
+  m.get = axiosGet;
+  m.post = vi.fn();
+  m.create = vi.fn(() => m);
+  return { default: m };
+});
+
+type HubReply = { ok: boolean; status: number; body?: any } | { error: string };
+let hubReply: HubReply = { ok: true, status: 200, body: [] };
+const hubCalls: Array<{ url: string; auth?: string }> = [];
+
+function stubHubFetch() {
+  vi.stubGlobal('fetch', vi.fn(async (url: string, init?: any) => {
+    hubCalls.push({ url: String(url), auth: init?.headers?.Authorization });
+    const r = hubReply;
+    if ('error' in r) throw new Error(r.error);
+    return {
+      status: r.status, ok: r.ok,
+      headers: { get: () => null },
+      json: async () => r.body,
+    } as any;
+  }));
+}
+
+describe('GET /registry/flows with a hub connection (CGLAB-138)', () => {
+  beforeAll(async () => {
+    for (const k of ENV_KEYS) savedEnv[k] = process.env[k];
+    process.env.AGENFK_HUB_URL = 'http://hub.example.test';
+    process.env.AGENFK_HUB_TOKEN = 'agk_test';
+    process.env.AGENFK_HUB_ORG = 'org-test';
+    process.env.AGENFK_HUB_FLOW_SYNC_FIRST_DELAY_MS = '3600000';
+    process.env.AGENFK_DB_PATH = TEST_DB;
+    stubHubFetch(); // stub before import so any startup fetch is intercepted
+    if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+    ({ app, initStorage } = await import('../server'));
+    await initStorage();
+  });
+
+  afterAll(() => {
+    vi.unstubAllGlobals();
+    for (const k of ENV_KEYS) {
+      if (savedEnv[k] === undefined) delete process.env[k];
+      else process.env[k] = savedEnv[k]!;
+    }
+    for (const suffix of ['', '-wal', '-shm']) {
+      const f = TEST_DB + suffix;
+      if (fs.existsSync(f)) fs.unlinkSync(f);
+    }
+  });
+
+  beforeEach(() => {
+    hubCalls.length = 0;
+    axiosGet.mockReset();
+    axiosGet.mockResolvedValue({ data: [] });
+    hubReply = { ok: true, status: 200, body: [] };
+    stubHubFetch();
+  });
+
+  it('asks the hub rather than GitHub when hub mode is on', async () => {
+    hubReply = {
+      ok: true, status: 200,
+      body: { repo: 'acme-corp/agenfk-flows', flows: [{ filename: 'x.json', name: 'X', stepCount: 2 }] },
+    };
+    const res = await request(app).get('/registry/flows');
+    expect(res.status).toBe(200);
+    // The hub is the source of truth: its payload is passed through.
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].name).toBe('X');
+    expect(hubCalls.some((c) => c.url.includes('/v1/registry/flows'))).toBe(true);
+  });
+
+  it('authenticates to the hub with the installation token, and never to GitHub directly', async () => {
+    hubReply = { ok: true, status: 200, body: { repo: 'acme-corp/agenfk-flows', flows: [] } };
+    await request(app).get('/registry/flows');
+    const call = hubCalls.find((c) => c.url.includes('/v1/registry/flows'));
+    expect(call).toBeTruthy();
+    expect(call!.auth).toBe('Bearer agk_test');
+    // The org's GitHub token must never reach this machine, and this machine
+    // must not go straight to GitHub for an org-managed registry.
+    expect(JSON.stringify(hubCalls)).not.toMatch(/api\.github\.com/);
+    expect(axiosGet).not.toHaveBeenCalled();
+  });
+
+  it('reports an error when the hub is unreachable instead of silently showing public flows', async () => {
+    // 502, not 200-with-public-flows. A sealed org must never be shown the
+    // community catalogue because the hub happened to be down.
+    hubReply = { error: 'ECONNREFUSED' };
+    const res = await request(app).get('/registry/flows');
+    expect(res.status).toBe(502);
+    expect(Array.isArray(res.body)).toBe(false);
+    expect(res.body.hubEnabled).toBe(true);
+    // And critically: we did not fall through to the public registry.
+    expect(axiosGet).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a hub 4xx rather than masking it as an empty registry', async () => {
+    hubReply = { ok: false, status: 403, body: { error: 'forbidden' } };
+    const res = await request(app).get('/registry/flows');
+    expect(res.status).toBe(502);
+    expect(axiosGet).not.toHaveBeenCalled();
+  });
+
+  // ── install follows the same rule ──────────────────────────────────────
+  // Browsing from the org repo while INSTALLING from the public one would let
+  // an org member pull in a community flow the org sealed away — the browse
+  // list is the only thing standing between them and that.
+  it('installs through the hub, not GitHub, when hub mode is on', async () => {
+    hubReply = {
+      ok: true, status: 200,
+      body: {
+        repo: 'acme-corp/agenfk-flows',
+        flow: {
+          name: 'Org Flow', description: '',
+          steps: [
+            { name: 'TODO', label: 'To Do', order: 0, isAnchor: true },
+            { name: 'BUILD', label: 'Build', order: 1 },
+            { name: 'DONE', label: 'Done', order: 2, isAnchor: true },
+          ],
+        },
+      },
+    };
+    const res = await request(app).post('/registry/flows/install').send({ filename: 'org-flow.json' });
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe('Org Flow');
+    expect(hubCalls.some((c) => c.url.includes('/v1/registry/flows/install'))).toBe(true);
+    expect(axiosGet).not.toHaveBeenCalled();
+  });
+
+  it('refuses to install when the hub is unreachable', async () => {
+    hubReply = { error: 'ECONNREFUSED' };
+    const res = await request(app).post('/registry/flows/install').send({ filename: 'x.json' });
+    expect(res.status).toBe(502);
+    expect(axiosGet).not.toHaveBeenCalled();
+  });
+});

--- a/packages/storage-sqlite/package.json
+++ b/packages/storage-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/storage-sqlite",
-  "version": "1.1.18-beta.1",
+  "version": "1.1.18-beta.2",
   "description": "SQLite storage implementation for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -11,7 +11,7 @@
     "uuid": "^14.0.2"
   },
   "devDependencies": {
-    "@agenfk/core": "1.1.18-beta.1",
+    "@agenfk/core": "1.1.18-beta.2",
     "@types/node": "^22.0.0",
     "@types/uuid": "^9.0.8",
     "typescript": "^5.3.3"

--- a/packages/storage-sqlite/package.json
+++ b/packages/storage-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/storage-sqlite",
-  "version": "1.1.17",
+  "version": "1.1.18-beta.1",
   "description": "SQLite storage implementation for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -11,7 +11,7 @@
     "uuid": "^14.0.2"
   },
   "devDependencies": {
-    "@agenfk/core": "1.1.17",
+    "@agenfk/core": "1.1.18-beta.1",
     "@types/node": "^22.0.0",
     "@types/uuid": "^9.0.8",
     "typescript": "^5.3.3"

--- a/packages/storage-sqlite/package.json
+++ b/packages/storage-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/storage-sqlite",
-  "version": "1.1.18-beta.2",
+  "version": "1.1.18-beta.3",
   "description": "SQLite storage implementation for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -11,7 +11,7 @@
     "uuid": "^14.0.2"
   },
   "devDependencies": {
-    "@agenfk/core": "1.1.18-beta.2",
+    "@agenfk/core": "1.1.18-beta.3",
     "@types/node": "^22.0.0",
     "@types/uuid": "^9.0.8",
     "typescript": "^5.3.3"

--- a/packages/storage-sqlite/package.json
+++ b/packages/storage-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/storage-sqlite",
-  "version": "1.1.18-beta.3",
+  "version": "1.1.18-beta.4",
   "description": "SQLite storage implementation for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -11,7 +11,7 @@
     "uuid": "^14.0.2"
   },
   "devDependencies": {
-    "@agenfk/core": "1.1.18-beta.3",
+    "@agenfk/core": "1.1.18-beta.4",
     "@types/node": "^22.0.0",
     "@types/uuid": "^9.0.8",
     "typescript": "^5.3.3"

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/telemetry",
-  "version": "1.1.18-beta.1",
+  "version": "1.1.18-beta.2",
   "description": "Anonymous telemetry client for AgenFK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/telemetry",
-  "version": "1.1.17",
+  "version": "1.1.18-beta.1",
   "description": "Anonymous telemetry client for AgenFK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/telemetry",
-  "version": "1.1.18-beta.2",
+  "version": "1.1.18-beta.3",
   "description": "Anonymous telemetry client for AgenFK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/telemetry",
-  "version": "1.1.18-beta.3",
+  "version": "1.1.18-beta.4",
   "description": "Anonymous telemetry client for AgenFK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.1.18-beta.1",
+  "version": "1.1.18-beta.2",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -12,7 +12,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.1.18-beta.1",
+    "@agenfk/flow-editor": "1.1.18-beta.2",
     "@fontsource-variable/jetbrains-mono": "^5.3.0",
     "@fontsource-variable/manrope": "^5.3.0",
     "@tailwindcss/postcss": "^4.3.3",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.1.17",
+  "version": "1.1.18-beta.1",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -12,7 +12,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.1.17",
+    "@agenfk/flow-editor": "1.1.18-beta.1",
     "@fontsource-variable/jetbrains-mono": "^5.3.0",
     "@fontsource-variable/manrope": "^5.3.0",
     "@tailwindcss/postcss": "^4.3.3",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.1.18-beta.2",
+  "version": "1.1.18-beta.3",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -12,7 +12,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.1.18-beta.2",
+    "@agenfk/flow-editor": "1.1.18-beta.3",
     "@fontsource-variable/jetbrains-mono": "^5.3.0",
     "@fontsource-variable/manrope": "^5.3.0",
     "@tailwindcss/postcss": "^4.3.3",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.1.18-beta.3",
+  "version": "1.1.18-beta.4",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -12,7 +12,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.1.18-beta.3",
+    "@agenfk/flow-editor": "1.1.18-beta.4",
     "@fontsource-variable/jetbrains-mono": "^5.3.0",
     "@fontsource-variable/manrope": "^5.3.0",
     "@tailwindcss/postcss": "^4.3.3",

--- a/packages/ui/src/test/FlowEditorModal.test.tsx
+++ b/packages/ui/src/test/FlowEditorModal.test.tsx
@@ -3,6 +3,7 @@
  */
 import { render, screen, fireEvent, cleanup, waitFor, act } from '@testing-library/react';
 import { FlowEditorModal } from '../components/FlowEditorModal';
+import { FlowEditorModal as SharedFlowEditorModal, type RegistryClient } from '@agenfk/flow-editor';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { api } from '../api';
@@ -1536,6 +1537,384 @@ describe('FlowEditorModal — save failures surface the reason (BUG 269eeec8)', 
     expect(api.updateFlow).not.toHaveBeenCalled();
   });
 });
+
+// ── Footer CTAs: capability-gated, not read-only-gated ──────────────────────
+//
+// The footer used to branch on `isReadOnly`, which produced three separate
+// confusions the admin reported as "Save / Publish / Use this flow — rather
+// confusing":
+//   1. A host with no registry publish path still rendered a Publish button
+//      wired to a client method that can only throw.
+//   2. "Use this Flow" bound the flow id it already had, so unsaved edits were
+//      silently dropped while the button looked like the primary action.
+//   3. A freshly created flow rendered the read-only footer, which offered
+//      neither Save (editable footer) nor Publish (gated on `flow?.id`).
+// The footer is now capability-driven: each CTA renders iff its host can do it.
+describe('flow editor footer CTAs', () => {
+  const NEW_FLOW = { ...SAMPLE_FLOW, id: 'created-flow' };
+
+  const HUB_FLOW_LOCAL: Flow = {
+    ...SAMPLE_FLOW,
+    id: 'flow-hub',
+    name: 'TDD Flow',
+    source: 'hub',
+    hubFlowId: 'hub-tdd',
+  };
+
+  // This block sits at module scope (it is not nested in the big
+  // `FlowEditorModal` describe), so it owns its fixtures — same shapes the
+  // sibling blocks use.
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(api.listFlows).mockResolvedValue([SAMPLE_FLOW, SAMPLE_FLOW_2]);
+    vi.mocked(api.getDefaultFlow).mockResolvedValue(DEFAULT_FLOW);
+    vi.mocked(api.getOrgAvailableFlows).mockResolvedValue({ flows: [], defaultFlowId: null, hubEnabled: false });
+  });
+
+  afterEach(() => cleanup());
+
+  const renderEditor = () =>
+    render(
+      <FlowEditorModal isOpen={true} onClose={() => {}} projectId={PROJECT_ID} />,
+      { wrapper: wrapper(makeQueryClient()) }
+    );
+
+  const openFlow = async (testId: string) => {
+    renderEditor();
+    await waitFor(() => screen.getByTestId(testId));
+    fireEvent.click(screen.getByTestId(testId));
+    await waitFor(() => screen.getByTestId('editor-panel'));
+  };
+
+  /** Drive the panel into the "new flow" state with a valid, saveable name. */
+  const startNewFlow = async () => {
+    renderEditor();
+    await waitFor(() => screen.getByTestId('new-flow-btn'));
+    fireEvent.click(screen.getByTestId('new-flow-btn'));
+    await waitFor(() => screen.getByTestId('flow-name-input'));
+    fireEvent.change(screen.getByTestId('flow-name-input'), { target: { value: 'Brand New' } });
+    fireEvent.change(screen.getByTestId('step-name-1'), { target: { value: 'in_progress' } });
+  };
+
+  /** The JSON the editor would send for the current panel state. */
+  const lastWrite = () => {
+    const updateCall = vi.mocked(api.updateFlow).mock.calls[0];
+    const createCall = vi.mocked(api.createFlow).mock.calls[0];
+    return (updateCall?.[1] ?? createCall?.[0]) as Partial<Flow>;
+  };
+
+  /**
+   * Render the SHARED editor with an explicit host, so a test can hand it a
+   * client that lacks a capability. The `../components/FlowEditorModal` wrapper
+   * builds its clients from the mocked api object, and a mocked method set to
+   * `undefined` still counts as present — which is exactly the distinction
+   * capability-gating turns on, so it has to be tested at the real boundary.
+   */
+  const renderHosted = (
+    overrides: Partial<React.ComponentProps<typeof SharedFlowEditorModal>> = {},
+  ) =>
+    render(
+      <SharedFlowEditorModal
+        isOpen={true}
+        onClose={() => {}}
+        projectId={PROJECT_ID}
+        flowClient={{
+          listFlows: () => api.listFlows(),
+          getDefaultFlow: () => api.getDefaultFlow(),
+          createFlow: (p) => api.createFlow(p),
+          updateFlow: (id, p) => api.updateFlow(id, p),
+          deleteFlow: (id) => api.deleteFlow(id),
+          setProjectFlow: (projectId, flowId) => api.setProjectFlow(projectId, flowId),
+        }}
+        registryClient={{
+          browseRegistry: () => api.browseRegistry(),
+          installFromRegistry: (f) => api.installFromRegistry(f),
+          publishToRegistry: (id) => api.publishToRegistry(id),
+        }}
+        theme="light"
+        {...overrides}
+      />,
+      { wrapper: wrapper(makeQueryClient()) }
+    );
+
+  /** A RegistryClient with `publishToRegistry` genuinely absent, not stubbed. */
+  const registryClientWithoutPublish = (): RegistryClient => ({
+    browseRegistry: () => api.browseRegistry(),
+    installFromRegistry: (f: string) => api.installFromRegistry(f),
+  });
+
+  // ── 1. Publish is capability-gated ────────────────────────────────────────
+
+  it('hides Publish when the host has no registry publish path', async () => {
+    // The hub admin's RegistryClient has no publish: the org's PAT lives on the
+    // hub and the hub has no publish route, so its client omits the method
+    // rather than carrying one that can only throw. A button that can only
+    // error is not an action.
+    renderHosted({ registryClient: registryClientWithoutPublish() });
+    await waitFor(() => screen.getByTestId('flow-item-flow-1'));
+    fireEvent.click(screen.getByTestId('flow-item-flow-1'));
+    await waitFor(() => screen.getByTestId('editor-panel'));
+
+    expect(screen.queryByTestId('publish-flow-btn')).toBeNull();
+    // Save is unaffected — losing publish must not cost the admin their editor.
+    expect(screen.getByTestId('save-flow-btn')).toBeDefined();
+  });
+
+  it('offers Publish when the host can publish', async () => {
+    await openFlow('flow-item-flow-1');
+
+    expect(screen.getByTestId('publish-flow-btn')).toBeDefined();
+  });
+
+  // ── 3. "Use this Flow" cannot bind an unsaved edit ────────────────────────
+
+  it('saves the pending edit before binding, so the assignment is not stale', async () => {
+    const callOrder: string[] = [];
+    vi.mocked(api.updateFlow).mockImplementation(async () => {
+      callOrder.push('updateFlow');
+      return SAMPLE_FLOW;
+    });
+    vi.mocked(api.setProjectFlow).mockImplementation(async () => {
+      callOrder.push('setProjectFlow');
+    });
+    await openFlow('flow-item-flow-1');
+
+    fireEvent.change(screen.getByTestId('flow-name-input'), { target: { value: 'Renamed' } });
+    fireEvent.click(screen.getByTestId('use-flow-btn'));
+
+    await waitFor(() => expect(api.updateFlow).toHaveBeenCalledTimes(1));
+    // The rename is what gets persisted — before the bind, not instead of it.
+    expect(lastWrite().name).toBe('Renamed');
+    await waitFor(() => expect(api.setProjectFlow).toHaveBeenCalledWith(PROJECT_ID, 'flow-1'));
+    // The bind must not have fired before the save resolved — that is the race
+    // this test exists for, and it is what made the button bind the old version.
+    expect(callOrder).toEqual(['updateFlow', 'setProjectFlow']);
+  });
+
+  it('binds without a redundant write when nothing changed', async () => {
+    vi.mocked(api.setProjectFlow).mockResolvedValue(undefined);
+    await openFlow('flow-item-flow-1');
+
+    fireEvent.click(screen.getByTestId('use-flow-btn'));
+
+    await waitFor(() => expect(api.setProjectFlow).toHaveBeenCalledWith(PROJECT_ID, 'flow-1'));
+    expect(api.updateFlow).not.toHaveBeenCalled();
+    expect(api.createFlow).not.toHaveBeenCalled();
+  });
+
+  it('refuses to bind a dirty flow whose save failed, rather than binding the old version', async () => {
+    vi.mocked(api.updateFlow).mockRejectedValue(
+      Object.assign(new Error('Request failed with status code 409'), {
+        isAxiosError: true,
+        response: { status: 409, data: { error: 'flow is managed by the Hub' } },
+      })
+    );
+    await openFlow('flow-item-flow-1');
+
+    fireEvent.change(screen.getByTestId('flow-name-input'), { target: { value: 'Renamed' } });
+    fireEvent.click(screen.getByTestId('use-flow-btn'));
+
+    await waitFor(() => expect(screen.getByTestId('flow-editor-error')).toBeDefined());
+    expect(api.setProjectFlow).not.toHaveBeenCalled();
+  });
+
+  // ── 4. A newly created flow is never a dead end ───────────────────────────
+
+  it('offers both Save and Publish on a newly created flow', async () => {
+    // The read-only footer gated Publish on `flow?.id`, which is undefined for
+    // an unsaved flow — so the new-flow panel showed neither Save (other
+    // footer) nor Publish (this gate).
+    await startNewFlow();
+
+    expect(screen.getByTestId('save-flow-btn')).toBeDefined();
+    expect(screen.getByTestId('publish-flow-btn')).toBeDefined();
+  });
+
+  it('publishes the flow created by Save, not a stale id', async () => {
+    vi.mocked(api.createFlow).mockResolvedValue(NEW_FLOW);
+    vi.mocked(api.publishToRegistry).mockResolvedValue({ url: 'https://example.test/pr/9', kind: 'pr' });
+    await startNewFlow();
+
+    fireEvent.click(screen.getByTestId('save-flow-btn'));
+    await waitFor(() => expect(api.createFlow).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByTestId('publish-flow-btn'));
+    await waitFor(() => expect(api.publishToRegistry).toHaveBeenCalledWith('created-flow'));
+    expect(screen.getByTestId('publish-success-link')).toBeDefined();
+  });
+
+  // ── Save clears the dirty state ───────────────────────────────────────────
+  //
+  // The dirty flag is what decides whether bind/publish must write first. A
+  // save that leaves it set would fire a redundant write on every following
+  // action — and `rebaseOn` is the only thing that clears it, so a mutant that
+  // drops the re-baseline is invisible to every other test here.
+
+  it('a successful Save clears the dirty state, so the next bind does not re-write', async () => {
+    // Both servers answer a write with the stored row, so the fake echoes the
+    // name back — that response is what the dirty baseline is rebuilt from.
+    vi.mocked(api.updateFlow).mockResolvedValue({ ...SAMPLE_FLOW, name: 'Renamed' });
+    vi.mocked(api.setProjectFlow).mockResolvedValue(undefined);
+    await openFlow('flow-item-flow-1');
+
+    fireEvent.change(screen.getByTestId('flow-name-input'), { target: { value: 'Renamed' } });
+    fireEvent.click(screen.getByTestId('save-flow-btn'));
+    await waitFor(() => expect(api.updateFlow).toHaveBeenCalledTimes(1));
+    // The badge is the visible half of the same fact.
+    expect((screen.getByTestId('save-flow-btn') as HTMLButtonElement).textContent).toContain('Saved');
+
+    // Clean now. Binding must not pay for a second write.
+    fireEvent.click(screen.getByTestId('use-flow-btn'));
+    await waitFor(() => expect(api.setProjectFlow).toHaveBeenCalledWith(PROJECT_ID, 'flow-1'));
+    expect(api.updateFlow).toHaveBeenCalledTimes(1);
+  });
+
+  it('the baseline comes from the server response, not the request', async () => {
+    // Both servers run steps through normalizeFlowSteps (field whitelist, ids
+    // re-issued for duplicates/missing ones). A baseline built from what the
+    // panel SENT would leave a legitimate write permanently dirty.
+    const serverNormalized: Flow = {
+      ...SAMPLE_FLOW,
+      name: 'Renamed',
+      steps: SAMPLE_FLOW.steps.map(s => ({ ...s, exitCriteria: s.exitCriteria ?? '' })),
+    };
+    vi.mocked(api.updateFlow).mockResolvedValue(serverNormalized);
+    vi.mocked(api.setProjectFlow).mockResolvedValue(undefined);
+    await openFlow('flow-item-flow-1');
+
+    fireEvent.change(screen.getByTestId('flow-name-input'), { target: { value: 'Renamed' } });
+    fireEvent.click(screen.getByTestId('save-flow-btn'));
+    await waitFor(() => expect(api.updateFlow).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByTestId('use-flow-btn'));
+    await waitFor(() => expect(api.setProjectFlow).toHaveBeenCalled());
+    expect(api.updateFlow).toHaveBeenCalledTimes(1);
+  });
+
+  it('publishes the edits made since the last save, not the stored version', async () => {
+    // Publish pushes the SERVER's copy. Without save-first, an edit typed after
+    // the last save would silently not be in what gets published.
+    vi.mocked(api.updateFlow).mockResolvedValue({ ...SAMPLE_FLOW, name: 'Renamed' });
+    vi.mocked(api.publishToRegistry).mockResolvedValue({ url: 'https://example.test/pr/9', kind: 'pr' });
+    await openFlow('flow-item-flow-1');
+
+    fireEvent.change(screen.getByTestId('flow-name-input'), { target: { value: 'Renamed' } });
+    fireEvent.click(screen.getByTestId('publish-flow-btn'));
+
+    await waitFor(() => expect(api.updateFlow).toHaveBeenCalledTimes(1));
+    expect(lastWrite().name).toBe('Renamed');
+    await waitFor(() => expect(api.publishToRegistry).toHaveBeenCalledWith('flow-1'));
+  });
+
+  // ── Publish is blocked for exactly the reasons Save is ────────────────────
+
+  it('disables Publish when the definition is unsaveable, with the reason as tooltip', async () => {
+    // Publish pushes the server's copy, and the way to fix a broken definition
+    // is to save a fixed one. Offering Publish on a flow that cannot be saved
+    // means a click that can only push the stale version.
+    await openFlow('flow-item-flow-1');
+
+    fireEvent.click(screen.getByTestId('add-step-btn'));
+
+    const publish = screen.getByTestId('publish-flow-btn') as HTMLButtonElement;
+    await waitFor(() => expect(publish.disabled).toBe(true));
+    // A dead button must say why — the same rule Save already follows.
+    expect(publish.title).toBeTruthy();
+    expect(api.publishToRegistry).not.toHaveBeenCalled();
+  });
+
+  it('re-enables Publish once the definition is valid again', async () => {
+    await openFlow('flow-item-flow-1');
+
+    fireEvent.click(screen.getByTestId('add-step-btn'));
+    await waitFor(() =>
+      expect((screen.getByTestId('publish-flow-btn') as HTMLButtonElement).disabled).toBe(true));
+
+    fireEvent.change(screen.getByTestId('step-name-3'), { target: { value: 'REFACTOR' } });
+
+    await waitFor(() =>
+      expect((screen.getByTestId('publish-flow-btn') as HTMLButtonElement).disabled).toBe(false));
+  });
+
+  // ── The "Saved" badge uses the HOST's caption ─────────────────────────────
+
+  it('uses the host\'s confirmation caption, not the editor default', async () => {
+    // The hub host renames Save; the confirmation has to follow it, or the
+    // button flips from "Save & publish to org" to the standalone "Saved" and
+    // the admin loses the fact that saving was the publish. Also why `saved`
+    // is its own caption rather than a suffix rule: appending "d" to the hub's
+    // caption would read "Save & publish to orgd".
+    vi.mocked(api.updateFlow).mockResolvedValue(SAMPLE_FLOW);
+    renderHosted({
+      labels: {
+        save: 'Save & publish to org',
+        saved: 'Published to org',
+        useFlow: 'Set as org default',
+      },
+    });
+    await waitFor(() => screen.getByTestId('flow-item-flow-1'));
+    fireEvent.click(screen.getByTestId('flow-item-flow-1'));
+    await waitFor(() => screen.getByTestId('save-flow-btn'));
+
+    fireEvent.click(screen.getByTestId('save-flow-btn'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('save-flow-btn').textContent).toBe('Published to org'));
+  });
+
+  it('renders ONE footer for a new flow, with both buttons in it', async () => {
+    // The two footers used to be picked by read-only-ness, which split Save and
+    // Publish across them. One footer now, so a button's outcome can never
+    // render somewhere the user isn't looking.
+    await startNewFlow();
+
+    const panel = screen.getByTestId('editor-panel');
+    const footers = Array.from(panel.querySelectorAll('[data-testid="flow-footer"]'));
+    expect(footers).toHaveLength(1);
+    expect(footers[0].querySelector('[data-testid="save-flow-btn"]')).not.toBeNull();
+    expect(footers[0].querySelector('[data-testid="publish-flow-btn"]')).not.toBeNull();
+  });
+
+  it('renders the publish outcome inside the same footer as the button', async () => {
+    vi.mocked(api.publishToRegistry).mockResolvedValue({ url: 'https://example.test/pr/9', kind: 'pr' });
+    await openFlow('flow-item-flow-1');
+
+    fireEvent.click(screen.getByTestId('publish-flow-btn'));
+    await waitFor(() => expect(screen.getByTestId('publish-success-link')).toBeDefined());
+
+    const footer = screen.getByTestId('flow-footer');
+    expect(footer.contains(screen.getByTestId('publish-flow-btn'))).toBe(true);
+    expect(footer.contains(screen.getByTestId('publish-success-link'))).toBe(true);
+  });
+
+  it('the read-only builtin flow offers no Save and no activation, only Clone', async () => {
+    // The builtin default has no row to write and is not a publishable
+    // definition; its actions are Clone to Edit and reverting to default.
+    renderEditor();
+    await waitFor(() => screen.getByTestId('flow-item-__builtin__'));
+    fireEvent.click(screen.getByTestId('flow-item-__builtin__'));
+    await waitFor(() => screen.getByTestId('editor-panel'));
+
+    expect(screen.queryByTestId('save-flow-btn')).toBeNull();
+    expect(screen.queryByTestId('use-flow-btn')).toBeNull();
+    expect(screen.getByTestId('clone-to-edit-btn')).toBeDefined();
+    expect(screen.getByTestId('use-default-flow-btn')).toBeDefined();
+  });
+
+  it('a hub-owned flow on a hub-connected client offers no Save', async () => {
+    // The local server 409s any write to a source='hub' flow, so Save must not
+    // be offered here (BUG 269eeec8 (b)).
+    vi.mocked(api.listFlows).mockResolvedValue([HUB_FLOW_LOCAL]);
+    renderEditor();
+    await waitFor(() => screen.getByTestId('flow-item-flow-hub'));
+    fireEvent.click(screen.getByTestId('flow-item-flow-hub'));
+    await waitFor(() => screen.getByTestId('editor-panel'));
+
+    expect(screen.getByTestId('hub-managed-badge')).toBeDefined();
+    expect(screen.queryByTestId('save-flow-btn')).toBeNull();
+  });
+});
+
 
 // ── CGLAB-109: Exit Criteria popup editor (markdown + preview + tokens) ─────
 // The flow builder's exit criteria were a short inline textarea. The new

--- a/scripts/killcheck-cglab138.sh
+++ b/scripts/killcheck-cglab138.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Apply one mutant at a time to flowRegistry.ts, run the service tests, and
+# report KILLED / SURVIVED / NO-OP. Verifies the replacement is actually
+# present in the LIVE file before trusting the verdict.
+F=packages/hub/src/services/flowRegistry.ts
+cp "$F" /tmp/fr.orig
+TESTS="${TESTS:-packages/hub/src/test/flow-registry-service.test.ts}"
+
+run() {
+  local desc="$1" old="$2" new="$3"
+  cp /tmp/fr.orig "$F"
+  python3 - "$old" "$new" <<'PY'
+import io, sys
+p = 'packages/hub/src/services/flowRegistry.ts'
+s = io.open(p, encoding='utf-8').read()
+old, new = sys.argv[1], sys.argv[2]
+if old not in s:
+    raise SystemExit('PATTERN-NOT-FOUND')
+io.open(p, 'w', encoding='utf-8').write(s.replace(old, new, 1))
+PY
+  if [ $? -ne 0 ]; then echo "NO-OP     | $desc"; return; fi
+  if ! grep -qF -- "$new" "$F"; then echo "NO-OP     | $desc (replacement absent)"; return; fi
+  local out
+  out=$(npx vitest run "$TESTS" 2>&1 | grep -E "^ +Tests " | tail -1)
+  if echo "$out" | grep -q "failed"; then echo "KILLED    | $desc"
+  elif echo "$out" | grep -q "passed"; then echo "SURVIVED  | $desc"
+  else echo "NO-OP     | $desc (no test summary: $out)"; fi
+}
+
+run "L305 !resp.ok -> false" \
+  'if (!resp.ok) { result.failed.push(file.name); continue; }' \
+  'if (false) { result.failed.push(file.name); continue; }'
+run "L305 push(file.name) -> push({})" \
+  'if (!resp.ok) { result.failed.push(file.name); continue; }' \
+  'if (!resp.ok) { result.failed.push({}); continue; }'
+run "L305 drop continue" \
+  'if (!resp.ok) { result.failed.push(file.name); continue; }' \
+  'if (!resp.ok) { result.failed.push(file.name); }'
+run "L233 existing.ok -> unconditional" \
+  'if (existing.ok) sha = (await existing.json())?.sha;' \
+  'sha = (await existing.json())?.sha;'
+run "L233 ?.sha -> .sha" \
+  'sha = (await existing.json())?.sha;' \
+  'sha = (await existing.json()).sha;'
+run "L155 ?.permissions?.push -> .permissions?.push" \
+  'const canPush = meta?.permissions?.push;' \
+  'const canPush = meta.permissions?.push;'
+run "L206 flow?.name -> flow.name" \
+  'name: flow?.name' \
+  'name: flow.name'
+run "L193 Array.isArray guard removed" \
+  'Array.isArray(flow?.steps) ? flow.steps : []' \
+  'flow?.steps'
+run "L152 typeof meta guard removed" \
+  "if (!meta || typeof meta !== 'object' || typeof meta.full_name !== 'string')" \
+  "if (!meta || typeof meta.full_name !== 'string')"
+run "L145 catch null -> undefined" \
+  '.catch(() => null)' \
+  '.catch(() => undefined)'
+run "L135 e?.message -> e.message" \
+  'could not reach GitHub: ${e?.message ?? e}' \
+  'could not reach GitHub: ${e.message}'
+
+cp /tmp/fr.orig "$F"
+echo "--- source restored ---"
+grep -n "if (!resp.ok) { result.failed" "$F"

--- a/scripts/killcheck-footerctas.sh
+++ b/scripts/killcheck-footerctas.sh
@@ -1,0 +1,205 @@
+#!/bin/bash
+# Apply one mutant at a time to the flow-editor footer CTA logic, run the specs
+# that exercise it, and report KILLED / SURVIVED / NO-OP. Same shape as
+# killcheck-cglab138.sh, and for the same reason: Stryker's vitest runner cannot
+# collect coverage from the jsdom component suite (it reported 0.14 tests per
+# mutant and marked all 1109 FlowEditorModal.tsx mutants NoCoverage), so an
+# automated mutation score for a .tsx component is not available here. Verifying
+# the replacement landed in the LIVE file before trusting the verdict is the
+# whole point — a mutant that was never applied reads exactly like a killed one.
+#
+# Each mutant below is a way the footer could quietly regress: a capability gate
+# widened until it always renders, an ordering rule dropped so the bind races
+# the save, a label falling back to the misleading default.
+#
+# LAST RUN: 21 killed, 3 survived, 0 no-op. All three survivors are recorded
+# below with why they are not worth a test, in the same spirit as the "what the
+# score does not say" section of HUB_ARCHITECTURE.md §6.1.1 — a survivor is only
+# interesting if some input makes the mutant behave differently, and for these
+# three none exists. Two are unreachable-by-construction guards kept as defence
+# in depth; one is a genuinely equivalent null-coalescing swap.
+#
+# Do not run this concurrently with a build or test run: it rewrites the source
+# files in place and restores them from a /tmp backup taken at start. A build
+# that lands mid-mutate poisons that backup, and the poisoned copy then
+# silently becomes the "restored" source.
+F=packages/flow-editor/src/FlowEditorModal.tsx
+R=packages/hub-ui/src/pages/adminFlowRegistry.ts
+cp "$F" /tmp/fem.orig
+cp "$R" /tmp/afr.orig
+TESTS="packages/ui/src/test/FlowEditorModal.test.tsx packages/hub-ui/src/test/adminFlowsEditor.test.tsx packages/hub-ui/src/test/adminFlowRegistry.test.ts"
+
+run() {
+  local desc="$1" file="$2" old="$3" new="$4"
+  cp /tmp/fem.orig packages/flow-editor/src/FlowEditorModal.tsx
+  cp /tmp/afr.orig packages/hub-ui/src/pages/adminFlowRegistry.ts
+  python3 - "$file" "$old" "$new" <<'PY'
+import io, sys
+p, old, new = sys.argv[1], sys.argv[2], sys.argv[3]
+s = io.open(p, encoding='utf-8').read()
+if old not in s:
+    raise SystemExit('PATTERN-NOT-FOUND')
+io.open(p, 'w', encoding='utf-8').write(s.replace(old, new, 1))
+PY
+  if [ $? -ne 0 ]; then echo "NO-OP     | $desc"; return; fi
+  if ! grep -qF -- "$new" "$file"; then echo "NO-OP     | $desc (replacement absent)"; return; fi
+  local out
+  out=$(npx vitest run --config vitest.footerctas.config.ts $TESTS 2>&1 | grep -E "^ +Tests " | tail -1)
+  if echo "$out" | grep -q "failed"; then echo "KILLED    | $desc"
+  elif echo "$out" | grep -q "passed"; then echo "SURVIVED  | $desc"
+  else echo "NO-OP     | $desc (no test summary: $out)"; fi
+}
+
+# ── Publish capability gate (item 1) ────────────────────────────────────────
+run "canPublish: typeof check -> always true" "$F" \
+  'const canPublish = typeof registryClient.publishToRegistry === '"'"'function'"'"';' \
+  'const canPublish = true;'
+
+run "canPublish: typeof check -> always false" "$F" \
+  'const canPublish = typeof registryClient.publishToRegistry === '"'"'function'"'"';' \
+  'const canPublish = false;'
+
+# SURVIVED, deliberately kept. The button is gated on the same `canPublish`, so
+# no UI path reaches this throw: the mutant is unreachable-by-construction, and
+# killing it would mean calling the mutation from outside the component, which
+# asserts on internals rather than behaviour. The guard stays as defence in
+# depth — if a future host renders the button off a different flag, the failure
+# is a legible error instead of a `publishToRegistry is not a function` TypeError.
+run "publish guard: !canPublish throw removed" "$F" \
+  "if (!canPublish) throw new Error('This host cannot publish flows.');" \
+  "if (false) throw new Error('This host cannot publish flows.');"
+
+# ── Bind saves before it binds (item 3) ─────────────────────────────────────
+run "bind: isDirty save-first -> bind the stale id" "$F" \
+  '      const current = isDirty ? await persist() : (flow as Flow);
+      await flowClient.setProjectFlow(projectId, current.id);
+      return current;' \
+  '      await flowClient.setProjectFlow(projectId, flow!.id);
+      return flow as Flow;'
+
+run "bind: always re-save, even when clean" "$F" \
+  '      const current = isDirty ? await persist() : (flow as Flow);' \
+  '      const current = await persist();'
+
+run "bind: bind BEFORE the save resolves (the original race)" "$F" \
+  '      const current = isDirty ? await persist() : (flow as Flow);
+      await flowClient.setProjectFlow(projectId, current.id);
+      return current;' \
+  '      const current = isDirty ? await persist() : (flow as Flow);
+      void flowClient.setProjectFlow(projectId, (flow as Flow).id);
+      return current;'
+
+run "bind: move the bind back into onSuccess (unmount loses it)" "$F" \
+  '      const current = isDirty ? await persist() : (flow as Flow);
+      await flowClient.setProjectFlow(projectId, current.id);
+      return current;' \
+  '      const current = isDirty ? await persist() : (flow as Flow);
+      return current;'
+
+# ── Publish saves before it publishes (item 4 support) ──────────────────────
+run "publish: dirty/new save-first -> publish whatever id is on hand" "$F" \
+  '      if (isDirty || !id) {
+        const saved = await persist();
+        rebaseOn(saved);
+        id = saved?.id;
+      }' \
+  '      if (false) {
+        const saved = await persist();
+        rebaseOn(saved);
+        id = saved?.id;
+      }'
+
+run "publish: only the missing-id case saves (dirty edits are dropped)" "$F" \
+  '      if (isDirty || !id) {' \
+  '      if (!id) {'
+
+# ── Dirty tracking (what makes the ordering rule decidable) ─────────────────
+run "isDirty: no-baseline case treated as clean" "$F" \
+  'const isDirty = persisted === null || serializeDefinition(name, description, steps) !== persisted;' \
+  'const isDirty = persisted !== null && serializeDefinition(name, description, steps) !== persisted;'
+
+run "isDirty: comparison inverted" "$F" \
+  'serializeDefinition(name, description, steps) !== persisted;' \
+  'serializeDefinition(name, description, steps) === persisted;'
+
+run "isDirty: always dirty" "$F" \
+  'const isDirty = persisted === null || serializeDefinition(name, description, steps) !== persisted;' \
+  'const isDirty = true;'
+
+run "isDirty: never dirty" "$F" \
+  'const isDirty = persisted === null || serializeDefinition(name, description, steps) !== persisted;' \
+  'const isDirty = false;'
+
+# ── Re-baseline on the SERVER response ──────────────────────────────────────
+# SURVIVED, deliberately kept. `persist()` types its result `Flow` and both
+# servers answer 201/200 with the stored row, so no caller can hand this a
+# null/undefined; the guard is a null-safety belt. The mutant replaces it with
+# a truthiness no-op, which is behaviourally identical for every reachable
+# input.
+run "rebaseOn: null-response guard removed" "$F" \
+  '    if (!savedFlow) return;' \
+  '    if (savedFlow) { void 0; }'
+
+run "rebaseOn: never re-baseline" "$F" \
+  '    setPersisted(serializeDefinition(
+      savedFlow.name,
+      savedFlow.description ?? '"'"''"'"',
+      [...(savedFlow.steps ?? [])].sort((a, b) => a.order - b.order),
+    ));' \
+  '    void savedFlow;'
+
+# ── Single footer, gated per capability (item 4) ────────────────────────────
+run "canSave: read-only gate removed" "$F" \
+  'const canSave = !isReadOnly;' \
+  'const canSave = true;'
+
+run "footer: publish button gated back on flow?.id" "$F" \
+  '            {canPublish && (
+              <button
+                data-testid="publish-flow-btn"' \
+  '            {canPublish && flow?.id && (
+              <button
+                data-testid="publish-flow-btn"'
+
+run "footer: use-flow button gated back on !isReadOnly" "$F" \
+  '            {canSelectFlow && !isReadOnly && (' \
+  '            {canSelectFlow && ('
+
+# ── Labels reach the button (item 2) ────────────────────────────────────────
+run "labels: save caption ignores the host" "$F" \
+  "save: labels?.save?.trim() || DEFAULT_EDITOR_LABELS.save," \
+  'save: DEFAULT_EDITOR_LABELS.save,'
+
+run "labels: useFlow caption ignores the host" "$F" \
+  "useFlow: labels?.useFlow?.trim() || DEFAULT_EDITOR_LABELS.useFlow," \
+  'useFlow: DEFAULT_EDITOR_LABELS.useFlow,'
+
+# SURVIVED — genuinely equivalent. `labels?.save ?? DEFAULT` differs from
+# `labels?.save?.trim() || DEFAULT` only for a host that passes a whitespace-only
+# caption, and `??` would then render a blank button. No host does that, and the
+# trim-then-fall-back form is the one that cannot produce an invisible label, so
+# it is kept on purpose. Killing it would mean asserting that the editor renders
+# a whitespace caption as whitespace.
+run "labels: empty-string host label not replaced by default" "$F" \
+  "save: labels?.save?.trim() || DEFAULT_EDITOR_LABELS.save," \
+  'save: labels?.save ?? DEFAULT_EDITOR_LABELS.save,'
+
+# ── The "Saved" badge survives the save ─────────────────────────────────────
+run "badge: confirmation falls back to the editor default, ignoring the host" "$F" \
+  "saved && !isDirty ? labels.saved : labels.save}" \
+  'saved && !isDirty ? DEFAULT_EDITOR_LABELS.saved : labels.save}'
+
+# ── Publish is blocked for the same reason Save is ───────────────────────────
+run "publish button ignores the blocked-definition state" "$F" \
+  'disabled={publishMutation.isPending || isSaveDisabled}' \
+  'disabled={publishMutation.isPending}'
+
+run "registryConfigSaveLabel: plain case collapses onto Save" "$R" \
+  "return base === 'Save' ? 'Save registry repo' : base;" \
+  'return base;'
+
+cp /tmp/fem.orig packages/flow-editor/src/FlowEditorModal.tsx
+cp /tmp/afr.orig packages/hub-ui/src/pages/adminFlowRegistry.ts
+echo "--- sources restored ---"
+grep -c "canPublish" packages/flow-editor/src/FlowEditorModal.tsx
+grep -c "registryConfigSaveLabel" packages/hub-ui/src/pages/adminFlowRegistry.ts

--- a/stryker.cglab138.config.mjs
+++ b/stryker.cglab138.config.mjs
@@ -1,0 +1,29 @@
+// Scoped StrykerJS config for CGLAB-138 (admin-settable private flow registry).
+//
+// Only the files this change touched are mutated, and each module is exercised
+// by its own test file, so the run stays short enough to iterate on. The
+// hub-ui validator is included because its whole point is agreeing with the
+// server-side validator — a weakened comparison there is a real defect, not a
+// cosmetic one.
+//
+// Run through the HOME guard (never bare `npx stryker run`):
+//   npm run test:stryker -- run stryker.cglab138.config.mjs
+export default {
+  mutate: [
+    'packages/hub/src/services/flowRegistry.ts',
+    'packages/hub-ui/src/pages/adminFlowRegistry.ts',
+  ],
+  testRunner: 'vitest',
+  vitest: {
+    configFile: 'vitest.cglab138.config.ts',
+    related: false,
+  },
+  reporters: ['clear-text', 'json', 'html'],
+  jsonReporter: { fileName: 'reports/mutation/cglab138.json' },
+  htmlReporter: { fileName: 'reports/mutation/cglab138.html' },
+  thresholds: { high: 80, low: 60, break: 0 },
+  timeoutMS: 120_000,
+  concurrency: 1,
+  logLevel: 'warn',
+  tempDirName: '.stryker-tmp',
+};

--- a/stryker.footerctas.config.mjs
+++ b/stryker.footerctas.config.mjs
@@ -1,0 +1,34 @@
+// Scoped StrykerJS run for the flow-editor footer CTA change (Publish is
+// capability-gated, "Use this Flow" saves before it binds, one footer instead
+// of two chosen by read-only-ness).
+//
+// Only the files this change touched are mutated. `FlowEditorModal.tsx` is the
+// behaviour; `adminFlowRegistry.ts` carries the hub-admin labels, where a
+// weakened comparison is a real defect (a label that collapses onto the other
+// button's label is the confusion this change exists to remove).
+//
+// Run through the HOME guard (never bare `npx stryker run`):
+//   npm run test:stryker -- run stryker.footerctas.config.mjs
+export default {
+  mutate: [
+    'packages/flow-editor/src/FlowEditorModal.tsx',
+    'packages/hub-ui/src/pages/adminFlowRegistry.ts',
+  ],
+  testRunner: 'vitest',
+  vitest: {
+    configFile: 'vitest.footerctas.config.ts',
+    // `related: true` so each mutant runs only against the tests that cover it.
+    // The CGLAB-138 config sets `related: false` because its mutated modules
+    // are pure functions with one obvious spec each; that assumption does not
+    // hold for a component file, and forcing every test against every mutant
+    // produced a run where nothing registered as covered.
+    related: true,
+  },
+  reporters: ['clear-text', 'json'],
+  jsonReporter: { fileName: 'reports/mutation/footerctas.json' },
+  thresholds: { high: 80, low: 60, break: 0 },
+  timeoutMS: 120_000,
+  concurrency: 1,
+  logLevel: 'warn',
+  tempDirName: '.stryker-tmp-footerctas',
+};

--- a/stryker.pi-extension.config.mjs
+++ b/stryker.pi-extension.config.mjs
@@ -1,0 +1,19 @@
+// Scoped StrykerJS config for the pi extension model-detection change.
+// Only the file this bug touched is mutated; vitest's own include filter keeps the
+// run to the test file that exercises it.
+export default {
+  mutate: ['bin/agenfk-pi-extension.ts'],
+  testRunner: 'vitest',
+  vitest: {
+    configFile: 'vitest.pi-extension.config.ts',
+    related: false,
+  },
+  reporters: ['clear-text', 'json', 'html'],
+  jsonReporter: { fileName: 'reports/mutation/pi-extension.json' },
+  htmlReporter: { fileName: 'reports/mutation/pi-extension.html' },
+  thresholds: { high: 80, low: 60, break: 0 },
+  timeoutMS: 60_000,
+  concurrency: 1,
+  logLevel: 'warn',
+  tempDirName: '.stryker-tmp',
+};

--- a/vitest.cglab138.config.ts
+++ b/vitest.cglab138.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig } from 'vitest/config';
+import { sharedResolve, sharedTest } from './scripts/vitest-shared-config.mjs';
+
+/**
+ * Vitest config used ONLY by the scoped Stryker run for CGLAB-138
+ * (stryker.cglab138.config.mjs). Narrows the suite to the tests that exercise
+ * the two mutated modules, so each mutant costs one small run rather than the
+ * whole serial suite.
+ */
+export default defineConfig({
+  define: {
+    __AGENFK_VERSION__: JSON.stringify('test'),
+  },
+  resolve: sharedResolve,
+  test: {
+    ...sharedTest({
+      include: [
+        'packages/hub/src/test/admin-flow-registry-config.test.ts',
+        'packages/hub/src/test/flow-registry-service.test.ts',
+        'packages/hub-ui/src/test/adminFlowRegistry.test.ts',
+      ],
+      // Serial. The three files are state-isolated — the hub app boots on an
+      // injected ':memory:' sqlite handle (no tmpdir file, no WAL sidecars),
+      // the service tests never boot a server, and the hub-ui tests are pure
+      // functions — but concurrency still costs more than it saves here: each
+      // hub boot runs bcrypt at the pinned cost on a synchronous path, and with
+      // three workers competing the setup hook trips the 30s ceiling. Same
+      // reason the rest of the hub suite is serial; the in-memory change
+      // removed the filesystem sharing, not the CPU-bound hashing.
+    }),
+  },
+});

--- a/vitest.footerctas.config.ts
+++ b/vitest.footerctas.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+import { testEnv } from './scripts/vitest-home-pin.mjs';
+
+/**
+ * Vitest config for the scoped Stryker run over the flow-editor footer CTA
+ * change (Publish capability-gating, save-before-bind, single footer).
+ * Narrows the suite to the specs that exercise the mutated modules.
+ */
+export default defineConfig({
+  plugins: [react()],
+  define: { __AGENFK_VERSION__: JSON.stringify('test') },
+  test: {
+    env: testEnv(),
+    environment: 'jsdom',
+    setupFiles: ['./packages/ui/src/test/setup.ts'],
+    globals: true,
+    include: [
+      'packages/ui/src/test/FlowEditorModal.test.tsx',
+      'packages/hub-ui/src/test/adminFlowRegistry.test.ts',
+      // The wiring spec that proves the hub captions reach the button and that
+      // Publish is absent. Without it in this list the label mutants are not
+      // exercised at all by this config, and the killcheck reports them as
+      // survivors — a hole in the harness reading as a hole in the tests.
+      'packages/hub-ui/src/test/adminFlowsEditor.test.tsx',
+    ],
+    fileParallelism: false,
+    testTimeout: 30_000,
+  },
+});

--- a/vitest.pi-extension.config.ts
+++ b/vitest.pi-extension.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+import { sharedResolve, sharedTest } from './scripts/vitest-shared-config.mjs';
+
+/**
+ * Vitest config used ONLY by the scoped Stryker run for the pi extension
+ * (stryker.pi-extension.config.mjs). It narrows the suite to the one test file
+ * that exercises bin/agenfk-pi-extension.ts, so mutation testing stays a
+ * seconds-long job instead of running the whole serial suite per mutant.
+ */
+export default defineConfig({
+  define: {
+    __AGENFK_VERSION__: JSON.stringify('test'),
+  },
+  resolve: sharedResolve,
+  test: {
+    ...sharedTest({ include: ['packages/server/src/test/pi-extension.test.ts'], parallel: true }),
+  },
+});


### PR DESCRIPTION
## The two problems

An admin asked where the flow editor's GitHub content comes from. It turned out the UI could not answer that honestly, for two reasons.

**1. The captions were wrong.** The shared `FlowEditorModal` hardcoded `My Flows` / `Community`. Correct for the standalone client, wrong in the hub admin:

- The first tab lists `/v1/admin/flows` — the **org's** catalogue that every installation inherits. "My" implies a personal list, which does not exist in an admin console.
- The second lists whatever `resolveRegistryRead` resolves to. After #176 that is the org's **own private repo** for any org that configured one — so a tab labelled "Community" was showing `cglab-PRIVATE/agenfk-flows`.

**2. Behind that was a real capability gap.** `resolveRegistryRead` answers **one repo per org**. Once a private registry is set, the actual community catalogue is invisible and uninstallable from the hub UI. The one-time copy masks it at switch time (the org repo starts as a superset) — but any flow published to community afterwards is unreachable.

## The fix

**Browse both.** `resolveRegistrySource(db, orgId, secretKey, source)` where `source` is `'org' | 'community'`; absent means `'org'`, so the shipped client keeps working untouched.

Two rules carry the design:

- **The caller picks a *source*, never a *repo*.** This route holds the org's `contents:write` PAT. Accepting `?repo=owner/name` would make it a proxy spending that credential against any repo the token can reach — a cross-tenant read driven by a server-side secret. Only two names are reachable, both already known to the server. A `repo` in the query is **ignored**; a `source` that isn't exactly `org`/`community` is a **400**, not a silent fallback to the org repo — a stale client would otherwise show private flows under a "Community" heading, the exact confusion this exists to remove.
- **`source=community` never sends the org token.** The PAT is scoped to the org's repo; attaching it to a public cglab-owned repo leaks the credential to a repo the org has no relationship with, and into GitHub's access logs. Anonymous is also simply what a public repo needs. Pinned on both browse and install.

`source=community` keeps the org's configured branch — a second setting would be left at `main` by everyone.

**Captions are host-supplied.** `FlowEditorModal` gained two *optional* props (`tabLabels`, `registryToolbar`), so the standalone client is untouched and keeps "My Flows"/"Community". Hub admin gets "Org Flows" and a registry tab named for the repo it is currently reading. The switcher renders only when the org actually has a private registry — with one registry, two options that do the same thing read as a broken control.

## Tests

Written first; **23 red before implementation**, including the tenancy guards.

- `resolveRegistrySource` — 10 service tests, incl. *"never returns a repo other than the org's or the public one"* asserted directly over 10 adversarial `source` values, and case-sensitivity pinned as deliberate.
- Route — 13 tests: anonymous-on-public for both browse and install, unknown source → 400, `?repo=victim/corp-secrets` ignored, non-admin → 403.
- 14 hub-ui tests for labels and picker visibility.

**Root suite 250 files / 3066 tests** (was 249/3029 at branch point — +1 file, +28 tests, nothing removed or weakened). **ui package 21 / 438** green with no edit to that package. `tsc --noEmit` clean for `flow-editor` and `hub-ui`; build clean.

## Notes

- Three of my own test expectations were wrong and I fixed the *tests*, not the code: the route returns the display `name` rather than the slug, and install returns **201** (a creation), not 200.
- `resolveRegistryRead` stays — the installation-facing `/v1/registry/flows` proxy still uses it; installations have no source switcher.
- Docs: `HUB_ARCHITECTURE.md` §6.1.2 records both rules and why; CHANGELOG entry under `1.1.18-beta.2`.

Depends on #176 — this branch is stacked on it for `resolveRegistryRead` / `org_settings`.
