### PR TITLE
feat(CGLAB-163): link cards to JIRA items outside of import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,77 @@
 
 All notable changes to AgEnFK are documented here.
 
+## [1.1.19-beta.3] — 2026-09-12
+
+Cut from `feat/CGLAB-163_jira-item-linking`, which branches off the
+`feat/CGLAB-151_pr-overview-pr-number-search` tip. Cumulative: it carries
+everything in `v1.1.19-beta.2` — the CGLAB-151 PR-number search and the
+verifyCommand diagnostics — plus the change below.
+
+### Cards can be linked to JIRA items outside of import (CGLAB-163)
+
+`externalId`/`externalUrl` have been on items since the JIRA importer landed,
+and the board has always rendered them as a clickable badge. But only the JIRA
+and GitHub imports ever wrote them: `POST /items` and `PUT /items/:id`
+destructured a fixed field list that omitted both, so a card created any other
+way could never point at an issue.
+
+Now any card can:
+
+```bash
+agenfk create TASK "Fix the picker dismiss" --project <id> --jira-item CGLAB-163
+agenfk update <id> --jira-item CGLAB-163     # link a card that already exists
+agenfk update <id> --jira-item none          # unlink
+```
+
+The same `jiraItem` field works on `POST /items`, `PUT /items/:id`,
+`POST /items/bulk`, and the `create_item` / `update_item` MCP tools.
+
+**The link is a reference, not an import.** The card keeps its own title and
+description; nothing is copied from JIRA and nothing is overwritten. Use the
+importer when you want the issue's content.
+
+**Validation depends on the connection.** With JIRA connected the key is checked
+against the real issue and the browse URL is derived from the token's cloud URL;
+a key that does not resolve is refused. Without a connection the key is
+format-checked and stored bare — which is what makes this usable offline and in
+CI. If JIRA is connected but unreachable the link still goes through and the
+command says it could not be verified, rather than reporting a plain success.
+
+Leaving the flag off never changes an existing link, so an ordinary
+`agenfk update <id> --title "..."` cannot silently drop a card's reference.
+
+The capability is documented in every shipped client bundle — `CLAUDE.md`,
+`AGENTS.md`, `GEMINI.md`, `agenfk.mdc` — plus `SKILL.md` and the `/agenfk` and
+`/agenfk-plan` commands.
+
+### Fixed along the way
+
+- **A JIRA reference with no browse URL now renders.** Both the board and the
+  card detail modal gated their badge on `externalUrl`, so a card linked while
+  disconnected — the documented offline mode — showed no reference at all.
+- **`agenfk list --active` is documented for every client.** It was in the
+  Claude bundle only, while all four bundles instruct the agent to use it, so
+  Codex, Gemini and Cursor agents were told to use a flag their own command
+  reference did not list.
+- **`POST /items/bulk` reports failed writes.** A `storage.updateItem` throw was
+  caught, logged and reported as nothing, so a failed entry looked like a
+  success. It now appears in `skipped`, alongside a new `warnings` array for
+  entries that applied with a caveat. Both fields are additive.
+- **Outbound JIRA calls are bounded.** Neither the API request helper nor the
+  token refresh it falls back to on a 401 set a timeout, so a stalled Atlassian
+  endpoint could hang a request indefinitely. Both now carry one.
+- **`externalUrl` is validated.** The board renders it straight into an `href`,
+  so the server refuses anything that is not `http(s)`, and refuses embedded
+  credentials.
+
+### Behaviour change
+
+`PUT /items/:id` now validates a requested type change and parent assignment
+*before* handling an archive transition. Previously an archiving request skipped
+both guards, so `{ status: "ARCHIVED", type: "BOGUS" }` archived the item; it now
+returns 400. Archiving without those fields is unaffected.
+
 ## [1.1.19-beta.2] — 2026-09-10
 
 Also cut from `feat/CGLAB-151_pr-overview-pr-number-search`, piling on

--- a/SKILL.md
+++ b/SKILL.md
@@ -91,9 +91,10 @@ enforced by the server. Each workflow tool name in this skill maps to a CLI comm
 | `update_project(id, {...})` | `agenfk update-project <id> [--name <name>][--description <text>][--verify-command <cmd>]` |
 | `list_items(projectId, ...)` | `agenfk list [--project <id>] [-t/--type <type>] [-s/--status <status>] [--active] [--all] [--json]` (`--active` = only items in an active working step; flow-aware) |
 | `get_item(id)` | `agenfk get <id> --json` |
-| `create_item(projectId, type, title)` | `agenfk create <TYPE> "<title>" --project <id> [-d/--description <desc>] [-p/--parent <id>]` |
+| `create_item(projectId, type, title)` | `agenfk create <TYPE> "<title>" --project <id> [-d/--description <desc>] [-p/--parent <id>] [--jira-item <KEY>]` |
 | `update_item(id, {status})` | `agenfk update <id> [--status <name>][--title <t>][--description <d>][--type <T>]` (status is backward/rollback only) |
 | `update_item(id, {parentId})` | `agenfk update <id> --parent <parentId>` — re-parent; `--parent none` detaches to top level. Parent must be in the same project and cannot be the item itself or a descendant. |
+| `update_item(id, {jiraItem})` | `agenfk update <id> --jira-item <KEY>` — link an EXISTING card to a JIRA item (e.g. `CGLAB-163`); `--jira-item none` unlinks. Reference only: the card keeps its own title and description. Validated against JIRA when connected, format-checked when not. |
 | `validate_progress(id, evidence, command?)` | `agenfk verify <id> --evidence "<text>" ["<command>"]` |
 | `add_comment(id, text)` | `agenfk comment <id> "<text>" [--author <name>]` |
 | `add_context(id, path)` | `agenfk add-context <id> --path <path> [--description <text>][--content <text>]` |
@@ -238,7 +239,8 @@ Use this skill whenever you are performing software engineering tasks to ensure 
 *   `agenfk current-project [--json]`: Print the current project id (resolved from the nearest `.agenfk/project.json`). Use this whenever a command needs `--project <id>` or the "active projectId".
 *   `agenfk list-projects --json`: List all existing projects.
 *   `agenfk create-project "<name>"`: Create a new project.
-*   `agenfk create <TYPE> "<title>" --project <id>`: Create a new workflow item.
+*   `agenfk create <TYPE> "<title>" --project <id>`: Create a new workflow item. Add `--jira-item <KEY>` to link it to a JIRA item as it is created.
+*   `agenfk update <id> --jira-item <KEY>`: Link an existing card to a JIRA item; `--jira-item none` unlinks. The link is a reference — the card keeps its own title and description.
 *   `agenfk update <id> --status <name>`: Update status (backward/rollback only — use `agenfk verify` for forward transitions).
 *   `agenfk list --project <id> --json`: Query the backlog.
 *   `agenfk get <id> --json`: Get full details.

--- a/clauderules/CLAUDE.md
+++ b/clauderules/CLAUDE.md
@@ -103,8 +103,9 @@ This is the full workflow surface. Each row notes the equivalent MCP tool (avail
 | Update a project | `agenfk update-project <id> [--name <name>][--description <text>][--verify-command <cmd>]` | `update_project` |
 | List items | `agenfk list [--project <id>] [-t/--type <type>] [-s/--status <status>] [--active] [--all] [--json]` (`--active` = only items in an active working step: excludes TODO/DONE anchors + PAUSED/BLOCKED/terminal; flow-aware — use it for the init resume-check to keep context small) | `list_items` |
 | Get an item | `agenfk get <id> --json` | `get_item` |
-| Create an item | `agenfk create <TYPE> "<title>" --project <id> [-d/--description <desc>] [-p/--parent <id>]` | `create_item` |
+| Create an item | `agenfk create <TYPE> "<title>" --project <id> [-d/--description <desc>] [-p/--parent <id>] [--jira-item <KEY>]` | `create_item` |
 | Update / roll back status | `agenfk update <id> [--status <name>][--title <t>][--description <d>][--type <T>]` (status is backward/rollback only) | `update_item` |
+| Link a card to a JIRA item | `agenfk update <id> --jira-item <KEY>` — attach a JIRA reference to an EXISTING card (e.g. `CGLAB-163`); `--jira-item none` unlinks. Also available at creation time as `agenfk create ... --jira-item <KEY>`. | `update_item` (`jiraItem`) |
 | Re-parent an item | `agenfk update <id> --parent <parentId>` — move it under another item; `--parent none` detaches it to top level. The parent must be in the same project, and cannot be the item itself or one of its descendants. | `update_item` (`parentId`) |
 | Advance a step (forward) | `agenfk verify <id> --evidence "<text>" ["<command>"]` | `validate_progress` |
 | Add a comment | `agenfk comment <id> "<text>" [--author <name>]` | `add_comment` |
@@ -179,6 +180,39 @@ This is the full workflow surface. Each row notes the equivalent MCP tool (avail
 | Set the community flow registry (local only — a Hub-connected org follows its admin's setting) | `agenfk config set flowRegistry <owner/repo>` |
 | Configure JIRA OAuth | `agenfk jira setup` · `agenfk jira status` · `agenfk jira disconnect` |
 | Configure GitHub Issues import | `agenfk github setup [--owner <owner>][--repo <repo>]` · `agenfk github status` · `agenfk github disconnect` |
+
+### Linking a card to a JIRA item
+
+Items imported from JIRA already carry their issue key. Any other card can be
+linked to one too — at creation time or long afterwards:
+
+```bash
+agenfk create TASK "Fix the picker dismiss" --project <id> --jira-item CGLAB-163
+agenfk update <id> --jira-item CGLAB-163     # link an existing card
+agenfk update <id> --jira-item none          # unlink
+```
+
+The key is stored as the item's external reference, and the board renders it as
+a badge linking straight to the issue.
+
+- **The link is a reference, not an import.** The card keeps its own title and
+  description; nothing is copied from JIRA and nothing is overwritten. Use the
+  JIRA import when you want the issue's content, and `--jira-item` when you
+  want a card you already have to point at an issue.
+- **Validation depends on the connection.** With JIRA connected
+  (`agenfk jira status`), the key is checked against the real issue and the
+  browse URL is filled in; a key that does not exist is refused. Without a
+  connection the key is format-checked and stored bare — which is what makes
+  this usable offline and in CI. If JIRA is connected but unreachable the link
+  still goes through and the command prints a warning that it could not be
+  verified; treat that as unconfirmed, not as success.
+- **Leaving the flag off never changes an existing link**, so an ordinary
+  `agenfk update <id> --title "..."` cannot silently drop a card's JIRA
+  reference.
+
+This pairs with the branch-naming convention: a card carrying `CGLAB-163` and a
+branch named `feat/CGLAB-163_<description>` are the two halves of the same
+trace, one on the board and one in git.
 
 ### Reading state — `--json`
 

--- a/codexrules/AGENTS.md
+++ b/codexrules/AGENTS.md
@@ -100,7 +100,7 @@ Codex's shell tool yields after a bounded window (the default `yield_time_ms` is
 
 | Forbidden | Use instead |
 |-----------|-------------|
-| Reading `.agenfk/db.sqlite` or `.agenfk/db.json` directly | `agenfk list --json`, `agenfk get <id> --json` |
+| Reading `.agenfk/db.sqlite` or `.agenfk/db.json` directly (Bash or Read) | `agenfk list --json`, `agenfk get <id> --json` |
 | `curl` / `wget` to `http://localhost:3000` | `agenfk list`, `agenfk create`, `agenfk update`, `agenfk verify` |
 
 Codex does not support PreToolUse hooks, so the above is enforced by instruction — you MUST comply. Always run `agenfk gatekeeper` before editing any file.
@@ -118,10 +118,11 @@ This is the full workflow surface. In Codex, call the **`mcp__agenfk__*` tool** 
 | Get the current project id | `agenfk current-project [--json]` (resolves the nearest `.agenfk/project.json`; `--json` adds the project name/description from the server when reachable) | — |
 | Create a project | `agenfk create-project "<name>" [-d/--description <desc>]` | `create_project` |
 | Update a project | `agenfk update-project <id> [--name <name>][--description <text>][--verify-command <cmd>]` | `update_project` |
-| List items | `agenfk list [--project <id>] [-t/--type <type>] [-s/--status <status>] [--all] [--json]` | `list_items` |
+| List items | `agenfk list [--project <id>] [-t/--type <type>] [-s/--status <status>] [--active] [--all] [--json]` | `list_items` |
 | Get an item | `agenfk get <id> --json` | `get_item` |
-| Create an item | `agenfk create <TYPE> "<title>" --project <id> [-d/--description <desc>] [-p/--parent <id>]` | `create_item` |
+| Create an item | `agenfk create <TYPE> "<title>" --project <id> [-d/--description <desc>] [-p/--parent <id>] [--jira-item <KEY>]` | `create_item` |
 | Update / roll back status | `agenfk update <id> [--status <name>][--title <t>][--description <d>][--type <T>]` (status is backward/rollback only) | `update_item` |
+| Link a card to a JIRA item | `agenfk update <id> --jira-item <KEY>` — attach a JIRA reference to an EXISTING card (e.g. `CGLAB-163`); `--jira-item none` unlinks. Also available at creation time as `agenfk create ... --jira-item <KEY>`. | `update_item` (`jiraItem`) |
 | Re-parent an item | `agenfk update <id> --parent <parentId>` — move it under another item; `--parent none` detaches it to top level. The parent must be in the same project, and cannot be the item itself or one of its descendants. | `update_item` (`parentId`) |
 | Advance a step (forward) | `agenfk verify <id> --evidence "<text>" ["<command>"]` | `validate_progress` |
 | Add a comment | `agenfk comment <id> "<text>" [--author <name>]` | `add_comment` |
@@ -196,6 +197,39 @@ This is the full workflow surface. In Codex, call the **`mcp__agenfk__*` tool** 
 | Set the community flow registry (local only — a Hub-connected org follows its admin's setting) | `agenfk config set flowRegistry <owner/repo>` |
 | Configure JIRA OAuth | `agenfk jira setup` · `agenfk jira status` · `agenfk jira disconnect` |
 | Configure GitHub Issues import | `agenfk github setup [--owner <owner>][--repo <repo>]` · `agenfk github status` · `agenfk github disconnect` |
+
+### Linking a card to a JIRA item
+
+Items imported from JIRA already carry their issue key. Any other card can be
+linked to one too — at creation time or long afterwards:
+
+```bash
+agenfk create TASK "Fix the picker dismiss" --project <id> --jira-item CGLAB-163
+agenfk update <id> --jira-item CGLAB-163     # link an existing card
+agenfk update <id> --jira-item none          # unlink
+```
+
+The key is stored as the item's external reference, and the board renders it as
+a badge linking straight to the issue.
+
+- **The link is a reference, not an import.** The card keeps its own title and
+  description; nothing is copied from JIRA and nothing is overwritten. Use the
+  JIRA import when you want the issue's content, and `--jira-item` when you
+  want a card you already have to point at an issue.
+- **Validation depends on the connection.** With JIRA connected
+  (`agenfk jira status`), the key is checked against the real issue and the
+  browse URL is filled in; a key that does not exist is refused. Without a
+  connection the key is format-checked and stored bare — which is what makes
+  this usable offline and in CI. If JIRA is connected but unreachable the link
+  still goes through and the command prints a warning that it could not be
+  verified; treat that as unconfirmed, not as success.
+- **Leaving the flag off never changes an existing link**, so an ordinary
+  `agenfk update <id> --title "..."` cannot silently drop a card's JIRA
+  reference.
+
+This pairs with the branch-naming convention: a card carrying `CGLAB-163` and a
+branch named `feat/CGLAB-163_<description>` are the two halves of the same
+trace, one on the board and one in git.
 
 ### Reading state — `--json`
 

--- a/commands/agenfk-plan.md
+++ b/commands/agenfk-plan.md
@@ -21,6 +21,7 @@ You are executing the `/agenfk-plan <id>` command as a **Planning Agent**. Follo
 
 **Step 3 — Propose**
 - Run `agenfk create <TYPE> "<title>" --project <id> --parent <parentId>` for each proposed sub-item, linking it to the provided parent `<id>`.
+- If the sub-item corresponds to a JIRA issue, add `--jira-item <KEY>` to the same command so the card carries the reference from the moment it exists, rather than needing a follow-up `agenfk update`.
 - Run `agenfk comment <id> "I have proposed the following decomposition: ..."` to log your reasoning on the parent item.
 
 **Step 4 — Finalize**

--- a/commands/agenfk.md
+++ b/commands/agenfk.md
@@ -60,6 +60,14 @@ Before creating any item, evaluate the request against these signals:
 
 **If EPIC**: create it with `agenfk create <TYPE> "<title>" --project <id>`, then immediately invoke `/agenfk-plan <id>` and **STOP** — do not write any code until the user approves the decomposition. An EPIC is never worked directly: all of its child stories must exist and be approved before any of them starts.
 
+> **Linking to a tracker.** Any card can carry a JIRA reference, not just ones
+> imported from JIRA. Pass `--jira-item <KEY>` when creating it, or attach one
+> later with `agenfk update <id> --jira-item <KEY>` (`--jira-item none` unlinks).
+> The link is a reference only — the card keeps its own title and description —
+> and it is validated against JIRA when connected, format-checked when not. If
+> the flow requires a JIRA key for branch naming, this is how the card records
+> the same key the branch carries.
+
 **If STORY**: create it with `agenfk create <TYPE> "<title>" --project <id>`. Decomposing a story into tasks is **not** mandatory: do it only when the story is large — multiple distinct deliverables, several packages, or more than one focused implementation pass — and that is the agent's judgement, stated with reasons. When you do decompose, invoke `/agenfk-plan <id>`, create every task before starting work, and **STOP** for the user's approval as with an EPIC. A small story goes straight to its first working step.
 
 ---

--- a/cursorrules/agenfk.mdc
+++ b/cursorrules/agenfk.mdc
@@ -91,7 +91,7 @@ After running `gh pr create`, you MUST run `agenfk pr-register --item <id> --num
 
 | Forbidden | Use instead |
 |-----------|-------------|
-| Reading `.agenfk/db.sqlite` or `.agenfk/db.json` directly | `agenfk list --json`, `agenfk get <id> --json` |
+| Reading `.agenfk/db.sqlite` or `.agenfk/db.json` directly (Bash or Read) | `agenfk list --json`, `agenfk get <id> --json` |
 | `curl` / `wget` to `http://localhost:3000` | `agenfk list`, `agenfk create`, `agenfk update`, `agenfk verify` |
 
 Cursor does not support PreToolUse hooks, so the above is enforced by instruction — you MUST comply. Always run `agenfk gatekeeper` before editing any file.
@@ -109,10 +109,11 @@ This is the full workflow surface. Each row notes the equivalent MCP tool (avail
 | Get the current project id | `agenfk current-project [--json]` (resolves the nearest `.agenfk/project.json`; `--json` adds the project name/description from the server when reachable) | — |
 | Create a project | `agenfk create-project "<name>" [-d/--description <desc>]` | `create_project` |
 | Update a project | `agenfk update-project <id> [--name <name>][--description <text>][--verify-command <cmd>]` | `update_project` |
-| List items | `agenfk list [--project <id>] [-t/--type <type>] [-s/--status <status>] [--all] [--json]` | `list_items` |
+| List items | `agenfk list [--project <id>] [-t/--type <type>] [-s/--status <status>] [--active] [--all] [--json]` | `list_items` |
 | Get an item | `agenfk get <id> --json` | `get_item` |
-| Create an item | `agenfk create <TYPE> "<title>" --project <id> [-d/--description <desc>] [-p/--parent <id>]` | `create_item` |
+| Create an item | `agenfk create <TYPE> "<title>" --project <id> [-d/--description <desc>] [-p/--parent <id>] [--jira-item <KEY>]` | `create_item` |
 | Update / roll back status | `agenfk update <id> [--status <name>][--title <t>][--description <d>][--type <T>]` (status is backward/rollback only) | `update_item` |
+| Link a card to a JIRA item | `agenfk update <id> --jira-item <KEY>` — attach a JIRA reference to an EXISTING card (e.g. `CGLAB-163`); `--jira-item none` unlinks. Also available at creation time as `agenfk create ... --jira-item <KEY>`. | `update_item` (`jiraItem`) |
 | Re-parent an item | `agenfk update <id> --parent <parentId>` — move it under another item; `--parent none` detaches it to top level. The parent must be in the same project, and cannot be the item itself or one of its descendants. | `update_item` (`parentId`) |
 | Advance a step (forward) | `agenfk verify <id> --evidence "<text>" ["<command>"]` | `validate_progress` |
 | Add a comment | `agenfk comment <id> "<text>" [--author <name>]` | `add_comment` |
@@ -184,9 +185,42 @@ This is the full workflow surface. Each row notes the equivalent MCP tool (avail
 | Resume integration(s) | `agenfk integration resume <platform\|all> [-y/--yes]` |
 | Install/uninstall workflow rules & skills | `agenfk skills install [-g/--global][-p/--project]` · `agenfk skills uninstall [-g/--global][-p/--project]` · `agenfk skills status` |
 | Enable/disable telemetry | `agenfk config set telemetry <true\|false>` |
-| Set the community flow registry | `agenfk config set flowRegistry <owner/repo>` |
+| Set the community flow registry (local only — a Hub-connected org follows its admin's setting) | `agenfk config set flowRegistry <owner/repo>` |
 | Configure JIRA OAuth | `agenfk jira setup` · `agenfk jira status` · `agenfk jira disconnect` |
 | Configure GitHub Issues import | `agenfk github setup [--owner <owner>][--repo <repo>]` · `agenfk github status` · `agenfk github disconnect` |
+
+### Linking a card to a JIRA item
+
+Items imported from JIRA already carry their issue key. Any other card can be
+linked to one too — at creation time or long afterwards:
+
+```bash
+agenfk create TASK "Fix the picker dismiss" --project <id> --jira-item CGLAB-163
+agenfk update <id> --jira-item CGLAB-163     # link an existing card
+agenfk update <id> --jira-item none          # unlink
+```
+
+The key is stored as the item's external reference, and the board renders it as
+a badge linking straight to the issue.
+
+- **The link is a reference, not an import.** The card keeps its own title and
+  description; nothing is copied from JIRA and nothing is overwritten. Use the
+  JIRA import when you want the issue's content, and `--jira-item` when you
+  want a card you already have to point at an issue.
+- **Validation depends on the connection.** With JIRA connected
+  (`agenfk jira status`), the key is checked against the real issue and the
+  browse URL is filled in; a key that does not exist is refused. Without a
+  connection the key is format-checked and stored bare — which is what makes
+  this usable offline and in CI. If JIRA is connected but unreachable the link
+  still goes through and the command prints a warning that it could not be
+  verified; treat that as unconfirmed, not as success.
+- **Leaving the flag off never changes an existing link**, so an ordinary
+  `agenfk update <id> --title "..."` cannot silently drop a card's JIRA
+  reference.
+
+This pairs with the branch-naming convention: a card carrying `CGLAB-163` and a
+branch named `feat/CGLAB-163_<description>` are the two halves of the same
+trace, one on the board and one in git.
 
 ### Reading state — `--json`
 

--- a/geminirules/GEMINI.md
+++ b/geminirules/GEMINI.md
@@ -87,7 +87,7 @@ After running `gh pr create`, you MUST run `agenfk pr-register --item <id> --num
 
 | Forbidden | Use instead |
 |-----------|-------------|
-| Reading `.agenfk/db.sqlite` or `.agenfk/db.json` directly | `agenfk list --json`, `agenfk get <id> --json` |
+| Reading `.agenfk/db.sqlite` or `.agenfk/db.json` directly (Bash or Read) | `agenfk list --json`, `agenfk get <id> --json` |
 | `curl` / `wget` to `http://localhost:3000` | `agenfk list`, `agenfk create`, `agenfk update`, `agenfk verify` |
 
 Gemini CLI does not support PreToolUse hooks, so the above is enforced by instruction — you MUST comply. Always run `agenfk gatekeeper` before editing any file.
@@ -105,10 +105,11 @@ This is the full workflow surface. Each row notes the equivalent MCP tool (avail
 | Get the current project id | `agenfk current-project [--json]` (resolves the nearest `.agenfk/project.json`; `--json` adds the project name/description from the server when reachable) | — |
 | Create a project | `agenfk create-project "<name>" [-d/--description <desc>]` | `create_project` |
 | Update a project | `agenfk update-project <id> [--name <name>][--description <text>][--verify-command <cmd>]` | `update_project` |
-| List items | `agenfk list [--project <id>] [-t/--type <type>] [-s/--status <status>] [--all] [--json]` | `list_items` |
+| List items | `agenfk list [--project <id>] [-t/--type <type>] [-s/--status <status>] [--active] [--all] [--json]` | `list_items` |
 | Get an item | `agenfk get <id> --json` | `get_item` |
-| Create an item | `agenfk create <TYPE> "<title>" --project <id> [-d/--description <desc>] [-p/--parent <id>]` | `create_item` |
+| Create an item | `agenfk create <TYPE> "<title>" --project <id> [-d/--description <desc>] [-p/--parent <id>] [--jira-item <KEY>]` | `create_item` |
 | Update / roll back status | `agenfk update <id> [--status <name>][--title <t>][--description <d>][--type <T>]` (status is backward/rollback only) | `update_item` |
+| Link a card to a JIRA item | `agenfk update <id> --jira-item <KEY>` — attach a JIRA reference to an EXISTING card (e.g. `CGLAB-163`); `--jira-item none` unlinks. Also available at creation time as `agenfk create ... --jira-item <KEY>`. | `update_item` (`jiraItem`) |
 | Re-parent an item | `agenfk update <id> --parent <parentId>` — move it under another item; `--parent none` detaches it to top level. The parent must be in the same project, and cannot be the item itself or one of its descendants. | `update_item` (`parentId`) |
 | Advance a step (forward) | `agenfk verify <id> --evidence "<text>" ["<command>"]` | `validate_progress` |
 | Add a comment | `agenfk comment <id> "<text>" [--author <name>]` | `add_comment` |
@@ -183,6 +184,39 @@ This is the full workflow surface. Each row notes the equivalent MCP tool (avail
 | Set the community flow registry (local only — a Hub-connected org follows its admin's setting) | `agenfk config set flowRegistry <owner/repo>` |
 | Configure JIRA OAuth | `agenfk jira setup` · `agenfk jira status` · `agenfk jira disconnect` |
 | Configure GitHub Issues import | `agenfk github setup [--owner <owner>][--repo <repo>]` · `agenfk github status` · `agenfk github disconnect` |
+
+### Linking a card to a JIRA item
+
+Items imported from JIRA already carry their issue key. Any other card can be
+linked to one too — at creation time or long afterwards:
+
+```bash
+agenfk create TASK "Fix the picker dismiss" --project <id> --jira-item CGLAB-163
+agenfk update <id> --jira-item CGLAB-163     # link an existing card
+agenfk update <id> --jira-item none          # unlink
+```
+
+The key is stored as the item's external reference, and the board renders it as
+a badge linking straight to the issue.
+
+- **The link is a reference, not an import.** The card keeps its own title and
+  description; nothing is copied from JIRA and nothing is overwritten. Use the
+  JIRA import when you want the issue's content, and `--jira-item` when you
+  want a card you already have to point at an issue.
+- **Validation depends on the connection.** With JIRA connected
+  (`agenfk jira status`), the key is checked against the real issue and the
+  browse URL is filled in; a key that does not exist is refused. Without a
+  connection the key is format-checked and stored bare — which is what makes
+  this usable offline and in CI. If JIRA is connected but unreachable the link
+  still goes through and the command prints a warning that it could not be
+  verified; treat that as unconfirmed, not as success.
+- **Leaving the flag off never changes an existing link**, so an ordinary
+  `agenfk update <id> --title "..."` cannot silently drop a card's JIRA
+  reference.
+
+This pairs with the branch-naming convention: a card carrying `CGLAB-163` and a
+branch named `feat/CGLAB-163_<description>` are the two halves of the same
+trace, one on the board and one in git.
 
 ### Reading state — `--json`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenfk",
-  "version": "1.1.19-beta.2",
+  "version": "1.1.19-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenfk",
-      "version": "1.1.19-beta.2",
+      "version": "1.1.19-beta.3",
       "license": "ISC",
       "workspaces": [
         "packages/core",
@@ -13317,11 +13317,11 @@
     },
     "packages/cli": {
       "name": "@agenfk/cli",
-      "version": "1.1.19-beta.2",
+      "version": "1.1.19-beta.3",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.1.19-beta.2",
-        "@agenfk/telemetry": "1.1.19-beta.2",
+        "@agenfk/core": "1.1.19-beta.3",
+        "@agenfk/telemetry": "1.1.19-beta.3",
         "axios": "^1.20.0",
         "chalk": "^4.1.2",
         "commander": "^12.0.0",
@@ -13341,7 +13341,7 @@
     },
     "packages/core": {
       "name": "@agenfk/core",
-      "version": "1.1.19-beta.2",
+      "version": "1.1.19-beta.3",
       "license": "ISC",
       "devDependencies": {
         "typescript": "^5.3.3"
@@ -13349,7 +13349,7 @@
     },
     "packages/create": {
       "name": "agenfk",
-      "version": "1.1.19-beta.2",
+      "version": "1.1.19-beta.3",
       "license": "ISC",
       "bin": {
         "agenfk": "bin/agenfk.js"
@@ -13360,7 +13360,7 @@
     },
     "packages/flow-editor": {
       "name": "@agenfk/flow-editor",
-      "version": "1.1.19-beta.2",
+      "version": "1.1.19-beta.3",
       "peerDependencies": {
         "@tanstack/react-query": "^5.102.8",
         "clsx": "^2.1.1",
@@ -13374,9 +13374,9 @@
     },
     "packages/hub": {
       "name": "@agenfk/hub",
-      "version": "1.1.19-beta.2",
+      "version": "1.1.19-beta.3",
       "dependencies": {
-        "@agenfk/core": "1.1.19-beta.2",
+        "@agenfk/core": "1.1.19-beta.3",
         "axios": "^1.20.0",
         "bcryptjs": "^2.4.3",
         "cookie-parser": "^1.4.7",
@@ -13400,9 +13400,9 @@
       }
     },
     "packages/hub-ui": {
-      "version": "1.1.19-beta.2",
+      "version": "1.1.19-beta.3",
       "dependencies": {
-        "@agenfk/flow-editor": "1.1.19-beta.2",
+        "@agenfk/flow-editor": "1.1.19-beta.3",
         "@fontsource-variable/jetbrains-mono": "^5.3.0",
         "@fontsource-variable/manrope": "^5.3.0",
         "@tailwindcss/postcss": "^4.3.3",
@@ -13778,12 +13778,12 @@
     },
     "packages/server": {
       "name": "@agenfk/server",
-      "version": "1.1.19-beta.2",
+      "version": "1.1.19-beta.3",
       "license": "ISC",
       "dependencies": {
-        "@agenfk/core": "1.1.19-beta.2",
-        "@agenfk/storage-sqlite": "1.1.19-beta.2",
-        "@agenfk/telemetry": "1.1.19-beta.2",
+        "@agenfk/core": "1.1.19-beta.3",
+        "@agenfk/storage-sqlite": "1.1.19-beta.3",
+        "@agenfk/telemetry": "1.1.19-beta.3",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "axios": "^1.20.0",
         "body-parser": "^2.3.0",
@@ -13806,13 +13806,13 @@
     },
     "packages/storage-sqlite": {
       "name": "@agenfk/storage-sqlite",
-      "version": "1.1.19-beta.2",
+      "version": "1.1.19-beta.3",
       "license": "ISC",
       "dependencies": {
         "uuid": "^14.0.2"
       },
       "devDependencies": {
-        "@agenfk/core": "1.1.19-beta.2",
+        "@agenfk/core": "1.1.19-beta.3",
         "@types/node": "^22.0.0",
         "@types/uuid": "^9.0.8",
         "typescript": "^5.3.3"
@@ -13830,7 +13830,7 @@
     },
     "packages/telemetry": {
       "name": "@agenfk/telemetry",
-      "version": "1.1.19-beta.2",
+      "version": "1.1.19-beta.3",
       "license": "ISC",
       "dependencies": {
         "posthog-node": "^4.0.0"
@@ -13841,9 +13841,9 @@
       }
     },
     "packages/ui": {
-      "version": "1.1.19-beta.2",
+      "version": "1.1.19-beta.3",
       "dependencies": {
-        "@agenfk/flow-editor": "1.1.19-beta.2",
+        "@agenfk/flow-editor": "1.1.19-beta.3",
         "@fontsource-variable/jetbrains-mono": "^5.3.0",
         "@fontsource-variable/manrope": "^5.3.0",
         "@tailwindcss/postcss": "^4.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "1.1.19-beta.2",
+  "version": "1.1.19-beta.3",
   "description": "AgenFK Engineering Framework",
   "private": true,
   "workspaces": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/cli",
-  "version": "1.1.19-beta.2",
+  "version": "1.1.19-beta.3",
   "description": "CLI for AgenFK Engineering Framework",
   "main": "dist/index.js",
   "bin": {
@@ -12,8 +12,8 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.19-beta.2",
-    "@agenfk/telemetry": "1.1.19-beta.2",
+    "@agenfk/core": "1.1.19-beta.3",
+    "@agenfk/telemetry": "1.1.19-beta.3",
     "axios": "^1.20.0",
     "chalk": "^4.1.2",
     "commander": "^12.0.0",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1497,12 +1497,57 @@ async function resolveItemProjectId(itemId: string): Promise<string | null> {
   }
 }
 
+/**
+ * Report what happened to a card's JIRA link after a create or update.
+ *
+ * The server may link WITHOUT having verified the key (JIRA unreachable). That
+ * is a fact the caller has to see: a silent unverified link is exactly the kind
+ * of best-effort that looks like success until someone clicks the badge.
+ */
+/** Name the tracker from the reference URL's host. */
+function trackerNameFor(externalUrl: unknown): string {
+  try {
+    const host = new URL(String(externalUrl)).hostname.toLowerCase();
+    return host === 'github.com' || host.endsWith('.github.com') ? 'GitHub' : 'JIRA';
+  } catch {
+    return 'JIRA';
+  }
+}
+
+function reportJiraLink(item: any, requested?: string): void {
+  if (!item) return;
+  if (item.jiraWarning) {
+    console.log(chalk.yellow(`  ! ${item.jiraWarning}`));
+  }
+  // Only report when this command actually touched the link (or the server had
+  // something to say about it). Reporting on every update meant a plain
+  // `--title` edit printed a tracker line it never asked about.
+  if (requested === undefined && !item.jiraWarning) return;
+
+  if (item.externalId) {
+    // Cards imported from GitHub carry externalId/externalUrl too, so the label
+    // is derived rather than assumed to be JIRA. Matched on the HOST, not on the
+    // whole URL: a JIRA link with 'github.com' in a query parameter would
+    // otherwise be labelled GitHub.
+    const tracker = trackerNameFor(item.externalUrl);
+    console.log(chalk.gray(`  ${tracker}: ${item.externalId}${item.externalUrl ? ` (${item.externalUrl})` : ''}`));
+    return;
+  }
+  // Unlink is the one operation with no positive confirmation otherwise: the
+  // generic "Updated item" line looks identical whether the flag took effect or
+  // was ignored, so say it explicitly.
+  if (requested !== undefined && requested.trim().toLowerCase() === 'none') {
+    console.log(chalk.gray('  JIRA: unlinked'));
+  }
+}
+
 program
   .command('create <type> [title]')
   .description('Create a new item (epic, story, task, bug)')
   .option('-d, --description <desc>', 'Description of the item', '')
   .option('-p, --parent <id>', 'Parent ID')
   .option('--project <id>', 'Project ID')
+  .option('--jira-item <key>', 'Link the new card to a JIRA item by key (e.g. CGLAB-163)')
   .action(async (type, title, options) => {
     try {
       const itemType = type.toUpperCase() as ItemType;
@@ -1514,7 +1559,7 @@ program
         process.exit(1);
       }
 
-      const payload = {
+      const payload: any = {
         type: itemType,
         title,
         description: options.description,
@@ -1522,8 +1567,13 @@ program
         projectId
       };
 
+      // Forwarded verbatim: the server owns key validation, because it is the
+      // only side that can check the key against a live JIRA.
+      if (options.jiraItem !== undefined) payload.jiraItem = options.jiraItem;
+
       const { data } = await axios.post(`${API_URL}/items`, payload);
       console.log(chalk.green(`Created ${type}: ${data.title} (ID: ${data.id})`));
+      reportJiraLink(data, options.jiraItem);
     } catch (error: any) {
       console.error(chalk.red('Error creating item:'), error.response?.data?.error || error.message);
     }
@@ -1580,6 +1630,7 @@ program
   .option('-d, --description <desc>', 'New description')
   .option('--type <type>', 'New type (EPIC, STORY, TASK, BUG)')
   .option('--parent <parentId>', "Re-parent under another item; pass 'none' to detach to top level")
+  .option('--jira-item <key>', "Link this card to a JIRA item by key (e.g. CGLAB-163); pass 'none' to unlink")
   .action(async (id, options) => {
     try {
       // Handle short ID
@@ -1636,8 +1687,13 @@ program
         }
       }
 
+      // Verbatim, like create: 'none' included, so the server owns both the
+      // key format and the unlink semantics.
+      if (options.jiraItem !== undefined) updates.jiraItem = options.jiraItem;
+
       const { data: updated } = await axios.put(`${API_URL}/items/${targetId}`, updates);
       console.log(chalk.green(`Updated item: ${updated.title} [${updated.type}] (${updated.status})`));
+      reportJiraLink(updated, options.jiraItem);
       if (options.parent !== undefined) {
         console.log(
           updated.parentId

--- a/packages/cli/src/test/jira-item-option.test.ts
+++ b/packages/cli/src/test/jira-item-option.test.ts
@@ -1,0 +1,296 @@
+/**
+ * `agenfk create --jira-item` and `agenfk update --jira-item` — attaching a JIRA
+ * reference from the CLI.
+ *
+ * The JIRA importer has always produced cards carrying externalId/externalUrl,
+ * but a card created any other way had no route to a JIRA reference at all: the
+ * server's item write paths ignored the fields, and the CLI had no flag. These
+ * tests pin the CLI half — the flag exists on both commands, forwards the raw
+ * value as `jiraItem` for the server to validate, and stays absent from the
+ * payload when unused so an ordinary `--title` edit cannot silently drop an
+ * existing link.
+ *
+ * Resolution deliberately stays server-side: the CLI must not second-guess the
+ * key format, because the server is the only place that can check it against a
+ * live JIRA, and duplicating the rule in two languages of validation is how the
+ * two drift apart.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockExistsSync, mockReadFileSync } = vi.hoisted(() => ({
+  mockExistsSync: vi.fn(),
+  mockReadFileSync: vi.fn(),
+}));
+
+vi.mock('@agenfk/telemetry', () => ({
+  TelemetryClient: vi.fn(function (this: any) {
+    this.capture = vi.fn();
+    this.shutdown = vi.fn().mockResolvedValue(undefined);
+    this.isEnabled = true;
+    this.id = 'test-install-id';
+  }),
+  getInstallationId: vi.fn().mockReturnValue('test-install-id'),
+  isTelemetryEnabled: vi.fn().mockReturnValue(true),
+  getApiUrl: vi.fn().mockReturnValue('http://localhost:3000'),
+  readServerPort: vi.fn().mockReturnValue(null),
+  DEFAULT_API_PORT: 3000,
+}));
+
+vi.mock('fs', () => ({
+  existsSync: mockExistsSync,
+  readFileSync: mockReadFileSync,
+  writeFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  default: {
+    existsSync: mockExistsSync,
+    readFileSync: mockReadFileSync,
+    writeFileSync: vi.fn(),
+    mkdirSync: vi.fn(),
+  },
+}));
+
+vi.mock('axios');
+vi.mock('child_process', () => ({
+  execSync: vi.fn(),
+  spawn: vi.fn(),
+  spawnSync: vi.fn(),
+  default: { execSync: vi.fn(), spawn: vi.fn(), spawnSync: vi.fn() },
+}));
+vi.mock('figlet', () => ({ default: { textSync: vi.fn().mockReturnValue('AgEnFK') } }));
+vi.mock('inquirer', () => ({ default: { prompt: vi.fn() } }));
+
+import { program } from '../index';
+import axios from 'axios';
+
+const mockedAxios = vi.mocked(axios, true);
+const API = 'http://localhost:3000';
+const PROJECT = '33333333-3333-3333-3333-333333333333';
+const ITEM = '11111111-1111-1111-1111-111111111111';
+
+function resetCommanderOptions(cmd: any) {
+  const options = (cmd as any).options || [];
+  options.forEach((opt: any) => cmd.setOptionValue(opt.attributeName(), undefined));
+  (cmd.commands || []).forEach(resetCommanderOptions);
+}
+
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockExistsSync.mockReturnValue(false);
+  mockReadFileSync.mockReturnValue('{}');
+  program.commands.forEach(resetCommanderOptions);
+  program.setOptionValue('toon', undefined);
+  logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  vi.spyOn(process, 'exit').mockImplementation((() => undefined) as any);
+});
+
+const outputText = () =>
+  [...logSpy.mock.calls, ...errorSpy.mock.calls].map(c => c.join(' ')).join('\n');
+
+describe('agenfk create --jira-item', () => {
+  it('exposes a --jira-item option on create', () => {
+    const create = program.commands.find(c => c.name() === 'create');
+    expect(create).toBeDefined();
+    const flags = (create as any).options.map((o: any) => o.long);
+    expect(flags).toContain('--jira-item');
+  });
+
+  it('forwards the key as jiraItem on the create payload', async () => {
+    mockedAxios.post.mockResolvedValue({ data: { id: ITEM, title: 'T', externalId: 'CGLAB-163' } });
+
+    await program.parseAsync([
+      'node', 'agenfk', 'create', 'TASK', 'Fix the picker', '--project', PROJECT, '--jira-item', 'CGLAB-163',
+    ]);
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      `${API}/items`,
+      expect.objectContaining({ jiraItem: 'CGLAB-163' }),
+    );
+  });
+
+  it('forwards the value verbatim, leaving format validation to the server', async () => {
+    mockedAxios.post.mockResolvedValue({ data: { id: ITEM, title: 'T' } });
+
+    await program.parseAsync([
+      'node', 'agenfk', 'create', 'TASK', 'T', '--project', PROJECT, '--jira-item', 'cglab-163',
+    ]);
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      `${API}/items`,
+      expect.objectContaining({ jiraItem: 'cglab-163' }),
+    );
+  });
+
+  it('omits jiraItem from the payload entirely when the flag is not passed', async () => {
+    mockedAxios.post.mockResolvedValue({ data: { id: ITEM, title: 'T' } });
+
+    await program.parseAsync(['node', 'agenfk', 'create', 'TASK', 'T', '--project', PROJECT]);
+
+    const body = mockedAxios.post.mock.calls[0][1] as any;
+    expect(body).not.toHaveProperty('jiraItem');
+  });
+
+  it('reports the linked key on success, so the link is visible without a second lookup', async () => {
+    mockedAxios.post.mockResolvedValue({
+      data: { id: ITEM, title: 'T', externalId: 'CGLAB-163', externalUrl: 'https://x.atlassian.net/browse/CGLAB-163' },
+    });
+
+    await program.parseAsync([
+      'node', 'agenfk', 'create', 'TASK', 'T', '--project', PROJECT, '--jira-item', 'CGLAB-163',
+    ]);
+
+    expect(outputText()).toContain('CGLAB-163');
+  });
+
+  it("surfaces the server's rejection of a bad key instead of claiming success", async () => {
+    const err: any = new Error('Request failed with status code 400');
+    err.response = { data: { error: "Invalid JIRA item 'nope'." }, status: 400 };
+    mockedAxios.post.mockRejectedValue(err);
+
+    await program.parseAsync([
+      'node', 'agenfk', 'create', 'TASK', 'T', '--project', PROJECT, '--jira-item', 'nope',
+    ]);
+
+    expect(outputText()).toContain("Invalid JIRA item 'nope'.");
+    expect(outputText()).not.toMatch(/Created TASK/);
+  });
+
+  it('surfaces an unverified-link warning returned by the server', async () => {
+    mockedAxios.post.mockResolvedValue({
+      data: { id: ITEM, title: 'T', externalId: 'CGLAB-163', jiraWarning: "Linked 'CGLAB-163' without verifying it — JIRA could not be reached." },
+    });
+
+    await program.parseAsync([
+      'node', 'agenfk', 'create', 'TASK', 'T', '--project', PROJECT, '--jira-item', 'CGLAB-163',
+    ]);
+
+    expect(outputText()).toMatch(/without verifying/i);
+  });
+});
+
+describe('agenfk update --jira-item', () => {
+  it('exposes a --jira-item option on update', () => {
+    const update = program.commands.find(c => c.name() === 'update');
+    expect(update).toBeDefined();
+    const flags = (update as any).options.map((o: any) => o.long);
+    expect(flags).toContain('--jira-item');
+  });
+
+  it('PUTs jiraItem when linking an existing card', async () => {
+    mockedAxios.put.mockResolvedValue({ data: { id: ITEM, title: 'T', type: 'TASK', status: 'TODO', externalId: 'CGLAB-163' } });
+
+    await program.parseAsync(['node', 'agenfk', 'update', ITEM, '--jira-item', 'CGLAB-163']);
+
+    expect(mockedAxios.put).toHaveBeenCalledWith(
+      `${API}/items/${ITEM}`,
+      expect.objectContaining({ jiraItem: 'CGLAB-163' }),
+    );
+  });
+
+  it("forwards 'none' unchanged so the server performs the unlink", async () => {
+    mockedAxios.put.mockResolvedValue({ data: { id: ITEM, title: 'T', type: 'TASK', status: 'TODO', externalId: null } });
+
+    await program.parseAsync(['node', 'agenfk', 'update', ITEM, '--jira-item', 'none']);
+
+    expect(mockedAxios.put).toHaveBeenCalledWith(
+      `${API}/items/${ITEM}`,
+      expect.objectContaining({ jiraItem: 'none' }),
+    );
+  });
+
+  it('confirms the unlink, which is otherwise indistinguishable from the flag being ignored', async () => {
+    mockedAxios.put.mockResolvedValue({ data: { id: ITEM, title: 'T', type: 'TASK', status: 'TODO', externalId: null } });
+
+    await program.parseAsync(['node', 'agenfk', 'update', ITEM, '--jira-item', 'none']);
+
+    expect(outputText()).toMatch(/unlinked/i);
+  });
+
+  it('does not claim an unlink when no jira flag was passed', async () => {
+    mockedAxios.put.mockResolvedValue({ data: { id: ITEM, title: 'New', type: 'TASK', status: 'TODO' } });
+
+    await program.parseAsync(['node', 'agenfk', 'update', ITEM, '--title', 'New']);
+
+    expect(outputText()).not.toMatch(/unlinked/i);
+  });
+
+  it('says nothing about the tracker on an edit that never mentioned it', async () => {
+    // A card linked by the GitHub importer used to make every --title edit print
+    // 'JIRA: 4321' — wrong tracker, and noise on an unrelated change.
+    mockedAxios.put.mockResolvedValue({
+      data: { id: ITEM, title: 'New', type: 'TASK', status: 'TODO', externalId: '4321', externalUrl: 'https://github.com/o/r/issues/4321' },
+    });
+
+    await program.parseAsync(['node', 'agenfk', 'update', ITEM, '--title', 'New']);
+
+    expect(outputText()).not.toMatch(/JIRA:/);
+    expect(outputText()).not.toMatch(/GitHub:/);
+  });
+
+  it('names GitHub rather than JIRA when the reference is a GitHub issue', async () => {
+    mockedAxios.put.mockResolvedValue({
+      data: { id: ITEM, title: 'T', type: 'TASK', status: 'TODO', externalId: '4321', externalUrl: 'https://github.com/o/r/issues/4321' },
+    });
+
+    await program.parseAsync(['node', 'agenfk', 'update', ITEM, '--jira-item', 'CGLAB-163']);
+
+    expect(outputText()).toMatch(/GitHub: 4321/);
+  });
+
+  it("labels a JIRA link as JIRA even when 'github.com' appears in its query string", async () => {
+    // The label is taken from the HOST, not from a substring of the whole URL.
+    mockedAxios.put.mockResolvedValue({
+      data: { id: ITEM, title: 'T', type: 'TASK', status: 'TODO', externalId: 'CGLAB-163', externalUrl: 'https://cg-lab.atlassian.net/browse/CGLAB-163?ref=github.com' },
+    });
+
+    await program.parseAsync(['node', 'agenfk', 'update', ITEM, '--jira-item', 'CGLAB-163']);
+
+    expect(outputText()).toMatch(/JIRA: CGLAB-163/);
+    expect(outputText()).not.toMatch(/GitHub:/);
+  });
+
+  it('surfaces a jiraWarning on the UPDATE path too, not only on create', async () => {
+    mockedAxios.put.mockResolvedValue({
+      data: { id: ITEM, title: 'T', type: 'TASK', status: 'TODO', externalId: 'CGLAB-163', jiraWarning: "Linked 'CGLAB-163' without verifying it — JIRA could not be reached." },
+    });
+
+    await program.parseAsync(['node', 'agenfk', 'update', ITEM, '--jira-item', 'CGLAB-163']);
+
+    expect(outputText()).toMatch(/without verifying/i);
+  });
+
+  it('does not send jiraItem when updating something else, so an existing link survives a rename', async () => {
+    mockedAxios.put.mockResolvedValue({ data: { id: ITEM, title: 'New', type: 'TASK', status: 'TODO', externalId: 'CGLAB-163' } });
+
+    await program.parseAsync(['node', 'agenfk', 'update', ITEM, '--title', 'New']);
+
+    const body = mockedAxios.put.mock.calls[0][1] as any;
+    expect(body).not.toHaveProperty('jiraItem');
+  });
+
+  it("surfaces the server's rejection rather than reporting an update that did not happen", async () => {
+    const err: any = new Error('Request failed with status code 400');
+    err.response = { data: { error: "JIRA item 'CGLAB-99999' could not be found" }, status: 400 };
+    mockedAxios.put.mockRejectedValue(err);
+
+    await program.parseAsync(['node', 'agenfk', 'update', ITEM, '--jira-item', 'CGLAB-99999']);
+
+    expect(outputText()).toContain("could not be found");
+  });
+
+  it('resolves a short item id before sending the link', async () => {
+    mockedAxios.get.mockResolvedValue({ data: [{ id: ITEM, title: 'T' }] });
+    mockedAxios.put.mockResolvedValue({ data: { id: ITEM, title: 'T', type: 'TASK', status: 'TODO', externalId: 'CGLAB-163' } });
+
+    await program.parseAsync(['node', 'agenfk', 'update', '11111111', '--jira-item', 'CGLAB-163']);
+
+    expect(mockedAxios.put).toHaveBeenCalledWith(
+      `${API}/items/${ITEM}`,
+      expect.objectContaining({ jiraItem: 'CGLAB-163' }),
+    );
+  });
+});

--- a/packages/cli/src/test/rule-bundle-parity.test.ts
+++ b/packages/cli/src/test/rule-bundle-parity.test.ts
@@ -1,0 +1,146 @@
+/**
+ * The per-client rule bundles must describe the SAME command surface.
+ *
+ * The installer copies one bundle per client — clauderules/CLAUDE.md,
+ * codexrules/AGENTS.md, geminirules/GEMINI.md, cursorrules/agenfk.mdc — and
+ * each is the entire contract its agent reads. They are maintained by hand, so
+ * they drift: a flag added to the table an author happens to have open is
+ * invisible to every other client, and the agent there simply never uses it.
+ *
+ * That is not hypothetical. When this test was written, `agenfk list --active`
+ * was documented only for Claude, while the initialization procedure in ALL
+ * FOUR bundles instructs the agent to run `--active` to keep its context small.
+ * Codex, Gemini and Cursor agents were being told to use a flag their own
+ * command reference did not list.
+ *
+ * This pins the invariant rather than the prose: whatever the tables say, they
+ * must say the same thing everywhere. It deliberately does NOT assert that any
+ * particular feature is mentioned — a test that greps docs for a phrase pins
+ * nothing and rots immediately.
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+
+const BUNDLES: Record<string, string> = {
+  'clauderules/CLAUDE.md': 'Claude Code',
+  'codexrules/AGENTS.md': 'Codex',
+  'geminirules/GEMINI.md': 'Gemini',
+  'cursorrules/agenfk.mdc': 'Cursor',
+};
+
+/**
+ * Pull the `agenfk …` invocations out of a bundle's command-reference tables.
+ * Keyed by the row label so a mismatch names the row that drifted, not an
+ * anonymous string difference.
+ */
+function commandRows(file: string): Map<string, string> {
+  const text = fs.readFileSync(path.join(REPO_ROOT, file), 'utf8');
+  const rows = new Map<string, string>();
+  for (const line of text.split('\n')) {
+    const m = line.match(/^\|\s*([^|]+?)\s*\|/);
+    if (!m) continue;
+    // ALL backticked invocations on the row, not just the first: several rows
+    // list more than one (`agenfk skills install … · agenfk skills uninstall …`)
+    // and comparing only the first hid drift in the rest.
+    const invocations = [...line.matchAll(/`(agenfk [^`]+)`/g)].map(x => x[1].replace(/\s+/g, ' ').trim());
+    if (invocations.length) rows.set(m[1], invocations.join(' · '));
+  }
+  return rows;
+}
+
+/** Long-form flags, including ones carrying digits or capitals — the previous
+ *  /--[a-z][a-z-]*​/ silently ignored those. */
+const FLAG_PATTERN = /--[A-Za-z][A-Za-z0-9-]*/g;
+
+/** A row may document several commands, joined by ' · '. */
+const invocationsOf = (row: string): string[] => row.split(' · ');
+
+/** 'agenfk flow show …' -> 'flow show' is not needed; the first word after
+ *  'agenfk' is what the option lookup keys on. */
+const commandNameOf = (invocation: string): string => invocation.split(/\s+/)[1] ?? '';
+
+describe('per-client rule bundle parity', () => {
+  const files = Object.keys(BUNDLES);
+
+  it.each(files)('%s exposes a command reference table', (file) => {
+    expect(commandRows(file).size).toBeGreaterThan(20);
+  });
+
+  it('every bundle documents the same set of commands', () => {
+    const reference = commandRows(files[0]);
+    for (const file of files.slice(1)) {
+      const rows = commandRows(file);
+      const missing = [...reference.keys()].filter(k => !rows.has(k));
+      const extra = [...rows.keys()].filter(k => !reference.has(k));
+      expect({ file, missing, extra }).toEqual({ file, missing: [], extra: [] });
+    }
+  });
+
+  it('every bundle documents each command with the same flags', () => {
+    const reference = commandRows(files[0]);
+    for (const file of files.slice(1)) {
+      const rows = commandRows(file);
+      for (const [label, invocation] of reference) {
+        expect(`${file} :: ${label} :: ${rows.get(label)}`).toBe(`${file} :: ${label} :: ${invocation}`);
+      }
+    }
+  });
+
+  it('documents every user-facing flag the CLI implements on create/update', async () => {
+    // The reverse direction of the check below, and the one that makes this
+    // file able to fail when a shipped capability is left out of the agent
+    // instructions — which is the whole point of the bundles. Anchored to the
+    // real commander definitions, so it is not a grep for a phrase: add a flag
+    // to the CLI and every bundle must document it or this fails.
+    const { program } = await import('../index');
+    const flagsOf = (name: string) =>
+      ((program.commands.find(c => c.name() === name) as any)?.options ?? [])
+        .map((o: any) => o.long)
+        .filter(Boolean);
+
+    for (const file of files) {
+      const rows = [...commandRows(file).values()];
+      for (const command of ['create', 'update']) {
+        // Only the rows that actually document THIS command. Joining every row
+        // meant documenting --jira-item on the `list` row would have passed.
+        const documented = rows.filter(r => invocationsOf(r).some(i => commandNameOf(i) === command)).join(' ');
+        for (const flag of flagsOf(command)) {
+          expect({ file, command, flag, documented: documented.includes(flag) })
+            .toEqual({ file, command, flag, documented: true });
+        }
+      }
+    }
+  });
+
+  it('documents no flag on create/update that the CLI does not actually implement', async () => {
+    // Ties the tables to the real command surface: a documented flag that does
+    // not exist sends every agent down a path that errors out.
+    const { program } = await import('../index');
+    const realFlags = (name: string) =>
+      new Set(
+        ((program.commands.find(c => c.name() === name) as any)?.options ?? [])
+          .map((o: any) => o.long)
+          .filter(Boolean),
+      );
+
+    for (const file of files) {
+      const rows = commandRows(file);
+      for (const [label, invocation] of rows) {
+        // Per invocation, not per row: a row may join several commands with
+        // '·', and scanning the whole joined string attributed one command's
+        // flags to another.
+        for (const single of invocationsOf(invocation)) {
+          const commandName = commandNameOf(single);
+          if (commandName !== 'create' && commandName !== 'update') continue;
+          const documented = single.match(FLAG_PATTERN) ?? [];
+          const actual = realFlags(commandName);
+          const bogus = documented.filter(f => !actual.has(f));
+          expect({ file, label, bogus }).toEqual({ file, label, bogus: [] });
+        }
+      }
+    }
+  });
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/core",
-  "version": "1.1.19-beta.2",
+  "version": "1.1.19-beta.3",
   "description": "Core logic and interfaces for the AgenFK Engineering Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -197,8 +197,8 @@ export interface BaseItem {
   previousStatus?: Status; // To restore status after unarchiving
   implementationPlan?: string; // Markdown implementation plan
   sortOrder?: number; // Position within column for prioritization
-  externalId?: string; // Reference to external systems (e.g. JIRA key)
-  externalUrl?: string; // Link to external system
+  externalId?: string | null; // Reference to external systems (e.g. JIRA key); null clears it
+  externalUrl?: string | null; // Link to external system; null clears it
   branchName?: string; // Git branch associated with this item
   prUrl?: string; // Pull request URL
   prNumber?: number; // Pull request number

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenfk",
-  "version": "1.1.19-beta.2",
+  "version": "1.1.19-beta.3",
   "description": "AgenFK Agentic Engineering Framework — installer",
   "bin": {
     "agenfk": "bin/agenfk.js"

--- a/packages/flow-editor/package.json
+++ b/packages/flow-editor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agenfk/flow-editor",
   "private": true,
-  "version": "1.1.19-beta.2",
+  "version": "1.1.19-beta.3",
   "type": "module",
   "main": "./src/index.ts",
   "exports": {

--- a/packages/hub-ui/package.json
+++ b/packages/hub-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hub-ui",
   "private": true,
-  "version": "1.1.19-beta.2",
+  "version": "1.1.19-beta.3",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.1.19-beta.2",
+    "@agenfk/flow-editor": "1.1.19-beta.3",
     "@fontsource-variable/jetbrains-mono": "^5.3.0",
     "@fontsource-variable/manrope": "^5.3.0",
     "@tailwindcss/postcss": "^4.3.3",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/hub",
-  "version": "1.1.19-beta.2",
+  "version": "1.1.19-beta.3",
   "description": "Corporate Hub for AgEnFK — fleet-wide metrics + timeline server",
   "main": "dist/server.js",
   "types": "dist/server.d.ts",
@@ -20,7 +20,7 @@
     "start": "node dist/bin.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.19-beta.2",
+    "@agenfk/core": "1.1.19-beta.3",
     "axios": "^1.20.0",
     "bcryptjs": "^2.4.3",
     "cookie-parser": "^1.4.7",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/server",
-  "version": "1.1.19-beta.2",
+  "version": "1.1.19-beta.3",
   "description": "MCP Server for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -12,9 +12,9 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agenfk/core": "1.1.19-beta.2",
-    "@agenfk/storage-sqlite": "1.1.19-beta.2",
-    "@agenfk/telemetry": "1.1.19-beta.2",
+    "@agenfk/core": "1.1.19-beta.3",
+    "@agenfk/storage-sqlite": "1.1.19-beta.3",
+    "@agenfk/telemetry": "1.1.19-beta.3",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "axios": "^1.20.0",
     "body-parser": "^2.3.0",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -143,6 +143,9 @@ const CreateItemSchema = z.object({
   parentId: z.string().optional(),
   status: z.string().optional(),
   implementationPlan: z.string().optional(),
+  // Link the new card to a JIRA item by key (e.g. "CGLAB-163"). Validated
+  // server-side by the REST route this proxies to.
+  jiraItem: z.string().optional(),
 });
 
 const UpdateItemSchema = z.object({
@@ -155,6 +158,10 @@ const UpdateItemSchema = z.object({
   // match and cycles.
   parentId: z.string().nullable().optional(),
   implementationPlan: z.string().optional(),
+  // JIRA issue key to link, or "none" to unlink. zod strips unknown keys, so
+  // without this the MCP surface silently could not link at all — and this repo
+  // documents the CLI and MCP surfaces as interchangeable.
+  jiraItem: z.string().optional(),
 });
 
 const ListItemsSchema = z.object({
@@ -265,6 +272,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             parentId: { type: "string" },
             status: { type: "string", description: "Step name from the project's active flow. Call get_flow(projectId) for valid step names." },
             implementationPlan: { type: "string" },
+            jiraItem: { type: "string", description: "JIRA issue key to link this card to, e.g. 'CGLAB-163'. Reference only: the card keeps its own title and description. Validated against JIRA when connected, format-checked when not." },
           },
           required: ["projectId", "type", "title"],
         },
@@ -282,6 +290,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             type: { type: "string", enum: ["EPIC", "STORY", "TASK", "BUG"] },
             parentId: { type: ["string", "null"], description: "Re-parent the item under this id; null detaches it to top level." },
             implementationPlan: { type: "string" },
+            jiraItem: { type: "string", description: "JIRA issue key to link this card to, e.g. 'CGLAB-163'; pass 'none' to unlink. Reference only: the card keeps its own title and description. Omit to leave any existing link untouched." },
           },
           required: ["id"],
         },

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -2362,6 +2362,305 @@ function sanitizeCreateStatus(status: any, flow: { steps: Array<{ name: string; 
   return match ? (match.name as Status) : Status.TODO;
 }
 
+// ── External tracker references (JIRA keys, and raw refs for other trackers) ──
+//
+// externalId/externalUrl have lived on AgEnFKItem since the JIRA importer, and
+// the UI renders them as a clickable badge, but until now ONLY the JIRA and
+// GitHub imports could write them — the item routes destructured a fixed field
+// list that omitted both. These helpers are what let a plain create/update
+// attach a reference, and they are the only validation standing in front of it.
+
+/** Passed as `jiraItem` to clear an existing link. Safe as a sentinel because a
+ *  bare word with no `-<number>` suffix can never be a valid issue key, so no
+ *  real project can collide with it — see parseJiraKey. */
+export const JIRA_UNLINK_SENTINEL = 'none';
+
+/**
+ * Strict JIRA issue-key parser, returning the canonical uppercase form or null.
+ *
+ * Anchored deliberately: an embedded key (a browse URL, or prose mentioning an
+ * issue) is REJECTED rather than extracted, because silently pulling a key out
+ * of arbitrary text turns a paste mistake into a wrong-but-plausible link. On
+ * the disconnected path this format check is the only gate there is.
+ */
+export const parseJiraKey = (raw: unknown): string | null => {
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  // Bounded FIRST. The grammar below is anchored but not finite — a 5000-char
+  // project key or a 400-digit issue number matches it — and this value becomes
+  // the item's externalId, part of the derived browse URL, and part of an
+  // outbound api.atlassian.com path. The raw-field branches cap their inputs;
+  // without this, `jiraItem` was the way around both caps.
+  if (trimmed.length > MAX_JIRA_KEY_LENGTH) return null;
+  // Matched BEFORE upper-casing and against explicit ASCII classes, because
+  // toUpperCase() folds non-ASCII into ASCII — 'ﬀ-1' would otherwise become the
+  // accepted 'FF-1'. The project key must start AND end alphanumeric, so the
+  // underscore can only appear between them: 'A_-1' is not a key JIRA issues.
+  // The issue number is a positive integer with no leading zeros: JIRA numbers
+  // issues from 1, and 'AB-007' would be a second spelling of 'AB-7', so two
+  // cards could carry different externalIds for one issue.
+  if (!/^[A-Za-z][A-Za-z0-9_]*[A-Za-z0-9]-[1-9]\d*$/.test(trimmed)) return null;
+  return trimmed.toUpperCase();
+};
+
+/** Upper bounds on a stored reference. Items persist as a whole-object JSON blob
+ *  (storage-sqlite), so an unbounded string here bloats every read of the item. */
+export const MAX_EXTERNAL_ID_LENGTH = 200;
+export const MAX_EXTERNAL_URL_LENGTH = 2048;
+/** Real JIRA keys are short (project key <= 10 chars by Atlassian's own limit).
+ *  This is deliberately generous while still finite. */
+export const MAX_JIRA_KEY_LENGTH = 64;
+
+/**
+ * externalUrl is rendered as `href={item.externalUrl}` by both KanbanBoard.tsx
+ * and CardDetailModal.tsx with no sanitising, so an attacker-supplied
+ * `javascript:` or `data:` URL stored here is a stored-XSS trigger on click.
+ * The server is the only place that can refuse it. http(s) only.
+ *
+ * Length is bounded separately, by the caller that accepts user-supplied URLs,
+ * so an over-long URL is reported as over-long rather than as an unsafe scheme.
+ * The internally derived browse URL is bounded at its source instead: the key
+ * is capped by MAX_JIRA_KEY_LENGTH and cloudUrl comes from the OAuth token.
+ */
+export const isSafeExternalUrl = (value: string): boolean => {
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
+    // `http://user:pass@evil.com` is a well-formed http URL, and as a board
+    // badge it is a credential-embedding phishing href. Nothing legitimate
+    // needs userinfo in a tracker link.
+    if (parsed.username || parsed.password) return false;
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/** Does this URL look like a JIRA browse link for exactly this key? Used to
+ *  decide whether a URL already on the card still describes the key being
+ *  linked. It is a shape check, not a provenance check — it cannot tell a
+ *  server-derived URL from a caller-supplied one. */
+export const isJiraBrowseUrlFor = (value: string, key: string): boolean => {
+  if (!isSafeExternalUrl(value)) return false;
+  try {
+    const parsed = new URL(value);
+    // Path only — the HOST is deliberately not checked, because this runs on
+    // the disconnected path where there is no token and therefore no known
+    // JIRA host to compare against. Stated plainly so nobody reads this as a
+    // host guarantee: it does NOT verify the URL points at a real JIRA site.
+    //
+    // What bounds the risk is that this branch only ever RETAINS a URL already
+    // stored on the card; it cannot introduce one. A caller able to plant
+    // https://evil.example/browse/KEY can already do so directly via the raw
+    // externalUrl field, which is an intentional capability for non-JIRA
+    // trackers, and the server binds loopback only.
+    //
+    // Matched on SEGMENTS, decoded one at a time — not on the decoded whole
+    // path. Decoding first and then comparing lets '%2F' smuggle a separator in,
+    // so '/x%2Fbrowse%2FKEY' (a single real segment) would read as a browse
+    // path. Per-segment decoding keeps '%2D' working as a spelling of '-' while
+    // '%2F' stays inside one segment and simply fails to match.
+    //
+    // The last two segments must be 'browse' and the key, which tolerates a
+    // context path ('/jira/browse/KEY' on JIRA Server/DC).
+    const segments = parsed.pathname.split('/').map(decodeURIComponent);
+    // A trailing slash leaves an empty final segment ('/browse/KEY/'), which
+    // would otherwise fail to match and silently drop a usable stored URL.
+    while (segments.length && segments[segments.length - 1] === '') segments.pop();
+    if (segments.length < 2) return false;
+    const last = segments[segments.length - 1].toUpperCase();
+    const penultimate = segments[segments.length - 2].toUpperCase();
+    return penultimate === 'BROWSE' && last === key.toUpperCase();
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Echo a rejected value back safely.
+ *
+ * `String(raw)` looks harmless but THROWS on an object with null toString and
+ * valueOf, which turned the clean-rejection path into a 500. And the echo is
+ * caller-controlled: unbounded it returns megabytes in the error body (and,
+ * through bulk, once per entry), and raw control bytes reach the operator's
+ * terminal, so it is truncated and stripped.
+ */
+export const describeRejectedInput = (raw: unknown): string => {
+  let text: string;
+  if (typeof raw === 'string') text = raw;
+  else {
+    try {
+      text = JSON.stringify(raw) ?? Object.prototype.toString.call(raw);
+    } catch {
+      text = Object.prototype.toString.call(raw);
+    }
+  }
+  // eslint-disable-next-line no-control-regex
+  const printable = text.replace(/[\u0000-\u001f\u007f]/g, '');
+  // Array.from, not slice: slice cuts UTF-16 code units and would emit a lone
+  // surrogate into the JSON error body for input ending in astral characters.
+  const chars = Array.from(printable);
+  return chars.length > 80 ? `${chars.slice(0, 80).join('')}…` : printable;
+};
+
+type JiraResolution =
+  | { kind: 'unlink' }
+  | { kind: 'link'; externalId: string; externalUrl: string | null; warning?: string }
+  | { kind: 'error'; error: string };
+
+// No JIRA call may hang a create/update behind an unresponsive Atlassian, so
+// every outbound call on the linking path is bounded — the API request helper
+// set no timeout of its own, and neither did the token refresh it falls back to
+// on a 401, which is the path that could stall unbounded.
+export const JIRA_HTTP_TIMEOUT_MS = 8000;
+
+/**
+ * Resolve a `jiraItem` value into the reference pair to store.
+ *
+ * Validate-if-connected: with an OAuth token present the key is confirmed
+ * against JIRA and the browse URL is derived from the token's cloudUrl; a key
+ * JIRA refuses (404/403) is rejected outright. Without a token — the offline
+ * and CI case — the format-checked key is stored bare, with no URL to invent.
+ * If JIRA is merely unreachable the link still goes through, but it comes back
+ * with a warning: an unverified link is a fact the caller must be told, not a
+ * failure to swallow.
+ */
+export const resolveJiraReference = async (
+  raw: unknown,
+  current?: { externalId?: string | null; externalUrl?: string | null },
+): Promise<JiraResolution> => {
+  if (typeof raw === 'string' && raw.trim().toLowerCase() === JIRA_UNLINK_SENTINEL) {
+    return { kind: 'unlink' };
+  }
+
+  const key = parseJiraKey(raw);
+  if (!key) {
+    return {
+      kind: 'error',
+      error: `Invalid JIRA item '${describeRejectedInput(raw)}'. Expected an issue key like 'CGLAB-163', or '${JIRA_UNLINK_SENTINEL}' to unlink.`,
+    };
+  }
+
+  const tokenData = loadJiraToken();
+  if (!tokenData) {
+    // Disconnected: the key is all we can honestly assert. But re-linking the
+    // SAME key while offline must not destroy the URL already on the card —
+    // that would silently strip the badge's href.
+    //
+    // Compared case-insensitively because `key` is normalised to upper case
+    // while a raw externalId is stored verbatim, so 'cglab-163' on the card
+    // would otherwise not match 'CGLAB-163' and the URL would be dropped.
+    //
+    // NOTE on provenance: the item carries no record of whether its stored URL
+    // was derived from a JIRA token or supplied raw by a caller, so this cannot
+    // claim the URL was ever "verified" — only that it is the URL already on
+    // the card and that it is shaped like a browse link for this exact key.
+    // That shape check is why a leftover URL for a DIFFERENT issue is dropped.
+    const sameKey = (current?.externalId ?? '').trim().toUpperCase() === key;
+    const keepUrl =
+      sameKey && current?.externalUrl && isJiraBrowseUrlFor(current.externalUrl, key)
+        ? current.externalUrl
+        : null;
+    return { kind: 'link', externalId: key, externalUrl: keepUrl };
+  }
+
+  const rawBrowseUrl = `${tokenData.cloudUrl}/browse/${key}`;
+  // The derived URL is stored and rendered as an href like any other, so it
+  // goes through the same guard. cloudUrl comes from the OAuth resource list
+  // unchecked, so a resource without a url yields the literal
+  // 'undefined/browse/KEY' — which is not a URL at all, and must not be stored.
+  const browseUrl = isSafeExternalUrl(rawBrowseUrl) ? rawBrowseUrl : null;
+  try {
+    await jiraApiRequest(
+      tokenData,
+      'get',
+      `https://api.atlassian.com/ex/jira/${tokenData.cloudId}/rest/api/3/issue/${encodeURIComponent(key)}?fields=summary`,
+      undefined,
+      JIRA_HTTP_TIMEOUT_MS,
+    );
+    return { kind: 'link', externalId: key, externalUrl: browseUrl };
+  } catch (err: any) {
+    const status = err?.response?.status;
+    if (status === 404 || status === 403 || status === 400) {
+      return {
+        kind: 'error',
+        error: `JIRA item '${key}' could not be found or is not readable with the connected account (HTTP ${status}).`,
+      };
+    }
+    // Transport failure, 5xx, expired refresh: the key is well-formed and JIRA
+    // simply could not answer. Link, but say so.
+    return {
+      kind: 'link',
+      externalId: key,
+      externalUrl: browseUrl,
+      warning: `Linked '${key}' without verifying it — JIRA could not be reached (${err?.code || err?.message || 'unknown error'}).`,
+    };
+  }
+};
+
+/** Attach an unverified-link warning to a response body, when there is one.
+ *  Both item write paths need this, and the shape must stay identical between
+ *  them so a client can read `jiraWarning` without caring which route ran. */
+export const withJiraWarning = <T extends object>(payload: T, warning?: string): T =>
+  warning ? { ...payload, jiraWarning: warning } : payload;
+
+/**
+ * Shared create/update handling for the reference fields. Returns the updates to
+ * apply (possibly nulls, to clear), or an error string for a 400.
+ */
+export const buildExternalRefUpdates = async (
+  body: any,
+  current?: { externalId?: string | null; externalUrl?: string | null },
+): Promise<{ error: string } | { updates: Record<string, any>; warning?: string }> => {
+  const updates: Record<string, any> = {};
+  let warning: string | undefined;
+
+  if (body.jiraItem !== undefined) {
+    const resolved = await resolveJiraReference(body.jiraItem, current);
+    if (resolved.kind === 'error') return { error: resolved.error };
+    if (resolved.kind === 'unlink') {
+      updates.externalId = null;
+      updates.externalUrl = null;
+    } else {
+      updates.externalId = resolved.externalId;
+      updates.externalUrl = resolved.externalUrl;
+      warning = resolved.warning;
+    }
+    // A validated key is authoritative: a conflicting raw externalId in the same
+    // payload must not be able to overwrite it below.
+    return { updates, warning };
+  }
+
+  if (body.externalId !== undefined) {
+    if (body.externalId === null || body.externalId === '') {
+      updates.externalId = null;
+    } else if (typeof body.externalId !== 'string') {
+      // String() would have turned an object into the literal '[object Object]'
+      // and stored it as the card's tracker id.
+      return { error: `Invalid externalId. Expected a string.` };
+    } else if (body.externalId.length > MAX_EXTERNAL_ID_LENGTH) {
+      return { error: `Invalid externalId. Maximum length is ${MAX_EXTERNAL_ID_LENGTH} characters.` };
+    } else {
+      updates.externalId = body.externalId;
+    }
+  }
+  if (body.externalUrl !== undefined) {
+    if (body.externalUrl === null || body.externalUrl === '') {
+      updates.externalUrl = null;
+    } else if (typeof body.externalUrl !== 'string') {
+      return { error: `Invalid externalUrl. Expected a string.` };
+    } else if (body.externalUrl.length > MAX_EXTERNAL_URL_LENGTH) {
+      return { error: `Invalid externalUrl. Maximum length is ${MAX_EXTERNAL_URL_LENGTH} characters.` };
+    } else if (!isSafeExternalUrl(body.externalUrl)) {
+      return { error: `Invalid externalUrl. Only http(s) URLs without embedded credentials are allowed.` };
+    } else {
+      updates.externalUrl = body.externalUrl;
+    }
+  }
+
+  return { updates, warning };
+};
+
 app.post("/items", asyncHandler(async (req: any, res: any) => {
   console.log(`[API_DEBUG] POST /items body keys: ${Object.keys(req.body).join(', ')}`);
   const { type, title, description, parentId, status, implementationPlan, projectId } = req.body;
@@ -2384,6 +2683,11 @@ app.post("/items", asyncHandler(async (req: any, res: any) => {
 
   const createParentError = await validateParentAssignment(null, projectId, parentId);
   if (createParentError) return res.status(400).json({ error: createParentError });
+
+  // Resolve the tracker reference BEFORE minting the item: a bad key must leave
+  // nothing behind, not create a card and then fail.
+  const externalRef = await buildExternalRefUpdates(req.body);
+  if ('error' in externalRef) return res.status(400).json({ error: externalRef.error });
 
   const newItem: AgEnFKItem = {
     id: uuidv4(),
@@ -2410,6 +2714,12 @@ app.post("/items", asyncHandler(async (req: any, res: any) => {
     (newItem as any).severity = "LOW";
   }
 
+  // On a brand-new item an unlink is a no-op — there is no prior reference to
+  // clear — so only real values are carried over, leaving the fields absent
+  // rather than explicitly null.
+  if (externalRef.updates.externalId) (newItem as any).externalId = externalRef.updates.externalId;
+  if (externalRef.updates.externalUrl) (newItem as any).externalUrl = externalRef.updates.externalUrl;
+
   const created = await storage.createItem(newItem);
   const timestamp = new Date().toISOString();
   console.log(`[${timestamp}] [API_CREATE] Item created: ${created.id} (${created.title}). Broadcasting refresh...`);
@@ -2430,7 +2740,7 @@ app.post("/items", asyncHandler(async (req: any, res: any) => {
     await syncParentStatus(created.parentId);
   }
 
-  res.status(201).json(created);
+  res.status(201).json(withJiraWarning(created, externalRef.warning));
 }));
 
 app.post("/items/bulk", asyncHandler(async (req: any, res: any) => {
@@ -2445,6 +2755,8 @@ app.post("/items/bulk", asyncHandler(async (req: any, res: any) => {
   // Rejected entries are reported back rather than silently dropped — the route
   // already `continue`s past unknown ids, which hides mistakes.
   const skipped: Array<{ id: string; error: string }> = [];
+  // Separate from `skipped`: these entries DID apply, with a caveat.
+  const warnings: Array<{ id: string; warning: string }> = [];
   const parentIdsToSync = new Set<string>();
   const projectIds = new Set<string>();
 
@@ -2475,15 +2787,40 @@ app.post("/items/bulk", asyncHandler(async (req: any, res: any) => {
       }
     }
 
+    // Resolved ABOVE the archive/unarchive `continue`s below. Those branches
+    // skip the rest of the loop, so a reference resolved after them was dropped
+    // on exactly those entries — a 200 with no link written and nothing in
+    // `skipped`, and a MALFORMED key accepted in silence. This is the same
+    // mistake PUT /items/:id had, so it gets the same fix.
+    const bulkRef = await buildExternalRefUpdates(bodyUpdates, currentItem as any);
+    if ('error' in bulkRef) {
+      skipped.push({ id, error: bulkRef.error });
+      continue;
+    }
+    const bulkRefUpdates = bulkRef.updates as any;
+    const hasBulkRef = Object.keys(bulkRefUpdates).length > 0;
+    // A bulk link made while JIRA was unreachable is written UNVERIFIED, and the
+    // caller has to be told. Reported through its OWN channel rather than
+    // through `skipped`: an entry in `skipped` means "this did not happen", and
+    // an unverified link DID happen. Emitted by noteUnverifiedLink() only after
+    // the write commits — pushing it here would claim a link on the entries that
+    // are later abandoned by the parent guard or by a failed write.
+    const noteUnverifiedLink = () => {
+      if (bulkRef.warning) warnings.push({ id, warning: bulkRef.warning });
+    };
+
     if (status === Status.ARCHIVED && currentItem.status !== Status.ARCHIVED) {
       await archiveRecursively(id);
+      if (hasBulkRef) await storage.updateItem(id, bulkRefUpdates);
+      noteUnverifiedLink();
       if (currentItem.parentId) parentIdsToSync.add(currentItem.parentId);
       continue;
     }
 
     if (status !== undefined && status !== Status.ARCHIVED && currentItem.status === Status.ARCHIVED) {
       await unarchiveRecursively(id);
-      await storage.updateItem(id, { status: status as Status });
+      await storage.updateItem(id, { status: status as Status, ...bulkRefUpdates });
+      noteUnverifiedLink();
       continue;
     }
 
@@ -2506,9 +2843,12 @@ app.post("/items/bulk", asyncHandler(async (req: any, res: any) => {
     if (comments !== undefined) updates.comments = comments;
     if (sortOrder !== undefined) updates.sortOrder = sortOrder;
 
+    Object.assign(updates, bulkRef.updates);
+
     try {
       const updated = await storage.updateItem(id, updates);
       results.push(updated);
+      noteUnverifiedLink();
       projectIds.add(updated.projectId);
 
       if (updated.parentId) {
@@ -2529,7 +2869,10 @@ app.post("/items/bulk", asyncHandler(async (req: any, res: any) => {
         }
       }
     } catch (e) {
+      // Previously swallowed entirely, so a failed write looked like a success
+      // to the caller. Reported now that there is a channel for it.
       console.error(`[API_BULK] Error updating ${id}:`, e);
+      skipped.push({ id, error: `Update failed: ${(e as any)?.message ?? 'unknown error'}` });
     }
   }
 
@@ -2542,8 +2885,14 @@ app.post("/items/bulk", asyncHandler(async (req: any, res: any) => {
     await syncParentStatus(parentId);
   }
 
-  // `skipped` is additive — existing callers read `results` only.
-  res.json(skipped.length > 0 ? { results, skipped } : { results });
+  // `skipped` and `warnings` are both additive — existing callers read `results`
+  // only. They mean different things: `skipped` did not apply, `warnings` did
+  // apply but with a caveat (an unverified JIRA link).
+  res.json({
+    results,
+    ...(skipped.length > 0 ? { skipped } : {}),
+    ...(warnings.length > 0 ? { warnings } : {}),
+  });
 }));
 
 app.put("/items/:id", asyncHandler(async (req: any, res: any) => {
@@ -2579,20 +2928,6 @@ app.put("/items/:id", asyncHandler(async (req: any, res: any) => {
     }
   }
 
-  if (status === Status.ARCHIVED && currentItem.status !== Status.ARCHIVED) {
-    await archiveRecursively(req.params.id);
-    io.emit('items_updated');
-    if (currentItem.parentId) await syncParentStatus(currentItem.parentId);
-    return res.json(await storage.getItem(req.params.id));
-  }
-
-  if (status !== undefined && status !== Status.ARCHIVED && currentItem.status === Status.ARCHIVED) {
-    await unarchiveRecursively(req.params.id);
-    await storage.updateItem(req.params.id, { status: status as Status });
-    io.emit('items_updated');
-    return res.json(await storage.getItem(req.params.id));
-  }
-
   // Validate type change
   if (type !== undefined) {
     const validTypes = Object.values(ItemType);
@@ -2616,6 +2951,42 @@ app.put("/items/:id", asyncHandler(async (req: any, res: any) => {
   const parentError = await validateParentAssignment(req.params.id, currentItem.projectId, parentId);
   if (parentError) return res.status(400).json({ error: parentError });
 
+  // Resolved AFTER the cheap local guards above, so a request already doomed by
+  // a bad type or parent never spends a live JIRA round-trip, and ABOVE the
+  // archive/unarchive early returns, because those returns used to skip the
+  // reference entirely: `--status ARCHIVED --jira-item X`
+  // answered 200 having written no link, and a MALFORMED key answered 200 instead
+  // of 400. Validation has to happen on every path that can answer success.
+  const externalRef = await buildExternalRefUpdates(req.body, currentItem as any);
+  if ('error' in externalRef) return res.status(400).json({ error: externalRef.error });
+  const hasExternalRefUpdate = Object.keys(externalRef.updates).length > 0;
+
+  // Both archive branches answer with the freshly-read item plus any
+  // unverified-link warning. Written once so the two cannot drift — the warning
+  // was originally dropped on exactly these paths.
+  const respondWithStoredItem = async () => {
+    const stored = await storage.getItem(req.params.id);
+    // Deleted between the archive write and this read: answer 404 rather than
+    // spreading null into an object and returning a 200 carrying only a warning.
+    if (!stored) return res.status(404).json({ error: "Item not found" });
+    return res.json(withJiraWarning(stored as any, externalRef.warning));
+  };
+
+  if (status === Status.ARCHIVED && currentItem.status !== Status.ARCHIVED) {
+    await archiveRecursively(req.params.id);
+    if (hasExternalRefUpdate) await storage.updateItem(req.params.id, externalRef.updates as any);
+    io.emit('items_updated');
+    if (currentItem.parentId) await syncParentStatus(currentItem.parentId);
+    return respondWithStoredItem();
+  }
+
+  if (status !== undefined && status !== Status.ARCHIVED && currentItem.status === Status.ARCHIVED) {
+    await unarchiveRecursively(req.params.id);
+    await storage.updateItem(req.params.id, { status: status as Status, ...(externalRef.updates as any) });
+    io.emit('items_updated');
+    return respondWithStoredItem();
+  }
+
   const updates: any = {};
   if (title !== undefined) updates.title = title;
   if (description !== undefined) updates.description = description;
@@ -2633,6 +3004,7 @@ app.put("/items/:id", asyncHandler(async (req: any, res: any) => {
   if (prUrl !== undefined) updates.prUrl = prUrl;
   if (prNumber !== undefined) updates.prNumber = prNumber;
   if (prStatus !== undefined) updates.prStatus = prStatus;
+  Object.assign(updates, externalRef.updates);
 
   try {
     const updated = await storage.updateItem(req.params.id, updates);
@@ -2699,7 +3071,7 @@ app.put("/items/:id", asyncHandler(async (req: any, res: any) => {
         }
       }
 
-    res.json(updated);
+    res.json(withJiraWarning(updated, externalRef.warning));
   } catch (error) {
     res.status(404).json({ error: "Item not found" });
   }
@@ -3526,7 +3898,7 @@ const refreshJiraToken = async (tokenData: JiraTokenData): Promise<JiraTokenData
         client_id: clientId,
         client_secret: clientSecret,
         refresh_token: tokenData.refresh_token,
-      });
+      }, { timeout: JIRA_HTTP_TIMEOUT_MS });
       const updated: JiraTokenData = {
         ...tokenData,
         access_token: data.access_token,
@@ -3550,10 +3922,17 @@ const jiraApiRequest = async (
   tokenData: JiraTokenData,
   method: string,
   url: string,
-  body?: any
+  body?: any,
+  timeoutMs?: number
 ): Promise<{ data: any; tokenData: JiraTokenData }> => {
   const makeRequest = (token: string) =>
-    axios({ method, url, data: body, headers: { Authorization: `Bearer ${token}`, Accept: 'application/json' } });
+    axios({
+      method,
+      url,
+      data: body,
+      headers: { Authorization: `Bearer ${token}`, Accept: 'application/json' },
+      ...(timeoutMs !== undefined ? { timeout: timeoutMs } : {}),
+    });
 
   try {
     const res = await makeRequest(tokenData.access_token);

--- a/packages/server/src/test/jira-item-linking.test.ts
+++ b/packages/server/src/test/jira-item-linking.test.ts
@@ -1,0 +1,781 @@
+/**
+ * Linking a card to a JIRA item outside of the importer.
+ *
+ * `externalId` / `externalUrl` have been on AgEnFKItem since the JIRA importer
+ * landed, and the UI already renders them as a clickable badge — but the only
+ * writers were the JIRA import (server.ts) and the GitHub import. `POST /items`
+ * and `PUT /items/:id` destructure a fixed field list that omits both, so no
+ * other route could attach a reference. These tests pin the write paths that
+ * close that gap:
+ *
+ *   - `jiraItem` on create and update resolves a key into the reference pair;
+ *   - `jiraItem: 'none'` unlinks;
+ *   - omitting `jiraItem` leaves an existing reference alone (a PUT that edits
+ *     the title must not silently drop the JIRA link);
+ *   - linking is REFERENCE ONLY — the card keeps its own title and description,
+ *     which is what separates a link from an import;
+ *   - with an OAuth token present the key is confirmed against JIRA and the
+ *     browse URL is derived from the token's cloudUrl; without one the key is
+ *     format-checked and stored bare.
+ *
+ * The externalUrl scheme check is a security control, not tidiness: both
+ * KanbanBoard.tsx and CardDetailModal.tsx render `href={item.externalUrl}`
+ * with no sanitising, so a stored `javascript:` URL is a stored-XSS trigger on
+ * click. The server is the only place that can refuse it.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import request from 'supertest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// Mockable homedir so the JIRA token this suite writes lands in a sandbox and
+// never touches the real ~/.agenfk (see home-isolation.test.ts for why).
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('os')>();
+  return { ...actual, default: { ...actual, homedir: vi.fn(() => actual.homedir()) }, homedir: vi.fn(() => actual.homedir()) };
+});
+
+// server.ts calls axios(...) as a function for every JIRA API request.
+vi.mock('axios', async (importOriginal) => {
+  const actual = await importOriginal<any>();
+  const fn: any = vi.fn(async () => ({ data: {} }));
+  fn.get = vi.fn(async () => ({ data: {} }));
+  fn.post = vi.fn(async () => ({ data: {} }));
+  fn.create = actual.default?.create ?? vi.fn(() => fn);
+  fn.isAxiosError = actual.default?.isAxiosError ?? (() => false);
+  return { ...actual, default: fn };
+});
+
+import axios from 'axios';
+import { app, initStorage, JIRA_HTTP_TIMEOUT_MS, isJiraBrowseUrlFor, describeRejectedInput } from '../server';
+
+const TEST_DB = path.resolve('./jira-item-linking-test-db.sqlite');
+const SANDBOX_HOME = path.join(os.tmpdir(), 'agenfk-jira-link-home');
+const CLOUD_URL = 'https://cg-lab.atlassian.net';
+
+const setHome = (dir: string | null) => {
+  const homedir = os.homedir as unknown as ReturnType<typeof vi.fn>;
+  homedir.mockImplementation(() => dir ?? SANDBOX_HOME);
+};
+
+const writeJiraToken = () => {
+  const dir = path.join(SANDBOX_HOME, '.agenfk');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'jira-token.json'),
+    JSON.stringify({
+      access_token: 'tok',
+      refresh_token: 'ref',
+      cloudId: 'cloud-1',
+      cloudUrl: CLOUD_URL,
+    }),
+  );
+};
+
+/** refreshJiraToken() returns early unless OAuth client credentials exist. */
+const writeJiraClientConfig = () => {
+  const dir = path.join(SANDBOX_HOME, '.agenfk');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'config.json'),
+    JSON.stringify({ jira: { clientId: 'cid', clientSecret: 'secret' } }),
+  );
+};
+
+const clearJiraToken = () => {
+  const tokenFile = path.join(SANDBOX_HOME, '.agenfk', 'jira-token.json');
+  if (fs.existsSync(tokenFile)) fs.unlinkSync(tokenFile);
+};
+
+/** An axios rejection shaped the way the JIRA client sees a real HTTP error. */
+const httpError = (status: number) => {
+  const err: any = new Error(`Request failed with status code ${status}`);
+  err.response = { status, data: {} };
+  err.isAxiosError = true;
+  return err;
+};
+
+describe('linking a card to a JIRA item', () => {
+  let projectId: string;
+
+  beforeAll(async () => {
+    process.env.AGENFK_DB_PATH = TEST_DB;
+    if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+    fs.mkdirSync(SANDBOX_HOME, { recursive: true });
+    await initStorage();
+  });
+
+  afterAll(() => {
+    if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+    fs.rmSync(SANDBOX_HOME, { recursive: true, force: true });
+  });
+
+  beforeEach(async () => {
+    // resetAllMocks, not clearAllMocks: clear wipes CALLS but keeps
+    // implementations, so a mockRejectedValue set in one test survives into the
+    // next. Harmless today only by luck of ordering — a landmine for the next
+    // test added here. Reset, then re-establish the benign default.
+    vi.resetAllMocks();
+    (axios as any).mockResolvedValue({ data: {} });
+    (axios as any).post.mockResolvedValue({ data: {} });
+    setHome(SANDBOX_HOME);
+    clearJiraToken();
+    if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+    await initStorage();
+    const p = await request(app).post('/projects').send({ name: 'jira-link' });
+    projectId = p.body.id;
+  });
+
+  const createItem = (body: Record<string, unknown> = {}) =>
+    request(app).post('/items').send({ type: 'TASK', title: 'Fix the picker dismiss', projectId, ...body });
+
+  // ── create ────────────────────────────────────────────────────────────────
+
+  describe('POST /items with jiraItem (disconnected)', () => {
+    it('stores the format-checked key with no URL when no JIRA token is present', async () => {
+      const res = await createItem({ jiraItem: 'CGLAB-163' });
+      expect(res.status).toBe(201);
+      expect(res.body.externalId).toBe('CGLAB-163');
+      expect(res.body.externalUrl ?? null).toBeNull();
+    });
+
+    it('persists the reference, so a later read still carries it', async () => {
+      const created = await createItem({ jiraItem: 'CGLAB-163' });
+      const read = await request(app).get(`/items/${created.body.id}`);
+      expect(read.body.externalId).toBe('CGLAB-163');
+    });
+
+    it('normalises a lowercase key before storing it', async () => {
+      const res = await createItem({ jiraItem: 'cglab-163' });
+      expect(res.body.externalId).toBe('CGLAB-163');
+    });
+
+    it('rejects a malformed key with 400 and creates nothing', async () => {
+      const res = await createItem({ jiraItem: 'not a key' });
+      expect(res.status).toBe(400);
+      expect(String(res.body.error)).toMatch(/not a key|JIRA/i);
+      const list = await request(app).get('/items').query({ projectId });
+      expect(list.body).toHaveLength(0);
+    });
+
+    it('leaves the reference empty when jiraItem is omitted', async () => {
+      const res = await createItem();
+      expect(res.status).toBe(201);
+      expect(res.body.externalId ?? null).toBeNull();
+    });
+
+    it('keeps the caller title — linking is a reference, not an import', async () => {
+      const res = await createItem({ jiraItem: 'CGLAB-163', description: 'mine' });
+      // The link must actually have happened, or this asserts nothing at all.
+      expect(res.body.externalId).toBe('CGLAB-163');
+      expect(res.body.title).toBe('Fix the picker dismiss');
+      expect(res.body.description).toBe('mine');
+    });
+  });
+
+  // ── update ────────────────────────────────────────────────────────────────
+
+  describe('PUT /items/:id with jiraItem', () => {
+    it('links an existing card that was created without a reference', async () => {
+      const created = await createItem();
+      expect(created.body.externalId ?? null).toBeNull();
+
+      const res = await request(app).put(`/items/${created.body.id}`).send({ jiraItem: 'CGLAB-163' });
+      expect(res.status).toBe(200);
+      expect(res.body.externalId).toBe('CGLAB-163');
+    });
+
+    it('does not touch the card title or description when linking', async () => {
+      const created = await createItem({ description: 'mine' });
+      const res = await request(app).put(`/items/${created.body.id}`).send({ jiraItem: 'CGLAB-163' });
+      expect(res.body.externalId).toBe('CGLAB-163');
+      expect(res.body.title).toBe('Fix the picker dismiss');
+      expect(res.body.description).toBe('mine');
+    });
+
+    it('re-links to a different key, replacing the previous reference', async () => {
+      const created = await createItem({ jiraItem: 'CGLAB-163' });
+      const res = await request(app).put(`/items/${created.body.id}`).send({ jiraItem: 'CGLAB-999' });
+      expect(res.body.externalId).toBe('CGLAB-999');
+    });
+
+    it("unlinks on the 'none' sentinel, clearing both the id and the URL", async () => {
+      writeJiraToken();
+      (axios as any).mockResolvedValue({ data: { key: 'CGLAB-163' } });
+      const created = await createItem({ jiraItem: 'CGLAB-163' });
+      expect(created.body.externalUrl).toBe(`${CLOUD_URL}/browse/CGLAB-163`);
+
+      const res = await request(app).put(`/items/${created.body.id}`).send({ jiraItem: 'none' });
+      expect(res.status).toBe(200);
+      expect(res.body.externalId ?? null).toBeNull();
+      expect(res.body.externalUrl ?? null).toBeNull();
+    });
+
+    it('accepts the unlink sentinel in any casing, clearing both fields', async () => {
+      writeJiraToken();
+      (axios as any).mockResolvedValue({ data: { key: 'CGLAB-163' } });
+      const created = await createItem({ jiraItem: 'CGLAB-163' });
+      expect(created.body.externalUrl).toBe(`${CLOUD_URL}/browse/CGLAB-163`);
+
+      const res = await request(app).put(`/items/${created.body.id}`).send({ jiraItem: '  NoNe  ' });
+      expect(res.body.externalId ?? null).toBeNull();
+      expect(res.body.externalUrl ?? null).toBeNull();
+    });
+
+    it('leaves an existing reference alone when the update omits jiraItem', async () => {
+      const created = await createItem({ jiraItem: 'CGLAB-163' });
+      const res = await request(app).put(`/items/${created.body.id}`).send({ title: 'Renamed' });
+      expect(res.body.title).toBe('Renamed');
+      expect(res.body.externalId).toBe('CGLAB-163');
+    });
+
+    it('rejects a malformed key with 400 and leaves the stored reference untouched', async () => {
+      const created = await createItem({ jiraItem: 'CGLAB-163' });
+      const res = await request(app).put(`/items/${created.body.id}`).send({ jiraItem: 'nope' });
+      expect(res.status).toBe(400);
+      const read = await request(app).get(`/items/${created.body.id}`);
+      expect(read.body.externalId).toBe('CGLAB-163');
+    });
+  });
+
+  // ── validate-if-connected ─────────────────────────────────────────────────
+
+  describe('with a JIRA OAuth token present', () => {
+    beforeEach(() => writeJiraToken());
+
+    it('confirms the key against JIRA and derives the browse URL from cloudUrl', async () => {
+      (axios as any).mockResolvedValue({ data: { key: 'CGLAB-163', fields: { summary: 'x' } } });
+
+      const res = await createItem({ jiraItem: 'CGLAB-163' });
+      expect(res.status).toBe(201);
+      expect(res.body.externalId).toBe('CGLAB-163');
+      expect(res.body.externalUrl).toBe(`${CLOUD_URL}/browse/CGLAB-163`);
+      expect(axios).toHaveBeenCalled();
+      const requestedUrl = (axios as any).mock.calls[0][0].url;
+      expect(requestedUrl).toContain('CGLAB-163');
+    });
+
+    it('rejects a well-formed key that does not exist in JIRA', async () => {
+      (axios as any).mockRejectedValue(httpError(404));
+
+      const res = await createItem({ jiraItem: 'CGLAB-99999' });
+      expect(res.status).toBe(400);
+      expect(String(res.body.error)).toContain('CGLAB-99999');
+      const list = await request(app).get('/items').query({ projectId });
+      expect(list.body).toHaveLength(0);
+    });
+
+    it('rejects a key the token is not authorised to read, creating nothing', async () => {
+      (axios as any).mockRejectedValue(httpError(403));
+      const res = await createItem({ jiraItem: 'SECRET-1' });
+      expect(res.status).toBe(400);
+      const list = await request(app).get('/items').query({ projectId });
+      expect(list.body).toHaveLength(0);
+    });
+
+    it('still links when JIRA is unreachable, and says so rather than failing silently', async () => {
+      (axios as any).mockRejectedValue(Object.assign(new Error('ECONNREFUSED'), { code: 'ECONNREFUSED' }));
+
+      const res = await createItem({ jiraItem: 'CGLAB-163' });
+      expect(res.status).toBe(201);
+      expect(res.body.externalId).toBe('CGLAB-163');
+      expect(String(res.body.jiraWarning ?? '')).toMatch(/verif/i);
+    });
+
+    it('does not call JIRA at all when unlinking', async () => {
+      (axios as any).mockResolvedValue({ data: { key: 'CGLAB-163' } });
+      const created = await createItem({ jiraItem: 'CGLAB-163' });
+      (axios as any).mockClear();
+
+      await request(app).put(`/items/${created.body.id}`).send({ jiraItem: 'none' });
+      expect(axios).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── the archive/unarchive early returns (found in adversarial review) ─────
+  //
+  // PUT /items/:id returns early for both archive transitions. The reference
+  // resolution originally sat BELOW those returns, so an archiving update
+  // answered 200 having written no link — and, worse, answered 200 for a
+  // MALFORMED key instead of 400. Every path that can answer success must
+  // validate.
+
+  describe('archive and unarchive transitions', () => {
+    it('applies the link on the same request that archives the card', async () => {
+      const created = await createItem();
+      const res = await request(app)
+        .put(`/items/${created.body.id}`)
+        .send({ status: 'ARCHIVED', jiraItem: 'CGLAB-163' });
+
+      expect(res.status).toBe(200);
+      const read = await request(app).get(`/items/${created.body.id}`);
+      expect(read.body.externalId).toBe('CGLAB-163');
+      expect(read.body.status).toBe('ARCHIVED');
+    });
+
+    it('rejects a malformed key on an archiving update instead of answering 200', async () => {
+      const created = await createItem();
+      const res = await request(app)
+        .put(`/items/${created.body.id}`)
+        .send({ status: 'ARCHIVED', jiraItem: 'not a key' });
+
+      expect(res.status).toBe(400);
+      const read = await request(app).get(`/items/${created.body.id}`);
+      expect(read.body.status).not.toBe('ARCHIVED');
+    });
+
+    it('refuses an unsafe externalUrl on an archiving update', async () => {
+      const created = await createItem();
+      const res = await request(app)
+        .put(`/items/${created.body.id}`)
+        .send({ status: 'ARCHIVED', externalUrl: 'javascript:alert(1)' });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects an invalid type on an archiving update, instead of archiving anyway', async () => {
+      // Behaviour CHANGE, pinned deliberately. The type and parent guards used
+      // to sit BELOW the archive early return, so an archiving request skipped
+      // them entirely. Moving the reference resolution above the return moved
+      // those guards with it. Recording the new answer so the change is visible
+      // rather than incidental.
+      const created = await createItem();
+
+      const res = await request(app)
+        .put(`/items/${created.body.id}`)
+        .send({ status: 'ARCHIVED', type: 'BOGUS' });
+
+      expect(res.status).toBe(400);
+      const read = await request(app).get(`/items/${created.body.id}`);
+      expect(read.body.status).not.toBe('ARCHIVED');
+    });
+
+    it('applies the link on the request that unarchives the card', async () => {
+      const created = await createItem();
+      await request(app).put(`/items/${created.body.id}`).send({ status: 'ARCHIVED' });
+
+      const res = await request(app)
+        .put(`/items/${created.body.id}`)
+        .send({ status: 'TODO', jiraItem: 'CGLAB-163' });
+
+      expect(res.status).toBe(200);
+      const read = await request(app).get(`/items/${created.body.id}`);
+      expect(read.body.externalId).toBe('CGLAB-163');
+      expect(read.body.status).toBe('TODO');
+    });
+  });
+
+  // ── bounded network calls ─────────────────────────────────────────────────
+
+  describe('outbound JIRA calls are bounded', () => {
+    it('passes an explicit timeout on the validation request, so a stalled JIRA cannot hang the write', async () => {
+      writeJiraToken();
+      (axios as any).mockResolvedValue({ data: { key: 'CGLAB-163' } });
+
+      await createItem({ jiraItem: 'CGLAB-163' });
+
+      const config = (axios as any).mock.calls[0][0];
+      expect(config.timeout).toBe(JIRA_HTTP_TIMEOUT_MS);
+      expect(config.timeout).toBeGreaterThan(0);
+    });
+
+    it('bounds the TOKEN REFRESH too, which is the call that could hang unbounded', async () => {
+      // A 401 sends jiraApiRequest through refreshJiraToken, whose POST to
+      // auth.atlassian.com carried no timeout of its own — so bounding only the
+      // validation request left the actual stall path open.
+      writeJiraToken();
+      writeJiraClientConfig();
+      const unauthorized = httpError(401);
+      (axios as any).mockRejectedValue(unauthorized);
+      (axios as any).post.mockResolvedValue({
+        data: { access_token: 'new', refresh_token: 'newref', expires_in: 3600 },
+      });
+
+      await createItem({ jiraItem: 'CGLAB-163' });
+
+      expect((axios as any).post).toHaveBeenCalled();
+      const [url, , config] = (axios as any).post.mock.calls[0];
+      expect(String(url)).toContain('auth.atlassian.com');
+      expect(config?.timeout).toBe(JIRA_HTTP_TIMEOUT_MS);
+    });
+  });
+
+  // ── a disconnected re-link must not destroy a verified URL ────────────────
+
+  describe('re-linking while disconnected', () => {
+    it('keeps a previously verified URL when the same key is re-linked offline', async () => {
+      writeJiraToken();
+      (axios as any).mockResolvedValue({ data: { key: 'CGLAB-163' } });
+      const created = await createItem({ jiraItem: 'CGLAB-163' });
+      expect(created.body.externalUrl).toBe(`${CLOUD_URL}/browse/CGLAB-163`);
+
+      clearJiraToken();
+      const res = await request(app).put(`/items/${created.body.id}`).send({ jiraItem: 'CGLAB-163' });
+
+      expect(res.body.externalId).toBe('CGLAB-163');
+      expect(res.body.externalUrl).toBe(`${CLOUD_URL}/browse/CGLAB-163`);
+    });
+
+    it('drops the stale URL when a DIFFERENT key is linked offline', async () => {
+      writeJiraToken();
+      (axios as any).mockResolvedValue({ data: { key: 'CGLAB-163' } });
+      const created = await createItem({ jiraItem: 'CGLAB-163' });
+
+      clearJiraToken();
+      const res = await request(app).put(`/items/${created.body.id}`).send({ jiraItem: 'CGLAB-999' });
+
+      expect(res.body.externalId).toBe('CGLAB-999');
+      // The old URL pointed at CGLAB-163; keeping it would mislabel the badge.
+      expect(res.body.externalUrl ?? null).toBeNull();
+    });
+
+    it('refuses to store a derived URL that is not a URL at all', async () => {
+      // A JIRA OAuth resource with no `url` yields the literal string
+      // "undefined/browse/KEY". It must not reach the item, because the UI
+      // renders externalUrl straight into an href.
+      const dir = path.join(SANDBOX_HOME, '.agenfk');
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, 'jira-token.json'),
+        JSON.stringify({ access_token: 't', refresh_token: 'r', cloudId: 'c' }),
+      );
+      (axios as any).mockResolvedValue({ data: { key: 'CGLAB-163' } });
+
+      const res = await createItem({ jiraItem: 'CGLAB-163' });
+      expect(res.status).toBe(201);
+      expect(res.body.externalId).toBe('CGLAB-163');
+      expect(res.body.externalUrl ?? null).toBeNull();
+    });
+  });
+
+  // ── 'none' on create ──────────────────────────────────────────────────────
+
+  describe("the unlink sentinel on create", () => {
+    it('creates an unlinked card without calling JIRA', async () => {
+      writeJiraToken();
+      const res = await createItem({ jiraItem: 'none' });
+      expect(res.status).toBe(201);
+      expect(res.body.externalId ?? null).toBeNull();
+      expect(axios).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── gaps found in the second adversarial review ──────────────────────────
+  //
+  // Each of these covers a fix that was in the code but pinned by NOTHING, so
+  // reverting the fix left the suite green.
+
+  describe('bounds on the jiraItem path', () => {
+    it('refuses an absurdly long key, which was the way around both length caps', async () => {
+      // The grammar is anchored but not finite, so a 5000-character project key
+      // matched it and landed in the item's JSON blob — and, when connected, in
+      // the derived browse URL, past the 2048 URL cap.
+      const res = await createItem({ jiraItem: `${'A'.repeat(5000)}-1` });
+      expect(res.status).toBe(400);
+      const list = await request(app).get('/items').query({ projectId });
+      expect(list.body).toHaveLength(0);
+    });
+
+    it('accepts a key of a realistic length', async () => {
+      const res = await createItem({ jiraItem: 'ABCDEFGHIJ-123456' });
+      expect(res.status).toBe(201);
+    });
+  });
+
+  describe('the archive path reports an unverified link', () => {
+    it('returns the warning when archiving and linking in one request', async () => {
+      writeJiraToken();
+      (axios as any).mockRejectedValue(Object.assign(new Error('ECONNREFUSED'), { code: 'ECONNREFUSED' }));
+      const created = await createItem();
+
+      const res = await request(app)
+        .put(`/items/${created.body.id}`)
+        .send({ status: 'ARCHIVED', jiraItem: 'CGLAB-163' });
+
+      expect(res.status).toBe(200);
+      // Without this the link is written unverified and the CLI prints nothing.
+      expect(String(res.body.jiraWarning ?? '')).toMatch(/verif/i);
+    });
+  });
+
+  describe('the update path reports an unverified link', () => {
+    it('returns the warning on an ordinary link of an existing card', async () => {
+      writeJiraToken();
+      (axios as any).mockRejectedValue(Object.assign(new Error('ETIMEDOUT'), { code: 'ETIMEDOUT' }));
+      const created = await createItem();
+
+      const res = await request(app).put(`/items/${created.body.id}`).send({ jiraItem: 'CGLAB-163' });
+
+      expect(res.status).toBe(200);
+      expect(String(res.body.jiraWarning ?? '')).toMatch(/verif/i);
+    });
+  });
+
+  describe('an offline re-link compares keys case-insensitively', () => {
+    it('keeps the URL when the stored id differs only in case', async () => {
+      // A raw externalId is stored verbatim, while a parsed key is uppercased,
+      // so a case-sensitive compare dropped a perfectly good URL.
+      const created = await createItem({
+        externalId: 'cglab-163',
+        externalUrl: 'https://cg-lab.atlassian.net/browse/cglab-163',
+      });
+
+      const res = await request(app).put(`/items/${created.body.id}`).send({ jiraItem: 'CGLAB-163' });
+
+      expect(res.body.externalId).toBe('CGLAB-163');
+      expect(res.body.externalUrl).toBe('https://cg-lab.atlassian.net/browse/cglab-163');
+    });
+
+    it('does not keep a URL that is not a browse link for this key', async () => {
+      const created = await createItem({
+        externalId: 'CGLAB-163',
+        externalUrl: 'https://example.com/somewhere-else',
+      });
+
+      const res = await request(app).put(`/items/${created.body.id}`).send({ jiraItem: 'CGLAB-163' });
+
+      expect(res.body.externalId).toBe('CGLAB-163');
+      expect(res.body.externalUrl ?? null).toBeNull();
+    });
+  });
+
+  describe('local guards run before the JIRA round-trip', () => {
+    it('rejects a bad type without spending a live JIRA call', async () => {
+      writeJiraToken();
+      (axios as any).mockResolvedValue({ data: { key: 'CGLAB-163' } });
+      const created = await createItem();
+
+      const res = await request(app)
+        .put(`/items/${created.body.id}`)
+        .send({ type: 'BOGUS', jiraItem: 'CGLAB-163' });
+
+      expect(res.status).toBe(400);
+      expect(axios).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /items/bulk carries a reference like the single-item routes', () => {
+    it('links through the bulk route instead of dropping the field', async () => {
+      const created = await createItem();
+
+      const res = await request(app)
+        .post('/items/bulk')
+        .send({ items: [{ id: created.body.id, updates: { jiraItem: 'CGLAB-163' } }] });
+
+      expect(res.status).toBe(200);
+      const read = await request(app).get(`/items/${created.body.id}`);
+      expect(read.body.externalId).toBe('CGLAB-163');
+    });
+
+    it('links on the same bulk entry that archives the card', async () => {
+      // The bulk loop `continue`s on the archive branches, so a reference
+      // resolved after them was dropped on exactly those entries — the same
+      // bug PUT had, inherited by the route that copied its shape.
+      const created = await createItem();
+
+      const res = await request(app)
+        .post('/items/bulk')
+        .send({ items: [{ id: created.body.id, updates: { status: 'ARCHIVED', jiraItem: 'CGLAB-163' } }] });
+
+      expect(res.status).toBe(200);
+      const read = await request(app).get(`/items/${created.body.id}`);
+      expect(read.body.externalId).toBe('CGLAB-163');
+      expect(read.body.status).toBe('ARCHIVED');
+    });
+
+    it('reports a malformed key on an archiving bulk entry instead of accepting it silently', async () => {
+      const created = await createItem();
+
+      const res = await request(app)
+        .post('/items/bulk')
+        .send({ items: [{ id: created.body.id, updates: { status: 'ARCHIVED', jiraItem: 'not a key' } }] });
+
+      expect(res.body.skipped).toEqual([
+        expect.objectContaining({ id: created.body.id, error: expect.stringContaining('JIRA') }),
+      ]);
+      const read = await request(app).get(`/items/${created.body.id}`);
+      expect(read.body.externalId ?? null).toBeNull();
+    });
+
+    it('reports an unverified bulk link in warnings, which is not the same as skipped', async () => {
+      // An entry in `skipped` means "this did not happen"; an unverified link
+      // DID happen. Reporting it as a skip would be a false failure.
+      writeJiraToken();
+      (axios as any).mockRejectedValue(Object.assign(new Error('ECONNREFUSED'), { code: 'ECONNREFUSED' }));
+      const created = await createItem();
+
+      const res = await request(app)
+        .post('/items/bulk')
+        .send({ items: [{ id: created.body.id, updates: { jiraItem: 'CGLAB-163' } }] });
+
+      expect(res.status).toBe(200);
+      expect(JSON.stringify(res.body.warnings ?? [])).toMatch(/verif/i);
+      expect(JSON.stringify(res.body.skipped ?? [])).not.toMatch(/verif/i);
+      const read = await request(app).get(`/items/${created.body.id}`);
+      expect(read.body.externalId).toBe('CGLAB-163');
+    });
+
+    it('does NOT claim an unverified link on an entry it then abandoned', async () => {
+      // The warning used to be emitted before the write, so an entry rejected
+      // later by the parent guard still reported a link that never happened.
+      writeJiraToken();
+      (axios as any).mockRejectedValue(Object.assign(new Error('ECONNREFUSED'), { code: 'ECONNREFUSED' }));
+      const created = await createItem();
+
+      const res = await request(app).post('/items/bulk').send({
+        items: [{ id: created.body.id, updates: { parentId: 'does-not-exist', jiraItem: 'CGLAB-163' } }],
+      });
+
+      expect(res.status).toBe(200);
+      expect(JSON.stringify(res.body.warnings ?? [])).not.toMatch(/verif/i);
+      expect(JSON.stringify(res.body.skipped ?? [])).toMatch(/not found/i);
+      const read = await request(app).get(`/items/${created.body.id}`);
+      expect(read.body.externalId ?? null).toBeNull();
+    });
+
+    it('reports a bad key in skipped rather than answering 200 with nothing done', async () => {
+      const created = await createItem();
+
+      const res = await request(app)
+        .post('/items/bulk')
+        .send({ items: [{ id: created.body.id, updates: { jiraItem: 'not a key' } }] });
+
+      expect(res.body.skipped).toEqual([
+        expect.objectContaining({ id: created.body.id, error: expect.stringContaining('JIRA') }),
+      ]);
+    });
+  });
+
+  // ── the browse-URL shape rule, pinned rather than merely commented ───────
+
+  describe('isJiraBrowseUrlFor', () => {
+    it('matches a plain browse URL for the key', () => {
+      expect(isJiraBrowseUrlFor('https://x.atlassian.net/browse/CGLAB-163', 'CGLAB-163')).toBe(true);
+    });
+
+    it('tolerates a context path, as JIRA Server/DC uses', () => {
+      expect(isJiraBrowseUrlFor('https://jira.acme.com/jira/browse/CGLAB-163', 'CGLAB-163')).toBe(true);
+    });
+
+    it("accepts a percent-encoded key, since '%2D' spells '-'", () => {
+      expect(isJiraBrowseUrlFor('https://x/browse/CGLAB%2D163', 'CGLAB-163')).toBe(true);
+    });
+
+    it('does not let %2F smuggle a path separator', () => {
+      // Decoding the whole path and then comparing would read this single real
+      // segment as '/x/browse/CGLAB-163'. Segments are decoded individually.
+      expect(isJiraBrowseUrlFor('https://x/x%2Fbrowse%2FCGLAB-163', 'CGLAB-163')).toBe(false);
+    });
+
+    it('returns false rather than throwing on a malformed percent escape', () => {
+      expect(isJiraBrowseUrlFor('https://x/browse/%E0%A4%A', 'CGLAB-163')).toBe(false);
+    });
+
+    it('tolerates a trailing slash rather than dropping a usable URL', () => {
+      expect(isJiraBrowseUrlFor('https://x/browse/CGLAB-163/', 'CGLAB-163')).toBe(true);
+    });
+
+    it('rejects a browse URL for a different key', () => {
+      expect(isJiraBrowseUrlFor('https://x/browse/OTHER-1', 'CGLAB-163')).toBe(false);
+    });
+
+    it('rejects an unsafe scheme even with the right path', () => {
+      expect(isJiraBrowseUrlFor('javascript:/browse/CGLAB-163', 'CGLAB-163')).toBe(false);
+    });
+  });
+
+  describe('describeRejectedInput', () => {
+    it('never throws, whatever it is handed', () => {
+      const circular: any = {}; circular.self = circular;
+      for (const value of [undefined, null, 42, Symbol('s'), 10n, () => {}, circular, { toString: null, valueOf: null }]) {
+        expect(() => describeRejectedInput(value)).not.toThrow();
+      }
+    });
+
+    it('strips control characters, which would otherwise reach the operator terminal', () => {
+      const out = describeRejectedInput('a\u0000b\u001bc\u007fd');
+      expect(out).toBe('abcd');
+    });
+
+    it('truncates without splitting an astral character in half', () => {
+      // The fixture matters. '😀'.repeat(200) cuts at code unit 80, which is an
+      // EVEN boundary, so even the broken slice() left the pairs intact and this
+      // test passed against unfixed code. 79 ASCII chars push the cut onto an
+      // odd offset, landing inside a surrogate pair.
+      const out = describeRejectedInput(`${'a'.repeat(79)}${'😀'.repeat(5)}`);
+      // A high surrogate not followed by a low one. Asserting a specific code
+      // unit was also wrong: 😀 is \uD83D\uDE00, so '\uD800' never appeared.
+      expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(out)).toBe(false);
+      expect([...out].length).toBeLessThanOrEqual(81);
+    });
+  });
+
+  // ── externalUrl is an href in the UI: the scheme is a security control ────
+
+  describe('raw externalId / externalUrl', () => {
+    it('accepts a caller-supplied http(s) reference, for non-JIRA trackers', async () => {
+      const res = await createItem({
+        externalId: '4321',
+        externalUrl: 'https://github.com/cglab-public/agenfk/issues/4321',
+      });
+      expect(res.status).toBe(201);
+      expect(res.body.externalId).toBe('4321');
+      expect(res.body.externalUrl).toBe('https://github.com/cglab-public/agenfk/issues/4321');
+    });
+
+    it('refuses a javascript: externalUrl, which the UI would render as a live href', async () => {
+      const res = await createItem({ externalId: 'X-1', externalUrl: 'javascript:alert(1)' });
+      expect(res.status).toBe(400);
+      const list = await request(app).get('/items').query({ projectId });
+      expect(list.body).toHaveLength(0);
+    });
+
+    it('refuses a data: externalUrl on update as well as on create', async () => {
+      const created = await createItem();
+      const res = await request(app)
+        .put(`/items/${created.body.id}`)
+        .send({ externalUrl: 'data:text/html;base64,PHNjcmlwdD4=' });
+      expect(res.status).toBe(400);
+      const read = await request(app).get(`/items/${created.body.id}`);
+      expect(read.body.externalUrl ?? null).toBeNull();
+    });
+
+    it('refuses a URL carrying embedded credentials, which reads as a phishing href', async () => {
+      const res = await createItem({ externalId: 'X-1', externalUrl: 'http://user:pass@evil.example.com/x' });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects an object with no primitive conversion as 400, not 500', async () => {
+      // String(raw) throws TypeError on { toString: null, valueOf: null },
+      // which escaped as a 500 from the very path meant to reject cleanly.
+      const res = await createItem({ jiraItem: { toString: null, valueOf: null } });
+      expect(res.status).toBe(400);
+    });
+
+    it('truncates the echo of a rejected value instead of returning it whole', async () => {
+      const res = await createItem({ jiraItem: 'Z'.repeat(5000) });
+      expect(res.status).toBe(400);
+      expect(String(res.body.error).length).toBeLessThan(300);
+    });
+
+    it('refuses a non-string externalId instead of storing "[object Object]"', async () => {
+      const res = await createItem({ externalId: { a: 1 } });
+      expect(res.status).toBe(400);
+    });
+
+    it('refuses an over-long externalId rather than bloating the stored item', async () => {
+      const res = await createItem({ externalId: 'X'.repeat(5000) });
+      expect(res.status).toBe(400);
+    });
+
+    it('refuses an over-long externalUrl', async () => {
+      const res = await createItem({ externalUrl: `https://example.com/${'x'.repeat(4000)}` });
+      expect(res.status).toBe(400);
+    });
+
+    it('lets jiraItem win over a conflicting raw externalId, so the validated value is the one stored', async () => {
+      const res = await createItem({ jiraItem: 'CGLAB-163', externalId: 'SPOOF-1' });
+      expect(res.body.externalId).toBe('CGLAB-163');
+    });
+  });
+});

--- a/packages/server/src/test/jira-key-parse.test.ts
+++ b/packages/server/src/test/jira-key-parse.test.ts
@@ -1,0 +1,112 @@
+/**
+ * JIRA key parsing — the format gate in front of every link.
+ *
+ * `--jira-item` reaches the server as free text, and on the offline path (no
+ * OAuth token) the format check is the ONLY thing standing between a typo and a
+ * card that advertises a JIRA badge pointing at nothing. So the parser has to be
+ * strict about what a JIRA issue key actually is, and it has to normalise, since
+ * users type `cglab-163` as readily as `CGLAB-163`.
+ *
+ * `none` is the unlink sentinel. It is unambiguous precisely because a bare word
+ * with no `-<number>` suffix is never a valid key, so no real project can
+ * collide with it — a property worth pinning, because it is the reason the
+ * sentinel is safe at all.
+ */
+import { describe, it, expect } from 'vitest';
+import { parseJiraKey, JIRA_UNLINK_SENTINEL } from '../server';
+
+describe('parseJiraKey', () => {
+  it('accepts a conventional PROJECT-123 key', () => {
+    expect(parseJiraKey('CGLAB-163')).toBe('CGLAB-163');
+  });
+
+  it('normalises a lowercase key to the canonical uppercase form', () => {
+    expect(parseJiraKey('cglab-163')).toBe('CGLAB-163');
+  });
+
+  it('trims surrounding whitespace before parsing', () => {
+    expect(parseJiraKey('  CGLAB-163  ')).toBe('CGLAB-163');
+  });
+
+  it('accepts digits and underscores inside the project key', () => {
+    expect(parseJiraKey('AB2_C-7')).toBe('AB2_C-7');
+  });
+
+  it('rejects a key whose project part does not start with a letter', () => {
+    expect(parseJiraKey('1CGLAB-163')).toBeNull();
+  });
+
+  it('rejects a single-character project key', () => {
+    expect(parseJiraKey('C-163')).toBeNull();
+  });
+
+  it('rejects a key with no issue number', () => {
+    expect(parseJiraKey('CGLAB-')).toBeNull();
+    expect(parseJiraKey('CGLAB')).toBeNull();
+  });
+
+  it('rejects a non-numeric issue number', () => {
+    expect(parseJiraKey('CGLAB-16a')).toBeNull();
+  });
+
+  it('rejects free text and anything that is not a string', () => {
+    expect(parseJiraKey('not a key')).toBeNull();
+    expect(parseJiraKey('')).toBeNull();
+    expect(parseJiraKey(undefined)).toBeNull();
+    expect(parseJiraKey(null)).toBeNull();
+    expect(parseJiraKey(42)).toBeNull();
+    expect(parseJiraKey({ key: 'CGLAB-163' })).toBeNull();
+  });
+
+  it('rejects an embedded key rather than extracting it, so a URL is not mistaken for a key', () => {
+    expect(parseJiraKey('https://cg-lab.atlassian.net/browse/CGLAB-163')).toBeNull();
+    expect(parseJiraKey('see CGLAB-163 for details')).toBeNull();
+  });
+
+  // ── found in adversarial review ────────────────────────────────────────────
+
+  it('rejects a project key that is a letter followed only by underscores', () => {
+    // 'A_-1' passed the original grammar. JIRA issues no such key, and on the
+    // disconnected path this parser is the only gate there is.
+    expect(parseJiraKey('A_-1')).toBeNull();
+    expect(parseJiraKey('A__-1')).toBeNull();
+  });
+
+  it('rejects a project key ending in an underscore', () => {
+    expect(parseJiraKey('AB_-1')).toBeNull();
+  });
+
+  it('still accepts an underscore BETWEEN alphanumerics', () => {
+    expect(parseJiraKey('A_B-1')).toBe('A_B-1');
+  });
+
+  it('does not let a non-ASCII character fold into an ASCII key', () => {
+    // toUpperCase() maps 'ﬀ' to 'FF', so matching after upper-casing accepted
+    // 'ﬀ-1' as 'FF-1'. The grammar is matched on the raw input for this reason.
+    expect(parseJiraKey('ﬀ-1')).toBeNull();
+    expect(parseJiraKey('ı_b-1')).toBeNull();
+  });
+
+  it('rejects issue number zero and leading zeros', () => {
+    // JIRA numbers issues from 1, and 'AB-007' would be a second spelling of
+    // 'AB-7' — two cards could then carry different externalIds for one issue.
+    expect(parseJiraKey('AB-0')).toBeNull();
+    expect(parseJiraKey('AB-007')).toBeNull();
+    expect(parseJiraKey('AB-7')).toBe('AB-7');
+  });
+
+  it('rejects a key longer than the bound, which was the way around both length caps', () => {
+    expect(parseJiraKey(`${'A'.repeat(5000)}-1`)).toBeNull();
+    expect(parseJiraKey(`AB-${'9'.repeat(400)}`)).toBeNull();
+  });
+
+  it('accepts a key of a realistic length', () => {
+    expect(parseJiraKey('ABCDEFGHIJ-123456')).toBe('ABCDEFGHIJ-123456');
+  });
+
+  it('never parses the unlink sentinel as a key, in any casing', () => {
+    expect(parseJiraKey(JIRA_UNLINK_SENTINEL)).toBeNull();
+    expect(parseJiraKey('none')).toBeNull();
+    expect(parseJiraKey('NONE')).toBeNull();
+  });
+});

--- a/packages/server/src/test/mcp-jira-item-schema.test.ts
+++ b/packages/server/src/test/mcp-jira-item-schema.test.ts
@@ -1,0 +1,102 @@
+/**
+ * `jiraItem` must be visible on the ADVERTISED MCP tool schema.
+ *
+ * The zod `CreateItemSchema`/`UpdateItemSchema` are server-side validation: they
+ * decide what is accepted once a call arrives. What an MCP client can *send* is
+ * decided by the `inputSchema` published in the ListTools response, and the two
+ * are maintained separately. Adding the field to zod alone — which is what the
+ * first attempt at this did — means the parameter exists but no agent ever
+ * discovers it, so the CLI and MCP surfaces this repo documents as
+ * interchangeable silently are not.
+ *
+ * Asserted through a real MCP client over the live ListTools handler, not by
+ * reading the source.
+ */
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { connectMcpClient, type ConnectedMcpClient } from './helpers/mcpClient';
+
+vi.mock('axios', () => {
+  const mockAxios = vi.fn() as any;
+  mockAxios.get = vi.fn();
+  mockAxios.post = vi.fn();
+  mockAxios.put = vi.fn();
+  mockAxios.delete = vi.fn();
+  mockAxios.interceptors = { request: { use: vi.fn() }, response: { use: vi.fn() } };
+  mockAxios.create = vi.fn(() => mockAxios);
+  return { default: mockAxios };
+});
+
+describe('MCP advertises the JIRA linking parameter', () => {
+  let mcp: ConnectedMcpClient;
+  let tools: any[];
+
+  beforeAll(async () => {
+    mcp = await connectMcpClient();
+    const listed: any = await mcp.client.listTools();
+    tools = listed.tools;
+  });
+
+  afterAll(async () => {
+    await mcp?.close?.();
+  });
+
+  const toolNamed = (name: string) => tools.find(t => t.name === name);
+
+  it('create_item accepts jiraItem', () => {
+    const props = toolNamed('create_item')?.inputSchema?.properties ?? {};
+    expect(Object.keys(props)).toContain('jiraItem');
+    expect(props.jiraItem.type).toBe('string');
+  });
+
+  it('update_item accepts jiraItem', () => {
+    const props = toolNamed('update_item')?.inputSchema?.properties ?? {};
+    expect(Object.keys(props)).toContain('jiraItem');
+    expect(props.jiraItem.type).toBe('string');
+  });
+
+  it('does not make jiraItem required on either tool', () => {
+    // Linking is optional; making it required would break every existing caller.
+    expect(toolNamed('create_item')?.inputSchema?.required ?? []).not.toContain('jiraItem');
+    expect(toolNamed('update_item')?.inputSchema?.required ?? []).not.toContain('jiraItem');
+  });
+
+  it("tells the agent how to unlink, since 'none' is not guessable", () => {
+    const description = toolNamed('update_item')?.inputSchema?.properties?.jiraItem?.description ?? '';
+    // Stronger than a bare substring match: the description has to actually
+    // instruct, not merely contain the word somewhere.
+    expect(description).toMatch(/['"`]?none['"`]? to unlink/i);
+  });
+
+  // Advertising the parameter is only half of it — the handler has to FORWARD
+  // it. Both handlers currently spread the parsed args into the REST call, but a
+  // refactor to an explicit field list would drop jiraItem with every schema
+  // assertion above still green.
+  describe('the handlers forward it to the REST route', () => {
+    it('create_item sends jiraItem onward', async () => {
+      const axiosMock: any = (await import('axios')).default;
+      axiosMock.post.mockResolvedValue({ data: { id: 'i1', title: 'T' } });
+
+      await mcp.client.callTool({
+        name: 'create_item',
+        arguments: { projectId: 'p1', type: 'TASK', title: 'T', jiraItem: 'CGLAB-163' },
+      });
+
+      const call = axiosMock.post.mock.calls.find((c: any[]) => String(c[0]).includes('/items'));
+      expect(call?.[1]).toEqual(expect.objectContaining({ jiraItem: 'CGLAB-163' }));
+    });
+
+    it('update_item sends jiraItem onward', async () => {
+      const axiosMock: any = (await import('axios')).default;
+      axiosMock.get.mockResolvedValue({ data: { id: 'i1', status: 'TODO' } });
+      axiosMock.put.mockResolvedValue({ data: { id: 'i1', title: 'T' } });
+
+      await mcp.client.callTool({
+        name: 'update_item',
+        arguments: { id: 'i1', jiraItem: 'none' },
+      });
+
+      const call = axiosMock.put.mock.calls.find((c: any[]) => String(c[0]).includes('/items/'));
+      expect(call?.[1]).toEqual(expect.objectContaining({ jiraItem: 'none' }));
+    });
+  });
+});

--- a/packages/storage-sqlite/package.json
+++ b/packages/storage-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/storage-sqlite",
-  "version": "1.1.19-beta.2",
+  "version": "1.1.19-beta.3",
   "description": "SQLite storage implementation for AgenFK Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -11,7 +11,7 @@
     "uuid": "^14.0.2"
   },
   "devDependencies": {
-    "@agenfk/core": "1.1.19-beta.2",
+    "@agenfk/core": "1.1.19-beta.3",
     "@types/node": "^22.0.0",
     "@types/uuid": "^9.0.8",
     "typescript": "^5.3.3"

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenfk/telemetry",
-  "version": "1.1.19-beta.2",
+  "version": "1.1.19-beta.3",
   "description": "Anonymous telemetry client for AgenFK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "1.1.19-beta.2",
+  "version": "1.1.19-beta.3",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -12,7 +12,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@agenfk/flow-editor": "1.1.19-beta.2",
+    "@agenfk/flow-editor": "1.1.19-beta.3",
     "@fontsource-variable/jetbrains-mono": "^5.3.0",
     "@fontsource-variable/manrope": "^5.3.0",
     "@tailwindcss/postcss": "^4.3.3",

--- a/packages/ui/src/components/CardDetailModal.tsx
+++ b/packages/ui/src/components/CardDetailModal.tsx
@@ -300,6 +300,17 @@ export const CardDetailModal: React.FC<CardDetailModalProps> = ({ item, allItems
                 <span>{item.externalId || 'JIRA'}</span>
               </a>
             )}
+            {/* Same as the board: a key stored without a browse URL (linked
+                while JIRA was disconnected) must still be visible. Plain text,
+                since there is nothing to open. */}
+            {!item.externalUrl && item.externalId && (
+              <span
+                className="flex items-center gap-1.5 px-2.5 py-1 rounded-md bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 text-slate-500 dark:text-slate-400 text-[10px] font-bold uppercase tracking-wider"
+                title={`JIRA ${item.externalId} — no link stored (JIRA was not connected when this reference was set)`}
+              >
+                <span>{item.externalId}</span>
+              </span>
+            )}
           </div>
           <div className="flex items-center gap-1">
             {!isNew && onUpdateItem && (

--- a/packages/ui/src/components/KanbanBoard.tsx
+++ b/packages/ui/src/components/KanbanBoard.tsx
@@ -400,6 +400,19 @@ const KanbanCard: React.FC<KanbanCardProps> = ({
               )}
             </a>
           )}
+          {/* A reference with no URL is a real, documented state: linking while
+              JIRA is disconnected stores the key and no browse URL. Gating the
+              badge on externalUrl alone made those links invisible on the
+              board. Rendered as plain text, not a link, because there is
+              nowhere to go. */}
+          {!item.externalUrl && item.externalId && (
+            <span
+              className="text-slate-400 dark:text-slate-500 flex items-center gap-0.5"
+              title={`JIRA ${item.externalId} (no link — JIRA was not connected when this was set)`}
+            >
+              <span className="font-bold">{item.externalId}</span>
+            </span>
+          )}
           <div 
             className="flex items-center gap-1 group/id cursor-pointer" 
             onClick={(e) => { e.stopPropagation(); onCopyId(item.id); }}

--- a/packages/ui/src/test/CardDetailModal.test.tsx
+++ b/packages/ui/src/test/CardDetailModal.test.tsx
@@ -89,6 +89,48 @@ describe('CardDetailModal', () => {
     cleanup();
   });
 
+  // The detail modal's tracker badge was gated on externalUrl, so a card linked
+  // while JIRA was disconnected — which stores the key with no URL by design —
+  // showed no reference at all here.
+  const renderModal = (item: Record<string, unknown>) => {
+    (api.getItem as any).mockResolvedValue(item);
+    return render(
+      <CardDetailModal
+        item={item as any}
+        allItems={[]}
+        onClose={() => {}}
+        onSelectItem={() => {}}
+        onAddItem={async () => {}}
+        onDeleteItem={async () => {}}
+      />,
+      { wrapper }
+    );
+  };
+
+  it('shows a JIRA reference that has no browse URL', async () => {
+    renderModal({ ...mockItem, externalId: 'CGLAB-163' });
+    expect(screen.getByText('CGLAB-163')).toBeDefined();
+  });
+
+  it('does not render the url-less reference as a link', async () => {
+    renderModal({ ...mockItem, externalId: 'CGLAB-163' });
+    expect(screen.getByText('CGLAB-163').closest('a')).toBeNull();
+  });
+
+  it('still renders a clickable badge when the URL is present', async () => {
+    renderModal({
+      ...mockItem,
+      externalId: 'CGLAB-163',
+      externalUrl: 'https://cg-lab.atlassian.net/browse/CGLAB-163',
+    });
+    expect(screen.getByText('CGLAB-163').closest('a')).not.toBeNull();
+  });
+
+  it('renders no reference badge when externalId is null', async () => {
+    renderModal({ ...mockItem, externalId: null, externalUrl: null });
+    expect(screen.queryByText('CGLAB-163')).toBeNull();
+  });
+
   it('should render item details and switch tabs', async () => {
     (api.getItem as any).mockResolvedValue(mockItem);
     

--- a/packages/ui/src/test/JiraReferenceBadge.test.tsx
+++ b/packages/ui/src/test/JiraReferenceBadge.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * A JIRA reference with NO browse URL must still be visible.
+ *
+ * Both badges were gated on `item.externalUrl &&`. That was fine while the only
+ * writers were the JIRA and GitHub importers, which always produce a URL. It
+ * stopped being fine when cards became linkable directly: linking while JIRA is
+ * disconnected stores the key with no URL by design — the offline/CI mode the
+ * shipped docs advertise — so those cards carried a reference that rendered
+ * nowhere on the board or in the detail modal.
+ */
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import { KanbanBoard } from '../components/KanbanBoard';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ThemeProvider } from '../ThemeContext';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { api } from '../api';
+import { ItemType, Status } from '../types';
+
+vi.mock('socket.io-client', () => ({
+  io: vi.fn(() => ({ on: vi.fn(), off: vi.fn(), emit: vi.fn(), disconnect: vi.fn() })),
+}));
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation(query => ({
+    matches: false, media: query, onchange: null,
+    addListener: vi.fn(), removeListener: vi.fn(),
+    addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn(),
+  })),
+});
+
+if (typeof window !== 'undefined') {
+  window.HTMLElement.prototype.scrollTo = vi.fn();
+  window.HTMLElement.prototype.scrollIntoView = vi.fn();
+}
+
+const FLOW = {
+  id: 'default', name: 'Default Flow', projectId: '__builtin__',
+  steps: [
+    { id: 's-todo', name: 'TODO', label: 'TODO', order: 0 },
+    { id: 's-done', name: 'DONE', label: 'DONE', order: 1 },
+  ],
+  createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+vi.mock('../api', () => ({
+  api: {
+    listProjects: vi.fn(() => Promise.resolve([])),
+    listItems: vi.fn(() => Promise.resolve([])),
+    getItem: vi.fn(() => Promise.resolve({})),
+    createItem: vi.fn(() => Promise.resolve({})),
+    updateItem: vi.fn(() => Promise.resolve({})),
+    deleteItem: vi.fn(() => Promise.resolve({})),
+    deleteProject: vi.fn(() => Promise.resolve({})),
+    createProject: vi.fn(() => Promise.resolve({})),
+    bulkUpdateItems: vi.fn(() => Promise.resolve({})),
+    trashArchivedItems: vi.fn(() => Promise.resolve({})),
+    getJiraStatus: vi.fn(() => Promise.resolve({ configured: false, connected: false })),
+    getLatestRelease: vi.fn(() => Promise.resolve(null)),
+    getVersion: vi.fn(() => Promise.resolve({ version: '1.0.0' })),
+    getProjectFlow: vi.fn(() => Promise.resolve(FLOW)),
+    getGitHubStatus: vi.fn(() => Promise.resolve({ configured: false })),
+  },
+}));
+
+const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={queryClient}>
+    <ThemeProvider>{children}</ThemeProvider>
+  </QueryClientProvider>
+);
+
+const PROJECT = { id: 'p1', name: 'P1', createdAt: new Date(), updatedAt: new Date() };
+const baseItem = {
+  id: 'i1', projectId: 'p1', type: ItemType.TASK, title: 'Fix the picker dismiss',
+  status: Status.TODO, createdAt: new Date(), updatedAt: new Date(),
+};
+
+const renderBoard = async (item: Record<string, unknown>) => {
+  vi.mocked(api.listProjects).mockResolvedValue([PROJECT] as any);
+  vi.mocked(api.listItems).mockResolvedValue([item] as any);
+  vi.mocked(api.getProjectFlow).mockResolvedValue(FLOW as any);
+  localStorage.setItem('agenfk_project_id', 'p1');
+  render(<KanbanBoard />, { wrapper });
+  await waitFor(() => expect(screen.getByText('Fix the picker dismiss')).toBeDefined());
+};
+
+describe('JIRA reference badge on the board', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    queryClient.clear();
+    vi.mocked(api.getProjectFlow).mockResolvedValue(FLOW as any);
+  });
+  afterEach(() => cleanup());
+
+  it('shows the key when the card has a reference but NO browse URL', async () => {
+    await renderBoard({ ...baseItem, externalId: 'CGLAB-163' });
+    expect(screen.getByText('CGLAB-163')).toBeDefined();
+  });
+
+  it('does not render it as a link, because there is nowhere to go', async () => {
+    await renderBoard({ ...baseItem, externalId: 'CGLAB-163' });
+    const badge = screen.getByText('CGLAB-163');
+    expect(badge.closest('a')).toBeNull();
+  });
+
+  it('still renders the clickable badge when a URL IS present', async () => {
+    await renderBoard({
+      ...baseItem,
+      externalId: 'CGLAB-163',
+      externalUrl: 'https://cg-lab.atlassian.net/browse/CGLAB-163',
+    });
+    const link = document.querySelector('a[href="https://cg-lab.atlassian.net/browse/CGLAB-163"]');
+    expect(link).not.toBeNull();
+  });
+
+  it('renders no reference badge at all when the card has none', async () => {
+    await renderBoard({ ...baseItem });
+    expect(screen.queryByText('CGLAB-163')).toBeNull();
+  });
+
+  it('treats a null externalId as no reference, not as an empty badge', async () => {
+    // The API clears a link by writing null rather than dropping the field.
+    await renderBoard({ ...baseItem, externalId: null, externalUrl: null });
+    expect(screen.queryByText('CGLAB-163')).toBeNull();
+  });
+});

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -131,8 +131,13 @@ export interface AgEnFKItem {
   previousStatus?: Status;
   implementationPlan?: string;
   sortOrder?: number;
-  externalId?: string;
-  externalUrl?: string;
+  // Nullable, because the API clears a tracker link by writing null rather than
+  // by removing the field, and the UI keeps its own copy of this type rather
+  // than importing @agenfk/core — so it was quietly describing a shape the API
+  // no longer returns. No current call site dereferences these without a guard;
+  // the point is that the type should not invite one.
+  externalId?: string | null;
+  externalUrl?: string | null;
   branchName?: string;
   prUrl?: string;
   prNumber?: number;


### PR DESCRIPTION
Stacked on #180 — base is `feat/CGLAB-151_pr-overview-pr-number-search`, so this diff shows only the CGLAB-163 work. Also cuts `v1.1.19-beta.3`, cumulative over `beta.2`.

JIRA: [CGLAB-163](https://cg-lab.atlassian.net/browse/CGLAB-163)

## What and why

`externalId`/`externalUrl` have been on items since the JIRA importer landed, and the board has always rendered them as a clickable badge. But only the JIRA and GitHub imports ever wrote them: `POST /items` and `PUT /items/:id` destructured a fixed field list that omitted both. A card created any other way could never point at an issue.

```bash
agenfk create TASK "Fix the picker dismiss" --project <id> --jira-item CGLAB-163
agenfk update <id> --jira-item CGLAB-163     # link a card that already exists
agenfk update <id> --jira-item none          # unlink
```

The same `jiraItem` field works on `POST /items`, `PUT /items/:id`, `POST /items/bulk`, and the `create_item`/`update_item` MCP tools.

**Reference, not import.** The card keeps its own title and description.

**Validate-if-connected.** With a JIRA token the key is confirmed against the real issue and the browse URL derived from the token's cloud URL; a key that does not resolve is refused. Without one the key is format-checked and stored bare — the offline/CI path. If JIRA is connected but unreachable the link goes through and the response carries a `jiraWarning`, so an unverified link is never reported as plain success.

Omitting the flag never touches an existing link.

Documented in all four shipped client bundles, `SKILL.md`, and the `/agenfk` + `/agenfk-plan` commands.

## Fixed along the way

- **A reference with no browse URL now renders.** Both the board and the detail modal gated their badge on `externalUrl`, so a card linked while disconnected — the documented offline mode — displayed nothing at all.
- **`agenfk list --active` is documented for every client.** It was Claude-only while all four bundles instruct agents to use it. A new parity test fails when the bundles diverge, in both directions.
- **`POST /items/bulk` reports failed writes.** A `storage.updateItem` throw was caught, logged, and reported as nothing, so a failed entry looked like success. Now in `skipped`, with a new `warnings` array for entries that applied with a caveat. Both additive; no current consumer reads either.
- **Outbound JIRA calls are bounded.** Neither the request helper nor the token refresh it falls back to on a 401 set a timeout.
- **`externalUrl` is validated.** It is rendered straight into an `href`, so the server refuses non-`http(s)` and embedded credentials.

## Behaviour change worth flagging

`PUT /items/:id` now validates a requested type change and parent assignment **before** handling an archive transition. Previously an archiving request skipped both guards, so `{ status: "ARCHIVED", type: "BOGUS" }` archived the item; it now returns 400. Archiving without those fields is unaffected. Pinned by a test so the change is deliberate rather than incidental.

## Verification

- Root suite **3341 passed (3341)**, UI **464 passed (464)**, zero TypeScript errors.
- Six independent adversarial review passes; 45 findings, every one verified against the code before acting. Each fix proved by **reverting it** and watching the specific test fail — not by watching a test pass.
- End-to-end against a real built server on an isolated port with a throwaway DB, driving the real CLI: link on create, link an existing card, link surviving a rename, a rejected key leaving title and existing link untouched, and unlink clearing both fields.
- Docs verified by **deploying**: installer run into a sandbox HOME, installed tree grepped across five client surfaces.

Known: the suite has a pre-existing wandering `read ECONNRESET` flake that lands on a different unrelated test roughly one run in three. Repeated clean runs at 3341 are recorded on the cards.

## Not done, deliberately

- `POST /items/bulk` makes N serialised 8s JIRA calls with no overall batch bound. Real, but bounding a batch changes that route's contract beyond this work.
- The bulk archive branch's `storage.updateItem` is unguarded, matching the pre-existing unguarded write beside it. Wrapping only the new line would leave the inconsistency.
- Gemini rule deployment is gated on the Gemini CLI being present, so it was not observed landing on disk in the sandbox. The source bundle is confirmed identical to the other three.
